### PR TITLE
fix: prismic-vue to @prismicio/vue package

### DIFF
--- a/packages/sm-api/bootstrap/nuxt/index.js
+++ b/packages/sm-api/bootstrap/nuxt/index.js
@@ -29,7 +29,7 @@ module.exports = {
     libraries: [],
     bootstraper: ["npx", ["create-nuxt-app"]],
     transpile: ["vue-slicezone", "nuxt-sm"],
-    dependencies: ["prismic-javascript", "prismic-vue", "@nuxtjs/prismic", "vue-slicezone", "nuxt-sm"],
+    dependencies: ["prismic-javascript", "@prismicio/vue", "@nuxtjs/prismic", "vue-slicezone", "nuxt-sm"],
     modules: [[
       '@nuxtjs/prismic',
       {


### PR DESCRIPTION
Bootstrapping Prismic Vue SDK with new package name: from `prismic-vue` to `@prismicio/vue`, should avoid errors like that: https://github.com/nuxt-community/prismic-module/issues/70#issuecomment-648665532

Wasn't able to test if that's enough as I have no idea how to test this part of the CLI locally haha~

@hypervillain
