### PR TITLE
fix(sm-commons): use platform-aware path parser

### DIFF
--- a/packages/sm-commons/methods/actions.js
+++ b/packages/sm-commons/methods/actions.js
@@ -86,7 +86,7 @@ function fetchSliceDefinitions(p) {
 
     const slices = {}
     folders.forEach((p) => {
-      const sliceName = p.split("/").pop()
+      const sliceName = path.basename(p)
 
       const { model } = tests.isSliceFolder(p)
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

<!--- Describe your changes in detail -->
Now getting directory name with platform aware `path.basename` method.
<!--- Why is this change required? What problem does it solve? -->
Parsing paths with `/` does not work with win32 paths.
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->