### PR TITLE
fix: render PageFetch with queryType="single" OR uid in vue-slicezone

### DIFF
--- a/packages/vue-slicezone/index.js
+++ b/packages/vue-slicezone/index.js
@@ -1,30 +1,30 @@
-import PageFetch from "./PageFetch";
-import SliceZone from "./SliceZone";
+import PageFetch from './PageFetch'
+import SliceZone from './SliceZone'
 
 export default {
-  name: "SliceZone",
+  name: 'SliceZone',
   render(h) {
     const {
       slices,
       type,
       uid,
       queryType,
-      resolver: maybeResolver,
-    } = this.$attrs;
+      resolver: maybeResolver
+    } = this.$attrs
 
-    const resolver = maybeResolver || this.$sliceMachine.resolver;
-    if (!slices && type && (uid || queryType === "single")) {
+    const resolver = maybeResolver || this.$sliceMachine.resolver
+    if (!slices && type && (uid || queryType === 'single')) {
       return h(PageFetch, {
         props: {
           ...this.$attrs,
           resolver,
-          scopedSlots: this.$scopedSlots,
-        },
-      });
+          scopedSlots: this.$scopedSlots
+        }
+      })
     }
     return h(SliceZone, {
       scopedSlots: this.$scopedSlots,
-      props: { ...this.$attrs, resolver },
-    });
-  },
-};
+      props: { ...this.$attrs, resolver }
+    })
+  }
+}

--- a/packages/vue-slicezone/index.js
+++ b/packages/vue-slicezone/index.js
@@ -1,29 +1,30 @@
-import PageFetch from './PageFetch'
-import SliceZone from './SliceZone'
+import PageFetch from "./PageFetch";
+import SliceZone from "./SliceZone";
 
 export default {
-  name: 'SliceZone',
+  name: "SliceZone",
   render(h) {
     const {
       slices,
       type,
       uid,
-      resolver: maybeResolver
-    } = this.$attrs
+      queryType,
+      resolver: maybeResolver,
+    } = this.$attrs;
 
-    const resolver = maybeResolver || this.$sliceMachine.resolver
-    if (!slices && type && uid) {
+    const resolver = maybeResolver || this.$sliceMachine.resolver;
+    if (!slices && type && (uid || queryType === "single")) {
       return h(PageFetch, {
         props: {
           ...this.$attrs,
           resolver,
           scopedSlots: this.$scopedSlots,
-        }
-      })
+        },
+      });
     }
     return h(SliceZone, {
       scopedSlots: this.$scopedSlots,
-      props: { ...this.$attrs, resolver }}
-    )
-  }
-}
+      props: { ...this.$attrs, resolver },
+    });
+  },
+};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

<!--- Describe your changes in detail -->

In the slice-zone documentation, the slice-zone component should work with only `type` defined if  `queryType="single"`. Currently, slice-zone requires a UID. This fix changes the control statement to render `PageFetch` if *either* `uid` is defined or `queryType === "single"`.

<!--- Why is this change required? What problem does it solve? -->

A singleton does not need a uid, as it is already unique. 

<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->
