### PR TITLE
Adding revalidate to getStaticProps

### DIFF
--- a/packages/next-slicezone/hooks/useGetStaticProps.js
+++ b/packages/next-slicezone/hooks/useGetStaticProps.js
@@ -36,7 +36,8 @@ export const useGetStaticProps = ({
           error: null,
           slices: doc ? doc.data[body] : [],
           registry
-        }
+        },
+        revalidate: 1,
       }
 
     } catch(e) {


### PR DESCRIPTION
Next.js will attempt to re-generate the page:
- When a request comes in
- At most once every second

## Types of changes

revalidate: 1, // In seconds

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [x ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

Support revalidate getStaticProps for Nextjs 9.5 for incremental builds
