### PR TITLE
Pass DocData to slices

### DIFF
--- a/packages/next-slicezone/index.js
+++ b/packages/next-slicezone/index.js
@@ -3,7 +3,7 @@ import React from 'react'
 import { pascalize } from 'sm-commons/utils/str'
 
 const Empty = () => <p>Your SliceZone is empty!</p>
-export default function SliceZone({ registry = {}, slices, resolver = () => null }) {
+export default function SliceZone({ registry = {}, slices, data, resolver = () => null }) {
   if (!slices || !slices.length) {
     return process.env.NODE_ENV !== 'production' ? <Empty /> : null
   }
@@ -21,7 +21,7 @@ export default function SliceZone({ registry = {}, slices, resolver = () => null
 
     const Component = typeof maybeRegister === 'object' ? resolver({ ...maybeRegister, slice, i }) : maybeRegister
     if (Component) {
-      return <Component key={`slice-${i + 1}`} slice={slice}  i={i} />
+      return <Component key={`slice-${i + 1}`} slice={slice}  i={i} docData={data} />
     }
     return null
   })


### PR DESCRIPTION
I would like to use DocData in my slices in order to be able to use in my Components elements like FirstPublicationDate or tags.

<!--- Provide a general summary of your changes in the title above -->

## Types of changes
Pass Document data through a prop (DocData) to the slice in order to use it in the slice level. 
Might be interesting to pass your custom data in the future


<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] New feature : Pass DocData at the Slicelevel

## Description

In my use case i would like to use FirstPublicationDate or tags in a slice. For that i need data coming fro the document not scoped in a slice only. 