### PR TITLE
update react dependencies to inclued 17 as npm 7 won't install without

### DIFF
--- a/packages/next-slicezone/package.json
+++ b/packages/next-slicezone/package.json
@@ -27,7 +27,7 @@
     "sm-commons": "^0.0.21"
   },
   "peerDependencies": {
-    "react": "^16.13.1",
-    "react-dom": "^16.13.1"
+    "react": "^16.13.3 || ^17.0.0",
+    "react-dom": "^16.13.1 || ^17.0.0"
   }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

Update to `react` and `react-dom` dependencies to include v17 as npm 7 will not install the slice-machine properly without them. 

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description
As I was working through the getting started I was having trouble getting the `prismic sm --setup` command to work.  I was getting errors about react dependencies and it would fail the install of them.  I was using npm v7 and it looks like it handles dependencies in a much more strict manner.  When I downgraded to npm v6 it worked with just warnings about the dependency issues.  This should fix that issue for this library.  I will put in another pr for the `essential-slices` package.

<!--- Describe your changes in detail -->
update `package.json` to include v17 of react
<!--- Why is this change required? What problem does it solve? -->
will fix install problem with npm v7 
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->
