### PR TITLE
feat(next-sz): handle local imports

### DIFF
--- a/packages/next-slicezone/features/resolver/file.js
+++ b/packages/next-slicezone/features/resolver/file.js
@@ -2,7 +2,12 @@ const ALL_KEY = '__allSlices'
 const DEFAULT_IMPORTS_STRING = 'import { Fragment } from \'react\''
 
 export const createDeclaration = (libs) => {
-  const imports = libs.reduce((acc, { name, pathToSlices }) => `${acc}import * as ${name} from '${pathToSlices}'\n`, '')
+  const imports = libs.reduce((acc, { name, from, isLocal }) => {
+    if (isLocal) {
+      return `${acc}import * as ${name} from './${from}'\n`
+    }
+    return `${acc}import { Slices as ${name} } from '${isLocal ? `${from}` : from}'\n`
+  }, '')
   const spread = `const ${ALL_KEY} = { ${libs.reverse().reduce((acc, { name }) => `${acc} ...${name},`, '')} }`
   return `${DEFAULT_IMPORTS_STRING}\n${imports}\n${spread}\n`
 }

--- a/packages/next-slicezone/package.json
+++ b/packages/next-slicezone/package.json
@@ -1,6 +1,6 @@
 {
   "name": "next-slicezone",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "description": "A component that maps other components to Prismic slices",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
In generated resolver, handle both local libraries:

```javascript
import * as slices from './slices'
````

and packaged libraries:

```javascript
import { Slices as MyLibSlices } from 'my-lib-slices'
````