### PR TITLE
maintain getStaticProps options when using useGetStaticProps

### DIFF
--- a/packages/next-slicezone/hooks/useGetStaticProps.js
+++ b/packages/next-slicezone/hooks/useGetStaticProps.js
@@ -8,6 +8,7 @@ export const useGetStaticProps = ({
   body = 'body',
   type = 'page',
   queryType = 'repeat',
+  paramsForGetStaticProps = {},
 }) => {
   const apiParams = params || { lang }
 
@@ -32,7 +33,8 @@ export const useGetStaticProps = ({
           ...doc,
           error: null,
           slices: doc ? doc.data[body] : [],
-        }
+        },
+        ...paramsForGetStaticProps,
       }
 
     } catch(e) {
@@ -46,7 +48,8 @@ export const useGetStaticProps = ({
           uid: resolvedUid,
           slices: [],
           // registry: null
-        }
+        },
+        ...paramsForGetStaticProps,
       }
     }
   }


### PR DESCRIPTION
## Types of changes

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

Currently `useGetStaticProps` doesn't allow us to control the `revalidate`, `notFound` or`redirect` values.
`revalidate` in particular is what allows [Incremental Static Regeneration](https://nextjs.org/docs/basic-features/data-fetching#incremental-static-regeneration) or the ability for a page to regenerate with updated dynamic content without a complete site rebuild.
This change should allow us to still configure these options when using `useGetStaticProps`
