### PR TITLE
feature(next-sz): Pass previewData to page props

### DIFF
--- a/packages/next-slicezone/README.md
+++ b/packages/next-slicezone/README.md
@@ -97,14 +97,15 @@ export default Page
 
 | Param     	| Type               	| Required 	| Default value      	| Description                                                                     	| Example value                        	|
 |-----------	|--------------------	|----------	|--------------------	|---------------------------------------------------------------------------------	|--------------------------------------	|
-| uid       	| string \| function 	| false    	| null               	| If queryType has value `repeatable`, pass document `uid` or function            	| ({params}) => `/pages/${params.uid}` 	|
+| uid       	| string \| function 	| false    	| null               	| If queryType has value `repeatable`, pass document `uid` or function            	| ({params}) => ({params}) => params.uid 	|
+| lang       	| string \| function 	| false    	| null               	| Use with `uid` to get document in defined lang            	| ({params}) => params.lang 	|
 | lang      	| string             	| false    	| null (master lang) 	| Lang attribute, disabled if `params` is passed                                  	| 'fr-fr'                              	|
 | params    	| object             	| false    	| null               	| Object passed to client `apiOptions`. Disables `lang`                           	| { lang: 'fr-fr' }                    	|
 | client    	| function           	| true     	| null               	| ATM, you have to pass a Prismic client here                                     	| Prismic.client(apiEndpoint)          	|
 | body      	| string             	| false    	| body               	| Key of slices array in API response (`doc.data[body]`)                          	| 'nobody'                             	|
 | type      	| string             	| false    	| page               	| Custom type to be queried                                                       	| 'another_cts'                        	|
 | queryType 	| string             	| false    	| repeat             	| One of 'repeat' or 'single', to switch between `getByUID` and `getSingle` calls 	| 'single'                             	|
-
+| getStaticPropsParams    	| object             	| false    	| null               	| Object passed to return object of `getStatcProps`| { revalidate: true }                    	|
 ### useGetStaticPaths
 
 `useGetStaticPaths` should be used *in each dynamic page* that relies on the SliceZone.

--- a/packages/next-slicezone/hooks/useGetStaticProps.js
+++ b/packages/next-slicezone/hooks/useGetStaticProps.js
@@ -7,6 +7,7 @@ export const useGetStaticProps = ({
   client,
   body = 'body',
   type = 'page',
+  getStaticPropsParams = {},
   queryType = 'repeat',
 }) => {
 
@@ -36,7 +37,8 @@ export const useGetStaticProps = ({
           preview,
           previewData,
           slices: doc ? doc.data[body] : [],
-        }
+        },
+        ...getStaticPropsParams
       }
 
     } catch(e) {
@@ -52,7 +54,8 @@ export const useGetStaticProps = ({
           preview,
           previewData,
           // registry: null
-        }
+        },
+        ...getStaticPropsParams
       }
     }
   }

--- a/packages/next-slicezone/hooks/useGetStaticProps.js
+++ b/packages/next-slicezone/hooks/useGetStaticProps.js
@@ -3,13 +3,12 @@ import { query } from '../features/query'
 export const useGetStaticProps = ({
   uid,
   lang,
-  params,
+  params: initialParams,
   client,
   body = 'body',
   type = 'page',
   queryType = 'repeat',
 }) => {
-  const apiParams = params || { lang }
 
   return async function getStaticProps({
     preview = null,
@@ -18,7 +17,10 @@ export const useGetStaticProps = ({
   }) {
 
     const { ref = null } = previewData
+    const resolvedLang = typeof lang === 'function' ? lang({ params, previewData, preview }) : (lang || null)
     const resolvedUid = typeof uid === 'function' ? uid({ params, previewData, preview }) : (uid || null)
+
+    const apiParams = initialParams || { lang: resolvedLang }
     try {
       const doc = await query({
         queryType,
@@ -31,6 +33,8 @@ export const useGetStaticProps = ({
         props: {
           ...doc,
           error: null,
+          preview,
+          previewData,
           slices: doc ? doc.data[body] : [],
         }
       }
@@ -45,6 +49,8 @@ export const useGetStaticProps = ({
           error: e.toString(),
           uid: resolvedUid,
           slices: [],
+          preview,
+          previewData,
           // registry: null
         }
       }

--- a/packages/next-slicezone/index.js
+++ b/packages/next-slicezone/index.js
@@ -33,6 +33,7 @@ const slicePropNotFoundProps = {
 }
 
 export default function SliceZone({ slices, resolver = () => null }) {
+  console.log('SliceZone')
   if (!slices || !slices.length) {
     return process.env.NODE_ENV !== 'production' ? <PageInfo {...emptySzProps} /> : null
   }

--- a/packages/next-slicezone/index.js
+++ b/packages/next-slicezone/index.js
@@ -33,7 +33,6 @@ const slicePropNotFoundProps = {
 }
 
 export default function SliceZone({ slices, resolver = () => null }) {
-  console.log('SliceZone')
   if (!slices || !slices.length) {
     return process.env.NODE_ENV !== 'production' ? <PageInfo {...emptySzProps} /> : null
   }

--- a/packages/next-slicezone/package.json
+++ b/packages/next-slicezone/package.json
@@ -1,6 +1,6 @@
 {
   "name": "next-slicezone",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "description": "A component that maps other components to Prismic slices",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
In order for Page components to handle NextJS preview data, pass it from `useGetStaticProps`. Also, allow `lang` to be a function.