### PR TITLE
fix: allow for slashes in libPath

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ nbproject
 .project
 .settings
 .vscode
+.history
 composer.lock
 *.sublime-workspace
 *.swp

--- a/packages/next-slicezone/features/resolver/index.js
+++ b/packages/next-slicezone/features/resolver/index.js
@@ -26,7 +26,7 @@ async function handleLibraryPath(libPath) {
   return {
     isLocal,
     from,
-    name: pascalize(from),
+    name: pascalize(from.replace(/\\/ / g, "_")),
     pathToSlices: endPathToSlices
   }
 }

--- a/packages/next-slicezone/features/resolver/index.js
+++ b/packages/next-slicezone/features/resolver/index.js
@@ -26,7 +26,7 @@ async function handleLibraryPath(libPath) {
   return {
     isLocal,
     from,
-    name: pascalize(from.replace(/\\/ / g, "_")),
+    name: pascalize(from),
     pathToSlices: endPathToSlices
   }
 }

--- a/packages/sm-commons/utils/str.js
+++ b/packages/sm-commons/utils/str.js
@@ -3,7 +3,7 @@ function pascalize(str) {
   if (!str) {
     return "";
   }
-  str = str.replace(/_/g, "-").replace(camelizeRE, (_, c) => {
+  str = str.replace(/[\W_]+/g, "-").replace(camelizeRE, (_, c) => {
     return c ? c.toUpperCase() : "";
   });
   return str[0].toUpperCase() + str.slice(1);
@@ -15,11 +15,11 @@ function hyphenate(str) {
 }
 
 function snakelize(str) {
-  return hyphenate(str).replace(/-/g, '_');
+  return hyphenate(str).replace(/-/g, "_");
 }
 
 module.exports = {
   pascalize,
   hyphenate,
-  snakelize
+  snakelize,
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
I didn't like having linted JS/TS outside of my `src` folder. Therefor I'm using the following config inside of `sm.json`:

```
{
  "apiEndpoint": "https://***.cdn.prismic.io/api/v2",
  "libraries": [
    "@/src/slices"
  ],
  "_latest": "0.0.45",
}
```
This made the import path incorrect inside of `sm-resolver.js` e.g.:

```
import { Fragment } from 'react'
import * as Src/Slices from './src/slices'

const __allSlices = {  ...Src/Slices, }
...
```

This MR changes the above to:
```
import { Fragment } from 'react'
import * as SrcSlices from './src/slices'

const __allSlices = {  ...SrcSlices, }
...
```

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->

Not sure if this is breaking anywhere else, otherwise, enough should be mentioned. Perhaps it's an idea to fix this in the `pascalize` function.

Edit: 2 commits, pick your poison :smile: 