### PR TITLE
feat(next-sz): handle dynamic params in getPaths

### DIFF
--- a/packages/next-slicezone/README.md
+++ b/packages/next-slicezone/README.md
@@ -1,27 +1,166 @@
-# Next SliceZone (wip)
+# Next SliceZone
 
-A component that matches front-end components with Prismic slices.
-Pretty much a work in progress ✌️
+A component that fetches Prismic files, returns slices found and matches them with front-end components.
 
 RFC: https://github.com/prismicio/slice-machine/issues/7
 
-## Status
+## Fetching content
 
-* [x] fetch content from getStaticProps
-* [x] fetch dynamic paths from Prismic endpoint
-[ ] Handle dynamic imports
-* [x] handle previews
-* [x] Create registry
-* [x] pass custom resolver
+Next SliceZone exports 2 functions that are designed to help you quickly get all static paths of a NextJS given route, fetch associated documents on Prismic, and return slices found there.
 
-## Usage
+### useGetStaticProps
+
+`useGetStaticProps` can be used in every page using the SliceZone.
+It's responsible for:
+- fetching content from Prismic
+- returning a pre-written Next `getStaticProps`
+
+#### Page example
+
+Query a singleton page of type "homepage"
+
+````javascript
+import { Client } from '../prismic'
+import { useGetStaticProps } from 'next-slicezone/hooks'
+import resolver from '../sm-resolver'
+
+const Page = ({ uid, slices }) => (
+    <SliceZone resolver={resolver} slices={slices} />
+)
+
+export const getStaticProps = useGetStaticProps({
+  client: Client(),
+  type: 'homepage', // query document of type "page"
+  queryType: 'single', // homepage is a singleton document
+})
+
+export default Page
+````
+
+#### Properties
+
+`useGetStaticProps` takes a params object as argument.
+
+| Param     	| Type               	| Required 	| Default value      	| Description                                                                     	| Example value                        	|
+|-----------	|--------------------	|----------	|--------------------	|---------------------------------------------------------------------------------	|--------------------------------------	|
+| apiParams    	| object             	| false    	| null               	| Object passed to client `apiOptions`.                           	| { lang: 'fr-fr' }                    	|
+| client    	| function           	| true     	| null               	| Pass a Prismic client here                                     	| Prismic.client(apiEndpoint)          	|
+| body      	| string             	| false    	| body               	| Key of slices array in API response (`doc.data[body]`)                          	| 'nobody'                             	|
+| type      	| string             	| false    	| page               	| Custom type to be queried                                                       	| 'another_cts'                        	|
+| queryType 	| string             	| false    	| repeat             	| One of 'repeat' or 'single', to switch between `getByUID` and `getSingle` calls 	| 'single'                             	|
+| getStaticPropsParams    	| object             	| false    	| null               	| Object passed to return object of `getStatcProps`| { revalidate: true }                    	|
+
+#### Example with API Params
+
+Your API calls might depend on other factors in your app, for example the language the user talks. Pass an `apiParams` object or function to transform your call to the Prismic API.
+
+````javascript
+const PageInFrench = ({ uid, slices }) => (
+    <SliceZone resolver={resolver} slices={slices} />
+)
+
+export const getStaticProps = useGetStaticProps({
+  client: Client(),
+  type: 'homepage', // query document of type "page"
+  queryType: 'single', // homepage is a singleton document
+  apiParams:  {
+      lang: 'fr-fr'
+  }
+})
+
+export default PageInFrench
+````
+👆 `apiParams` can also be a function! See example below
+
+### useGetStaticPaths
+
+`useGetStaticPaths` should be used *in each dynamic page* that relies on the SliceZone.
+It's responsible for:
+- fetching documents by type on Prismic
+- formatting params passed to getStaticProps
+
+#### Page example (`/pages/[lang]/[uid]`)
+
+Query a repeatable type "page" in a language based on URL parameter.
+
+````javascript
+import { useGetStaticProps, useGetStaticPaths } from 'next-slicezone/hooks'
+
+const Page = ({ uid, slices, data }) => (
+    <div>
+        <h1>{data.keyTextTitle}</h1>
+        <SliceZone resolver={resolver} slices={slices} />
+    </div>
+)
+
+
+export const getStaticProps = useGetStaticProps({
+    type: 'page',
+    queryType: 'repeat',
+    apiParams({ params }) {
+        // params are passed by getStaticPaths
+        return {
+            lang: params.lang,
+            uid: params.uid
+        }
+    }
+})
+
+// fetch all docs of type `MyPage` and pass params accordingly
+export const getStaticPaths = useGetStaticPaths({
+  client: Client(),
+  type: 'page',
+  formatPath: (prismicDocument) => {
+      return {
+          params: {
+              uid: prismicDocument.uid,
+              lang: prismicDocument.lang
+          }
+      }
+  }
+})
+
+export default Page
+````
+
+#### Properties
+
+`useGetStaticPaths` takes a params object as argument.
+Refer to [Next docs](https://nextjs.org/docs/basic-features/data-fetching#getstaticpaths-static-generation) to understand what's expected from `formatPath`.
+
+| Param      	| Type     	| Required 	| Default Value 	| Description                           	| Example                       	|
+|------------	|----------	|----------	|---------------	|---------------------------------------	|-------------------------------	|
+| type       	| -        	| -        	| -             	| Same as useGetStaticProps             	| -                             	|
+| apiParams     	| -        	| -        	| -             	| Same as useGetStaticProps             	| -                             	|
+| client     	| -        	| -        	| -             	| Same as useGetStaticProps             	| -                             	|
+| formatPath 	| function 	| true     	| (doc) => null  	| Function to format Next path argument. Pass null to skip. 	| ({uid}) =>({ params:{ uid }}) 	|
+
+
+### SliceZone
+
+Once slices have been fetched server-side, we need to get all slices found and match them with your components.
 
 To display the right content, the SliceZone takes as parameters
 props passed at build time by `useGetStaticProps`. Notably:
 
 - `slices`, the array data components fetched from Prismic
-- `theme`, an arbitrary object passed as prop to all slices
 - `resolver`, a function that resolves calls to components from the SliceZone
+- `sliceProps`, an object or function that passes props to matched slices
+ 
+#### Example SliceZone
+
+```
+const Page = ({ data, slices }) => (
+    <SliceZone
+        slices={slices}
+        resolver={resolver}
+        sliceProps={({ slice, sliceName, i }) => ({
+           theme: i % 1 ? 'light' : 'dark',
+           alignLeft: data.keyTextTitle?.length > 35
+        })}
+)
+
+```
 
 The resolver function can be generated for you and should be everytime you make a change to your slices structure (rename, add, delete a slice, add a library...). To do this, create a `pages/_document` file and add the `createResolver` method to its `getInitialProps` method:
 
@@ -54,158 +193,3 @@ export default class extends Document {
     )
   }
 }
-
-````
-
-⚠️ If you don't already have a resolver file and import it in your page components,
-you might encounter an error that should disappear on complete reload of the page.
-
-## Hooks
-
-The SliceZone exports 2 hooks to help Next.js statically export SliceMachine pages.
-
-### useGetStaticProps
-
-`useGetStaticProps` can be used in every page using the SliceZone.
-It's responsible for:
-- fetching content from Prismic
-- returning a pre-written Next `getStaticProps`
-
-#### example
-⚠️ Signature is subject to change
-
-````javascript
-import { useGetStaticProps, useGetStaticPaths } from 'next-slicezone/hooks'
-import resolver from '../sm-resolver'
-
-const Page = ({ uid, slices }) => (
-    <SliceZone resolver={resolver} slices={slices} />
-)
-
-export const getStaticProps = useGetStaticProps({
-  client, // pass Prismic client here
-  type: 'page', // query document of type "page"
-  uid: ({ params }) => params.uid // pass a function to `uid` to resolve dynamic content
-})
-
-export default Page
-````
-
-#### Properties
-
-`useGetStaticProps` takes a params object as argument.
-
-| Param     	| Type               	| Required 	| Default value      	| Description                                                                     	| Example value                        	|
-|-----------	|--------------------	|----------	|--------------------	|---------------------------------------------------------------------------------	|--------------------------------------	|
-| uid       	| string \| function 	| false    	| null               	| If queryType has value `repeatable`, pass document `uid` or function            	| ({params}) => ({params}) => params.uid 	|
-| lang       	| string \| function 	| false    	| null               	| Use with `uid` to get document in defined lang            	| ({params}) => params.lang 	|
-| lang      	| string             	| false    	| null (master lang) 	| Lang attribute, disabled if `params` is passed                                  	| 'fr-fr'                              	|
-| params    	| object             	| false    	| null               	| Object passed to client `apiOptions`. Disables `lang`                           	| { lang: 'fr-fr' }                    	|
-| client    	| function           	| true     	| null               	| ATM, you have to pass a Prismic client here                                     	| Prismic.client(apiEndpoint)          	|
-| body      	| string             	| false    	| body               	| Key of slices array in API response (`doc.data[body]`)                          	| 'nobody'                             	|
-| type      	| string             	| false    	| page               	| Custom type to be queried                                                       	| 'another_cts'                        	|
-| queryType 	| string             	| false    	| repeat             	| One of 'repeat' or 'single', to switch between `getByUID` and `getSingle` calls 	| 'single'                             	|
-| getStaticPropsParams    	| object             	| false    	| null               	| Object passed to return object of `getStatcProps`| { revalidate: true }                    	|
-### useGetStaticPaths
-
-`useGetStaticPaths` should be used *in each dynamic page* that relies on the SliceZone.
-It's responsible for:
-- fetching documents by type on Prismic
-- 
-
-#### example
-⚠️ Signature is subject to change
-
-````javascript
-import { useGetStaticProps, useGetStaticPaths } from 'next-slicezone/hooks'
-
-const Page = ({ uid, registry, slices }) => (
-    <SliceZone resolver={resolver} registry={registry} slices={slices} />
-)
-
-// fetch all docs of type `MyPage` and pass params accordingly
-export const getStaticPaths = useGetStaticPaths({
-  client: Client(),
-  fallback: false,
-  type: 'MyPage',
-  formatPath: ({ uid }) => ({ params: { uid }})
-})
-
-export default Page
-````
-
-#### Properties
-
-`useGetStaticPaths` takes a params object as argument.
-Refer to [Next docs](https://nextjs.org/docs/basic-features/data-fetching#getstaticpaths-static-generation) to understand what's expected from `formatPath`.
-
-| Param      	| Type     	| Required 	| Default Value 	| Description                           	| Example                       	|
-|------------	|----------	|----------	|---------------	|---------------------------------------	|-------------------------------	|
-| type       	| -        	| -        	| -             	| Same as useGetStaticProps             	| -                             	|
-| params     	| -        	| -        	| -             	| Same as useGetStaticProps             	| -                             	|
-| lang       	| -        	| -        	| -             	| Same as useGetStaticProps             	| -                             	|
-| client     	| -        	| -        	| -             	| Same as useGetStaticProps             	| -                             	|
-| formatPath 	| function 	| true     	| (doc) => '/'  	| Function to format Next path argument 	| ({uid}) =>({ params:{ uid }}) 	|
-
-## Installation guide
-
-This guide assumes you have a running 9.3+ Next.js project, configured to use Prismic.
-
-#### 1/ Create an `sm.json` file at the root of your Next app
-```bash
-{ "libraries": ["~/slices"] }
-```
-👆 This will help the SliceZone locate your slices.
-
-#### 2/ Then install the SliceZone
-
-```bash
-yarn add next-slicezone
-```
-
-#### 3/ create a `[uid].js` page 
-
-```javascript
-import SliceZone from 'next-slicezone'
-import { useGetStaticProps, useGetStaticPaths } from 'next-slicezone/hooks'
-
-// you may want to do this somewhere else
-const client = Prismic.client(apiEndpoint)
-
-import resolver from '../sm-resolver'
-
-const Page = ({ uid, slices }) =>  (
-    <SliceZone
-        resolver={resolver}
-        slices={slices}
-    />
-)
-
-export const getStaticProps = useGetStaticProps({
-  client,
-  type: 'page',
-  uid: ({ params }) => params.uid
-})
-
-export const getStaticPaths = useGetStaticPaths({
-  client,
-  type: 'page',
-  fallback: false,
-  formatPath: ({ uid }) => ({ params: { uid }})
-})
-
-export default Page
-````
-
-
-#### 4/ Add a slice `my_slice` to your "page" custom type
-
-In your custom types builder, add a slice with key `my_slice` and save it.
-
-#### 5/ Create a page with uid `my-page` on Prismic
-
-Create some content using your `my_slice` slice.
-
-### 6/ create a `MySlice` component in `/slices`
-
-Your pages are now synced with the writing room ✌️

--- a/packages/next-slicezone/features/query.js
+++ b/packages/next-slicezone/features/query.js
@@ -4,12 +4,13 @@ export async function query({
   queryType,
   apiParams,
   type,
-  uid,
   client,
 }) {
+
+  const { uid, ...restApiParams } = apiParams
   const caller = multiQueryTypes.indexOf(queryType) !== -1 ?
-    ['getByUID', [type, uid, apiParams]] :
-    ['getSingle', [type, apiParams]]
+    ['getByUID', [type, uid, restApiParams]] :
+    ['getSingle', [type, restApiParams]]
 
   return await client[caller[0]](...caller[1])
 }

--- a/packages/next-slicezone/hooks/useGetStaticPaths.js
+++ b/packages/next-slicezone/hooks/useGetStaticPaths.js
@@ -1,38 +1,48 @@
-async function fetchDocs(client, docType, params, page = 1, routes = []) {
-  const response = await client.query(`[at(document.type, "${docType}")]`, { pageSize: 100, lang: '*', ...params, page });
+async function fetchDocs(client, docType, apiParams, page = 1, routes = []) {
+  const response = await client.query(`[at(document.type, "${docType}")]`, { pageSize: 100, lang: '*', ...apiParams, page });
   const allRoutes = routes.concat(response.results);
   if (response.results_size + routes.length < response.total_results_size) {
-    return fetchDocs(client, params, page + 1, allRoutes);
+    return fetchDocs(client, docType, apiParams, page + 1, allRoutes);
   }
   return [...new Set(allRoutes)];
-};
+}
 
-async function queryRepeatableDocuments(client, docType, params = {}) {
-  return await fetchDocs(client, docType, params)
+async function queryRepeatableDocuments(client, docType, apiParams = {}) {
+  return await fetchDocs(client, docType, apiParams)
 }
 
 const handleParams = (apiParams = {}, deprecatedParams, lang) => {
-  let params = { lang, ...apiParams }
+  if (lang) {
+    console.warn('[next-slicezone] Parameter `lang` is deprecated. Use `apiParams.lang` instead.')
+  }
   if (deprecatedParams) {
     console.warn('[next-slicezone] Parameter `params` is deprecated. Use `apiParams` instead.')
-    params = { lang, ...deprecatedParams }
+    return deprecatedParams
   }
-  return params
+  return apiParams
+}
+
+const fbWarn = (fallback) => {
+  if (fallback != null) {
+    console.warn('[next-slicezone] Parameter `fallback` is deprecated. Use getStaticPathsParams.fallback instead.')
+  }
 }
 
 export const useGetStaticPaths = ({
   type = 'page', /* document type to retrieve */
-  fallback = false, /* should I return 404 on route not found? */
   formatPath = () => null, /* format document to path value expected by Next ({ params...} )*/
   apiParams, /* api params passed to Prismic client */
-  params, /* deprecated, use apiParams instead */
-  lang = '*', /* set lang in API params */
   client, /* instance of Prismic client */
-  getStaticPathsParams = {}, /* params passed to return object of getStaticPaths */
+  getStaticPathsParams = { fallback: false }, /* params passed to return object of getStaticPaths */
+
+  lang, /* deprecated, use apiParams.lang instead */
+  params, /* deprecated, use apiParams instead */
+  fallback, /* deprecated, use getStaticPathsParams.fallback instead */
 }) => {
+  fbWarn(fallback)
   const prismicClientParams = handleParams(apiParams, params, lang)
   return async function getStaticPaths() {
-     const documents = await queryRepeatableDocuments(client, type, prismicClientParams)
+    const documents = await queryRepeatableDocuments(client, type, prismicClientParams)
     return {
       paths: documents.reduce((acc, doc) => {
         const p = formatPath(doc)

--- a/packages/next-slicezone/index.js
+++ b/packages/next-slicezone/index.js
@@ -32,18 +32,29 @@ const slicePropNotFoundProps = {
   description: 'This usually means that data passed as property `slices` is not right. Check your configuuration and logs for more info!'
 }
 
-export default function SliceZone({ slices, resolver = () => null }) {
+export default function SliceZone({ slices, sliceProps = {}, resolver = () => null }) {
   if (!slices || !slices.length) {
     return process.env.NODE_ENV !== 'production' ? <PageInfo {...emptySzProps} /> : null
   }
   return slices.map((slice, i) => {
     if (!slice || !slice.slice_type) {
-      return <PageInfo {...slicePropNotFoundProps }/>
+      return <PageInfo {...slicePropNotFoundProps} />
     }
     const sliceName = pascalize(slice.slice_type)
     const Component = resolver({ sliceName, slice, i })
+    const finalSliceProps = sliceProps && typeof sliceProps === 'function'
+      ? sliceProps({ sliceName, slice, i })
+      : sliceProps
+
     if (Component) {
-      return <Component key={`slice-${i + 1}`} slice={slice}  i={i} />
+      return (
+        <Component
+          key={`slice-${i + 1}`}
+          slice={slice}
+          i={i}
+          {...finalSliceProps}
+        />
+      )
     }
     console.error('Could not resolve slice, check that you properly pass a `resolver` property to SliceZone')
     return null

--- a/packages/next-slicezone/package.json
+++ b/packages/next-slicezone/package.json
@@ -1,6 +1,6 @@
 {
   "name": "next-slicezone",
-  "version": "0.0.15",
+  "version": "0.1.0",
   "description": "A component that maps other components to Prismic slices",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
1/ Handle dynamic params in getStatic paths and props
2/ rename arguments `params` to `apiParams`
3/ SliceZone can pass props to slices via `sliceProps`
4/ `formatPath` skips a path if null is returned
5/ arguments like `uid` and `lang` should be passed in `apiParams`