### PR TITLE
feat: allow user-definable framework

### DIFF
--- a/packages/slice-machine/lib/framework.ts
+++ b/packages/slice-machine/lib/framework.ts
@@ -27,3 +27,7 @@ export function detectFramework(cwd: string): Framework {
     throw new Error(message)
   }
 }
+
+export function isValidFramework(framework: string): framework is Framework {
+  return SupportedFrameworks.hasOwnProperty(framework)
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This PR allows users to explicitly define their framework in `sm.json` using the `framework` property.

```javascript
// sm.json

{
  "framework": "next"
}
```

Currently, a project's framework is detected via the `detectFramework` function in `slice-machine/packages/slice-machine/lib/framework.ts`. This function compares a constant list of supported frameworks (`next`, `nuxt`, `react`, `vue`) against the project's `package.json`. If a supported framework (practically speaking, it is a supported library, not framework) is found, it sets that library as the project's framework. If it cannot find a matching library, it defaults to a fallback `vanillajs` identifier.

Allowing a user to optionally define their framework in `sm.json` allows the name of the project's framework to differ from the name of the library used. This means we can support variants of frameworks, such as `next-typescript`. It also allows us to support meta templates, such as a `none` framework that doesn't generate component files, only JSON models.

```javascript
// sm.json

{
  "framework": "none"
}
```

If a user does not define a framework in `sm.json`, the current behavior of calling `detectFramework` is used.

```javascript
// sm.json

{
}

// Since `framework` was not defined, `detectFramework` will be used instead.
```

If a user defines an invalid framework (i.e. one not supported by Slice Machine), a warning will be displayed in the Slice Machine UI.
