### PR TITLE
feat: pass all getStaticProps arguments to apiParams function

### DIFF
--- a/packages/next-slicezone/README.md
+++ b/packages/next-slicezone/README.md
@@ -70,7 +70,10 @@ export const getStaticProps = useGetStaticProps({
 
 export default PageInFrench
 ````
-👆 `apiParams` can also be a function! See example below
+👆 `apiParams` can also be a function!
+The arguments passed to `apiParams` are the same as for [`getStaticProps`](https://nextjs.org/docs/basic-features/data-fetching#getstaticprops-static-generation). 
+
+ See example below
 
 ### useGetStaticPaths
 

--- a/packages/next-slicezone/hooks/useGetStaticProps.js
+++ b/packages/next-slicezone/hooks/useGetStaticProps.js
@@ -52,15 +52,12 @@ export const useGetStaticProps = ({
     console.warn(`[next-slicezone/useGetStaticProps]: Parameter "body" is deprecated, use "slicesKey" instead.`)
   }
 
-  return async function getStaticProps({
-    preview = null,
-    previewData = {},
-    params = {}
-  }) {
+  return async function getStaticProps(args) {
+    const { preview = null, previewData = {} } = args;
+    const { ref = null } = previewData;
 
-    const { ref = null } = previewData
     const finalApiParams = apiParams && typeof apiParams === 'function'
-      ? apiParams({ params, previewData, preview })
+      ? apiParams(args)
       : apiParams
 
     try {


### PR DESCRIPTION
Correct me if I'm wrong please. :) 

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

I needed my SSG pages to respect locale parameter, then noticed that at build time there was no way to get that information to pass it on to Prismic. 

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly. (PR: #)
- [x] All new and existing tests are passing.

<!--- A cute animal picture is welcome to close your PR! -->
