### PR TITLE
Fix node js aliases

### DIFF
--- a/packages/slice-machine/babel.next.config.js
+++ b/packages/slice-machine/babel.next.config.js
@@ -1,3 +1,18 @@
 module.exports = {
   "presets": ["next/babel"],
+  "plugins": [
+    ["module-resolver", {
+      "root": ["."],
+      "alias": {
+        "@": "./",
+        "@lib": "lib",
+        "@utils": "lib/utils",
+        "@builders": "lib/builders",
+        "@models": "lib/models",
+        "@src": "src",
+        "@hooks": "hooks",
+        "@components": "components"
+      }
+    }]
+  ]
 }

--- a/packages/slice-machine/babel.next.config.js
+++ b/packages/slice-machine/babel.next.config.js
@@ -1,18 +1,3 @@
 module.exports = {
   "presets": ["next/babel"],
-  "plugins": [
-    ["module-resolver", {
-      "root": ["./"],
-      "alias": {
-        "@": "./",
-        "@lib": "lib",
-        "@utils": "lib/utils",
-        "@builders": "lib/builders",
-        "@models": "lib/models",
-        "@src": "src",
-        "@hooks": "hooks",
-        "@components": "components"
-      }
-    }]
-  ]
 }

--- a/packages/slice-machine/lib/builders/CustomTypeBuilder/TabZone/index.js
+++ b/packages/slice-machine/lib/builders/CustomTypeBuilder/TabZone/index.js
@@ -1,16 +1,16 @@
 import { Fragment, useState } from 'react'
-import * as Widgets from 'lib/models/common/widgets/withGroup'
+import * as Widgets from '@lib/models/common/widgets/withGroup'
 import EditModal from '../../common/EditModal'
 
 import {
   ensureDnDDestination,
   ensureWidgetTypeExistence
-} from 'lib/utils'
+} from '@lib/utils'
 
 import Zone from '../../common/Zone'
 
-import ctBuilderArray from 'lib/models/common/widgets/ctBuilderArray'
-import { CustomTypeMockConfig } from 'lib/models/common/MockConfig'
+import ctBuilderArray from '@lib/models/common/widgets/ctBuilderArray'
+import { CustomTypeMockConfig } from '@lib/models/common/MockConfig'
 
 import SliceZone from '../SliceZone'
 

--- a/packages/slice-machine/lib/builders/SliceBuilder/FieldZones/index.js
+++ b/packages/slice-machine/lib/builders/SliceBuilder/FieldZones/index.js
@@ -1,13 +1,13 @@
 import { Fragment } from 'react'
 import { Box } from 'theme-ui'
 
-import { ensureDnDDestination } from 'lib/utils'
+import { ensureDnDDestination } from '@lib/utils'
 
 import Zone from '../../common/Zone'
 import EditModal from '../../common/EditModal'
 
-import * as Widgets from 'lib/models/common/widgets'
-import sliceBuilderWidgetsArray from 'lib/models/common/widgets/sliceBuilderArray'
+import * as Widgets from '@lib/models/common/widgets'
+import sliceBuilderWidgetsArray from '@lib/models/common/widgets/sliceBuilderArray'
 
 import { SliceMockConfig } from '../../../models/common/MockConfig'
 

--- a/packages/slice-machine/lib/builders/SliceBuilder/index.js
+++ b/packages/slice-machine/lib/builders/SliceBuilder/index.js
@@ -7,7 +7,7 @@ import { handleRemoteResponse } from "src/ToastProvider/utils";
 import { SliceContext } from 'src/models/slice/context'
 import { ConfigContext } from 'src/config-context'
 
-import { createStorybookUrl } from 'lib/utils'
+import { createStorybookUrl } from '@lib/utils'
 
 import {
   Box,

--- a/packages/slice-machine/lib/builders/SliceBuilder/layout/SideBar/components/ImagePreview.js
+++ b/packages/slice-machine/lib/builders/SliceBuilder/layout/SideBar/components/ImagePreview.js
@@ -1,6 +1,6 @@
 import { memo, useState, useRef, Fragment } from 'react'
 import { Label, Flex, Image, Button, Text, Spinner } from 'theme-ui'
-import { acceptedImagesTypes } from 'lib/consts'
+import { acceptedImagesTypes } from '@lib/consts'
 
 const MemoedImage = memo(({ src }) => (
   <Image src={src} alt="Preview image" /> 

--- a/packages/slice-machine/lib/builders/SliceBuilder/layout/SideBar/index.js
+++ b/packages/slice-machine/lib/builders/SliceBuilder/layout/SideBar/index.js
@@ -13,7 +13,7 @@ import StorybookGrey from './icons/storybookGrey.svg'
 import Li from './components/Li'
 import ImagePreview from './components/ImagePreview'
 import FooterButton from './components/FooterButton'
-import { storybookWarningStates } from 'lib/consts'
+import { storybookWarningStates } from '@lib/consts'
 
 const MemoizedImagePreview = memo(ImagePreview)
 

--- a/packages/slice-machine/lib/builders/common/Zone/Card/components/NewField.js
+++ b/packages/slice-machine/lib/builders/common/Zone/Card/components/NewField.js
@@ -5,13 +5,13 @@ import { Box, Input, Flex, Text, Button, Label, useThemeUI } from 'theme-ui'
 import {
   DefaultFields,
   validateId
-} from 'lib/forms/defaults'
+} from '@lib/forms/defaults'
 import {
   createInitialValues,
   createValidationSchema
-} from 'lib/forms'
+} from '@lib/forms'
 
-import * as Widgets from 'lib/models/common/widgets/withGroup'
+import * as Widgets from '@lib/models/common/widgets/withGroup'
 
 import ErrorTooltip from './ErrorTooltip'
 

--- a/packages/slice-machine/lib/builders/common/Zone/Card/index.js
+++ b/packages/slice-machine/lib/builders/common/Zone/Card/index.js
@@ -15,7 +15,7 @@ import Hint from './components/Hints'
 
 import { findWidgetByConfigOrType } from '../../../utils'
 
-import * as Widgets from 'lib/models/common/widgets/withGroup'
+import * as Widgets from '@lib/models/common/widgets/withGroup'
 
 import Li from 'components/Li'
 

--- a/packages/slice-machine/lib/models/common/widgets/Boolean/Mock/Form.js
+++ b/packages/slice-machine/lib/models/common/widgets/Boolean/Mock/Form.js
@@ -3,7 +3,7 @@ import { useFormikContext } from 'formik'
 
 import { initialValues } from '.'
 
-import { MockConfigKey } from 'lib/consts'
+import { MockConfigKey } from '@lib/consts'
 
 const RAND = 'RANDOM'
 

--- a/packages/slice-machine/lib/models/common/widgets/Color/Mock/Form.js
+++ b/packages/slice-machine/lib/models/common/widgets/Color/Mock/Form.js
@@ -5,7 +5,7 @@ import { BlockPicker } from 'react-color'
 
 import { initialValues } from '.'
 
-import { MockConfigKey } from 'lib/consts'
+import { MockConfigKey } from '@lib/consts'
 
 const RAND = 'random'
 

--- a/packages/slice-machine/lib/models/common/widgets/ContentRelationship/Form.js
+++ b/packages/slice-machine/lib/models/common/widgets/ContentRelationship/Form.js
@@ -5,9 +5,9 @@ import { Label, Box } from 'theme-ui'
 
 import { CustomTypesContext } from "src/models/customTypes/context"
 
-import { DefaultFields } from 'lib/forms/defaults'
+import { DefaultFields } from '@lib/forms/defaults'
 
-import WidgetFormField from 'lib/builders/common/EditModal/Field'
+import WidgetFormField from '@lib/builders/common/EditModal/Field'
 
 import { Col, Flex as FlexGrid } from 'components/Flex'
 import { createFieldNameFromKey } from '@lib/forms'

--- a/packages/slice-machine/lib/models/common/widgets/Embed/Mock/Form.js
+++ b/packages/slice-machine/lib/models/common/widgets/Embed/Mock/Form.js
@@ -4,7 +4,7 @@ import { useFormikContext } from 'formik'
 
 import { initialValues } from '.'
 
-import { MockConfigKey } from 'lib/consts'
+import { MockConfigKey } from '@lib/consts'
 import { useState } from 'react'
 
 import InputDeleteIcon from 'components/InputDeleteIcon'

--- a/packages/slice-machine/lib/models/common/widgets/GeoPoint/Mock/Form.js
+++ b/packages/slice-machine/lib/models/common/widgets/GeoPoint/Mock/Form.js
@@ -5,7 +5,7 @@ import { useFormikContext } from 'formik'
 
 import { initialValues } from '.'
 
-import { MockConfigKey } from 'lib/consts'
+import { MockConfigKey } from '@lib/consts'
 
 import InputDeleteIcon from 'components/InputDeleteIcon'
 import PreviewCard from 'components/Card/Preview'

--- a/packages/slice-machine/lib/models/common/widgets/Group/ListItem/index.js
+++ b/packages/slice-machine/lib/models/common/widgets/Group/ListItem/index.js
@@ -4,7 +4,7 @@ import { DragDropContext, Droppable } from "react-beautiful-dnd";
 
 import { Box, Button } from "theme-ui";
 
-import { ensureDnDDestination, ensureWidgetTypeExistence } from 'lib/utils'
+import { ensureDnDDestination, ensureWidgetTypeExistence } from '@lib/utils'
 
 import SelectFieldTypeModal from "lib/builders/common/SelectFieldTypeModal";
 import NewField from "lib/builders/common/Zone/Card/components/NewField";

--- a/packages/slice-machine/lib/models/common/widgets/Group/index.ts
+++ b/packages/slice-machine/lib/models/common/widgets/Group/index.ts
@@ -1,5 +1,5 @@
 import * as yup from 'yup'
-import { DefaultFields } from 'lib/forms/defaults'
+import { DefaultFields } from '@lib/forms/defaults'
 import  { MdPlaylistAdd } from 'react-icons/md'
 
 import { FieldType } from '../../CustomType/fields'

--- a/packages/slice-machine/lib/models/common/widgets/Image/Form.js
+++ b/packages/slice-machine/lib/models/common/widgets/Image/Form.js
@@ -1,11 +1,11 @@
 import * as yup from 'yup'
 import { useEffect, useState, Fragment } from 'react'
 
-import { DefaultFields } from 'lib/forms/defaults'
-import { createFieldNameFromKey } from 'lib/forms'
+import { DefaultFields } from '@lib/forms/defaults'
+import { createFieldNameFromKey } from '@lib/forms'
 
 
-import WidgetFormField from 'lib/builders/common/EditModal/Field'
+import WidgetFormField from '@lib/builders/common/EditModal/Field'
 
 import { FieldArray } from 'formik'
 

--- a/packages/slice-machine/lib/models/common/widgets/Link/Form.js
+++ b/packages/slice-machine/lib/models/common/widgets/Link/Form.js
@@ -1,9 +1,9 @@
-import { DefaultFields } from 'lib/forms/defaults'
+import { DefaultFields } from '@lib/forms/defaults'
 
-import WidgetFormField from 'lib/builders/common/EditModal/Field'
+import WidgetFormField from '@lib/builders/common/EditModal/Field'
 
 import { Col, Flex as FlexGrid } from 'components/Flex'
-import { createFieldNameFromKey } from 'lib/forms'
+import { createFieldNameFromKey } from '@lib/forms'
 
 const FormFields = { ...DefaultFields }
 

--- a/packages/slice-machine/lib/models/common/widgets/Select/FormFields.js
+++ b/packages/slice-machine/lib/models/common/widgets/Select/FormFields.js
@@ -1,9 +1,9 @@
 import * as yup from 'yup'
 import { FormFieldCheckboxControl } from 'components/FormFields'
 
-import { FormTypes } from 'lib/forms/types'
+import { FormTypes } from '@lib/forms/types'
 
-import { DefaultFields } from 'lib/forms/defaults'
+import { DefaultFields } from '@lib/forms/defaults'
 import { FormFieldArray } from 'components/FormFields'
 
 const FormFields = {

--- a/packages/slice-machine/lib/models/common/widgets/StructuredText/Form.js
+++ b/packages/slice-machine/lib/models/common/widgets/StructuredText/Form.js
@@ -1,12 +1,12 @@
 import { useEffect, useState } from 'react'
 import * as yup from 'yup'
-import { createFieldNameFromKey } from 'lib/forms'
-import { CheckBox as CheckBoxConstructor } from 'lib/forms/fields'
-import { DefaultFields } from 'lib/forms/defaults'
+import { createFieldNameFromKey } from '@lib/forms'
+import { CheckBox as CheckBoxConstructor } from '@lib/forms/fields'
+import { DefaultFields } from '@lib/forms/defaults'
 
 import options, { optionValues } from './options'
 
-import WidgetFormField from 'lib/builders/common/EditModal/Field'
+import WidgetFormField from '@lib/builders/common/EditModal/Field'
 
 import { Text, Button, Label, Checkbox, Flex, Box } from 'theme-ui'
 import { Col, Flex as FlexGrid } from 'components/Flex'

--- a/packages/slice-machine/lib/models/server/ServerState.ts
+++ b/packages/slice-machine/lib/models/server/ServerState.ts
@@ -1,11 +1,11 @@
-import Environment from '../../../lib/models/common/Environment'
-import Slice from '../../../lib/models/common/Slice'
-import Warning from '../../../lib/models/common/Warning'
-import ErrorWithStatus from '../../../lib/models/common/ErrorWithStatus'
-import { Library } from '../../../lib/models/common/Library'
-import { AsObject } from '../../../lib/models/common/Variation'
+import Environment from '@lib/models/common/Environment'
+import Slice from '@lib/models/common/Slice'
+import Warning from '@lib/models/common/Warning'
+import ErrorWithStatus from '@lib/models/common/ErrorWithStatus'
+import { Library } from '@lib/models/common/Library'
+import { AsObject } from '@lib/models/common/Variation'
 
-import { CustomType, ObjectTabs } from '../../../lib/models/common/CustomType'
+import { CustomType, ObjectTabs } from '@lib/models/common/CustomType'
 
 import ServerError from './ServerError'
 

--- a/packages/slice-machine/next.config.js
+++ b/packages/slice-machine/next.config.js
@@ -16,12 +16,6 @@ module.exports = withPlugins([
           fs: "empty",
         };
       }
-      // config.resolve.alias['@'] = __dirname
-      // config.resolve.alias.src = path.join(__dirname, "src");
-      // config.resolve.alias.lib = path.join(__dirname, "lib");
-      // config.resolve.alias['@lib'] = path.join(__dirname, "lib");
-      // config.resolve.alias.models = path.join(__dirname, "lib/models");
-      // config.resolve.alias.components= path.join(__dirname, "components");
 
       config.module.rules.push({
         test: /\.svg$/,

--- a/packages/slice-machine/next.config.js
+++ b/packages/slice-machine/next.config.js
@@ -7,7 +7,7 @@ module.exports = withPlugins([
   [withCustomBabelConfigFile, {
     babelConfigFile: path.resolve("./babel.next.config.js"),
     env: {
-      // overriden by start script
+      // overridden by start script
       CWD: path.resolve("./tests/project"),
     },
     webpack: (config, { isServer }) => {

--- a/packages/slice-machine/package.json
+++ b/packages/slice-machine/package.json
@@ -15,7 +15,7 @@
     "postinstall": "node postinstall",
     "prepublishOnly": "yarn bundle",
     "serve": "node -r esm ./build/server/src/index.js",
-    "watch-server": "tsc -w --project ./server/index.ts",
+    "watch-server": "tsc -w --project server/tsconfig.json",
     "dev-server": "cross-env PORT=9999 CWD=./tests/project node build/server/src/index.js",
     "build": "yarn build-server && yarn build-next-app",
     "build-server": "tsc --project server/tsconfig.json",

--- a/packages/slice-machine/package.json
+++ b/packages/slice-machine/package.json
@@ -4,7 +4,7 @@
   "private": false,
   "license": "MIT",
   "_moduleAliases": {
-    "foo": "build"
+    "@lib": "build/lib"
   },
   "scripts": {
     "dev": "next dev",
@@ -17,7 +17,7 @@
     "watch-server": "tsc -w --project ./server/index.ts",
     "dev-server": "cross-env PORT=9999 CWD=./tests/project node build/server/src/index.js",
     "build": "yarn build-server && yarn build-next-app",
-    "build-server": "tsc --project server/tsconfig.json && yarn build-ts-paths",
+    "build-server": "tsc --project server/tsconfig.json",
     "build-ts-paths": "tscpaths --project ./tsconfig.json --src ./lib --out ./build/lib && tscpaths --project ./tsconfig.json --src ./server --out ./build/server",
     "build-next-app": "cross-env NODE_OPTIONS=--max_old_space_size=8192 next build",
     "export-build": "next export && yarn clean-build",
@@ -52,6 +52,7 @@
     "lodash": "^4.17.21",
     "lorem-ipsum": "^2.0.3",
     "mime": "^2.5.2",
+    "module-alias": "^2.2.2",
     "multer": "^1.4.2",
     "neverthrow": "^4.2.1",
     "oembed-parser": "^1.4.5",

--- a/packages/slice-machine/package.json
+++ b/packages/slice-machine/package.json
@@ -4,7 +4,8 @@
   "private": false,
   "license": "MIT",
   "_moduleAliases": {
-    "@lib": "build/lib"
+    "@lib": "build/lib",
+    "@models": "build/lib/models"
   },
   "scripts": {
     "dev": "next dev",
@@ -18,7 +19,6 @@
     "dev-server": "cross-env PORT=9999 CWD=./tests/project node build/server/src/index.js",
     "build": "yarn build-server && yarn build-next-app",
     "build-server": "tsc --project server/tsconfig.json",
-    "build-ts-paths": "tscpaths --project ./tsconfig.json --src ./lib --out ./build/lib && tscpaths --project ./tsconfig.json --src ./server --out ./build/server",
     "build-next-app": "cross-env NODE_OPTIONS=--max_old_space_size=8192 next build",
     "export-build": "next export && yarn clean-build",
     "bundle": "yarn build && yarn test && yarn export-build",
@@ -68,7 +68,6 @@
     "serve-static": "^1.14.1",
     "slash": "3.0.0",
     "sm-commons": "^0.0.22",
-    "tscpaths": "^0.0.9",
     "uniqid": "^5.2.0",
     "yargs": "^16.0.3",
     "yup": "^0.32.9"

--- a/packages/slice-machine/server/src/api/common/error.ts
+++ b/packages/slice-machine/server/src/api/common/error.ts
@@ -1,4 +1,4 @@
-import { FakeResponse } from '../../../../lib/models/common/http/FakeClient'
+import { FakeResponse } from '@lib/models/common/http/FakeClient'
 
 export const onError = (r: Response | FakeResponse | null, message = 'Unspecified error occured.') => ({
   err: r || new Error(message),

--- a/packages/slice-machine/server/src/api/common/storybook.ts
+++ b/packages/slice-machine/server/src/api/common/storybook.ts
@@ -1,6 +1,6 @@
 import path from 'path'
 import puppeteer from 'puppeteer'
-import Files from '../../../../lib/utils/files'
+import Files from '@lib/utils/files'
 import { delay } from './utils'
 
 export const fetchStorybookUrl = async (storybookUrl: string) => {

--- a/packages/slice-machine/server/src/api/custom-screenshot.ts
+++ b/packages/slice-machine/server/src/api/custom-screenshot.ts
@@ -1,7 +1,7 @@
-import { getPathToScreenshot } from '../../../lib/queries/screenshot'
-import { getEnv } from '../../../lib/env'
-import { CustomPaths } from '../../../lib/models/paths'
-import Files from '../../../lib/utils/files'
+import { getPathToScreenshot } from '@lib/queries/screenshot'
+import { getEnv } from '@lib/env'
+import { CustomPaths } from '@lib/models/paths'
+import Files from '@lib/utils/files'
 
 export default async function handler(file: File & { path: string }, { from, sliceName, variationId }: { from: string, sliceName: string, variationId: string }) {
   const { env } = await getEnv()

--- a/packages/slice-machine/server/src/api/custom-types/push.ts
+++ b/packages/slice-machine/server/src/api/custom-types/push.ts
@@ -3,14 +3,14 @@ import { handler as pushSlice } from '../slices/push'
 import { handler as saveSlice } from '../slices/save'
 
 import { onError } from '../common/error'
-import Files from '../../../../lib/utils/files'
-import { CustomTypesPaths } from '../../../../lib/models/paths'
-import DefaultClient from '../../../../lib/models/common/http/DefaultClient'
-import FakeClient from '../../../../lib/models/common/http/FakeClient'
+import Files from '@lib/utils/files'
+import { CustomTypesPaths } from '@lib/models/paths'
+import DefaultClient from '@lib/models/common/http/DefaultClient'
+import FakeClient from '@lib/models/common/http/FakeClient'
 
-import { ComponentWithLibStatus } from '../../../../lib/models/common/Library'
-import { Tab, TabAsObject } from '../../../../lib/models/common/CustomType/tab'
-import { CustomType } from '../../../../lib/models/common/CustomType'
+import { ComponentWithLibStatus } from '@lib/models/common/Library'
+import { Tab, TabAsObject } from '@lib/models/common/CustomType/tab'
+import { CustomType } from '@lib/models/common/CustomType'
 
 const createOrUpdate = (client: DefaultClient | FakeClient, model: any, remoteCustomType: any) => {
   if (remoteCustomType) {

--- a/packages/slice-machine/server/src/api/custom-types/save.ts
+++ b/packages/slice-machine/server/src/api/custom-types/save.ts
@@ -1,12 +1,12 @@
-import { getEnv } from '../../../../lib/env'
-import Files from '../../../../lib/utils/files'
-import { CustomTypesPaths, GeneratedCustomTypesPaths } from '../../../../lib/models/paths'
+import { getEnv } from '@lib/env'
+import Files from '@lib/utils/files'
+import { CustomTypesPaths, GeneratedCustomTypesPaths } from '@lib/models/paths'
 
-import { insert as insertMockConfig } from '../../../../lib/mock/misc/fs'
+import { insert as insertMockConfig } from '@lib/mock/misc/fs'
 
-import mock from '../../../../lib/mock/CustomType'
-import { CustomTypeMockConfig } from '../../../../lib/models/common/MockConfig'
-import { CustomType, ObjectTabs } from '../../../../lib/models/common/CustomType'
+import mock from '@lib/mock/CustomType'
+import { CustomTypeMockConfig } from '@lib/models/common/MockConfig'
+import { CustomType, ObjectTabs } from '@lib/models/common/CustomType'
 
 interface Body {
   model: CustomType<ObjectTabs>;

--- a/packages/slice-machine/server/src/api/env.js
+++ b/packages/slice-machine/server/src/api/env.js
@@ -1,4 +1,4 @@
-import { getEnv } from '../../../lib/env'
+import { getEnv } from '@lib/env'
 
 export default async function handler() {
   return getEnv()

--- a/packages/slice-machine/server/src/api/libraries.ts
+++ b/packages/slice-machine/server/src/api/libraries.ts
@@ -1,11 +1,11 @@
-import { listComponentsByLibrary } from '../../../lib/queries/listComponents'
+import { listComponentsByLibrary } from '@lib/queries/listComponents'
 
-import Environment from '../../../lib/models/common/Environment'
-import { Library } from '../../../lib/models/common/Library'
-import Slice from '../../../lib/models/common/Slice'
-import { AsObject } from '../../../lib/models/common/Variation'
+import Environment from '@lib/models/common/Environment'
+import { Library } from '@lib/models/common/Library'
+import Slice from '@lib/models/common/Slice'
+import { AsObject } from '@lib/models/common/Variation'
 
-import ErrorWithStatus from '../../../lib/models/common/ErrorWithStatus'
+import ErrorWithStatus from '@lib/models/common/ErrorWithStatus'
 
 export async function getLibrariesWithFlags(env: Environment): Promise<{ remoteSlices: ReadonlyArray<Slice<AsObject>>, clientError: ErrorWithStatus | undefined, libraries: ReadonlyArray<Library> }> {
   const res = await env.client.getSlice()

--- a/packages/slice-machine/server/src/api/libraries/push.ts
+++ b/packages/slice-machine/server/src/api/libraries/push.ts
@@ -1,11 +1,11 @@
-import { getEnv } from '../../../../lib/env'
+import { getEnv } from '@lib/env'
 
 import { getSlices } from '../slices'
 import { onError } from '../common/error'
 
 import { purge } from '../upload'
 
-import { handleLibraryPath } from '../../../../lib/queries/listComponents'
+import { handleLibraryPath } from '@lib/queries/listComponents'
 
 export default async function handler(query: { from: string }) {
   const { from } = query

--- a/packages/slice-machine/server/src/api/previews.ts
+++ b/packages/slice-machine/server/src/api/previews.ts
@@ -1,10 +1,10 @@
-import Files from '../../../lib/utils/files'
-import Environment from '../../../lib/models/common/Environment'
-import { Preview } from '../../../lib/models/common/Component'
-import { CustomPaths, GeneratedPaths } from '../../../lib/models/paths'
-import { createScreenshotUrl } from '../../../lib/utils'
+import Files from '@lib/utils/files'
+import Environment from '@lib/models/common/Environment'
+import { Preview } from '@lib/models/common/Component'
+import { CustomPaths, GeneratedPaths } from '@lib/models/paths'
+import { createScreenshotUrl } from '@lib/utils'
 import { handleStorybookPreview } from './common/storybook'
-import { getPathToScreenshot } from '../../../lib/queries/screenshot'
+import { getPathToScreenshot } from '@lib/queries/screenshot'
 
 type Previews = ReadonlyArray<{ variationId: string, hasPreview: boolean, error: Error } | Preview>
 

--- a/packages/slice-machine/server/src/api/push-all.js
+++ b/packages/slice-machine/server/src/api/push-all.js
@@ -1,4 +1,4 @@
-import { getEnv } from '../../../lib/env'
+import { getEnv } from '@lib/env'
 import push from './slices/push'
 import getLibs from './libraries'
 

--- a/packages/slice-machine/server/src/api/screenshot.ts
+++ b/packages/slice-machine/server/src/api/screenshot.ts
@@ -1,5 +1,5 @@
-import { getEnv } from '../../../lib/env'
-import { Preview } from '../../../lib/models/common/Component'
+import { getEnv } from '@lib/env'
+import { Preview } from '@lib/models/common/Component'
 import Previews from './previews'
 
 export default async function handler({ from, sliceName }: { from: string, sliceName: string })

--- a/packages/slice-machine/server/src/api/slices/index.ts
+++ b/packages/slice-machine/server/src/api/slices/index.ts
@@ -1,7 +1,7 @@
-import { getEnv } from '../../../../lib/env'
+import { getEnv } from '@lib/env'
 
-import DefaultClient from '../../../../lib/models/common/http/DefaultClient'
-import FakeClient from '../../../../lib/models/common/http/FakeClient'
+import DefaultClient from '@lib/models/common/http/DefaultClient'
+import FakeClient from '@lib/models/common/http/FakeClient'
 
 export const getSlices = async(client: DefaultClient | FakeClient) => {
   try {

--- a/packages/slice-machine/server/src/api/slices/push.ts
+++ b/packages/slice-machine/server/src/api/slices/push.ts
@@ -1,18 +1,18 @@
-import { snakelize } from '../../../../lib/utils/str'
+import { snakelize } from '@lib/utils/str'
 
-import { getEnv } from '../../../../lib/env'
+import { getEnv } from '@lib/env'
 import { getSlices } from './'
-import Files from '../../../../lib/utils/files'
+import Files from '@lib/utils/files'
 
-import { getPathToScreenshot } from '../../../../lib/queries/screenshot'
+import { getPathToScreenshot } from '@lib/queries/screenshot'
 
 import { onError } from '../common/error'
 import { purge, upload } from '../upload'
-import DefaultClient from '../../../../lib/models/common/http/DefaultClient'
-import FakeClient from '../../../../lib/models/common/http/FakeClient'
-import { Variation, AsObject } from '../../../../lib/models/common/Variation'
-import Slice from '../../../../lib/models/common/Slice'
-import { CustomPaths } from '../../../../lib/models/paths'
+import DefaultClient from '@lib/models/common/http/DefaultClient'
+import FakeClient from '@lib/models/common/http/FakeClient'
+import { Variation, AsObject } from '@lib/models/common/Variation'
+import Slice from '@lib/models/common/Slice'
+import { CustomPaths } from '@lib/models/paths'
 import Environment from '@lib/models/common/Environment'
 
 const createOrUpdate = async ({

--- a/packages/slice-machine/server/src/api/state.ts
+++ b/packages/slice-machine/server/src/api/state.ts
@@ -1,14 +1,14 @@
 import fetchLibs from './libraries'
 import fetchCustomTypes from './custom-types/index'
-import { getEnv } from '../../../lib/env'
-import { warningStates, warningTwoLiners } from '../../../lib/consts'
+import { getEnv } from '@lib/env'
+import { warningStates, warningTwoLiners } from '@lib/consts'
 import { fetchStorybookUrl } from './common/storybook'
-import Environment from '../../../lib/models/common/Environment'
-import Warning from '../../../lib/models/common/Warning'
-import ErrorWithStatus from '../../../lib/models/common/ErrorWithStatus'
-import ServerError from '../../../lib/models/server/ServerError'
-import Files from '../../../lib/utils/files'
-import { Pkg } from '../../../lib/models/paths'
+import Environment from '@lib/models/common/Environment'
+import Warning from '@lib/models/common/Warning'
+import ErrorWithStatus from '@lib/models/common/ErrorWithStatus'
+import ServerError from '@lib/models/server/ServerError'
+import Files from '@lib/utils/files'
+import { Pkg } from '@lib/models/paths'
 
 const hasStorybookScript = (cwd: string) => {
   const pathToManifest = Pkg(cwd)

--- a/packages/slice-machine/server/src/api/storybook.ts
+++ b/packages/slice-machine/server/src/api/storybook.ts
@@ -1,11 +1,11 @@
 import path from 'path'
 import TemplateEngine from 'ejs'
 
-import Files from '../../../lib/utils/files'
-import { Framework } from '../../../lib/models/common/Framework'
-import { CustomPaths, GeneratedPaths } from '../../../lib/models/paths'
+import Files from '@lib/utils/files'
+import { Framework } from '@lib/models/common/Framework'
+import { CustomPaths, GeneratedPaths } from '@lib/models/paths'
 
-import { createStorybookId } from '../../../lib/utils/str'
+import { createStorybookId } from '@lib/utils/str'
 
 const Paths = {
   nuxtTemplate: (appRoot: string) => path.join(appRoot, 'templates/storybook/nuxt.template.ejs'),

--- a/packages/slice-machine/server/src/api/upload.ts
+++ b/packages/slice-machine/server/src/api/upload.ts
@@ -1,5 +1,5 @@
 // @ts-ignore
-import { snakelize } from '../../../lib/utils/str'
+import { snakelize } from '@lib/utils/str'
 import path from 'path'
 import uniqid from 'uniqid'
 
@@ -7,7 +7,7 @@ import Environment from "../../../lib/models/common/Environment"
 import Slice from "../../../lib/models/common/Slice"
 import { AsObject } from "../../../lib/models/common/Variation"
 
-import { s3DefaultPrefix } from '../../../lib/consts'
+import { s3DefaultPrefix } from '@lib/consts'
 
 export async function purge(env: Environment, slices: ReadonlyArray<Slice<AsObject>>, sliceName: string, onError: (error?: any, msg?: string) => any): Promise<{ err?: any }> {
   if (slices.find(e => e.id === snakelize(sliceName))) {

--- a/packages/slice-machine/server/src/index.js
+++ b/packages/slice-machine/server/src/index.js
@@ -1,6 +1,7 @@
 /// <reference path="../../../sm-commons/index.d.ts" />
 
 require("@babel/register");
+require('module-alias/register');
 
 console.log('\nLaunching server...')
 

--- a/packages/slice-machine/server/tsconfig.json
+++ b/packages/slice-machine/server/tsconfig.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    
     "target": "ES2019",
     "module": "commonjs",
     "allowJs": true,
@@ -10,7 +9,8 @@
     "strictNullChecks": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "baseUrl": "../",
+    "baseUrl": ".",
+    "moduleResolution": "node",
     "typeRoots": [
       "../node_modules/@types",
       "../../sm-commons/index.d.ts"
@@ -21,12 +21,7 @@
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "paths": {
-      "@/*": ["/*"],
-      "@lib/*": ["lib/*"],
-      "@utils/*": ["lib/utils/*"],
-      "@models/*": ["lib/models/*"],
-      "@src/*": ["src/*"],
-      "@components/*": ["components/*"]
+      "@lib/*": ["../lib/*"],
     }
   },
   "include": [

--- a/packages/slice-machine/server/tsconfig.json
+++ b/packages/slice-machine/server/tsconfig.json
@@ -22,6 +22,7 @@
     "forceConsistentCasingInFileNames": true,
     "paths": {
       "@lib/*": ["../lib/*"],
+      "@models/*": ["../lib/models/*"]
     }
   },
   "include": [

--- a/packages/slice-machine/yarn.lock
+++ b/packages/slice-machine/yarn.lock
@@ -7512,6 +7512,11 @@ mkdirp@^1.0.3, mkdirp@^1.0.4:
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
 
+module-alias@^2.2.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/module-alias/-/module-alias-2.2.2.tgz#151cdcecc24e25739ff0aa6e51e1c5716974c0e0"
+  integrity sha512-A/78XjoX2EmNvppVWEhM2oGk3x4lLxnkEA4jTbaK97QKSDjkIoOsKQlfylt/d3kKKi596Qy3NP5XrXJ6fZIC9Q==
+
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"

--- a/packages/slice-machine/yarn.lock
+++ b/packages/slice-machine/yarn.lock
@@ -1435,14 +1435,6 @@
   resolved "https://registry.yarnpkg.com/@mdx-js/util/-/util-1.6.22.tgz#219dfd89ae5b97a8801f015323ffa4b62f45718b"
   integrity sha512-H1rQc1ZOHANWBvPcW+JpGwr+juXSxM8Q8YCkm3GhZd8REu1fHR3z99CErO1p9pkcfcxZnMdIZdIsXkOHY0NilA==
 
-"@mrmlnc/readdir-enhanced@^2.2.1":
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz#524af240d1a360527b730475ecfa1344aa540dde"
-  integrity sha512-bPHp6Ji8b41szTOcaP63VlnbbO5Ny6dwAATtY6JTjh5N2OLrb5Qk/Th5cRkRQhkWCt+EJsYrNB0MiL+Gpn6e3g==
-  dependencies:
-    call-me-maybe "^1.0.1"
-    glob-to-regexp "^0.3.0"
-
 "@next/env@10.0.9":
   version "10.0.9"
   resolved "https://registry.yarnpkg.com/@next/env/-/env-10.0.9.tgz#455fd364c8a5ee012b2cd4406d5294164990706d"
@@ -1492,11 +1484,6 @@
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz#5bd262af94e9d25bd1e71b05deed44876a222e8b"
   integrity sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==
-
-"@nodelib/fs.stat@^1.1.2":
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz#2b5a3ab3f918cca48a8c754c08168e3f03eba61b"
-  integrity sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==
 
 "@nodelib/fs.walk@^1.2.3":
   version "1.2.8"
@@ -2096,14 +2083,6 @@
   resolved "https://registry.yarnpkg.com/@types/faker/-/faker-5.5.5.tgz#b2e60fd1c3e2e5911791425b37b936faf4adc1af"
   integrity sha512-TNR5SjCg8sSfU4bdXsPJlpLXOH4YGBCVggvdZnttD2SMiONSxfJm231Nxn1VaQWWF2Twl4Wr2KC1hYaNd4M5Zw==
 
-"@types/glob@^7.1.1":
-  version "7.1.4"
-  resolved "https://registry.yarnpkg.com/@types/glob/-/glob-7.1.4.tgz#ea59e21d2ee5c517914cb4bc8e4153b99e566672"
-  integrity sha512-w+LsMxKyYQm347Otw+IfBXOv9UWVjpHpCDdbBMt8Kz/xbvCYNjP+0qPh91Km3iKfSRLBB0P7fAMf0KHrPu+MyA==
-  dependencies:
-    "@types/minimatch" "*"
-    "@types/node" "*"
-
 "@types/glob@^7.1.3":
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/@types/glob/-/glob-7.1.3.tgz#e6ba80f36b7daad2c685acd9266382e68985c183"
@@ -2690,22 +2669,10 @@ array-includes@^3.1.3:
     get-intrinsic "^1.1.1"
     is-string "^1.0.5"
 
-array-union@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/array-union/-/array-union-1.0.2.tgz#9a34410e4f4e3da23dea375be5be70f24778ec39"
-  integrity sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=
-  dependencies:
-    array-uniq "^1.0.1"
-
 array-union@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/array-union/-/array-union-2.1.0.tgz#b798420adbeb1de828d84acd8a2e23d3efe85e8d"
   integrity sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==
-
-array-uniq@^1.0.1:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/array-uniq/-/array-uniq-1.0.3.tgz#af6ac877a25cc7f74e058894753858dfdb24fdb6"
-  integrity sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=
 
 array-unique@^0.3.2:
   version "0.3.2"
@@ -3340,11 +3307,6 @@ call-bind@^1.0.0, call-bind@^1.0.2:
     function-bind "^1.1.1"
     get-intrinsic "^1.0.2"
 
-call-me-maybe@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/call-me-maybe/-/call-me-maybe-1.0.1.tgz#26d208ea89e37b5cbde60250a15f031c16a4d66b"
-  integrity sha1-JtII6onje1y95gJQoV8DHBak1ms=
-
 callsites@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/callsites/-/callsites-3.1.0.tgz#b3630abd8943432f54b3f0519238e33cd7df2f73"
@@ -3694,7 +3656,7 @@ comma-separated-tokens@^1.0.0:
   resolved "https://registry.yarnpkg.com/comma-separated-tokens/-/comma-separated-tokens-1.0.8.tgz#632b80b6117867a158f1080ad498b2fbe7e3f5ea"
   integrity sha512-GHuDRO12Sypu2cV70d1dkA2EUmXHgntrzbpvOB+Qy+49ypNfGgFQIC2fhhXbnyrJRynDCAARsT7Ou0M6hirpfw==
 
-commander@^2.17.1, commander@^2.20.0:
+commander@^2.17.1:
   version "2.20.3"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
@@ -4295,13 +4257,6 @@ diffie-hellman@^5.0.0:
     miller-rabin "^4.0.0"
     randombytes "^2.0.0"
 
-dir-glob@^2.2.2:
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/dir-glob/-/dir-glob-2.2.2.tgz#fa09f0694153c8918b18ba0deafae94769fc50c4"
-  integrity sha512-f9LBi5QWzIW3I6e//uxZoLBlUt9kcp66qo0sSCxL6YZKc75R1c4MFCoe/LaZiBGmgujvQdxc5Bn3QhfyvK5Hsw==
-  dependencies:
-    path-type "^3.0.0"
-
 dir-glob@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/dir-glob/-/dir-glob-3.0.1.tgz#56dbf73d992a4a93ba1584f4534063fd2e41717f"
@@ -4879,18 +4834,6 @@ fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
 
-fast-glob@^2.2.6:
-  version "2.2.7"
-  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-2.2.7.tgz#6953857c3afa475fff92ee6015d52da70a4cd39d"
-  integrity sha512-g1KuQwHOZAmOZMuBtHdxDtju+T2RT8jgCC9aANsbpdiDDTSnjgfuVsIBNKbUeJI3oKMRExcfNDtJl4OhbffMsw==
-  dependencies:
-    "@mrmlnc/readdir-enhanced" "^2.2.1"
-    "@nodelib/fs.stat" "^1.1.2"
-    glob-parent "^3.1.0"
-    is-glob "^4.0.0"
-    merge2 "^1.2.3"
-    micromatch "^3.1.10"
-
 fast-glob@^3.1.1:
   version "3.2.7"
   resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.7.tgz#fd6cb7a2d7e9aa7a7846111e85a196d6b2f766a1"
@@ -5249,25 +5192,12 @@ getpass@^0.1.1:
   dependencies:
     assert-plus "^1.0.0"
 
-glob-parent@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-3.1.0.tgz#9e6af6299d8d3bd2bd40430832bd113df906c5ae"
-  integrity sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=
-  dependencies:
-    is-glob "^3.1.0"
-    path-dirname "^1.0.0"
-
 glob-parent@^5.1.2, glob-parent@~5.1.0:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.2.tgz#869832c58034fe68a4093c17dc15e8340d8401c4"
   integrity sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==
   dependencies:
     is-glob "^4.0.1"
-
-glob-to-regexp@^0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz#8c5a1494d2066c570cc3bfe4496175acc4d502ab"
-  integrity sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs=
 
 glob-to-regexp@^0.4.1:
   version "0.4.1"
@@ -5309,20 +5239,6 @@ globby@^11.0.3:
     ignore "^5.1.4"
     merge2 "^1.3.0"
     slash "^3.0.0"
-
-globby@^9.2.0:
-  version "9.2.0"
-  resolved "https://registry.yarnpkg.com/globby/-/globby-9.2.0.tgz#fd029a706c703d29bdd170f4b6db3a3f7a7cb63d"
-  integrity sha512-ollPHROa5mcxDEkwg6bPt3QbEf4pDQSNtd6JPL1YvOvAo/7/0VAm9TccUeoTmarjPw4pfUthSCqcyfNB1I3ZSg==
-  dependencies:
-    "@types/glob" "^7.1.1"
-    array-union "^1.0.2"
-    dir-glob "^2.2.2"
-    fast-glob "^2.2.6"
-    glob "^7.1.3"
-    ignore "^4.0.3"
-    pify "^4.0.1"
-    slash "^2.0.0"
 
 got@^9.6.0:
   version "9.6.0"
@@ -5691,11 +5607,6 @@ ignore-walk@^3.0.3:
   dependencies:
     minimatch "^3.0.4"
 
-ignore@^4.0.3:
-  version "4.0.6"
-  resolved "https://registry.yarnpkg.com/ignore/-/ignore-4.0.6.tgz#750e3db5862087b4737ebac8207ffd1ef27b25fc"
-  integrity sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==
-
 ignore@^5.1.4:
   version "5.1.8"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.1.8.tgz#f150a8b50a34289b33e22f5889abd4d8016f0e57"
@@ -5985,7 +5896,7 @@ is-extendable@^1.0.1:
   dependencies:
     is-plain-object "^2.0.4"
 
-is-extglob@^2.1.0, is-extglob@^2.1.1:
+is-extglob@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/is-extglob/-/is-extglob-2.1.1.tgz#a88c02535791f02ed37c76a1b9ea9773c833f8c2"
   integrity sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=
@@ -6022,14 +5933,7 @@ is-generator-fn@^2.0.0:
   resolved "https://registry.yarnpkg.com/is-generator-fn/-/is-generator-fn-2.1.0.tgz#7d140adc389aaf3011a8f2a2a4cfa6faadffb118"
   integrity sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==
 
-is-glob@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-3.1.0.tgz#7ba5ae24217804ac70707b96922567486cc3e84a"
-  integrity sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=
-  dependencies:
-    is-extglob "^2.1.0"
-
-is-glob@^4.0.0, is-glob@^4.0.1, is-glob@~4.0.1:
+is-glob@^4.0.1, is-glob@~4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.1.tgz#7567dbe9f2f5e2467bc77ab83c4a29482407a5dc"
   integrity sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==
@@ -7302,7 +7206,7 @@ merge-stream@^2.0.0:
   resolved "https://registry.yarnpkg.com/merge-stream/-/merge-stream-2.0.0.tgz#52823629a14dd00c9770fb6ad47dc6310f2c1f60"
   integrity sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==
 
-merge2@^1.2.3, merge2@^1.3.0:
+merge2@^1.3.0:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
   integrity sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
@@ -8412,11 +8316,6 @@ path-browserify@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/path-browserify/-/path-browserify-1.0.1.tgz#d98454a9c3753d5790860f16f68867b9e46be1fd"
   integrity sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==
-
-path-dirname@^1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/path-dirname/-/path-dirname-1.0.2.tgz#cc33d24d525e099a5388c0336c6e32b9160609e0"
-  integrity sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA=
 
 path-exists@^2.0.0:
   version "2.1.0"
@@ -9901,11 +9800,6 @@ slash@3.0.0, slash@^3.0.0:
   resolved "https://registry.yarnpkg.com/slash/-/slash-3.0.0.tgz#6539be870c165adbd5240220dbe361f1bc4d4634"
   integrity sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==
 
-slash@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/slash/-/slash-2.0.0.tgz#de552851a1759df3a8f206535442f5ec4ddeab44"
-  integrity sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==
-
 sm-commons@^0.0.22:
   version "0.0.22"
   resolved "https://registry.yarnpkg.com/sm-commons/-/sm-commons-0.0.22.tgz#5027b50b23964c74ed3eda150fd58c39e44ac7b0"
@@ -10727,14 +10621,6 @@ tsconfig-paths@^3.9.0:
     json5 "^2.2.0"
     minimist "^1.2.0"
     strip-bom "^3.0.0"
-
-tscpaths@^0.0.9:
-  version "0.0.9"
-  resolved "https://registry.yarnpkg.com/tscpaths/-/tscpaths-0.0.9.tgz#c77abfde6820920f10c64f83c27753b9505814ab"
-  integrity sha512-tz4qimSJTCjYtHVsoY7pvxLcxhmhgmwzm7fyMEiL3/kPFFVyUuZOwuwcWwjkAsIrSUKJK22A7fNuJUwxzQ+H+w==
-  dependencies:
-    commander "^2.20.0"
-    globby "^9.2.0"
 
 tslib@^1.10.0, tslib@^1.8.1:
   version "1.14.1"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

<!--- Describe your changes in detail -->

The watch server command wasn't working because of the alias not executed properly. 

Before the express build part was in 2 steps : 
- compilation with typescript
- alias replacement with tscpaths

I replace tspath by module alias which allow to resolve the path aliases during the node runtime. With this we don't need the tscpaths step anymore during the build phase.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [x] All new and existing tests are passing.

<!--- A cute animal picture is welcome to close your PR! -->
