### PR TITLE
fix key accessors in Field zones + fix Svelte hints

### DIFF
--- a/packages/slice-machine/lib/builders/CustomTypeBuilder/TabZone/index.js
+++ b/packages/slice-machine/lib/builders/CustomTypeBuilder/TabZone/index.js
@@ -2,7 +2,12 @@ import { Fragment, useState } from "react";
 import * as Widgets from "@lib/models/common/widgets/withGroup";
 import EditModal from "../../common/EditModal";
 
-import { ensureDnDDestination, ensureWidgetTypeExistence } from "@lib/utils";
+import {
+  ensureDnDDestination,
+  ensureWidgetTypeExistence
+} from "@lib/utils";
+
+import { transformKeyAccessor } from "@utils/str";
 
 import Zone from "../../common/Zone";
 
@@ -98,8 +103,8 @@ const TabZone = ({ Model, store, tabId, fields, sliceZone, showHints }) => {
         onSave={onSave}
         onSaveNewField={onSaveNewField}
         onDragEnd={onDragEnd}
-        renderHintBase={({ item }) => `data.${item.key}`}
-        renderFieldAccessor={(key) => `data.${key}`}
+        renderHintBase={({ item }) => `data${transformKeyAccessor(item.key)}`}
+        renderFieldAccessor={(key) => `data${transformKeyAccessor(key)}`}
       />
       <SliceZone
         tabId={tabId}

--- a/packages/slice-machine/lib/builders/SliceBuilder/FieldZones/index.jsx
+++ b/packages/slice-machine/lib/builders/SliceBuilder/FieldZones/index.jsx
@@ -1,6 +1,7 @@
 import { Box } from "theme-ui";
 
 import { ensureDnDDestination } from "@lib/utils";
+import { transformKeyAccessor } from "@utils/str";
 
 import Zone from "../../common/Zone";
 import EditModal from "../../common/EditModal";
@@ -97,8 +98,8 @@ const Zones = ({ Model, store, variation, showHints }) => {
         onSaveNewField={_onSaveNewField("primary")}
         onDragEnd={_onDragEnd("primary")}
         poolOfFieldsToCheck={variation.primary || []}
-        renderHintBase={({ item }) => `slice.primary.${item.key}`}
-        renderFieldAccessor={(key) => `slice.primary.${key}`}
+        renderHintBase={({ item }) => `slice.primary${transformKeyAccessor(item.key)}`}
+        renderFieldAccessor={(key) => `slice.primary${transformKeyAccessor(key)}`}
       />
       <Box mt={4} />
       <Zone
@@ -116,8 +117,8 @@ const Zones = ({ Model, store, variation, showHints }) => {
         onSaveNewField={_onSaveNewField("items")}
         onDragEnd={_onDragEnd("items")}
         poolOfFieldsToCheck={variation.items || []}
-        renderHintBase={({ item }) => `item.${item.key}`}
-        renderFieldAccessor={(key) => `slice.items[i].${key}`}
+        renderHintBase={({ item }) => `item${transformKeyAccessor(item.key)}`}
+        renderFieldAccessor={(key) => `slice.items[i]${transformKeyAccessor(key)}`}
       />
     </>
   );

--- a/packages/slice-machine/lib/builders/common/Zone/Card/components/Hints/Renderers/svelte.js
+++ b/packages/slice-machine/lib/builders/common/Zone/Card/components/Hints/Renderers/svelte.js
@@ -8,7 +8,7 @@ const richTextCode = (fieldText) =>
   `{@html PrismicDom.RichText.asHtml(${fieldText}, linkResolver)}`;
 
 const linkCode = (fieldText) =>
-  `<a href={PrismicDom.RichText.Link.url(${fieldText}, linkResolver)}> My Link</a>`;
+  `<a href={PrismicDom.Link.url(${fieldText}, linkResolver)}> My Link</a>`;
 
 const dateCode = (fieldText) =>
   `<time datetime={${fieldText}}>{${fieldText}}</time>`;
@@ -33,7 +33,7 @@ const codeByWidgetType = (Widgets) => ({
     `{#if ${fieldText}} <p>true</p> {:else} <p>false</p>{/if}`,
   [Widgets.Embed?.TYPE_NAME]: (fieldText) => `{@html ${fieldText}.html}`,
   [Widgets.Color?.TYPE_NAME]: (fieldText) =>
-    `<span style={\`color: \${${fieldText}};\`}}>Some Text</span>`,
+    `<span style={\`color: \${${fieldText}};\`}>Some Text</span>`,
 });
 
 export default ({ Widgets, item, typeName, renderHintBase, isRepeatable }) => {

--- a/packages/slice-machine/lib/models/common/widgets/Group/ListItem/index.js
+++ b/packages/slice-machine/lib/models/common/widgets/Group/ListItem/index.js
@@ -4,7 +4,12 @@ import { DragDropContext, Droppable } from "react-beautiful-dnd";
 
 import { Box, Button } from "theme-ui";
 
-import { ensureDnDDestination, ensureWidgetTypeExistence } from "@lib/utils";
+import {
+  ensureDnDDestination,
+  ensureWidgetTypeExistence
+} from "@lib/utils";
+
+import { transformKeyAccessor } from "@utils/str";
 
 import SelectFieldTypeModal from "@lib/builders/common/SelectFieldTypeModal";
 import NewField from "@lib/builders/common/Zone/Card/components/NewField";
@@ -160,9 +165,7 @@ const CustomListItem = ({
                           item={item}
                           show={showHints}
                           isRepeatable={isRepeatable}
-                          renderHintBase={({ item }) =>
-                            `data.${groupItem.key}.${item.key}`
-                          }
+                          renderHintBase={({ item }) => `data.${groupItem.key}${transformKeyAccessor(item.key)}`}
                           framework={framework}
                           Widgets={Widgets}
                           typeName={widget.CUSTOM_NAME || widget.TYPE_NAME}

--- a/packages/slice-machine/lib/utils/str.ts
+++ b/packages/slice-machine/lib/utils/str.ts
@@ -1,6 +1,14 @@
 import camelCase from "lodash/camelCase";
 
 const camelizeRE = /-(\w)/g;
+
+export function transformKeyAccessor(str: string): string {
+  if (str.includes('-')) {
+    return `["${str}"]`
+  }
+  return `.${str}`
+}
+
 export function pascalize(str: string): string {
   if (!str) {
     return "";

--- a/packages/slice-machine/lib/utils/str.ts
+++ b/packages/slice-machine/lib/utils/str.ts
@@ -4,7 +4,7 @@ const camelizeRE = /-(\w)/g;
 
 export function transformKeyAccessor(str: string): string {
   if (str.includes('-')) {
-    return `["${str}"]`
+    return `['${str}']`
   }
   return `.${str}`
 }


### PR DESCRIPTION
I tested slices and stories created with Svelte integration.
I fixed fields that did not render correctly. I also spotted that fields containing a '-' would always break in JS, I added a small utility which formats these fields using brackets and leaves other fields untouched