### PR TITLE
Fix: Puppeteer waits for root element to display and not for network …

### DIFF
--- a/packages/slice-machine/package-lock.json
+++ b/packages/slice-machine/package-lock.json
@@ -2874,6 +2874,148 @@
         "@sinonjs/commons": "^1.7.0"
       }
     },
+    "@slicemachine/core": {
+      "version": "1.0.2-alpha.12",
+      "resolved": "https://registry.npmjs.org/@slicemachine/core/-/core-1.0.2-alpha.12.tgz",
+      "integrity": "sha512-9O9yZkzfoJCMgIaLSd78Q5aIDhZW+MuKQtNYYJBh1liani1s4dIMcP8Z3ucXFy00+FHXKQpLTl517CQPJYVmzQ==",
+      "requires": {
+        "@hapi/hapi": "^20.2.0",
+        "axios": "^0.22.0",
+        "chalk": "^4.1.2",
+        "cookie": "^0.4.1",
+        "fp-ts": "^2.11.5",
+        "fs-extra": "^10.0.0",
+        "io-ts": "^2.2.16",
+        "open": "^8.2.1",
+        "ora": "^5.4.1",
+        "prompt": "^1.2.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "axios": {
+          "version": "0.22.0",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-0.22.0.tgz",
+          "integrity": "sha512-Z0U3uhqQeg1oNcihswf4ZD57O3NrR1+ZXhxaROaWpDmsDTx7T2HNBV2ulBtie2hwJptu8UvgnJoK+BIqdzh/1w==",
+          "requires": {
+            "follow-redirects": "^1.14.4"
+          }
+        },
+        "bl": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+          "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+          "requires": {
+            "buffer": "^5.5.0",
+            "inherits": "^2.0.4",
+            "readable-stream": "^3.4.0"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "cli-cursor": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+          "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+          "requires": {
+            "restore-cursor": "^3.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+        },
+        "is-interactive": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
+          "integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w=="
+        },
+        "is-unicode-supported": {
+          "version": "0.1.0",
+          "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+          "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw=="
+        },
+        "log-symbols": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+          "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
+          "requires": {
+            "chalk": "^4.1.0",
+            "is-unicode-supported": "^0.1.0"
+          }
+        },
+        "ora": {
+          "version": "5.4.1",
+          "resolved": "https://registry.npmjs.org/ora/-/ora-5.4.1.tgz",
+          "integrity": "sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==",
+          "requires": {
+            "bl": "^4.1.0",
+            "chalk": "^4.1.0",
+            "cli-cursor": "^3.1.0",
+            "cli-spinners": "^2.5.0",
+            "is-interactive": "^1.0.0",
+            "is-unicode-supported": "^0.1.0",
+            "log-symbols": "^4.1.0",
+            "strip-ansi": "^6.0.0",
+            "wcwidth": "^1.0.1"
+          }
+        },
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        },
+        "restore-cursor": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+          "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+          "requires": {
+            "onetime": "^5.1.0",
+            "signal-exit": "^3.0.2"
+          }
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
     "@styled-system/background": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/@styled-system/background/-/background-5.1.2.tgz",

--- a/packages/slice-machine/server/src/api/screenshots/generate.ts
+++ b/packages/slice-machine/server/src/api/screenshots/generate.ts
@@ -131,10 +131,7 @@ async function generateForVariation(
     screenshotUrl,
     pathToFile,
   });
-  if (maybeError instanceof Error) {
-    return maybeError;
-  }
-
+  if (maybeError instanceof Error) return maybeError;
   return createScreenshotUI(env.baseUrl, pathToFile);
 }
 

--- a/packages/slice-machine/server/src/api/screenshots/puppeteer.ts
+++ b/packages/slice-machine/server/src/api/screenshots/puppeteer.ts
@@ -44,8 +44,12 @@ const generateScreenshot = async (
   try {
     Files.mkdir(path.dirname(pathToFile), { recursive: true });
     const page = await browser.newPage();
+
+    /* We use the waitUntil option in order for the component to be rendered properly.
+     ** The value networkidle2 is required because Nuxt has an open socket with Webpack.
+     */
     await page.goto(screenshotUrl, {
-      waitUntil: "networkidle2", // websocket open for webpack in nuxt.
+      waitUntil: "networkidle2",
     });
 
     await page.waitForSelector("#root", { timeout: 2000 });

--- a/packages/slice-machine/server/src/api/screenshots/puppeteer.ts
+++ b/packages/slice-machine/server/src/api/screenshots/puppeteer.ts
@@ -44,15 +44,14 @@ const generateScreenshot = async (
   try {
     Files.mkdir(path.dirname(pathToFile), { recursive: true });
     const page = await browser.newPage();
-    await page.goto(screenshotUrl);
-
-    await page.waitForNavigation({
+    await page.goto(screenshotUrl, {
       waitUntil: "networkidle2", // websocket open for webpack in nuxt.
     });
 
     await page.waitForSelector("#root", { timeout: 2000 });
     const element = await page.$("#root");
     if (element) await element.screenshot({ path: pathToFile });
+    await page.close();
 
     return;
   } catch (err) {

--- a/packages/slice-machine/server/src/api/screenshots/puppeteer.ts
+++ b/packages/slice-machine/server/src/api/screenshots/puppeteer.ts
@@ -46,7 +46,11 @@ const generateScreenshot = async (
     const page = await browser.newPage();
     await page.goto(screenshotUrl);
 
-    await page.waitForSelector("#root", { visible: true, timeout: 20000 }); // wait 20 secs top.
+    await page.waitForNavigation({
+      waitUntil: "networkidle2", // websocket open for webpack in nuxt.
+    });
+
+    await page.waitForSelector("#root", { timeout: 2000 });
     const element = await page.$("#root");
     if (element) await element.screenshot({ path: pathToFile });
 

--- a/packages/slice-machine/server/src/api/screenshots/puppeteer.ts
+++ b/packages/slice-machine/server/src/api/screenshots/puppeteer.ts
@@ -46,11 +46,7 @@ const generateScreenshot = async (
     const page = await browser.newPage();
     await page.goto(screenshotUrl);
 
-    await page.waitForNavigation({
-      waitUntil: "networkidle0",
-    });
-
-    await page.waitForSelector("#root", { timeout: 2000 });
+    await page.waitForSelector("#root", { visible: true, timeout: 20000 }); // wait 20 secs top.
     const element = await page.$("#root");
     if (element) await element.screenshot({ path: pathToFile });
 

--- a/packages/slice-machine/server/src/api/screenshots/screenshots.ts
+++ b/packages/slice-machine/server/src/api/screenshots/screenshots.ts
@@ -12,7 +12,7 @@ export default async function handler({
   const { env } = await getEnv();
   if (!env.manifest.localSliceCanvasURL) {
     const reason =
-      "Could not generate preview: localSliceCanvasUrl undefined in sm.json file";
+      "Could not generate screenshots: localSliceCanvasUrl undefined in sm.json file";
 
     return {
       err: new Error(reason),
@@ -28,7 +28,7 @@ export default async function handler({
   );
 
   const message: string | null = failure.length
-    ? `Could not generate previews for variations: ${failure
+    ? `Could not generate screenshots for variations: ${failure
         .map((f) => f.variationId)
         .join(" | ")}`
     : null;

--- a/packages/slice-machine/server/src/api/slices/save.ts
+++ b/packages/slice-machine/server/src/api/slices/save.ts
@@ -66,15 +66,16 @@ export async function handler(
   console.log("[slice/save]: Generating stories");
   Storybook.generateStories(appRoot, env.framework, env.cwd, from, sliceName);
 
+  console.log("[slice/save]: Slice was saved!");
+
+  await onSaveSlice(env);
+  console.log("[slice/save]: Libraries index files regenerated!");
+
   const { previewUrls, warning } = await generateScreenshotsWithLogs(
     env,
     from,
     sliceName
   );
-  console.log("[slice/save]: Slice was saved!");
-
-  await onSaveSlice(env);
-  console.log("[slice/save]: Libraries index files regenerated!");
 
   return { previewUrls, warning };
 }

--- a/packages/slice-machine/src/models/slice/actions/save.ts
+++ b/packages/slice-machine/src/models/slice/actions/save.ts
@@ -35,10 +35,7 @@ export default function save(
       }) {
         const savedState = {
           ...slice,
-          infos: {
-            ...slice.infos,
-            previewUrls,
-          },
+          screenshotUrls: previewUrls,
           initialMockConfig: slice.mockConfig,
           initialVariations: slice.variations,
         };


### PR DESCRIPTION
…idle

<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->

Issue: We can't take screenshot with a Nuxt project.

After adding some logs and testing, it appears that we used to wait non active network (all the connections are done and closed), while Nuxt keeps a socket open for webpack's hotreload.
We choose to wait until a maximum of two connections are left open (an option of puppeteer).

On top of that, while tested we noticed that after two screenshot, it stopped working.
We realised that the puppeteer pages were never closed which means they remained open and with them the sockets.
We now close the page after each screenshot, preventing an endless amount of pages to be opened.

Extra:
- On slice creation, the screenshot was not generated because the library state was generated after trying to take the actual screenshot.
 -> We generate the state before now.
- On slice save, we could generate the screenshots but they weren't displayed until the page reloads.
 -> We fixed the front-end state when a save is performed, it was still adapted to the old models.

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] All new and existing tests are passing.

<!--- A cute animal picture is welcome to close your PR! -->
