### PR TITLE
Fix: isolate puppeteer page creation

### DIFF
--- a/packages/slice-machine/server/src/api/screenshots/puppeteer.ts
+++ b/packages/slice-machine/server/src/api/screenshots/puppeteer.ts
@@ -41,9 +41,13 @@ const generateScreenshot = async (
   screenshotUrl: string,
   pathToFile: string
 ): Promise<void | Error> => {
+  // Create an incognito contexte to isolate screenshots.
+  const context = await browser.createIncognitoBrowserContext();
+  // Create a new page in the context.
+  const page = await context.newPage();
+
   try {
     Files.mkdir(path.dirname(pathToFile), { recursive: true });
-    const page = await browser.newPage();
 
     /* We use the waitUntil option in order for the component to be rendered properly.
      ** The value networkidle2 is required because Nuxt has an open socket with Webpack.
@@ -55,10 +59,11 @@ const generateScreenshot = async (
     await page.waitForSelector("#root", { timeout: 2000 });
     const element = await page.$("#root");
     if (element) await element.screenshot({ path: pathToFile });
-    await page.close();
 
+    await context.close();
     return;
   } catch (err) {
+    await context.close();
     return err as Error;
   }
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->

The issue:
- While testing the screenshot features, it still didn't worked for Nuxt, it seems that when there was more than 2 screenshots done at the same time, the two first succeed and then the rest failed.
- On top of that, we didn't close a browser page when the screenshot failed, meaning it remained open on the virtual chromium opened by puppeteer.

The fix:
- extract the page creation
- open the page from an isolated incognito context
- close the context (and the page) on both success and fail of the screenshot.

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] All new and existing tests are passing.

<!--- A cute animal picture is welcome to close your PR! -->
