### PR TITLE
If not all screenshot fail I can still see the screenshots that succeeded in the UI.

### DIFF
--- a/packages/slice-machine/lib/models/common/Screenshots.ts
+++ b/packages/slice-machine/lib/models/common/Screenshots.ts
@@ -1,4 +1,7 @@
 import { ScreenshotUI } from "./ComponentUI";
+import type { Models } from "@slicemachine/core";
+
+export type Screenshots = Record<Models.VariationAsObject["id"], ScreenshotUI>;
 
 export interface ScreenshotRequest {
   libraryName: string;
@@ -8,7 +11,8 @@ export interface ScreenshotRequest {
 export interface ScreenshotResponse {
   err: Error | null;
   reason: string | null;
-  screenshots: Record<string, ScreenshotUI>;
+  warning?: string | null;
+  screenshots: Screenshots;
 }
 
 export type TmpFile = File & { path: string };

--- a/packages/slice-machine/lib/models/common/Slice.ts
+++ b/packages/slice-machine/lib/models/common/Slice.ts
@@ -1,4 +1,6 @@
 import type Models from "@slicemachine/core/build/src/models";
+import { SliceMockConfig } from "./MockConfig";
+import { Screenshots } from "./Screenshots";
 import { Variation } from "./Variation";
 
 const Slice = {
@@ -16,5 +18,17 @@ const Slice = {
     };
   },
 };
+
+export interface SliceSaveBody {
+  sliceName: string;
+  from: string;
+  model: Models.SliceAsObject;
+  mockConfig?: SliceMockConfig;
+}
+
+export interface SliceSaveResponse {
+  screenshots: Screenshots;
+  warning: string | null;
+}
 
 export default Slice;

--- a/packages/slice-machine/package.json
+++ b/packages/slice-machine/package.json
@@ -28,7 +28,7 @@
     "export-build": "next export && npm run clean-build",
     "bundle": "npm run build && npm run test && npm run export-build",
     "slicemachine": "start-slicemachine --port 9999",
-    "lint": "eslint --max-warnings 1078 --ext .ts,.tsx .",
+    "lint": "eslint --max-warnings 1068 --ext .ts,.tsx .",
     "lint:precommit": "eslint",
     "audit": "better-npm-audit audit -l high -p -x 1002475,1006754",
     "audit-fix": "npm audit fix"

--- a/packages/slice-machine/server/src/api/screenshots/generate.ts
+++ b/packages/slice-machine/server/src/api/screenshots/generate.ts
@@ -8,33 +8,16 @@ import {
   createScreenshotUI,
   ScreenshotUI,
 } from "@lib/models/common/ComponentUI";
+import { Screenshots } from "@lib/models/common/Screenshots";
 
-export type Screenshots = Record<Models.VariationAsObject["id"], ScreenshotUI>;
 type FailedScreenshot = {
-  error: Error;
   variationId: Models.VariationAsObject["id"];
+  error: Error;
 };
 
-interface ScreenshotResults {
+export interface ScreenshotResults {
   screenshots: Screenshots;
   failure: FailedScreenshot[];
-}
-
-export async function generateScreenshot(
-  env: BackendEnvironment,
-  libraryName: string,
-  sliceName: string
-): Promise<ScreenshotResults> {
-  const { screenshots, failure } = await generateForSlice(
-    env,
-    libraryName,
-    sliceName
-  );
-
-  return {
-    screenshots: screenshots,
-    failure: failure,
-  };
 }
 
 export async function generateScreenshotAndRemoveCustom(
@@ -59,7 +42,7 @@ export async function generateScreenshotAndRemoveCustom(
   };
 }
 
-async function generateForSlice(
+export async function generateScreenshot(
   env: BackendEnvironment,
   libraryName: string,
   sliceName: string

--- a/packages/slice-machine/server/src/api/screenshots/screenshots.ts
+++ b/packages/slice-machine/server/src/api/screenshots/screenshots.ts
@@ -49,15 +49,27 @@ export default async function handler({
     sliceName
   );
 
-  const message: string | null = failure.length
-    ? `Could not generate screenshots for variations: ${failure
-        .map((f) => f.variationId)
-        .join(" | ")}`
-    : null;
+  if (failure.length > 0) {
+    const message:
+      | string
+      | null = `Could not generate screenshots for variations: ${failure
+      .map((f) => f.variationId)
+      .join(" | ")}`;
+
+    /* We display an error if no screenshot has been taken */
+    const isError = Object.keys(screenshots).length === 0;
+
+    return {
+      err: isError ? new Error(message) : null,
+      reason: isError ? message : null,
+      warning: isError ? null : message,
+      screenshots,
+    };
+  }
 
   return {
-    err: message ? new Error(message) : null,
-    reason: message,
+    err: null,
+    reason: null,
     screenshots,
   };
 }

--- a/packages/slice-machine/src/models/slice/actions/save.ts
+++ b/packages/slice-machine/src/models/slice/actions/save.ts
@@ -1,9 +1,9 @@
-import type Models from "@slicemachine/core/build/src/models";
 import { Variation } from "../../../../lib/models/common/Variation";
 import { fetchApi } from "../../../../lib/builders/common/fetch";
 import SliceState from "../../../../lib/models/ui/SliceState";
 import { ActionType } from "./ActionType";
 import { ToastPayload } from "../../../../src/ToastProvider/utils";
+import { SliceSaveResponse } from "@lib/models/common/Slice";
 
 export default function save(
   dispatch: ({ type, payload }: { type: string; payload?: any }) => void
@@ -28,14 +28,10 @@ export default function save(
       },
       setData,
       successMessage: "Model & mocks have been generated successfully!",
-      onSuccess({
-        previewUrls,
-      }: {
-        previewUrls: { [variationId: string]: Models.Screenshot };
-      }) {
+      onSuccess({ screenshots }: SliceSaveResponse) {
         const savedState = {
           ...slice,
-          screenshotUrls: previewUrls,
+          screenshotUrls: screenshots,
           initialMockConfig: slice.mockConfig,
           initialVariations: slice.variations,
         };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->

Bug fix,

When taking screenshots using the screenshot button, if some variation screenshot did not work (code breaks most likely),
we use to return a message as Error, and the front-end state would not update showing the screenshots that succedeed.

<!--- A cute animal picture is welcome to close your PR! -->
