### PR TITLE
Use canvas Url for previewing slices

### DIFF
--- a/packages/slice-machine/components/Preview/index.tsx
+++ b/packages/slice-machine/components/Preview/index.tsx
@@ -8,12 +8,18 @@ import { SliceContext } from "@src/models/slice/context";
 import Header from "./components/Header";
 import { Size } from "./components/ScreenSizes";
 import IframeRenderer from "./components/IframeRenderer";
+import { SliceMachineStoreType } from "@src/redux/type";
+import { useSelector } from "react-redux";
+import { getCanvasUrl } from "@src/modules/environment";
 
 export type SliceView = SliceViewItem[];
 export type SliceViewItem = Readonly<{ sliceID: string; variationID: string }>;
 
-export default function Preview() {
+export default function Preview(): JSX.Element {
   const { Model, variation } = useContext(SliceContext);
+  const { canvasUrl } = useSelector((store: SliceMachineStoreType) => ({
+    canvasUrl: getCanvasUrl(store),
+  }));
 
   const [state, setState] = useState({ size: Size.FULL });
 
@@ -29,10 +35,6 @@ export default function Preview() {
     { sliceID: Model.infos.model.id, variationID: variation.id },
   ];
 
-  const canvasUrl = `http://localhost:${
-    process.env.NODE_ENV === "development" ? "3001" : "3000"
-  }/_canvas`;
-
   return (
     <Flex sx={{ height: "100vh", flexDirection: "column" }}>
       <Header
@@ -42,11 +44,17 @@ export default function Preview() {
         handleScreenSizeChange={handleScreenSizeChange}
         size={state.size}
       />
-      <IframeRenderer
-        size={state.size}
-        canvasUrl={canvasUrl}
-        sliceView={sliceView}
-      />
+      {canvasUrl ? (
+        <IframeRenderer
+          size={state.size}
+          canvasUrl={canvasUrl}
+          sliceView={sliceView}
+        />
+      ) : (
+        <div>
+          It seems that your canvas Url is not configured yet in the manifest.
+        </div>
+      )}
     </Flex>
   );
 }

--- a/packages/slice-machine/package.json
+++ b/packages/slice-machine/package.json
@@ -28,7 +28,7 @@
     "export-build": "next export && npm run clean-build",
     "bundle": "npm run build && npm run test && npm run export-build",
     "slicemachine": "start-slicemachine --port 9999",
-    "lint": "eslint --max-warnings 1067 --ext .ts,.tsx .",
+    "lint": "eslint --max-warnings 1065 --ext .ts,.tsx .",
     "lint:precommit": "eslint",
     "audit": "better-npm-audit audit -l high -p -x 1002475,1006754",
     "audit-fix": "npm audit fix"

--- a/packages/slice-machine/src/modules/environment/index.ts
+++ b/packages/slice-machine/src/modules/environment/index.ts
@@ -49,7 +49,13 @@ export const getUpdateVersionInfo = (
   return store.environment.env.updateVersionInfo;
 };
 
-export const getStorybookUrl = (state: SliceMachineStoreType) => {
+export const getCanvasUrl = (state: SliceMachineStoreType): string | null => {
+  return state.environment.env.manifest.localSliceCanvasURL || null;
+};
+
+export const getStorybookUrl = (
+  state: SliceMachineStoreType
+): string | null => {
   return state.environment.env.manifest.storybook || null;
 };
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->

The Canvas Url on the manifest was not used to preview slices.
The value was hardset, so I used the manifest.
We might need an error screen when the canvasUrl is not defined and someone access the preview screen manually

<!--- A cute animal picture is welcome to close your PR! -->
