### PR TITLE
Fix side bar inconsistencies

### DIFF
--- a/packages/slice-machine/lib/builders/SliceBuilder/SideBar/components/ImagePreview.tsx
+++ b/packages/slice-machine/lib/builders/SliceBuilder/SideBar/components/ImagePreview.tsx
@@ -16,7 +16,7 @@ interface ImagePreviewProps {
   src?: string;
   onScreenshot: () => void;
   imageLoading: boolean;
-  onHandleFile: (file: any) => void;
+  onHandleFile: (file: File) => void;
   preventScreenshot: boolean;
 }
 
@@ -35,7 +35,7 @@ const ImagePreview: React.FC<ImagePreviewProps> = ({
 
   const handleFile = (file: File | undefined) => {
     if (inputFile?.current) {
-      onHandleFile(file);
+      file && onHandleFile(file);
       inputFile.current.value = "";
     }
   };
@@ -85,15 +85,14 @@ const ImagePreview: React.FC<ImagePreviewProps> = ({
             {display ? (
               <Fragment>
                 <Flex sx={{ flexDirection: "column" }}>
-                  {!preventScreenshot ? (
-                    <Button
-                      sx={{ mb: 3 }}
-                      variant="primary"
-                      onClick={onScreenshot}
-                    >
-                      Take screenshot
-                    </Button>
-                  ) : null}
+                  <Button
+                    sx={{ mb: 3 }}
+                    onClick={onScreenshot}
+                    disabled={preventScreenshot}
+                    variant={preventScreenshot ? "disabled" : "primary"}
+                  >
+                    Take screenshot
+                  </Button>
                   <Label
                     htmlFor="input-file"
                     variant="buttons.primary"

--- a/packages/slice-machine/lib/builders/SliceBuilder/SideBar/index.tsx
+++ b/packages/slice-machine/lib/builders/SliceBuilder/SideBar/index.tsx
@@ -91,14 +91,7 @@ const SideBar: React.FunctionComponent<SideBarProps> = ({
       >
         {isCheckingPreviewSetup ? <Spinner size={12} /> : "Open Slice Preview"}
       </Button>
-      {storybookUrl && (
-        <Link href={storybookUrl}>
-          <Button variant={"secondary"} sx={{ width: "100%", mt: 3 }}>
-            Open Storybook
-          </Button>
-        </Link>
-      )}
-      {!storybookUrl && !isPreviewAvailableForFramework && (
+      {!isPreviewAvailableForFramework && (
         <Text
           as="p"
           sx={{
@@ -112,13 +105,26 @@ const SideBar: React.FunctionComponent<SideBarProps> = ({
         >
           {framework
             ? `${framework} does not support Slice Preview.`
-            : "Slice Preview is not supported by your framework."}{" "}
-          You can{" "}
-          <a target={"_blank"} href={linkToStorybookDocs}>
-            install Storybook
-          </a>{" "}
-          instead.
+            : "Slice Preview is not supported by your framework."}
+          &nbsp;
+          {!storybookUrl ? (
+            <>
+              You can{" "}
+              <a target={"_blank"} href={linkToStorybookDocs}>
+                install Storybook
+              </a>{" "}
+              instead.
+            </>
+          ) : null}
         </Text>
+      )}
+
+      {storybookUrl && (
+        <Link href={storybookUrl}>
+          <Button variant={"secondary"} sx={{ width: "100%", mt: 3 }}>
+            Open Storybook
+          </Button>
+        </Link>
       )}
     </Box>
   );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->

Small PR to solve inconsitencies in the SideBar of the Slice builder
- the preview / screenshots button where not aligned on their behavior
- the text stating that the preview is not accessible for a given framework wasn't showing up when storybook was activated.

<!--- A cute animal picture is welcome to close your PR! -->
