### PR TITLE
use new URL to create sb slice href

### DIFF
--- a/packages/slice-machine/lib/builders/SliceBuilder/SideBar/index.tsx
+++ b/packages/slice-machine/lib/builders/SliceBuilder/SideBar/index.tsx
@@ -19,6 +19,7 @@ import {
   getStorybookUrl,
   getLinkToStorybookDocs,
 } from "@src/modules/environment";
+import { createStorybookUrl } from "@lib/utils/storybook";
 
 const MemoizedImagePreview = memo(ImagePreview);
 
@@ -92,7 +93,14 @@ const SideBar: React.FunctionComponent<SideBarProps> = ({
         {isCheckingPreviewSetup ? <Spinner size={12} /> : "Open Slice Preview"}
       </Button>
       {storybookUrl && (
-        <Link href={storybookUrl}>
+        <Link
+          href={createStorybookUrl({
+            storybook: storybookUrl,
+            libraryName: Model.from,
+            sliceName: Model.infos.sliceName,
+            variationId: variation.id,
+          })}
+        >
           <Button variant={"secondary"} sx={{ width: "100%", mt: 3 }}>
             Open Storybook
           </Button>

--- a/packages/slice-machine/lib/utils/storybook.ts
+++ b/packages/slice-machine/lib/utils/storybook.ts
@@ -1,0 +1,48 @@
+import { createStorybookId, camelCaseToDash } from "./str";
+
+export const sanitizeSbId = (str: string) => {
+  return str
+    .toLowerCase()
+    .replace(/[ ’–—―′¿'`~!@#$%^&*()_|+\-=?;:'",.<>\{\}\[\]\\\/]/gi, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-+/, "")
+    .replace(/-+$/, "");
+};
+
+const createStorybookPath = ({
+  libraryName,
+  sliceName,
+  variationId,
+}: {
+  libraryName: string;
+  sliceName: string;
+  variationId: string;
+}) =>
+  `${sanitizeSbId(libraryName)}-${sliceName.toLowerCase()}--${camelCaseToDash(
+    createStorybookId(variationId).slice(1)
+  )}`;
+
+export const createStorybookUrl = ({
+  storybook,
+  libraryName,
+  sliceName,
+  variationId,
+}: {
+  storybook: string;
+  libraryName: string;
+  sliceName: string;
+  variationId: string;
+}) => {
+  try {
+    return new URL(
+      `/?path=/story/${createStorybookPath({
+        libraryName,
+        sliceName,
+        variationId,
+      })}`,
+      storybook
+    ).toString();
+  } catch (e) {
+    return storybook;
+  }
+};

--- a/packages/slice-machine/tests/storybook.test.ts
+++ b/packages/slice-machine/tests/storybook.test.ts
@@ -1,0 +1,56 @@
+import { createStorybookUrl } from "../lib/utils/storybook";
+
+const storybook = "http://localhost:6006";
+const slices = "slices";
+const lowerSliceName = "myawesomez";
+
+const variations = [
+  [
+    "my-variation",
+    `${storybook}/?path=/story/${slices}-${lowerSliceName}--my-variation`,
+  ],
+  [
+    "myVariation2",
+    `${storybook}/?path=/story/${slices}-${lowerSliceName}--my-variation-2`,
+  ],
+  [
+    "2MyVariation",
+    `${storybook}/?path=/story/${slices}-${lowerSliceName}--2-my-variation`,
+  ],
+  [
+    "myVariation20",
+    `${storybook}/?path=/story/${slices}-${lowerSliceName}--my-variation-20`,
+  ],
+  [
+    "myVariation2With20",
+    `${storybook}/?path=/story/${slices}-${lowerSliceName}--my-variation-2-with-20`,
+  ],
+];
+
+describe("screenshots", () => {
+  test("Can create Storybook url from variation id", () => {
+    for (const variation of variations) {
+      const [id, expectedUrl] = variation;
+      const url = createStorybookUrl({
+        storybook,
+        libraryName: slices,
+        sliceName: "MyAwesomeZ",
+        variationId: id,
+      });
+      expect(url).toBe(expectedUrl);
+    }
+  });
+
+  test("Trailing slash creates same result", () => {
+    for (const variation of variations) {
+      const [id, expectedUrl] = variation;
+      const url = createStorybookUrl({
+        storybook: `${storybook}/`,
+        libraryName: slices,
+        sliceName: "MyAwesomeZ",
+        variationId: id,
+      });
+      expect(url).toBe(expectedUrl);
+    }
+  });
+});


### PR DESCRIPTION
Fix a bug that created wrong Storybook Slice URLs when manifest `storybook` property ended with a slash