### PR TITLE
Identify the user if there is a short id on page load

### DIFF
--- a/packages/slice-machine/lib/models/common/Environment.ts
+++ b/packages/slice-machine/lib/models/common/Environment.ts
@@ -24,6 +24,7 @@ export interface BackendEnvironment {
 }
 
 export interface FrontEndEnvironment {
+  shortId?: string;
   manifest: Models.Manifest;
   repo?: string;
   updateVersionInfo: UpdateVersionInfo;

--- a/packages/slice-machine/pages/_app.tsx
+++ b/packages/slice-machine/pages/_app.tsx
@@ -110,6 +110,9 @@ function MyApp({ Component, pageProps }: AppContext & AppInitialProps) {
         serverState.libraries || [],
         serverState.env.updateVersionInfo.currentVersion
       );
+
+      serverState.env.shortId &&
+        Tracker.get().identifyUser(serverState.env.shortId);
     }
 
     const newSliceMap = mapSlices(serverState.libraries);

--- a/packages/slice-machine/server/src/api/state.ts
+++ b/packages/slice-machine/server/src/api/state.ts
@@ -106,6 +106,7 @@ export default async function handler(
   const frontEndEnv: FrontEndEnvironment = {
     ...frontEnv,
     sliceMachineAPIUrl: baseUrl,
+    shortId: prismicData.shortId,
     prismicAPIUrl: prismicData.base,
   };
 


### PR DESCRIPTION
If the user start the sm with the init, we have to identify on the page load to login the user into the segment tracker
