### PR TITLE
fix: pushing slice screenshot to Prismic repo

### DIFF
--- a/packages/slice-machine/server/src/api/slices/push.ts
+++ b/packages/slice-machine/server/src/api/slices/push.ts
@@ -62,7 +62,7 @@ export async function handler(
       const variationId = variationIds[i];
 
       const screenshot = resolvePathsToScreenshot({
-        paths: [env.cwd, path.join(env.cwd, ".slicemchine/assets")],
+        paths: [env.cwd, path.join(env.cwd, ".slicemachine/assets")],
         from,
         sliceName,
         // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Bug fix for pushing slice screenshots to prismic repo

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

Fixes users not being able to push slice screen to Prismic repository.
The change is a fix for a typo. When pushing the screenshots the code could not find the `.slicemachine` folder and therefore could not push to repo

## Checklist:

- [x ] All new and existing tests are passing.

![image](https://user-images.githubusercontent.com/8678089/151532122-a38be4d5-0623-4cad-8b1e-ec2b45708c7f.png)

