### PR TITLE
Rename code widgets to code snippets

### DIFF
--- a/packages/slice-machine/lib/builders/common/Zone/index.js
+++ b/packages/slice-machine/lib/builders/common/Zone/index.js
@@ -90,7 +90,7 @@ const Zone = ({
                     top: "2px",
                   }}
                 />{" "}
-                {showHints ? "Hide" : "Show"} Code Widgets
+                {showHints ? "Hide" : "Show"} code snippets
               </Button>
               <Button
                 ml={2}


### PR DESCRIPTION
Rename code widgets to code snippets

Screenshoot : 

![image](https://user-images.githubusercontent.com/15800180/151963044-9ce95f30-0c85-4b1b-ba20-fc5de5fc71b4.png)
