### PR TITLE
Fix Status on slice list page

### DIFF
--- a/packages/slice-machine/lib/builders/SliceBuilder/Header/index.tsx
+++ b/packages/slice-machine/lib/builders/SliceBuilder/Header/index.tsx
@@ -103,7 +103,7 @@ const Header: React.FC<{
             onClick={Model.isTouched ? onSave : onPush}
             loading={isLoading && !imageLoading}
             disabled={
-              isLoading || !!imageLoading || (!Model.isTouched && !unSynced)
+              isLoading || imageLoading || (!Model.isTouched && !unSynced)
             }
           >
             {Model.isTouched

--- a/packages/slice-machine/lib/builders/SliceBuilder/Header/index.tsx
+++ b/packages/slice-machine/lib/builders/SliceBuilder/Header/index.tsx
@@ -30,7 +30,7 @@ const Header: React.FC<{
   const router = useRouter();
   const [showMeta, setShowMeta] = useState(false);
   const [showVariationModal, setShowVariationModal] = useState(false);
-  const unsynced = ["MODIFIED", "NEW_SLICE"].indexOf(Model.__status) !== -1;
+  const unSynced = ["MODIFIED", "NEW_SLICE"].indexOf(Model.__status) !== -1;
 
   return (
     <Flex
@@ -103,14 +103,12 @@ const Header: React.FC<{
             onClick={Model.isTouched ? onSave : onPush}
             loading={isLoading && !imageLoading}
             disabled={
-              isLoading === true ||
-              imageLoading === true ||
-              (Model.isTouched === false && unsynced === false)
+              isLoading || !!imageLoading || (!Model.isTouched && !unSynced)
             }
           >
             {Model.isTouched
               ? "Save model to filesystem"
-              : unsynced
+              : unSynced
               ? "Push Slice to Prismic"
               : "Your Slice is up to date!"}
           </SaveButton>

--- a/packages/slice-machine/lib/models/common/ComponentUI.ts
+++ b/packages/slice-machine/lib/models/common/ComponentUI.ts
@@ -82,7 +82,7 @@ function computeStatus(
   const slice = remoteSlices.find((s) => component.model.id === s.id);
   if (!slice) return LibStatus.NewSlice;
 
-  const sameVersion = !compareVariations(
+  const sameVersion = compareVariations(
     component.model.variations,
     slice.variations
   );

--- a/packages/slice-machine/src/models/slice/reducer.ts
+++ b/packages/slice-machine/src/models/slice/reducer.ts
@@ -203,11 +203,7 @@ export function reducer(
   return {
     ...result,
     isTouched: (() => {
-      // If the model is not pushed the model cannot be touched
-      if (result.__status === LibStatus.NewSlice) {
-        return false;
-      }
-
+      // Should be the slice be saved ?
       return (
         !equal(result.initialVariations, result.variations) ||
         !equal(result.initialMockConfig, result.mockConfig)
@@ -223,12 +219,14 @@ export function reducer(
         result.screenshotUrls,
         result.initialScreenshotUrls
       );
+
+      // Should be the slice be pushed ?
       const isModelModified = !compareVariations(
         result.remoteVariations,
         result.initialVariations
       );
 
-      return isScreenshotModified || isModelModified
+      return isModelModified || isScreenshotModified
         ? LibStatus.Modified
         : result.__status;
     })(),

--- a/packages/slice-machine/src/models/slice/reducer.ts
+++ b/packages/slice-machine/src/models/slice/reducer.ts
@@ -36,6 +36,7 @@ export function reducer(
       case SliceActions.Push:
         return {
           ...prevState,
+          __status: LibStatus.Synced,
           initialScreenshotUrls: prevState.screenshotUrls,
           remoteVariations: prevState.variations,
         };
@@ -202,16 +203,34 @@ export function reducer(
   return {
     ...result,
     isTouched: (() => {
+      // If the model is not pushed the model cannot be touched
+      if (result.__status === LibStatus.NewSlice) {
+        return false;
+      }
+
       return (
         !equal(result.initialVariations, result.variations) ||
         !equal(result.initialMockConfig, result.mockConfig)
       );
     })(),
     __status: (() => {
-      return !equal(result.screenshotUrls, result.initialScreenshotUrls) ||
-        !compareVariations(result.remoteVariations, result.initialVariations)
+      // If the model is not pushed the only status possible is new slice
+      if (result.__status === LibStatus.NewSlice) {
+        return result.__status;
+      }
+
+      const isScreenshotModified = !equal(
+        result.screenshotUrls,
+        result.initialScreenshotUrls
+      );
+      const isModelModified = !compareVariations(
+        result.remoteVariations,
+        result.initialVariations
+      );
+
+      return isScreenshotModified || isModelModified
         ? LibStatus.Modified
-        : LibStatus.Synced;
+        : result.__status;
     })(),
   };
 }

--- a/packages/slice-machine/tests/__mocks__/componentModel.ts
+++ b/packages/slice-machine/tests/__mocks__/componentModel.ts
@@ -1,0 +1,457 @@
+const allFieldComponent = {
+  from: "slices",
+  href: "slices",
+  pathToSlice: "./slices",
+  infos: {
+    sliceName: "AllFields",
+    fileName: "index",
+    isDirectory: true,
+    extension: "vue",
+    model: {
+      id: "all_fields",
+      type: "SharedSlice",
+      name: "AllFields",
+      description: "AllFields",
+      variations: [
+        {
+          id: "default-slice",
+          name: "Default slice",
+          docURL: "...",
+          version: "sktwi1xtmkfgx8626",
+          description: "AllFields",
+          primary: {
+            "rich-1": {
+              config: {
+                label: "rich-1",
+                placeholder: "",
+                allowTargetBlank: true,
+                single:
+                  "paragraph,preformatted,heading1,heading2,heading3,heading4,heading5,heading6,strong,em,hyperlink,image,embed,list-item,o-list-item,rtl",
+              },
+              type: "StructuredText",
+            },
+            "link-2": {
+              config: {
+                label: "link-2",
+                placeholder: "",
+                select: "web",
+                allowTargetBlank: false,
+              },
+              type: "Link",
+            },
+            "select-3": {
+              config: {
+                label: "select-3",
+                placeholder: "",
+                options: ["1", "2"],
+              },
+              type: "Select",
+            },
+            "date-4": {
+              config: { label: "date-4", placeholder: "" },
+              type: "Date",
+            },
+            "embed-5": {
+              config: { label: "embed-5", placeholder: "" },
+              type: "Embed",
+            },
+            "geo-6": { config: { label: "geo-6" }, type: "GeoPoint" },
+            "keytext-7": {
+              config: { label: "keytext-7", placeholder: "" },
+              type: "Text",
+            },
+            "image-8": {
+              config: { label: "image-8", constraint: {}, thumbnails: [] },
+              type: "Image",
+            },
+            "contentRS-9": {
+              config: {
+                label: "contentRS-9",
+                select: "document",
+                customtypes: [],
+              },
+              type: "Link",
+            },
+            "bool-10": {
+              config: {
+                label: "bool-10",
+                placeholder_false: "false",
+                placeholder_true: "true",
+                default_value: false,
+              },
+              type: "Boolean",
+            },
+            "ts-11": {
+              config: { label: "ts-11", placeholder: "" },
+              type: "Timestamp",
+            },
+            "number-12": {
+              config: { label: "number-12", placeholder: "" },
+              type: "Number",
+            },
+            "color-13": {
+              config: { label: "color-13", placeholder: "" },
+              type: "Color",
+            },
+          },
+          items: {},
+        },
+        {
+          id: "newVar",
+          name: "NewVar",
+          docURL: "...",
+          version: "sktwi1xtmkfgx8626",
+          description: "AllFields",
+          primary: {
+            "rich-1": {
+              config: {
+                label: "rich-1",
+                placeholder: "",
+                allowTargetBlank: true,
+                single:
+                  "paragraph,preformatted,heading1,heading2,heading3,heading4,heading5,heading6,strong,em,hyperlink,image,embed,list-item,o-list-item,rtl",
+              },
+              type: "StructuredText",
+            },
+            "link-2": {
+              config: {
+                label: "link-2",
+                placeholder: "",
+                select: "web",
+                allowTargetBlank: false,
+              },
+              type: "Link",
+            },
+            "select-3": {
+              config: {
+                label: "select-3",
+                placeholder: "",
+                options: ["1", "2"],
+              },
+              type: "Select",
+            },
+            "date-4": {
+              config: { label: "date-4", placeholder: "" },
+              type: "Date",
+            },
+            "embed-5": {
+              config: { label: "embed-5", placeholder: "" },
+              type: "Embed",
+            },
+            "geo-6": { config: { label: "geo-6" }, type: "GeoPoint" },
+            "keytext-7": {
+              config: { label: "keytext-7", placeholder: "" },
+              type: "Text",
+            },
+            "image-8": {
+              config: { label: "image-8", constraint: {}, thumbnails: [] },
+              type: "Image",
+            },
+            "contentRS-9": {
+              config: {
+                label: "contentRS-9",
+                select: "document",
+                customtypes: [],
+              },
+              type: "Link",
+            },
+            "bool-10": {
+              config: {
+                label: "bool-10",
+                placeholder_false: "false",
+                placeholder_true: "true",
+                default_value: false,
+              },
+              type: "Boolean",
+            },
+            "ts-11": {
+              config: { label: "ts-11", placeholder: "" },
+              type: "Timestamp",
+            },
+            "number-12": {
+              config: { label: "number-12", placeholder: "" },
+              type: "Number",
+            },
+            "color-13": {
+              config: { label: "color-13", placeholder: "" },
+              type: "Color",
+            },
+          },
+          items: {},
+        },
+      ],
+    },
+    meta: { id: "all_fields", name: "AllFields", description: "AllFields" },
+    mock: [
+      {
+        variation: "default-slice",
+        name: "Default slice",
+        slice_type: "all_fields",
+        items: [],
+        primary: {
+          "link-2": { link_type: "Web", url: "https://slicemachine.dev" },
+          "select-3": "1",
+          "rich-1": [
+            {
+              type: "paragraph",
+              text: "Eiusmod duis veniam excepteur. Veniam ullamco culpa elit cillum laboris aliquip occaecat culpa quis.",
+              spans: [],
+            },
+          ],
+          "date-4": "2020-10-08",
+          "embed-5": {
+            title: "Data Modelling — Create your Custom Types and Slices",
+            author_name: "Prismic",
+            author_url:
+              "https://www.youtube.com/channel/UCJq6AEgtWeZt7ziQ-fLKOeA",
+            type: "video",
+            height: 113,
+            width: 200,
+            version: "1.0",
+            provider_name: "YouTube",
+            provider_url: "https://www.youtube.com/",
+            thumbnail_height: 360,
+            thumbnail_width: 480,
+            thumbnail_url: "https://i.ytimg.com/vi/c-ATzcy6VkI/hqdefault.jpg",
+            html: '<iframe width="200" height="113" src="https://www.youtube.com/embed/c-ATzcy6VkI?feature=oembed" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>',
+          },
+          "geo-6": { latitude: 48.8583736, longitude: 2.2922926 },
+          "keytext-7": "streamline vertical supply-chains",
+          "image-8": {
+            dimensions: { width: 900, height: 500 },
+            alt: "Placeholder image",
+            copyright: null,
+            url: "https://images.unsplash.com/photo-1525547719571-a2d4ac8945e2?w=900&h=500&fit=crop",
+          },
+          "contentRS-9": { link_type: "Web", url: "https://prismic.io" },
+          "bool-10": false,
+          "ts-11": "2013-09-01T02:40:40.639Z",
+          "number-12": 3620,
+          "color-13": "#068de5",
+        },
+      },
+      {
+        variation: "newVar",
+        name: "NewVar",
+        slice_type: "all_fields",
+        items: [],
+        primary: {
+          "rich-1": [
+            {
+              type: "paragraph",
+              text: "Ut laborum velit eu occaecat sint. Eu laboris ullamco ea ullamco deserunt anim Lorem proident magna deserunt Lorem excepteur.",
+              spans: [],
+            },
+          ],
+          "link-2": { link_type: "Web", url: "https://slicemachine.dev" },
+          "select-3": "1",
+          "date-4": "2021-09-03",
+          "embed-5": {
+            title: "Introducing Slice Machine",
+            author_name: "Prismic",
+            author_url:
+              "https://www.youtube.com/channel/UCJq6AEgtWeZt7ziQ-fLKOeA",
+            type: "video",
+            height: 113,
+            width: 200,
+            version: "1.0",
+            provider_name: "YouTube",
+            provider_url: "https://www.youtube.com/",
+            thumbnail_height: 360,
+            thumbnail_width: 480,
+            thumbnail_url: "https://i.ytimg.com/vi/iewZXv94XGY/hqdefault.jpg",
+            html: '<iframe width="200" height="113" src="https://www.youtube.com/embed/iewZXv94XGY?feature=oembed" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>',
+          },
+          "geo-6": { latitude: 48.8606111, longitude: 2.337644 },
+          "keytext-7": "visualize cross-media action-items",
+          "image-8": {
+            dimensions: { width: 900, height: 500 },
+            alt: "Placeholder image",
+            copyright: null,
+            url: "https://images.unsplash.com/photo-1600861194802-a2b11076bc51?w=900&h=500&fit=crop",
+          },
+          "contentRS-9": { link_type: "Web", url: "http://google.com" },
+          "bool-10": true,
+          "ts-11": "2016-12-06T20:50:21.298Z",
+          "number-12": 7100,
+          "color-13": "#232f0f",
+        },
+      },
+    ],
+    nameConflict: { sliceName: "AllFields", id: "all_fields" },
+    screenshotPaths: {
+      "default-slice": {
+        path: "tests/project/slices/AllFields/default-slice/preview.jpeg",
+      },
+    },
+  },
+  model: {
+    id: "all_fields",
+    type: "SharedSlice",
+    name: "AllFields",
+    description: "AllFields",
+    variations: [
+      {
+        id: "default-slice",
+        name: "Default slice",
+        docURL: "...",
+        version: "sktwi1xtmkfgx8626",
+        description: "AllFields",
+        primary: {
+          "rich-1": {
+            config: {
+              label: "rich-1",
+              placeholder: "",
+              allowTargetBlank: true,
+              single:
+                "paragraph,preformatted,heading1,heading2,heading3,heading4,heading5,heading6,strong,em,hyperlink,image,embed,list-item,o-list-item,rtl",
+            },
+            type: "StructuredText",
+          },
+          "link-2": {
+            config: {
+              label: "link-2",
+              placeholder: "",
+              select: "web",
+              allowTargetBlank: false,
+            },
+            type: "Link",
+          },
+          "select-3": {
+            config: { label: "select-3", placeholder: "", options: ["1", "2"] },
+            type: "Select",
+          },
+          "date-4": {
+            config: { label: "date-4", placeholder: "" },
+            type: "Date",
+          },
+          "embed-5": {
+            config: { label: "embed-5", placeholder: "" },
+            type: "Embed",
+          },
+          "geo-6": { config: { label: "geo-6" }, type: "GeoPoint" },
+          "keytext-7": {
+            config: { label: "keytext-7", placeholder: "" },
+            type: "Text",
+          },
+          "image-8": {
+            config: { label: "image-8", constraint: {}, thumbnails: [] },
+            type: "Image",
+          },
+          "contentRS-9": {
+            config: {
+              label: "contentRS-9",
+              select: "document",
+              customtypes: [],
+            },
+            type: "Link",
+          },
+          "bool-10": {
+            config: {
+              label: "bool-10",
+              placeholder_false: "false",
+              placeholder_true: "true",
+              default_value: false,
+            },
+            type: "Boolean",
+          },
+          "ts-11": {
+            config: { label: "ts-11", placeholder: "" },
+            type: "Timestamp",
+          },
+          "number-12": {
+            config: { label: "number-12", placeholder: "" },
+            type: "Number",
+          },
+          "color-13": {
+            config: { label: "color-13", placeholder: "" },
+            type: "Color",
+          },
+        },
+        items: {},
+      },
+      {
+        id: "newVar",
+        name: "NewVar",
+        docURL: "...",
+        version: "sktwi1xtmkfgx8626",
+        description: "AllFields",
+        primary: {
+          "rich-1": {
+            config: {
+              label: "rich-1",
+              placeholder: "",
+              allowTargetBlank: true,
+              single:
+                "paragraph,preformatted,heading1,heading2,heading3,heading4,heading5,heading6,strong,em,hyperlink,image,embed,list-item,o-list-item,rtl",
+            },
+            type: "StructuredText",
+          },
+          "link-2": {
+            config: {
+              label: "link-2",
+              placeholder: "",
+              select: "web",
+              allowTargetBlank: false,
+            },
+            type: "Link",
+          },
+          "select-3": {
+            config: { label: "select-3", placeholder: "", options: ["1", "2"] },
+            type: "Select",
+          },
+          "date-4": {
+            config: { label: "date-4", placeholder: "" },
+            type: "Date",
+          },
+          "embed-5": {
+            config: { label: "embed-5", placeholder: "" },
+            type: "Embed",
+          },
+          "geo-6": { config: { label: "geo-6" }, type: "GeoPoint" },
+          "keytext-7": {
+            config: { label: "keytext-7", placeholder: "" },
+            type: "Text",
+          },
+          "image-8": {
+            config: { label: "image-8", constraint: {}, thumbnails: [] },
+            type: "Image",
+          },
+          "contentRS-9": {
+            config: {
+              label: "contentRS-9",
+              select: "document",
+              customtypes: [],
+            },
+            type: "Link",
+          },
+          "bool-10": {
+            config: {
+              label: "bool-10",
+              placeholder_false: "false",
+              placeholder_true: "true",
+              default_value: false,
+            },
+            type: "Boolean",
+          },
+          "ts-11": {
+            config: { label: "ts-11", placeholder: "" },
+            type: "Timestamp",
+          },
+          "number-12": {
+            config: { label: "number-12", placeholder: "" },
+            type: "Number",
+          },
+          "color-13": {
+            config: { label: "color-13", placeholder: "" },
+            type: "Color",
+          },
+        },
+        items: {},
+      },
+    ],
+  },
+  migrated: false,
+};
+
+export default allFieldComponent;

--- a/packages/slice-machine/tests/__mocks__/sliceModel.ts
+++ b/packages/slice-machine/tests/__mocks__/sliceModel.ts
@@ -1,6 +1,6 @@
 import { SliceAsObject } from "@slicemachine/core/build/src/models";
 
-export const allFieldSliceModel: SliceAsObject = {
+const allFieldSliceModel: SliceAsObject = {
   id: "all_fields",
   type: "SharedSlice",
   name: "AllFields",
@@ -228,3 +228,5 @@ export const allFieldSliceModel: SliceAsObject = {
     },
   ],
 };
+
+export default allFieldSliceModel;

--- a/packages/slice-machine/tests/lib/models/common/ComponentUI.test.ts
+++ b/packages/slice-machine/tests/lib/models/common/ComponentUI.test.ts
@@ -1,0 +1,42 @@
+import "@testing-library/jest-dom";
+
+import { ComponentUI, LibStatus } from "@lib/models/common/ComponentUI";
+import backendEnvironment from "../../../__mocks__/backendEnvironment";
+import allFieldComponent from "../../../__mocks__/componentModel";
+import allFieldSliceModel from "../../../__mocks__/sliceModel";
+
+describe("ComponentUI", () => {
+  describe("build", () => {
+    test("return NEW_SLICE as status when the slice don't exist", async () => {
+      const componentUI = ComponentUI.build(
+        allFieldComponent,
+        [],
+        backendEnvironment
+      );
+      expect(componentUI.__status).toBe(LibStatus.NewSlice);
+    });
+    test("return SYNCED as status when the slice don't exist", async () => {
+      const componentUI = ComponentUI.build(
+        allFieldComponent,
+        [allFieldSliceModel],
+        backendEnvironment
+      );
+      expect(componentUI.__status).toBe(LibStatus.Synced);
+    });
+    test("return MODIFIED as status when the slice don't exist", async () => {
+      const modifiedAllFieldComponent = {
+        ...allFieldComponent,
+        model: {
+          ...allFieldComponent.model,
+          variations: [],
+        },
+      };
+      const componentUI = ComponentUI.build(
+        modifiedAllFieldComponent,
+        [allFieldSliceModel],
+        backendEnvironment
+      );
+      expect(componentUI.__status).toBe(LibStatus.Modified);
+    });
+  });
+});

--- a/packages/slice-machine/tests/server/services/sliceService.test.ts
+++ b/packages/slice-machine/tests/server/services/sliceService.test.ts
@@ -7,7 +7,7 @@ import {
 import { upload } from "../../../server/src/api/services/uploadScreenshotClient";
 
 import DefaultClient from "../../../lib/models/common/http/DefaultClient";
-import { allFieldSliceModel } from "../../__mocks__/sliceModel";
+import allFieldSliceModel from "../../__mocks__/sliceModel";
 import backendEnvironment from "../../__mocks__/backendEnvironment";
 import { resolvePathsToScreenshot } from "@slicemachine/core/build/src/libraries/screenshot";
 


### PR DESCRIPTION
This PR fix 3 bugs : 
- When you go on a slice detail page, the status is always set to modified even if you don't do any modifications
- After pushing a slice to prismic the status was not changed to synced on the client side
- A slice synced with the remote slice had the "modified" status instead of "synced"