### PR TITLE
Fix mock override

### DIFF
--- a/packages/slice-machine/server/src/api/custom-types/push.ts
+++ b/packages/slice-machine/server/src/api/custom-types/push.ts
@@ -127,7 +127,6 @@ export default async function handler(req: RequestWithEnv): Promise<ApiResult> {
           sliceName: slice.infos.sliceName,
           from: slice.from,
           model: slice.model,
-          mockConfig: slice.infos.mock,
         });
         console.log("[custom-types/push] Pushing slice", sliceKey);
         await pushSlice(state.env, state.remoteSlices, {

--- a/packages/slice-machine/server/src/api/custom-types/push.ts
+++ b/packages/slice-machine/server/src/api/custom-types/push.ts
@@ -1,6 +1,5 @@
 import { getBackendState } from "../state";
 import { pushSlice } from "../slices/push";
-import { handler as saveSlice } from "../slices/save";
 
 import { onError } from "../common/error";
 import Files from "@lib/utils/files";
@@ -122,12 +121,6 @@ export default async function handler(req: RequestWithEnv): Promise<ApiResult> {
     const slice = localSlices[sliceKey];
     if (slice) {
       try {
-        console.log("[custom-types/push] Saving slice", sliceKey);
-        await saveSlice(state.env, {
-          sliceName: slice.infos.sliceName,
-          from: slice.from,
-          model: slice.model,
-        });
         console.log("[custom-types/push] Pushing slice", sliceKey);
         await pushSlice(state.env, state.remoteSlices, {
           sliceName: slice.infos.sliceName,

--- a/packages/slice-machine/server/src/api/slices/save.ts
+++ b/packages/slice-machine/server/src/api/slices/save.ts
@@ -5,7 +5,7 @@ import Storybook from "../storybook";
 
 import getEnv from "../services/getEnv";
 import mock from "@lib/mock/Slice";
-import { insert as insertMockConfig } from "@lib/mock/misc/fs";
+import { getConfig, insert as insertMockConfig } from "@lib/mock/misc/fs";
 import Files from "@lib/utils/files";
 import { SliceMockConfig } from "@lib/models/common/MockConfig";
 import { generateScreenshot } from "../screenshots/generate";
@@ -22,11 +22,13 @@ export async function handler(
   await onBeforeSaveSlice({ from, sliceName, model }, env);
 
   // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-  const updatedMockConfig = insertMockConfig(env.cwd, {
-    key: sliceName,
-    prefix: from,
-    value: mockConfig,
-  });
+  const updatedMockConfig = mockConfig
+    ? insertMockConfig(env.cwd, {
+        key: sliceName,
+        prefix: from,
+        value: mockConfig,
+      })
+    : getConfig(env.cwd);
 
   console.log("\n\n[slice/save]: Updating slice model");
 


### PR DESCRIPTION
We fix two problems : 
- The mock configuration can be override 
- The slices are saved in the filesystem before pushing the customTypes (not required anymore as we save the slice in the FS on creation)
- 