### PR TITLE
update the slicezone modal style

### DIFF
--- a/packages/slice-machine/lib/builders/CustomTypeBuilder/SliceZone/UpdateSliceZoneModal.tsx
+++ b/packages/slice-machine/lib/builders/CustomTypeBuilder/SliceZone/UpdateSliceZoneModal.tsx
@@ -29,7 +29,7 @@ const UpdateSliceZoneModal: React.FC<UpdateSliceModalProps> = ({
 
   return (
     <ModalFormCard
-      widthInPx={"500px"}
+      widthInPx={projectHasAvailableSlices ? undefined : "500px"}
       isOpen={isOpen}
       formId={formId}
       close={close}


### PR DESCRIPTION
- change the width of the modal when there is no slice only

Before
![image (4)](https://user-images.githubusercontent.com/15800180/157908386-b5598d32-43f9-42fa-b776-da5150db0e06.png)

After : 
<img width="955" alt="image" src="https://user-images.githubusercontent.com/15800180/157908315-f0ff8ebd-df81-468a-9b27-2299182007c4.png">
