### PR TITLE
Fix video tutorials tooltip to be under modals.

### DIFF
--- a/packages/slice-machine/components/AppLayout/Navigation/Menu/Navigation/VideoItem.module.css
+++ b/packages/slice-machine/components/AppLayout/Navigation/Menu/Navigation/VideoItem.module.css
@@ -1,4 +1,5 @@
 div.videoTutorialsContainer {
   border-radius: 4px;
   padding: 16px;
+  z-index: 0;
 }


### PR DESCRIPTION
## Description

Small fix to prevent the video tutorial tooltip to be over the modals.

<img width="1202" alt="image" src="https://user-images.githubusercontent.com/41187899/162262871-127e9b08-6a23-47d6-ad45-86ff42a48cb0.png">
