### PR TITLE
[Tech-debt] Remove initialModel from the selectedCustomType store

### DIFF
--- a/packages/slice-machine/src/modules/availableCustomTypes/index.ts
+++ b/packages/slice-machine/src/modules/availableCustomTypes/index.ts
@@ -17,6 +17,7 @@ import {
   normalizeFrontendCustomType,
   normalizeFrontendCustomTypes,
 } from "@src/normalizers/customType";
+import { saveCustomTypeCreator } from "../selectedCustomType";
 
 // Action Creators
 export const createCustomTypeCreator = createAsyncAction(
@@ -36,7 +37,8 @@ export const createCustomTypeCreator = createAsyncAction(
 
 type CustomTypesActions =
   | ActionType<typeof refreshStateCreator>
-  | ActionType<typeof createCustomTypeCreator>;
+  | ActionType<typeof createCustomTypeCreator>
+  | ActionType<typeof saveCustomTypeCreator>; // save of custom type in the builder
 
 // Selectors
 export const selectAllCustomTypes = (
@@ -98,6 +100,23 @@ export const availableCustomTypesReducer: Reducer<
         ...normalizedNewCustomType,
       };
     }
+
+    case getType(saveCustomTypeCreator.success): {
+      const updatedCustomType: CustomTypeSM = action.payload;
+
+      // local should be updated after a save.
+      const actualCustomType = state[updatedCustomType.id];
+      const normalizedNewCustomType = normalizeFrontendCustomType(
+        updatedCustomType,
+        actualCustomType.remote
+      );
+
+      return {
+        ...state,
+        ...normalizedNewCustomType,
+      };
+    }
+
     default:
       return state;
   }

--- a/packages/slice-machine/src/modules/selectedCustomType/actions.ts
+++ b/packages/slice-machine/src/modules/selectedCustomType/actions.ts
@@ -40,7 +40,7 @@ export const saveCustomTypeCreator = createAsyncAction(
   "CUSTOM_TYPE/SAVE.REQUEST",
   "CUSTOM_TYPE/SAVE.RESPONSE",
   "CUSTOM_TYPE/SAVE.FAILURE"
-)<undefined, undefined>();
+)<undefined, CustomTypeSM>();
 
 export const pushCustomTypeCreator = createAsyncAction(
   "CUSTOM_TYPE/PUSH.REQUEST",

--- a/packages/slice-machine/src/modules/selectedCustomType/reducer.ts
+++ b/packages/slice-machine/src/modules/selectedCustomType/reducer.ts
@@ -47,7 +47,6 @@ export const selectedCustomTypeReducer: Reducer<
       return {
         ...state,
         model: action.payload.model,
-        initialModel: action.payload.model,
         remoteModel: action.payload.remoteModel,
         mockConfig: action.payload.mockConfig,
         initialMockConfig: action.payload.mockConfig,
@@ -57,7 +56,6 @@ export const selectedCustomTypeReducer: Reducer<
 
       return {
         ...state,
-        initialModel: state.model,
         initialMockConfig: state.mockConfig,
       };
     }
@@ -66,7 +64,6 @@ export const selectedCustomTypeReducer: Reducer<
 
       return {
         ...state,
-        initialModel: state.model,
         remoteModel: state.model,
       };
     case getType(createTabCreator):

--- a/packages/slice-machine/src/modules/selectedCustomType/sagas.ts
+++ b/packages/slice-machine/src/modules/selectedCustomType/sagas.ts
@@ -30,7 +30,7 @@ export function* saveCustomTypeSaga() {
     }
 
     yield call(saveCustomType, currentCustomType, currentMockConfig);
-    yield put(saveCustomTypeCreator.success());
+    yield put(saveCustomTypeCreator.success(currentCustomType));
     yield put(
       openToasterCreator({
         message: "Model & mocks have been generated successfully!",

--- a/packages/slice-machine/src/modules/selectedCustomType/selectors.ts
+++ b/packages/slice-machine/src/modules/selectedCustomType/selectors.ts
@@ -9,6 +9,7 @@ import {
   CustomTypeSM,
   TabSM,
 } from "@slicemachine/core/build/models/CustomType";
+import { selectCustomTypeById } from "../availableCustomTypes";
 
 // Selectors
 export const selectCurrentCustomType = (
@@ -41,11 +42,13 @@ export const selectIsCurrentCustomTypeHasPendingModifications = (
   store: SliceMachineStoreType
 ) => {
   if (!store.selectedCustomType) return false;
+  const initialModel = selectCustomTypeById(
+    store,
+    store.selectedCustomType.model.id
+  );
+
   return (
-    !equal(
-      store.selectedCustomType.initialModel,
-      store.selectedCustomType.model
-    ) ||
+    !equal(initialModel?.local, store.selectedCustomType.model) ||
     !equal(
       store.selectedCustomType.initialMockConfig,
       store.selectedCustomType.mockConfig

--- a/packages/slice-machine/src/modules/selectedCustomType/types.ts
+++ b/packages/slice-machine/src/modules/selectedCustomType/types.ts
@@ -14,7 +14,6 @@ export type PoolOfFields = ReadonlyArray<{ key: string; value: TabField }>;
 
 export type SelectedCustomTypeStoreType = {
   model: CustomTypeSM;
-  initialModel: CustomTypeSM;
   remoteModel: CustomTypeSM | undefined;
   mockConfig: CustomTypeMockConfig;
   initialMockConfig: CustomTypeMockConfig;

--- a/packages/slice-machine/tests/src/modules/selectedCustomType/reducer.test.ts
+++ b/packages/slice-machine/tests/src/modules/selectedCustomType/reducer.test.ts
@@ -22,7 +22,6 @@ const customTypeAsArray = CustomTypes.toSM(jsonModel as unknown as CustomType);
 
 const dummyCustomTypesState: SelectedCustomTypeStoreType = {
   model: customTypeAsArray,
-  initialModel: customTypeAsArray,
   remoteModel: null,
   mockConfig: {},
   initialMockConfig: {},
@@ -54,7 +53,6 @@ describe("[Selected Custom type module]", () => {
         )
       ).toEqual({
         model: customTypeAsArray,
-        initialModel: customTypeAsArray,
         remoteModel: null,
         mockConfig: {},
         initialMockConfig: {},

--- a/packages/slice-machine/tests/src/modules/selectedCustomType/sagas.test.ts
+++ b/packages/slice-machine/tests/src/modules/selectedCustomType/sagas.test.ts
@@ -56,7 +56,7 @@ describe("[Selected Custom type sagas]", () => {
       saga.next(customTypeModel).select(selectCurrentMockConfig);
       saga.next({}).call(saveCustomType, customTypeModel, {});
 
-      saga.next().put(saveCustomTypeCreator.success());
+      saga.next().put(saveCustomTypeCreator.success(customTypeModel));
       saga.next().put(
         openToasterCreator({
           message: "Model & mocks have been generated successfully!",

--- a/packages/slice-machine/tests/src/modules/selectedCustomType/selectors.test.ts
+++ b/packages/slice-machine/tests/src/modules/selectedCustomType/selectors.test.ts
@@ -56,9 +56,11 @@ describe("[Selected Custom type selectors]", () => {
     test("it computes correctly the state of the modifications 1/4", () => {
       const customTypeStatus = selectIsCurrentCustomTypeHasPendingModifications(
         {
+          availableCustomTypes: {
+            // no custom type here, as if changes weren't saved yet
+          },
           selectedCustomType: {
             model,
-            initialModel: null,
             mockConfig: {},
             initialMockConfig: {},
           },
@@ -70,9 +72,13 @@ describe("[Selected Custom type selectors]", () => {
     test("it computes correctly the state of the modifications 2/4", () => {
       const customTypeStatus = selectIsCurrentCustomTypeHasPendingModifications(
         {
+          availableCustomTypes: {
+            [model.id]: {
+              local: model,
+            },
+          },
           selectedCustomType: {
             model,
-            initialModel: model,
             mockConfig: {},
             initialMockConfig: {},
           },
@@ -84,9 +90,13 @@ describe("[Selected Custom type selectors]", () => {
     test("it computes correctly the state of the modifications 3/4", () => {
       const customTypeStatus = selectIsCurrentCustomTypeHasPendingModifications(
         {
+          availableCustomTypes: {
+            [model.id]: {
+              local: { ...model, label: `differ-from-${model.label}` },
+            },
+          },
           selectedCustomType: {
             model,
-            initialModel: { ...model, label: `differ-from-${model.label}` },
             mockConfig: {},
             initialMockConfig: {},
           },
@@ -97,9 +107,13 @@ describe("[Selected Custom type selectors]", () => {
     test("it computes correctly the state of the modifications 4/4", () => {
       const customTypeStatus = selectIsCurrentCustomTypeHasPendingModifications(
         {
+          availableCustomTypes: {
+            [model.id]: {
+              local: { ...model, tabs: {} },
+            },
+          },
           selectedCustomType: {
             model,
-            initialModel: { ...model, tabs: {} },
             mockConfig: {},
             initialMockConfig: {},
           },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

This PR is meant to simplify the Redux stores of Slice Machine UI by removing duplicated data between the custom type list and the selected custom type.

<!--- A cute animal picture is welcome to close your PR! -->
