### PR TITLE
Mm/initconfigre with framework

### DIFF
--- a/packages/init/__tests__/configure-project.test.ts
+++ b/packages/init/__tests__/configure-project.test.ts
@@ -137,6 +137,7 @@ describe("configure-project", () => {
       _latest: "0.0.41",
       apiEndpoint: "https://testing-repo.prismic.io/api/v2",
       libraries: ["@/slices"],
+      framework: "react",
     });
     expect(patchManifestMock).not.toBeCalled();
 

--- a/packages/init/__tests__/configure-project.test.ts
+++ b/packages/init/__tests__/configure-project.test.ts
@@ -145,6 +145,70 @@ describe("configure-project", () => {
     expect(MockTracker).toHaveBeenCalled();
   });
 
+  test("it should add the framework to sm.json if frame work was detected", async () => {
+    retrieveManifestMock.mockReturnValue({
+      exists: false,
+      content: null,
+    });
+    addJsonPackageSmScriptMock.mockReturnValue(true);
+
+    await configureProject(
+      client,
+      fakeCwd,
+      fakeRepository,
+      {
+        value: Models.Frameworks.next,
+        manuallyAdded: true,
+      },
+      []
+    );
+
+    expect(retrieveManifestMock).toBeCalled();
+    expect(createManifestMock).toHaveBeenCalledWith("./", {
+      _latest: "0.0.41",
+      apiEndpoint: "https://testing-repo.prismic.io/api/v2",
+      libraries: ["@/slices"],
+      framework: "next",
+    });
+    expect(patchManifestMock).not.toBeCalled();
+
+    expect(successFn).toHaveBeenCalled();
+    expect(failFn).not.toHaveBeenCalled();
+    expect(MockTracker).toHaveBeenCalled();
+  });
+
+  test("should set the framework property if detect frame work had to prompt for the framework", async () => {
+    retrieveManifestMock.mockReturnValue({
+      exists: false,
+      content: null,
+    });
+    addJsonPackageSmScriptMock.mockReturnValue(true);
+
+    await configureProject(
+      client,
+      fakeCwd,
+      fakeRepository,
+      {
+        value: Models.Frameworks.next,
+        manuallyAdded: false,
+      },
+      []
+    );
+
+    expect(retrieveManifestMock).toBeCalled();
+    expect(createManifestMock).toHaveBeenCalledWith("./", {
+      _latest: "0.0.41",
+      apiEndpoint: "https://testing-repo.prismic.io/api/v2",
+      libraries: ["@/slices"],
+      framework: "next",
+    });
+    expect(patchManifestMock).not.toBeCalled();
+
+    expect(successFn).toHaveBeenCalled();
+    expect(failFn).not.toHaveBeenCalled();
+    expect(MockTracker).toHaveBeenCalled();
+  });
+
   test("it should patch the existing manifest", async () => {
     retrieveManifestMock.mockReturnValue({
       exists: true,

--- a/packages/init/src/steps/configure-project.ts
+++ b/packages/init/src/steps/configure-project.ts
@@ -47,7 +47,7 @@ export async function configureProject(
         repositoryDomainName
       ),
       libraries: [...libs, ...sliceLibPath], // odd case here for staters
-      ...(framework.manuallyAdded ? { framework: framework.value } : {}),
+      framework: framework.value,
       ...(!tracking ? { tracking } : {}),
     };
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
Issue:  Framework was set in the sm.json to `previouseNext` still investigating the cause of the issue.

Looks like this isn't an init script problem.

To recreate: 

`npx create-next-app foo && npx @slicemachine/init@alpha`
wait until install completes, check sm.json it should be fine
`npm install --save-dev slice-machine-ui@alpha`
`npm run slicemachine`

notice some migrations happen
<img width="688" alt="Screenshot 2022-08-02 at 19 01 07" src="https://user-images.githubusercontent.com/7499570/182432505-0931172d-8d37-4248-a959-aff1fd63a557.png">

but if I cat sm.json framework is set to the wrong value.
```
{
  "_latest": "0.3.0",
  "apiEndpoint": "https://init-test-020822.prismic.io/api/v2",
  "libraries": [
    "@/slices"
  ],
  "framework": "previousNext"
}
```
 
 Found the issue,
 
 So configure-project happens before slice-machine is installed, therefore it sets _latest to the default version.
 A fix for this would be to wait until after npm install has run then set the version in sm.json

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] All new and existing tests are passing.

<!--- A cute animal picture is welcome to close your PR! -->
