### PR TITLE
Mm/init fix setting latest

### DIFF
--- a/packages/init/__tests__/configure-project.test.ts
+++ b/packages/init/__tests__/configure-project.test.ts
@@ -134,7 +134,6 @@ describe("configure-project", () => {
 
     expect(retrieveManifestMock).toBeCalled();
     expect(createManifestMock).toHaveBeenCalledWith("./", {
-      _latest: "0.0.41",
       apiEndpoint: "https://testing-repo.prismic.io/api/v2",
       libraries: ["@/slices"],
     });

--- a/packages/init/__tests__/set-version.test.ts
+++ b/packages/init/__tests__/set-version.test.ts
@@ -1,0 +1,55 @@
+import { describe, test, afterEach, expect } from "@jest/globals";
+import { setVersion } from "../src/steps/set-version";
+import mockfs from "mock-fs";
+import os from "os";
+import path from "path";
+import fs from "fs";
+
+const TMP_DIR = path.join(os.tmpdir(), "init-version");
+
+describe("set-version", () => {
+  afterEach(() => {
+    mockfs.restore();
+  });
+
+  test("it should not set _latest in sm.json if it is already defined", () => {
+    mockfs({
+      [TMP_DIR]: {
+        "sm.json": JSON.stringify({
+          apiEndpoint: "https://foo-bar.prismic.io",
+          _latest: "0.0.1",
+        }),
+        "package.json": JSON.stringify({
+          devDependencies: { "slice-machine-ui": "5.0.0" },
+        }),
+      },
+    });
+
+    setVersion(TMP_DIR);
+
+    const smJson = JSON.parse(
+      fs.readFileSync(path.join(TMP_DIR, "sm.json"), "utf-8")
+    ) as unknown as { _latest?: string };
+    expect(smJson._latest).toEqual("0.0.1");
+  });
+
+  test("it should set _latest in sm.json to the installed version of slice-machine-ui", () => {
+    mockfs({
+      [TMP_DIR]: {
+        "sm.json": JSON.stringify({
+          apiEndpoint: "https://foo-bar.prismic.io",
+        }),
+        "package.json": JSON.stringify({
+          devDependencies: { "slice-machine-ui": "5.0.0" },
+        }),
+      },
+    });
+
+    setVersion(TMP_DIR);
+
+    const smJson = JSON.parse(
+      fs.readFileSync(path.join(TMP_DIR, "sm.json"), "utf-8")
+    ) as unknown as { _latest?: string };
+    expect(smJson._latest).toEqual("5.0.0");
+  });
+});

--- a/packages/init/src/index.ts
+++ b/packages/init/src/index.ts
@@ -11,6 +11,7 @@ import {
   detectFramework,
   installLib,
   sendStarterData,
+  setVersion,
 } from "./steps";
 import {
   findArgument,
@@ -96,6 +97,8 @@ async function init() {
 
   // Install the required dependencies in the project.
   await installRequiredDependencies(cwd, frameworkResult.value, wasStarter);
+
+  setVersion();
 
   // Ask the user to run slice-machine.
   displayFinalMessage(cwd, wasStarter, repository, client.apisEndpoints.Wroom);

--- a/packages/init/src/index.ts
+++ b/packages/init/src/index.ts
@@ -98,7 +98,7 @@ async function init() {
   // Install the required dependencies in the project.
   await installRequiredDependencies(cwd, frameworkResult.value, wasStarter);
 
-  setVersion();
+  setVersion(cwd);
 
   // Ask the user to run slice-machine.
   displayFinalMessage(cwd, wasStarter, repository, client.apisEndpoints.Wroom);

--- a/packages/init/src/steps/configure-project.ts
+++ b/packages/init/src/steps/configure-project.ts
@@ -1,12 +1,9 @@
-import { CONSTS } from "@slicemachine/core";
 import type { Models } from "@slicemachine/core";
 import * as Prismic from "@slicemachine/core/build/prismic";
 import * as NodeUtils from "@slicemachine/core/build/node-utils";
 import { FrameworkResult } from "./detect-framework";
 import { InitClient, logs } from "../utils";
 import Tracker from "../utils/tracker";
-
-const defaultSliceMachineVersion = "0.0.41";
 
 export async function configureProject(
   client: InitClient,
@@ -24,11 +21,6 @@ export async function configureProject(
 
   try {
     const manifest = NodeUtils.retrieveManifest(cwd);
-    const packageJson = NodeUtils.retrieveJsonPackage(cwd);
-
-    const sliceMachineVersionInstalled =
-      getTheSliceMachineVersionInstalled(packageJson);
-
     const manifestAlreadyExistWithContent = manifest.exists && manifest.content;
 
     const libs =
@@ -39,9 +31,7 @@ export async function configureProject(
         : ["@/slices"];
 
     const manifestUpdated: Models.Manifest = {
-      ...(manifestAlreadyExistWithContent
-        ? manifest.content
-        : { _latest: sliceMachineVersionInstalled }),
+      ...(manifestAlreadyExistWithContent ? manifest.content : {}),
       apiEndpoint: Prismic.Endpoints.buildRepositoryEndpoint(
         client.apisEndpoints.Wroom,
         repositoryDomainName
@@ -80,39 +70,3 @@ export async function configureProject(
     process.exit(-1);
   }
 }
-
-const getTheSliceMachineVersionInstalled = (
-  packageJson: NodeUtils.FileContent<NodeUtils.JsonPackage>
-) => {
-  const sliceMachinePackageInstalled = Object.entries(
-    packageJson.content?.devDependencies || {}
-  ).find((devDependency) => {
-    if (devDependency[0] === CONSTS.SM_PACKAGE_NAME) {
-      return devDependency;
-    }
-  });
-
-  if (!sliceMachinePackageInstalled) {
-    return defaultSliceMachineVersion;
-  }
-
-  const extractedVersion = extractVersionNumberFromSemver(
-    sliceMachinePackageInstalled[1]
-  );
-
-  if (!extractedVersion) {
-    return defaultSliceMachineVersion;
-  }
-
-  return extractedVersion;
-};
-
-const extractVersionNumberFromSemver = (semver: string) => {
-  const versionFound = semver.match(/\d+\.\d+\.\d+/);
-
-  if (versionFound && versionFound.length > 0) {
-    return versionFound[0];
-  }
-
-  return null;
-};

--- a/packages/init/src/steps/index.ts
+++ b/packages/init/src/steps/index.ts
@@ -7,3 +7,4 @@ export { configureProject } from "./configure-project";
 export { displayFinalMessage } from "./display-final-message";
 export { installLib } from "./install-lib";
 export { sendStarterData } from "./sendStarterData";
+export { setVersion } from "./set-version";

--- a/packages/init/src/steps/set-version.ts
+++ b/packages/init/src/steps/set-version.ts
@@ -1,0 +1,61 @@
+import { CONSTS } from "@slicemachine/core";
+import * as NodeUtils from "@slicemachine/core/build/node-utils";
+import { logs } from "../utils";
+
+const defaultSliceMachineVersion = "0.0.41";
+
+const getTheSliceMachineVersionInstalled = (
+  packageJson: NodeUtils.FileContent<NodeUtils.JsonPackage>
+) => {
+  const sliceMachinePackageInstalled = Object.entries(
+    packageJson.content?.devDependencies || {}
+  ).find((devDependency) => {
+    if (devDependency[0] === CONSTS.SM_PACKAGE_NAME) {
+      return devDependency;
+    }
+  });
+
+  if (!sliceMachinePackageInstalled) {
+    return defaultSliceMachineVersion;
+  }
+
+  const extractedVersion = extractVersionNumberFromSemver(
+    sliceMachinePackageInstalled[1]
+  );
+
+  if (!extractedVersion) {
+    return defaultSliceMachineVersion;
+  }
+
+  return extractedVersion;
+};
+
+const extractVersionNumberFromSemver = (semver: string) => {
+  const versionFound = semver.match(/\d+\.\d+\.\d+/);
+
+  if (versionFound && versionFound.length > 0) {
+    return versionFound[0];
+  }
+
+  return null;
+};
+
+export function setVersion(cwd: string): void {
+  try {
+    const manifest = NodeUtils.retrieveManifest(cwd);
+
+    if (manifest.content?._latest) {
+      return;
+    }
+
+    const packageJson = NodeUtils.retrieveJsonPackage(cwd);
+    const sliceMachineVersionInstalled =
+      getTheSliceMachineVersionInstalled(packageJson);
+
+    NodeUtils.patchManifest(cwd, { _latest: sliceMachineVersionInstalled });
+  } catch {
+    logs.warning(
+      "Could not set _latest to installed slice-machine-ui version in sm.json"
+    );
+  }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
Set version was being called before install, which cause the _latest property in sm.json to default to an old version and slice-machine-ui would try to migrate when being run
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] All new and existing tests are passing.

<!--- A cute animal picture is welcome to close your PR! -->
