### PR TITLE
fix: move `checkSimulatorSetup` to when taking screenshot with simulator rather than when uploading custom screenshot file

### DIFF
--- a/packages/slice-machine/lib/builders/SliceBuilder/index.tsx
+++ b/packages/slice-machine/lib/builders/SliceBuilder/index.tsx
@@ -105,13 +105,13 @@ const SliceBuilder: React.FC<SliceBuilderProps> = ({
   if (!variation || !sliceView) return null;
 
   const onTakingSliceScreenshot = () => {
-    generateSliceScreenshot(variation.id, component, setData);
+    checkSimulatorSetup(true, () =>
+      generateSliceScreenshot(variation.id, component, setData)
+    );
   };
 
   const onTakingSliceCustomScreenshot = (file: Blob) => {
-    checkSimulatorSetup(true, () =>
-      generateSliceCustomScreenshot(variation.id, component, setData, file)
-    );
+    generateSliceCustomScreenshot(variation.id, component, setData, file);
   };
 
   const onPushSlice = () => {


### PR DESCRIPTION
## Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description
During the last refactor it seems `checkSimulatorSetup` was accidentally applied to the function that handles uploading custom screenshot files rather than the function that handles taking a screenshot with the simulator.

We are using storybook, not slice simulator, and this broke uploading custom screenshots for us. It seemed strange why we would need the slice simulator set up to simply upload a screenshot.

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] All new and existing tests are passing.

![samoyed-dog](https://user-images.githubusercontent.com/128399/183055788-26304bc2-4eee-48fa-b147-38fe71b7a6c0.gif)
