### PR TITLE
feature(): add ct status when user is offline

### DIFF
--- a/packages/slice-machine/components/Badge/StatusBadgeWithTooltip.tsx
+++ b/packages/slice-machine/components/Badge/StatusBadgeWithTooltip.tsx
@@ -2,6 +2,7 @@ import ReactTooltip from "react-tooltip";
 import { Badge, Flex, Text } from "theme-ui";
 import { CustomTypeSM } from "@slicemachine/core/build/models/CustomType";
 import { CustomTypeStatus } from "../../src/modules/selectedCustomType/types";
+import { useNetwork } from "@src/hooks/useNetwork";
 
 const statusEnumToDisplayNameAndTooltip = (status?: string) => {
   switch (status) {
@@ -23,7 +24,19 @@ const statusEnumToDisplayNameAndTooltip = (status?: string) => {
         statusTooltip:
           "This Custom Type is in sync with the remote repository.",
       };
-    case CustomTypeStatus.Unknown:
+    case CustomTypeStatus.UnknownOffline:
+      return {
+        statusDisplayName: "Unknown",
+        statusTooltip:
+          "Data from the remote repository could not be fetched (no internet connection).",
+      };
+    case CustomTypeStatus.UnknownDisconnected:
+      return {
+        statusDisplayName: "Unknown",
+        statusTooltip:
+          "Data from the remote repository could not be fetched (not connected to Prismic).",
+      };
+    case CustomTypeStatus.UnknownDefault:
       return {
         statusDisplayName: "Unknown",
         statusTooltip:
@@ -45,6 +58,12 @@ interface StatusBadgeWithTooltipProps {
 export const StatusBadgeWithTooltip: React.FC<StatusBadgeWithTooltipProps> = ({
   customType,
 }) => {
+  const isOnline = useNetwork();
+
+  customType.__status = !isOnline
+    ? CustomTypeStatus.UnknownOffline
+    : customType.__status;
+
   const { statusDisplayName, statusTooltip } =
     statusEnumToDisplayNameAndTooltip(customType.__status);
 

--- a/packages/slice-machine/components/Badge/StatusBadgeWithTooltip.tsx
+++ b/packages/slice-machine/components/Badge/StatusBadgeWithTooltip.tsx
@@ -36,12 +36,6 @@ const statusEnumToDisplayNameAndTooltip = (status?: string) => {
         statusTooltip:
           "Data from the remote repository could not be fetched (not connected to Prismic).",
       };
-    case CustomTypeStatus.UnknownDefault:
-      return {
-        statusDisplayName: "Unknown",
-        statusTooltip:
-          "Data from the remote repository could not be fetched (unknown error).",
-      };
     default:
       return {
         statusDisplayName: "Unknown",

--- a/packages/slice-machine/components/Badge/StatusBadgeWithTooltip.tsx
+++ b/packages/slice-machine/components/Badge/StatusBadgeWithTooltip.tsx
@@ -54,22 +54,27 @@ export const StatusBadgeWithTooltip: React.FC<StatusBadgeWithTooltipProps> = ({
 }) => {
   const isOnline = useNetwork();
 
-  customType.__status = !isOnline
+  const updatedCustomTypeStatus = !isOnline
     ? CustomTypeStatus.UnknownOffline
     : customType.__status;
 
+  const updatedCustomType = {
+    ...customType,
+    __status: updatedCustomTypeStatus,
+  };
+
   const { statusDisplayName, statusTooltip } =
-    statusEnumToDisplayNameAndTooltip(customType.__status);
+    statusEnumToDisplayNameAndTooltip(updatedCustomType.__status);
 
   return (
     <>
-      <Text data-for={`${customType.id}-tooltip`} data-tip>
-        <Badge mr="2" variant={customType.__status}>
+      <Text data-for={`${updatedCustomType.id}-tooltip`} data-tip>
+        <Badge mr="2" variant={updatedCustomType.__status}>
           {statusDisplayName}
         </Badge>
       </Text>
       <ReactTooltip
-        id={`${customType.id}-tooltip`}
+        id={`${updatedCustomType.id}-tooltip`}
         type="dark"
         multiline
         border

--- a/packages/slice-machine/lib/builders/CustomTypeBuilder/Layout/Header/primaryButton.tsx
+++ b/packages/slice-machine/lib/builders/CustomTypeBuilder/Layout/Header/primaryButton.tsx
@@ -47,14 +47,7 @@ export const PrimaryButton: React.FC<PrimaryButtonProps> = ({
     );
   }
 
-  if (
-    [
-      CustomTypeStatus.New,
-      CustomTypeStatus.Modified,
-      CustomTypeStatus.UnknownOffline,
-      CustomTypeStatus.UnknownDisconnected,
-    ].includes(customTypeStatus)
-  ) {
+  if (customTypeStatus !== CustomTypeStatus.Synced) {
     return (
       <Button
         onClick={() => {

--- a/packages/slice-machine/lib/builders/CustomTypeBuilder/Layout/Header/primaryButton.tsx
+++ b/packages/slice-machine/lib/builders/CustomTypeBuilder/Layout/Header/primaryButton.tsx
@@ -51,7 +51,6 @@ export const PrimaryButton: React.FC<PrimaryButtonProps> = ({
     [
       CustomTypeStatus.New,
       CustomTypeStatus.Modified,
-      CustomTypeStatus.UnknownDefault,
       CustomTypeStatus.UnknownOffline,
       CustomTypeStatus.UnknownDisconnected,
     ].includes(customTypeStatus)

--- a/packages/slice-machine/lib/builders/CustomTypeBuilder/Layout/Header/primaryButton.tsx
+++ b/packages/slice-machine/lib/builders/CustomTypeBuilder/Layout/Header/primaryButton.tsx
@@ -51,7 +51,9 @@ export const PrimaryButton: React.FC<PrimaryButtonProps> = ({
     [
       CustomTypeStatus.New,
       CustomTypeStatus.Modified,
-      CustomTypeStatus.Unknown,
+      CustomTypeStatus.UnknownDefault,
+      CustomTypeStatus.UnknownOffline,
+      CustomTypeStatus.UnknownDisconnected,
     ].includes(customTypeStatus)
   ) {
     return (

--- a/packages/slice-machine/server/src/api/custom-types/index.ts
+++ b/packages/slice-machine/server/src/api/custom-types/index.ts
@@ -48,7 +48,7 @@ export default async function handler(env: BackendEnvironment): Promise<{
       } else {
         return {
           ...customType,
-          __status: CustomTypeStatus.Unknown,
+          __status: CustomTypeStatus.UnknownDisconnected,
         };
       }
     }

--- a/packages/slice-machine/src/modules/availableCustomTypes/index.ts
+++ b/packages/slice-machine/src/modules/availableCustomTypes/index.ts
@@ -182,8 +182,6 @@ export const availableCustomTypesReducer: Reducer<
       const id = action.payload.customTypeId;
       const newName = action.payload.newCustomTypeName;
       const newLocalCustomType = { ...state[id].local, label: newName };
-      const isCustomTypeDisconnected =
-        newLocalCustomType.__status === CustomTypeStatus.UnknownDisconnected;
 
       const remoteCustomType: CustomTypeSM | undefined = state[id].remote;
 
@@ -191,9 +189,7 @@ export const availableCustomTypesReducer: Reducer<
         ...state[id],
         local: {
           ...newLocalCustomType,
-          __status: isCustomTypeDisconnected
-            ? CustomTypeStatus.UnknownDisconnected
-            : getCustomTypeStatus(newLocalCustomType, remoteCustomType),
+          __status: getCustomTypeStatus(newLocalCustomType, remoteCustomType),
         },
       };
 

--- a/packages/slice-machine/src/modules/availableCustomTypes/index.ts
+++ b/packages/slice-machine/src/modules/availableCustomTypes/index.ts
@@ -145,13 +145,18 @@ export const availableCustomTypesReducer: Reducer<
       const remoteCustomType: CustomTypeSM | undefined =
         state[localCustomType.id].remote;
 
+      const isCustomTypeDisconnected =
+        localCustomType.__status === CustomTypeStatus.UnknownDisconnected;
+
       return {
         ...state,
         [localCustomType.id]: {
           ...state[localCustomType.id],
           local: {
             ...localCustomType,
-            __status: getCustomTypeStatus(localCustomType, remoteCustomType),
+            __status: isCustomTypeDisconnected
+              ? CustomTypeStatus.UnknownDisconnected
+              : getCustomTypeStatus(localCustomType, remoteCustomType),
           },
         },
       };
@@ -177,6 +182,8 @@ export const availableCustomTypesReducer: Reducer<
       const id = action.payload.customTypeId;
       const newName = action.payload.newCustomTypeName;
       const newLocalCustomType = { ...state[id].local, label: newName };
+      const isCustomTypeDisconnected =
+        newLocalCustomType.__status === CustomTypeStatus.UnknownDisconnected;
 
       const remoteCustomType: CustomTypeSM | undefined = state[id].remote;
 
@@ -184,7 +191,9 @@ export const availableCustomTypesReducer: Reducer<
         ...state[id],
         local: {
           ...newLocalCustomType,
-          __status: getCustomTypeStatus(newLocalCustomType, remoteCustomType),
+          __status: isCustomTypeDisconnected
+            ? CustomTypeStatus.UnknownDisconnected
+            : getCustomTypeStatus(newLocalCustomType, remoteCustomType),
         },
       };
 

--- a/packages/slice-machine/src/modules/selectedCustomType/reducer.ts
+++ b/packages/slice-machine/src/modules/selectedCustomType/reducer.ts
@@ -56,16 +56,22 @@ export const selectedCustomTypeReducer: Reducer<
       };
     case getType(saveCustomTypeCreator.success): {
       if (!state) return state;
+      const isCustomTypeDisconnected =
+        state.model.__status === CustomTypeStatus.UnknownDisconnected;
 
       return {
         ...state,
         model: {
           ...state.model,
-          __status: getCustomTypeStatus(state.model, state.remoteModel),
+          __status: isCustomTypeDisconnected
+            ? CustomTypeStatus.UnknownDisconnected
+            : getCustomTypeStatus(state.model, state.remoteModel),
         },
         initialModel: {
           ...state.model,
-          __status: getCustomTypeStatus(state.model, state.remoteModel),
+          __status: isCustomTypeDisconnected
+            ? CustomTypeStatus.UnknownDisconnected
+            : getCustomTypeStatus(state.model, state.remoteModel),
         },
         initialMockConfig: state.mockConfig,
       };

--- a/packages/slice-machine/src/modules/selectedCustomType/types.ts
+++ b/packages/slice-machine/src/modules/selectedCustomType/types.ts
@@ -8,7 +8,9 @@ export enum CustomTypeStatus {
   New = "NEW_CT",
   Modified = "MODIFIED",
   Synced = "SYNCED",
-  Unknown = "UNKNOWN",
+  UnknownDefault = "UNKNOWN_DEFAULT",
+  UnknownOffline = "UNKNOWN_OFFLINE",
+  UnknownDisconnected = "UNKNOWN_DISCONNECTED",
 }
 
 export type PoolOfFields = ReadonlyArray<{ key: string; value: TabField }>;

--- a/packages/slice-machine/src/modules/selectedCustomType/types.ts
+++ b/packages/slice-machine/src/modules/selectedCustomType/types.ts
@@ -8,7 +8,6 @@ export enum CustomTypeStatus {
   New = "NEW_CT",
   Modified = "MODIFIED",
   Synced = "SYNCED",
-  UnknownDefault = "UNKNOWN_DEFAULT",
   UnknownOffline = "UNKNOWN_OFFLINE",
   UnknownDisconnected = "UNKNOWN_DISCONNECTED",
 }

--- a/packages/slice-machine/src/theme.ts
+++ b/packages/slice-machine/src/theme.ts
@@ -196,7 +196,21 @@ const AppTheme = (): Theme =>
         px: 1,
         py: "1px",
       },
-      UNKNOWN: {
+      UNKNOWN_DEFAULT: {
+        fontWeight: "body",
+        color: "badge.unknown.color",
+        bg: "badge.unknown.bg",
+        px: 1,
+        py: "1px",
+      },
+      UNKNOWN_OFFLINE: {
+        fontWeight: "body",
+        color: "badge.unknown.color",
+        bg: "badge.unknown.bg",
+        px: 1,
+        py: "1px",
+      },
+      UNKNOWN_DISCONNECTED: {
         fontWeight: "body",
         color: "badge.unknown.color",
         bg: "badge.unknown.bg",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description
- If user is offline -> display `unknown (no internet connection)` label

https://user-images.githubusercontent.com/69536010/185614165-30a61f1b-faf6-4345-9b81-4f113046adab.mov


- If user is disconnected from Prismic -> display `unknown (not connected to Prismic)` label
   - If user attempts to save a custom type while disconnected -> keep status the same and display `unknown (not connected to Prismic)` label.
   

https://user-images.githubusercontent.com/69536010/185616703-4844b22e-a585-433b-98cf-2734ef50ad80.mov


<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] All new and existing tests are passing.

<!--- A cute animal picture is welcome to close your PR! -->
