### PR TITLE
fix(init): allow `@slicemachine/init` to run in Gatsby projects

### DIFF
--- a/packages/core/src/models/Framework.ts
+++ b/packages/core/src/models/Framework.ts
@@ -31,6 +31,7 @@ export const SupportedFrameworks: Frameworks[] = [
   Frameworks.nuxt,
   Frameworks.previousNuxt,
   Frameworks.next,
+  Frameworks.gatsby,
   Frameworks.vue,
   Frameworks.react,
   Frameworks.svelte,

--- a/packages/init/__tests__/detect-framework.test.ts
+++ b/packages/init/__tests__/detect-framework.test.ts
@@ -86,41 +86,4 @@ describe("detect-framework", () => {
     expect(stderr.output).toContain("package.json not found");
     expect(exitSpy).toHaveBeenCalled();
   });
-
-  test("Unsupported framework: gatsby", async () => {
-    jest.spyOn(fs, "lstatSync").mockReturnValueOnce({ dev: 1 } as fs.Stats);
-    jest.spyOn(fs, "readFileSync").mockReturnValueOnce(
-      JSON.stringify({
-        dependencies: {
-          [Models.Frameworks.gatsby]: "beta",
-          [Models.Frameworks.react]: "beta",
-        },
-      })
-    );
-
-    const exitSpy = jest
-      .spyOn(process, "exit")
-      .mockImplementationOnce(() => undefined as never);
-    const errorSpy = jest
-      .spyOn(console, "error")
-      .mockImplementation(() => undefined);
-
-    const logSpy = jest
-      .spyOn(console, "log")
-      .mockImplementation(() => undefined);
-
-    stderr.start();
-    await detectFramework(__dirname);
-    stderr.stop();
-
-    expect(exitSpy).toHaveBeenCalled();
-    expect(errorSpy).toHaveBeenCalledWith(
-      `${logs.error("Error!")} Gatsby is currently not supported`
-    );
-    expect(logSpy).toHaveBeenCalledWith(
-      `Please run ${logs.bold(
-        "npx @slicemachine/init"
-      )} in a Nuxt or Next.js project`
-    );
-  });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This PR allows `@slicemachine/init` to be used in Gatsby project. Slice Machine itself does not fully support Gatsby, but `@slicemachine/init` should be usable in projects that have Gatsby installed. Gatsby projects can use Slice Machine in its framework-agnostic mode.

This PR treats Gatsby like other non-Next.js/Nuxt supported frameworks, including React, Svelte, and Vanilla JS.

### Current behavior

Running `npx @slicemachine/init` today in a project with `gatsby` as a dependency displays the following error:

```
You're about to configure Slicemachine... Press ctrl + C to cancel
✔ Logged in as name@example.com
Error! Gatsby is currently not supported
Please run npx @slicemachine/init in a Nuxt or Next.js project
```

You can see this happening by testing the [Gatsby Blog starter](https://github.com/prismicio-community/gatsby-starter-prismic-blog):

```sh
npx degit prismicio-community/gatsby-starter-prismic-blog your-project-name
cd your-project-name
npx @slicemachine/init
```

### Alternatives

1. We could introduce an `--ignore-framework` flag that bypasses the framework check:

   ```sh
   npx @slicemachine/init --ignore-framework
   ```

2. We could read the `framework` property in `sm.json` to detect the framework. `@slicemachine/init` currently ignores the `framework` configuration property.

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [x] All new and existing tests are passing.

<!--- A cute animal picture is welcome to close your PR! -->
