### PR TITLE
fix: image thumbnail dimensions should only require one dimension, not both

### DIFF
--- a/packages/slice-machine/lib/models/common/widgets/Image/Form.js
+++ b/packages/slice-machine/lib/models/common/widgets/Image/Form.js
@@ -175,17 +175,11 @@ FormFields.thumbnails = {
           name: "Thumbnails",
           message: "Must set name and width or height at minimum",
           test: function (value) {
-            if (!value.name) {
-              return false;
-            }
-            if (
-              (!value.width && !value.height) ||
-              typeof value.width !== "number" ||
-              typeof value.height !== "number"
-            ) {
-              return false;
-            }
-            return true;
+            return (
+              value.name &&
+              (typeof value.width === "number" ||
+                typeof value.height === "number")
+            );
           },
         })
       ),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This PR fixes an issue where image thumbnails could only be saved if both a width and a height were provided.

The legacy builder allows only one dimension. As of this PR, the legacy builder behavior is replicated.

The new validation function checks for the following:

- A name is required.
- Only one of width or height is required. Both can be provided as well.

Fixes 594

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] All new and existing tests are passing.

<!--- A cute animal picture is welcome to close your PR! -->
