### PR TITLE
fix: only display validation errors on Custom Type model after touching

### DIFF
--- a/packages/slice-machine/components/Forms/CreateCustomTypeModal.tsx
+++ b/packages/slice-machine/components/Forms/CreateCustomTypeModal.tsx
@@ -148,7 +148,7 @@ const CreateCustomTypeModal: React.FC = () => {
         title: "Create a new custom type",
       }}
     >
-      {({ errors, setValues, setFieldValue, values }) => (
+      {({ errors, setValues, setFieldValue, values, touched }) => (
         <Box>
           <SelectRepeatable />
           <InputBox
@@ -156,7 +156,7 @@ const CreateCustomTypeModal: React.FC = () => {
             label="Custom Type Name"
             dataCy="ct-name-input"
             placeholder="A display name for the Custom type"
-            error={errors.label}
+            error={touched.label ? errors.label : undefined}
             onChange={(e) => handleLabelChange(e, values, setValues)}
           />
           <InputBox
@@ -164,7 +164,7 @@ const CreateCustomTypeModal: React.FC = () => {
             dataCy="ct-id-input"
             label="Custom Type ID"
             placeholder="ID to query the Custom Type in the API (e.g. 'BlogPost')"
-            error={errors.id}
+            error={touched.id ? errors.id : undefined}
             onChange={(e) => handleIdChange(e, setFieldValue)}
           />
         </Box>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This PR fixes a UX bug.

When creating a new Custom Type, the modal immediately asks if you want to create a Repeatable or Single type. If a user changes from the default (Repeatable) to Single, validation runs immediately on the fields further down the modal before the user has a chance to fill them in.

This PR changes the error display behavior to only display once the fields have been touched. This results in a better experience.

Fixes Linear issue SM-788: https://linear.app/prismic/issue/SM-788/ux-bug-ct-creation-empty-field-errors-when-switching-from-repeatable

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] All new and existing tests are passing.

<!--- A cute animal picture is welcome to close your PR! -->
