### PR TITLE
fix: disabled buttons should use disabled styling in all states (`:active` and `:hover`)

### DIFF
--- a/packages/slice-machine/src/theme.ts
+++ b/packages/slice-machine/src/theme.ts
@@ -223,8 +223,9 @@ const AppTheme = (): Theme =>
         },
         "&:disabled": {
           bg: lighten("primary", 0.2),
+          cursor: "default",
         },
-        "&:active": {
+        "&:active:not(:disabled)": {
           boxShadow:
             "0px 1px 0px rgba(0, 0, 0, 0.1), inset 0px -1px 0px rgba(0, 0, 0, 0.1)",
           bg: darken("primary", 0.05),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This PR fixes a styling issue with model buttons.

When the button is disabled due to a validation error, the button is given "disabled" styling. When the button is hovered, however, the cursor changes to a pointer. When the button is pressed (i.e. active), the button changes to dark purple.

This PR changes the behavior such that when a button is disabled, the styling remains in the "disabled" state when hovered or active.

Fixes Linear issue SM-818: https://linear.app/prismic/issue/SM-818/aauser-when-a-button-is-disabled-i-cannot-interact-with-it

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] All new and existing tests are passing.

<!--- A cute animal picture is welcome to close your PR! -->
