### PR TITLE
fix: reformat code snippets for repeatable zones

### DIFF
--- a/packages/slice-machine/lib/builders/common/Zone/Card/components/Hints/Renderers/react.tsx
+++ b/packages/slice-machine/lib/builders/common/Zone/Card/components/Hints/Renderers/react.tsx
@@ -1,10 +1,28 @@
 import React from "react";
 import CodeBlock, { Item, RenderHintBaseFN, WidgetsType } from "../CodeBlock";
 
-const wrapRepeatable = (code: string): string =>
-  `
-{ slice?.items?.map((item, i) => ${code}) }
-`;
+const wrapRepeatable = (code: string): string => {
+  // const lines = code.split("\n").join("\n   ");
+  const lines = code.split("\n");
+
+  const commentRegex = /^\/\*/;
+
+  const commentsLines = lines.filter((line) => {
+    return commentRegex.test(line);
+  });
+
+  const codeLines = lines.filter((line) => {
+    return !commentRegex.test(line);
+  });
+
+  return `${commentsLines.join("\n")}
+{
+  slice?.items?.map((item, i) =>
+    ${codeLines.join("\n   ")}
+  )
+}
+`.trim();
+};
 
 const createDefaultField =
   (tag = "span") =>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This PR fixes formatting of code snippets for repeatable zones.

Before:

```

{ slice?.items?.map((item, i) => /* import { PrismicRichText } from '@prismicio/react' */
<PrismicRichText field={item.title} />) }
```

After:

```
/* import { PrismicRichText } from '@prismicio/react' */
{
  slice?.items?.map((item, i) =>
    <PrismicRichText field={item.title} />
  )
}
```

Fixes Linear issue SM-820: https://github.com/prismicio/slice-machine/pull/606

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] All new and existing tests are passing.

<!--- A cute animal picture is welcome to close your PR! -->
