### PR TITLE
fix: remove unused reorder icon/button

### DIFF
--- a/packages/slice-machine/components/ItemHeader/index.js
+++ b/packages/slice-machine/components/ItemHeader/index.js
@@ -11,14 +11,6 @@ const ItemHeader = ({
   iconButtonProps = {},
 }) => (
   <Flex sx={{ alignItems: "center" }}>
-    <SliceMachineIconButton
-      label="Reorder slice field (drag and drop)"
-      Icon={FaBars}
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
-      color={theme.colors.icons}
-      mr={1}
-      {...iconButtonProps}
-    />
     <WidgetIcon
       size={28}
       style={{

--- a/packages/slice-machine/components/ItemHeader/index.tsx
+++ b/packages/slice-machine/components/ItemHeader/index.tsx
@@ -1,27 +1,23 @@
+import React from "react";
 import { Flex, Text } from "theme-ui";
+import type { Theme } from "theme-ui";
 
-import SliceMachineIconButton from "@components/SliceMachineIconButton";
-import { FaBars } from "react-icons/fa";
-
-const ItemHeader = ({
-  text,
-  sliceFieldName,
-  theme,
-  WidgetIcon,
-  iconButtonProps = {},
-}) => (
+const ItemHeader: React.FC<{
+  text: React.ReactNode;
+  sliceFieldName: React.ReactNode;
+  theme: Theme;
+  WidgetIcon: React.ElementType;
+}> = ({ text, sliceFieldName, theme, WidgetIcon }) => (
   <Flex sx={{ alignItems: "center" }}>
     <WidgetIcon
       size={28}
       style={{
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
-        color: theme.colors.primary,
+        color: theme.colors?.primary,
         marginRight: "8px",
         borderRadius: "4px",
         padding: "4px",
         border: "2px solid",
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
-        borderColor: theme.colors.primary,
+        borderColor: theme.colors?.primary,
       }}
     />
     <Text


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This PR removes an unused hamburger/reorder menu icon in the edit field modal.

**Before:**
<img width="324" alt="image" src="https://user-images.githubusercontent.com/8601064/191767290-af1d2948-1b18-47a2-ab2e-e5397a6ffa98.png">

**After:**
<img width="397" alt="image" src="https://user-images.githubusercontent.com/8601064/191767241-46045e30-c213-41e1-8bd0-b1c085fff1de.png">

Fixes Linear issue SM-822: https://linear.app/prismic/issue/SM-822/aauser-i-am-not-confused-by-an-unusable-burger-menu-in-the-field


## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] All new and existing tests are passing.

<!--- A cute animal picture is welcome to close your PR! -->
