### PR TITLE
update screenshot on the slice page when coming back to tab

### DIFF
--- a/packages/slice-machine/src/modules/selectedSlice/actions.ts
+++ b/packages/slice-machine/src/modules/selectedSlice/actions.ts
@@ -5,6 +5,7 @@ import { SliceMockConfig } from "@lib/models/common/MockConfig";
 import { ComponentUI } from "@lib/models/common/ComponentUI";
 import { renameSliceCreator } from "../slices";
 import { SelectedSliceStoreType } from "./types";
+import { refreshStateCreator } from "../environment";
 
 export type SelectedSliceActions =
   | ActionType<typeof initSliceStoreCreator>
@@ -16,7 +17,8 @@ export type SelectedSliceActions =
   | ActionType<typeof deleteSliceWidgetMockCreator>
   | ActionType<typeof saveSliceCreator>
   | ActionType<typeof copyVariationSliceCreator>
-  | ActionType<typeof renameSliceCreator>;
+  | ActionType<typeof renameSliceCreator>
+  | ActionType<typeof refreshStateCreator>;
 
 export const initSliceStoreCreator =
   createAction("SLICE/INIT")<SelectedSliceStoreType>();

--- a/packages/slice-machine/src/modules/selectedSlice/reducer.ts
+++ b/packages/slice-machine/src/modules/selectedSlice/reducer.ts
@@ -20,6 +20,7 @@ import { SliceMockConfig } from "@lib/models/common/MockConfig";
 import { ComponentUI } from "@lib/models/common/ComponentUI";
 import { SliceSM } from "@slicemachine/core/build/models";
 import { renamedComponentUI, renameSliceCreator } from "../slices";
+import { refreshStateCreator } from "../environment";
 
 // Reducer
 export const selectedSliceReducer: Reducer<
@@ -31,6 +32,21 @@ export const selectedSliceReducer: Reducer<
       if (!action.payload) return null;
       return action.payload;
     }
+    case getType(refreshStateCreator):
+      if (prevState === null || !action.payload.libraries) return prevState;
+
+      const updatedSlice = action.payload.libraries
+        .find((l) => l.name === prevState.from)
+        ?.components.find((c) => c.model.id === prevState.model.id);
+
+      if (updatedSlice === undefined) {
+        return prevState;
+      }
+
+      return {
+        ...prevState,
+        screenshots: updatedSlice.screenshots,
+      };
     case getType(addSliceWidgetCreator): {
       if (!prevState) return prevState;
       const { variationId, widgetsArea, key, value } = action.payload;

--- a/packages/slice-machine/tests/src/modules/selectedSlice/reducer.test.ts
+++ b/packages/slice-machine/tests/src/modules/selectedSlice/reducer.test.ts
@@ -12,7 +12,11 @@ import {
 import { Models } from "@slicemachine/core";
 import { WidgetTypes } from "@prismicio/types-internal/lib/customtypes/widgets";
 import { NestableWidget } from "@prismicio/types-internal/lib/customtypes/widgets/nestable";
-import { getSelectedSliceDummyData } from "./utils";
+import {
+  getSelectedSliceDummyData,
+  getRefreshStateCreatorPayloadData,
+} from "./utils";
+import { refreshStateCreator } from "@src/modules/environment";
 
 const { dummyModelVariationID, dummyMockConfig, dummySliceState } =
   getSelectedSliceDummyData();
@@ -169,6 +173,39 @@ describe("[Selected Slice module]", () => {
       expect(variations?.length).toEqual(preVariations.length + 1);
       expect(variations?.at(-1)?.id).toEqual("new-variation");
       expect(variations?.at(-1)?.name).toEqual("New Variation");
+    });
+
+    it("should update the selected slice screenshots given STATE/REFRESH.RESPONSE action if the component is found", () => {
+      const action = refreshStateCreator(
+        getRefreshStateCreatorPayloadData(
+          dummySliceState.from,
+          dummySliceState.model.id
+        )
+      );
+
+      const newState = selectedSliceReducer(dummySliceState, action);
+
+      expect(newState?.screenshots).toEqual({
+        "default-slice": {
+          hash: "f92c69c60df8fd8eb42902bfb6574776",
+          path: "updated-screenshot-path",
+          url: "http://localhost:9999/api/__preview?q=default-slice",
+        },
+      });
+    });
+
+    it("should do nothing given STATE/REFRESH.RESPONSE action if the component is not found", () => {
+      const action = refreshStateCreator(
+        getRefreshStateCreatorPayloadData(
+          "unknown-livrary",
+          dummySliceState.model.id
+        )
+      );
+
+      const newState = selectedSliceReducer(dummySliceState, action);
+
+      expect(newState?.screenshots).toEqual({});
+      expect(newState).toEqual(dummySliceState);
     });
   });
 });

--- a/packages/slice-machine/tests/src/modules/selectedSlice/utils.ts
+++ b/packages/slice-machine/tests/src/modules/selectedSlice/utils.ts
@@ -1,8 +1,14 @@
 import jsonModel from "./__mockData__/model.json";
 import mocks from "./__mockData__/mocks.json";
 import { SliceMock, Slices } from "@slicemachine/core/build/models";
-import { SharedSlice } from "@prismicio/types-internal/lib/customtypes/widgets/slices";
+import {
+  SharedSlice,
+  SlicesTypes,
+} from "@prismicio/types-internal/lib/customtypes/widgets/slices";
 import { ComponentUI } from "@lib/models/common/ComponentUI";
+import { dummyServerState } from "../__mocks__/serverState";
+import { LibraryUI } from "@lib/models/common/LibraryUI";
+import { WidgetTypes } from "@prismicio/types-internal/lib/customtypes/widgets";
 
 export const getSelectedSliceDummyData = () => {
   const dummyModel = Slices.toSM(jsonModel as unknown as SharedSlice);
@@ -36,5 +42,77 @@ export const getSelectedSliceDummyData = () => {
     dummyModelVariationID,
     dummyMockConfig,
     dummySliceState,
+  };
+};
+
+export const getRefreshStateCreatorPayloadData = (
+  libraryName: string,
+  modelId: string
+) => {
+  const MOCK_UPDATED_LIBRARY: LibraryUI[] = [
+    {
+      path: "../../e2e-projects/next/slices/ecommerce",
+      isLocal: true,
+      name: libraryName,
+      components: [
+        {
+          from: "slices/ecommerce",
+          href: "slices--ecommerce",
+          pathToSlice: "./slices/ecommerce",
+          fileName: "index",
+          extension: "js",
+          screenshots: {
+            "default-slice": {
+              path: "updated-screenshot-path",
+              hash: "f92c69c60df8fd8eb42902bfb6574776",
+              url: "http://localhost:9999/api/__preview?q=default-slice",
+            },
+          },
+          mock: [],
+          model: {
+            id: modelId,
+            type: SlicesTypes.SharedSlice,
+            name: "CategoryPreviewWithImageBackgrounds",
+            description: "CategoryPreviewWithImageBackgrounds",
+            variations: [
+              {
+                id: "default-slice",
+                name: "Default slice",
+                docURL: "...",
+                version: "sktwi1xtmkfgx8626",
+                description: "MockSlice",
+                primary: [
+                  {
+                    key: "Title",
+                    value: {
+                      config: {
+                        label: "Title",
+                        placeholder: "My first Title...",
+                      },
+                      type: WidgetTypes.Text,
+                    },
+                  },
+                ],
+                items: [],
+              },
+            ],
+          },
+          mockConfig: {},
+        },
+      ],
+      meta: {
+        isNodeModule: false,
+        isDownloaded: false,
+        isManual: true,
+      },
+    },
+  ];
+
+  return {
+    env: dummyServerState.env,
+    libraries: MOCK_UPDATED_LIBRARY,
+    localCustomTypes: [],
+    remoteCustomTypes: [],
+    remoteSlices: [],
   };
 };


### PR DESCRIPTION
When coming back to the tab a request to /state is triggered. This changes propagates changes to the screenshot to the `selectedSlice` reducer if a match is found, updating the screenshot a user sees.

## Types of changes

- [ x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

The `selectedSliceReducer` now listens to the `STATE/REFRESH.RESPONSE` action, and update the screenshot data **only** on the selected slice if found in the response.

## Checklist:


- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ x] All new and existing tests are passing.