### PR TITLE
display global warning on changes page

### DIFF
--- a/packages/slice-machine/components/ChangesItems/ChangesItems.tsx
+++ b/packages/slice-machine/components/ChangesItems/ChangesItems.tsx
@@ -1,6 +1,6 @@
 import React, { ReactNode, useState } from "react";
 import { Box, Button, Text } from "theme-ui";
-import { AiFillCamera } from "react-icons/ai";
+import { AiFillCamera, AiOutlineExclamationCircle } from "react-icons/ai";
 
 import useSliceMachineActions from "@src/modules/useSliceMachineActions";
 
@@ -20,6 +20,7 @@ import { ErrorBanner } from "./ErrorBanner";
 import ScreenshotChangesModal, {
   SliceVariationSelector,
 } from "@components/ScreenshotChangesModal";
+import { countMissingScreenshots } from "@src/utils/screenshots/missing";
 
 interface ChangesItemsProps extends ModelStatusInformation {
   unSyncedCustomTypes: FrontEndCustomType[];
@@ -92,6 +93,29 @@ export const ChangesItems: React.FC<ChangesItemsProps> = ({
                 </Text>
               </Box>
               <Box>
+                {unSyncedSlices.some(
+                  (slice) => countMissingScreenshots(slice) > 0
+                ) && (
+                  <Text
+                    sx={{
+                      mr: 2,
+                      color: "warning02",
+                      fontSize: "12px",
+                      lineHeight: "16px",
+                      fontWeight: 600,
+                    }}
+                  >
+                    <AiOutlineExclamationCircle
+                      size={16}
+                      style={{
+                        marginRight: "4px",
+                        position: "relative",
+                        top: "3px",
+                      }}
+                    />
+                    Missing Screenshots
+                  </Text>
+                )}
                 <Button
                   variant="darkSmall"
                   sx={{ mr: 2 }}

--- a/packages/slice-machine/jest.config.js
+++ b/packages/slice-machine/jest.config.js
@@ -8,6 +8,7 @@ module.exports = {
   moduleNameMapper: {
     "^lib(.*)$": "<rootDir>/lib$1",
     "^src(.*)$": "<rootDir>/src$1",
+    "^tests(.*)$": "<rootDir>/tests$1",
     "^components(.*)$": "<rootDir>/components$1",
   },
   transform: {

--- a/packages/slice-machine/lib/models/ui/Slice/index.tsx
+++ b/packages/slice-machine/lib/models/ui/Slice/index.tsx
@@ -19,6 +19,7 @@ import { ModelStatus } from "@lib/models/common/ModelStatus";
 import { AuthStatus } from "@src/modules/userContext/types";
 import { Button } from "theme-ui";
 import { AiOutlineCamera, AiOutlineExclamationCircle } from "react-icons/ai";
+import { countMissingScreenshots } from "@src/utils/screenshots/missing";
 
 const borderedSx = (sx: ThemeUIStyleObject = {}): ThemeUICSSObject => ({
   bg: "transparent",
@@ -146,8 +147,7 @@ const ScreenshotMissingBanner = ({
   visible?: boolean;
   slice: ComponentUI;
 }) => {
-  const missingScreenshots =
-    slice.model.variations.length - Object.entries(slice.screenshots).length;
+  const missingScreenshots = countMissingScreenshots(slice);
 
   if (!visible || !missingScreenshots) {
     return null;
@@ -164,6 +164,8 @@ const ScreenshotMissingBanner = ({
         bg: "missingScreenshotBanner.bg",
         color: "missingScreenshotBanner.color",
         width: "100%",
+        fontSize: "12px",
+        lineHeight: "16px",
       }}
     >
       <AiOutlineExclamationCircle style={{ marginRight: "8px" }} />{" "}

--- a/packages/slice-machine/src/utils/screenshots/missing.test.ts
+++ b/packages/slice-machine/src/utils/screenshots/missing.test.ts
@@ -1,0 +1,51 @@
+import { getSelectedSliceDummyData } from "tests/src/modules/screenshots/utils";
+import { countMissingScreenshots } from "./missing";
+
+describe("[utils - screenshot - missing]", () => {
+  it("should return the number of missing screenshots", () => {
+    const { dummySliceState } = getSelectedSliceDummyData();
+
+    expect(countMissingScreenshots(dummySliceState)).toEqual(1);
+
+    expect(
+      countMissingScreenshots({
+        ...dummySliceState,
+        model: {
+          ...dummySliceState.model,
+          variations: [
+            ...dummySliceState.model.variations,
+            ...dummySliceState.model.variations,
+          ],
+        },
+      })
+    ).toEqual(2);
+
+    expect(
+      countMissingScreenshots({
+        ...dummySliceState,
+        model: {
+          ...dummySliceState.model,
+          variations: [
+            ...dummySliceState.model.variations,
+            ...dummySliceState.model.variations,
+          ],
+        },
+        screenshots: { "default-variation": {} },
+      })
+    ).toEqual(1);
+
+    expect(
+      countMissingScreenshots({
+        ...dummySliceState,
+        model: {
+          ...dummySliceState.model,
+          variations: [
+            ...dummySliceState.model.variations,
+            ...dummySliceState.model.variations,
+          ],
+        },
+        screenshots: { "default-variation": {}, "variation-1": {} },
+      })
+    ).toEqual(0);
+  });
+});

--- a/packages/slice-machine/src/utils/screenshots/missing.ts
+++ b/packages/slice-machine/src/utils/screenshots/missing.ts
@@ -1,0 +1,4 @@
+import { ComponentUI } from "@lib/models/common/ComponentUI";
+
+export const countMissingScreenshots = (slice: ComponentUI) =>
+  slice.model.variations.length - Object.entries(slice.screenshots).length;


### PR DESCRIPTION
Display a global warning on the `Changes` page if a screenshot is missing

<img width="745" alt="image" src="https://user-images.githubusercontent.com/1148164/194517046-578b1108-1e92-4b68-b92d-feff35fdafc0.png"> 

## Types of changes

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

