### PR TITLE
make screenshot URL optional in modal so it doesn't fail before one i…

### DIFF
--- a/packages/slice-machine/components/ScreenshotPreviewModal/index.tsx
+++ b/packages/slice-machine/components/ScreenshotPreviewModal/index.tsx
@@ -9,7 +9,7 @@ import Card from "@components/Card";
 
 type ScreenshotModalProps = {
   sliceName: string;
-  screenshotUrl: string;
+  screenshotUrl?: string;
 };
 
 // For displaying the screenshot preview in the slice simulator after the user has taken a screenshot

--- a/packages/slice-machine/components/Simulator/index.tsx
+++ b/packages/slice-machine/components/Simulator/index.tsx
@@ -78,10 +78,12 @@ export default function Simulator() {
         simulatorUrl={simulatorUrl}
         sliceView={sliceView}
       />
-      <ScreenshotPreviewModal
-        sliceName={Router.router?.query.sliceName as string}
-        screenshotUrl={component.screenshots[variation.id]?.url}
-      />
+      {!!component.screenshots[variation.id]?.url && (
+        <ScreenshotPreviewModal
+          sliceName={Router.router?.query.sliceName as string}
+          screenshotUrl={component.screenshots[variation.id]?.url}
+        />
+      )}
     </Flex>
   );
 }

--- a/packages/slice-machine/components/Simulator/index.tsx
+++ b/packages/slice-machine/components/Simulator/index.tsx
@@ -80,7 +80,7 @@ export default function Simulator() {
       />
       <ScreenshotPreviewModal
         sliceName={Router.router?.query.sliceName as string}
-        screenshotUrl={component.screenshots[variation.id].url}
+        screenshotUrl={component.screenshots[variation.id]?.url}
       />
     </Flex>
   );


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->

Previously the slice preview page failed if there was no screenshot for the given slice since the URL was required for the modal. Now we don't need this to allow the page to open for the first time.

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] All new and existing tests are passing.

<!--- A cute animal picture is welcome to close your PR! -->
