### PR TITLE
pinpoint @types/react to avoid installing broken version

### DIFF
--- a/packages/slice-machine/package-lock.json
+++ b/packages/slice-machine/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "slice-machine-ui",
-			"version": "0.5.2-dev-screenshotv2.0",
+			"version": "0.5.2-dev-screenshotv2.1",
 			"license": "MIT",
 			"dependencies": {
 				"@babel/register": "^7.17.7",
@@ -92,7 +92,7 @@
 				"@types/probe-image-size": "^7.0.1",
 				"@types/prompts": "^2.0.14",
 				"@types/puppeteer": "^5.4.3",
-				"@types/react": "^17.0.2",
+				"@types/react": "17.0.2",
 				"@types/react-beautiful-dnd": "^13.0.0",
 				"@types/react-modal": "^3.12.0",
 				"@types/react-redux": "^7.1.20",
@@ -4460,13 +4460,12 @@
 			"dev": true
 		},
 		"node_modules/@types/react": {
-			"version": "17.0.50",
-			"resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.50.tgz",
-			"integrity": "sha512-ZCBHzpDb5skMnc1zFXAXnL3l1FAdi+xZvwxK+PkglMmBrwjpp9nKaWuEvrGnSifCJmBFGxZOOFuwC6KH/s0NuA==",
+			"version": "17.0.2",
+			"resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.2.tgz",
+			"integrity": "sha512-Xt40xQsrkdvjn1EyWe1Bc0dJLcil/9x2vAuW7ya+PuQip4UYUaXyhzWmAbwRsdMgwOFHpfp7/FFZebDU6Y8VHA==",
 			"dev": true,
 			"dependencies": {
 				"@types/prop-types": "*",
-				"@types/scheduler": "*",
 				"csstype": "^3.0.2"
 			}
 		},
@@ -4555,12 +4554,6 @@
 			"dependencies": {
 				"@types/node": "*"
 			}
-		},
-		"node_modules/@types/scheduler": {
-			"version": "0.16.2",
-			"resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
-			"integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==",
-			"dev": true
 		},
 		"node_modules/@types/semver": {
 			"version": "7.3.12",
@@ -24550,13 +24543,12 @@
 			"dev": true
 		},
 		"@types/react": {
-			"version": "17.0.50",
-			"resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.50.tgz",
-			"integrity": "sha512-ZCBHzpDb5skMnc1zFXAXnL3l1FAdi+xZvwxK+PkglMmBrwjpp9nKaWuEvrGnSifCJmBFGxZOOFuwC6KH/s0NuA==",
+			"version": "17.0.2",
+			"resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.2.tgz",
+			"integrity": "sha512-Xt40xQsrkdvjn1EyWe1Bc0dJLcil/9x2vAuW7ya+PuQip4UYUaXyhzWmAbwRsdMgwOFHpfp7/FFZebDU6Y8VHA==",
 			"dev": true,
 			"requires": {
 				"@types/prop-types": "*",
-				"@types/scheduler": "*",
 				"csstype": "^3.0.2"
 			}
 		},
@@ -24645,12 +24637,6 @@
 			"requires": {
 				"@types/node": "*"
 			}
-		},
-		"@types/scheduler": {
-			"version": "0.16.2",
-			"resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
-			"integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==",
-			"dev": true
 		},
 		"@types/semver": {
 			"version": "7.3.12",

--- a/packages/slice-machine/package.json
+++ b/packages/slice-machine/package.json
@@ -121,7 +121,7 @@
     "@types/probe-image-size": "^7.0.1",
     "@types/prompts": "^2.0.14",
     "@types/puppeteer": "^5.4.3",
-    "@types/react": "^17.0.2",
+    "@types/react": "17.0.2",
     "@types/react-beautiful-dnd": "^13.0.0",
     "@types/react-modal": "^3.12.0",
     "@types/react-redux": "^7.1.20",


### PR DESCRIPTION
## Context

<!--
Please include either
- a ticket
    - [Link text Here](https://link-url-here.org)

- a github issue / forum thread
    - Fixes #

- a detailed description of the issue and it's implications

- any extra work / rework you did on the codebase and why.
-->

The CD broke on [the last PR merge](https://github.com/prismicio/slice-machine/actions/runs/3272930633/jobs/5384528047#step:6:577).
We did not detect this before because our CI uses `npm install` while the CD uses `npm CI`

After investigating a bit, I found on some forum mention that the last versions of `@types/react` were broken.
I verified the NPM repo of `@types/react` and the last versions that could be installed automatically were from 1-2 months ago.
I suspected that the package lock wasn't updated since then and so I pinpointed the exact version of `@types/react` and it worked locally.


## Dependencies

<!--
Link of any other PRs that is related to this development.
They should also be referenced in the ticket for reviews.
-->




## Checklist before requesting a review
- [x] I hereby declare my code ready for review.
- [ ] If it is a critical feature, I have added tests.
- [x] The CI is successful.
- [ ] If there could backward compatibility issues, it has been discussed and planned.

<!-- Extra information that the reviewer should know about -->
[OPT] N.B for the reviewer:




## [OPT] Preview

<!--
Visual aid of your work.
It can either be screenshots or a video.
This could help reviewers to get context quickly.
-->

![dan-cook-MCauAnBJeig-unsplash](https://user-images.githubusercontent.com/41187899/196468708-93899e6f-0c50-41c5-a32e-e8b5dfe0c32b.jpg)

<!--
A funny animal picture is welcome to close your PR!
You can find one here https://unsplash.com/s/photos/funny-animal-picture
-->