### PR TITLE
Fix button padding

### DIFF
--- a/packages/slice-machine/src/theme.ts
+++ b/packages/slice-machine/src/theme.ts
@@ -324,8 +324,7 @@ const AppTheme = (): Theme =>
         lineHeight: "16px",
         pl: 2,
         pr: 2,
-        pb: "6px",
-        pt: "6px",
+        py: "5px",
         cursor: "pointer",
         "&:hover": {
           background: "#F4F2F4",


### PR DESCRIPTION
Fixing back from validation defect of this ticket: https://linear.app/prismic/issue/SM-804/aauser-i-see-slices-card-redesigned-with-a-new-screenshot-button

<img width="350" alt="image" src="https://user-images.githubusercontent.com/47107427/197074660-32bab9c6-80cc-4c8b-9e15-22824fe0a7a5.png">
