### PR TITLE
Parallelise CI jobs

### DIFF
--- a/.github/actions/build-essential/action.yml
+++ b/.github/actions/build-essential/action.yml
@@ -5,4 +5,4 @@ runs:
   steps:
     - name: Build essential packages used by others
       shell: bash
-      run: npm run build-essential && npm run build --prefix packages/init && npm run build --prefix packages/slice-machine
+      run: npm run build-essential

--- a/.github/actions/build-essential/action.yml
+++ b/.github/actions/build-essential/action.yml
@@ -1,0 +1,8 @@
+name: 'Build essential packages'
+description: 'Build essential packages'
+runs:
+  using: 'composite'
+  steps:
+    - name: Build essential packages used by others
+      shell: bash
+      run: npm run build-essential && npm run build --prefix packages/init && npm run build --prefix packages/slice-machine

--- a/.github/actions/restore-cache/action.yml
+++ b/.github/actions/restore-cache/action.yml
@@ -1,0 +1,20 @@
+name: 'Cache node modules'
+description: 'Cache node modules'
+outputs:
+  cache-hit:
+    description: 'True if cache was hit, false otherwise'
+    value: ${{ steps.restore-cache.outputs.cache-hit }}
+runs:
+  using: 'composite'
+  steps:
+    - name: Restore cache
+      id: restore-cache
+      uses: actions/cache@v2
+      with:
+        path: |
+          node_modules
+          */*/node_modules
+          ~/.cache/Cypress
+        key: abcd-${{ runner.os }}-lerna-${{ hashFiles('**/package-lock.json') }}
+        restore-keys: |
+          abcd-${{ runner.os }}-lerna-

--- a/.github/actions/restore-cache/action.yml
+++ b/.github/actions/restore-cache/action.yml
@@ -1,9 +1,5 @@
 name: 'Cache node modules'
 description: 'Cache node modules'
-outputs:
-  cache-hit:
-    description: 'True if cache was hit, false otherwise'
-    value: ${{ steps.restore-cache.outputs.cache-hit }}
 runs:
   using: 'composite'
   steps:
@@ -15,6 +11,6 @@ runs:
           node_modules
           */*/node_modules
           ~/.cache/Cypress
-        key: abcd-${{ runner.os }}-lerna-${{ hashFiles('**/package-lock.json') }}
+        key: ${{ runner.os }}-lerna-${{ hashFiles('**/package-lock.json') }}
         restore-keys: |
-          abcd-${{ runner.os }}-lerna-
+          ${{ runner.os }}-lerna-

--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -1,0 +1,11 @@
+
+name: 'Setup Node 16'
+description: 'Setup Node 16'
+runs:
+  using: 'composite'
+  steps:
+    - name: Use Node.js 16
+      uses: actions/setup-node@v2
+      with:
+        node-version: 16
+        cache: "npm"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -79,30 +79,6 @@ jobs:
       - name: Audit
         run: lerna run audit
 
-  build-init:
-    needs: install-deps
-    runs-on: [ubuntu-latest]
-    steps:
-      - uses: actions/checkout@v2
-      - uses: ./.github/actions/restore-cache
-      - uses: ./.github/actions/setup-node
-      - uses: ./.github/actions/build-essential
-      - name: Build slice machine init
-        working-directory: ./packages/init
-        run: npm run build
-
-  build-ui:
-    needs: install-deps
-    runs-on: [ubuntu-latest]
-    steps: 
-      - uses: actions/checkout@v2
-      - uses: ./.github/actions/restore-cache
-      - uses: ./.github/actions/setup-node
-      - uses: ./.github/actions/build-essential
-      - name: Build and export slice machine UI
-        working-directory: ./packages/slice-machine
-        run: npm run build && npm run export-build
-
   e2e-tests:
     needs: install-deps
     runs-on: [ubuntu-latest]
@@ -111,8 +87,12 @@ jobs:
       - uses: ./.github/actions/restore-cache
       - uses: ./.github/actions/setup-node
       - uses: ./.github/actions/build-essential
-      - name: Install slice-machine and init
-        run: npm run build --prefix packages/init && npm run build --prefix packages/slice-machine
+      - name: Build slice machine init
+        working-directory: ./packages/init
+        run: npm run build
+      - name: Build and export slice machine UI
+        working-directory: ./packages/slice-machine
+        run: npm run build && npm run export-build
       - name: Running End to End tests
         env:
           EMAIL: ${{ secrets.EMAIL }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -111,6 +111,8 @@ jobs:
       - uses: ./.github/actions/restore-cache
       - uses: ./.github/actions/setup-node
       - uses: ./.github/actions/build-essential
+      - name: Install slice-machine and init
+        run: npm run build --prefix packages/init && npm run build --prefix packages/slice-machine
       - name: Running End to End tests
         env:
           EMAIL: ${{ secrets.EMAIL }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@ name: test
 on: [push]
 
 jobs:
-  build:
+  install-deps:
     runs-on: [ubuntu-latest]
     steps:
       - uses: actions/checkout@v2
@@ -14,23 +14,15 @@ jobs:
       - name: List all dependencies
         shell: bash
         run: npm list
-      - name: Build essential packages used by others
-        run: npm run build-essential
 
   unit-tests:
-    needs: build
+    needs: install-deps
     runs-on: [ubuntu-latest]
     steps:
       - uses: actions/checkout@v2
       - uses: ./.github/actions/restore-cache
       - uses: ./.github/actions/setup-node
-      - name: Install dependencies
-        run: npm i
-      - name: List all dependencies
-        shell: bash
-        run: npm list
-      - name: Build essential packages used by others
-        run: npm run build-essential
+      - uses: ./.github/actions/build-essential
       - name: Running functional and unit tests
         env:
           EMAIL: ${{ secrets.EMAIL }}
@@ -44,74 +36,81 @@ jobs:
         run: lerna run test
   
   dep-check:
-    needs: build
+    needs: install-deps
     runs-on: [ubuntu-latest]
     steps: 
       - uses: actions/checkout@v2
       - uses: ./.github/actions/restore-cache
       - uses: ./.github/actions/setup-node
+      - uses: ./.github/actions/build-essential
       - name: Dependency Checks
         run: npm run depcheck
   
   prettier:
-    needs: build
+    needs: install-deps
     runs-on: [ubuntu-latest]
     steps: 
       - uses: actions/checkout@v2
       - uses: ./.github/actions/restore-cache
       - uses: ./.github/actions/setup-node
+      - uses: ./.github/actions/build-essential
       - name: Prettier
         run: npm run prettier:check
   
   linting:
-    needs: build
+    needs: install-deps
     runs-on: [ubuntu-latest]
     steps: 
       - uses: actions/checkout@v2
       - uses: ./.github/actions/restore-cache
       - uses: ./.github/actions/setup-node
+      - uses: ./.github/actions/build-essential
       - name: Linting
         run: lerna run lint
 
   audit:
-    needs: build
+    needs: install-deps
     runs-on: [ubuntu-latest]
     steps: 
       - uses: actions/checkout@v2
       - uses: ./.github/actions/restore-cache
       - uses: ./.github/actions/setup-node
+      - uses: ./.github/actions/build-essential
       - name: Audit
         run: lerna run audit
 
   build-init:
-    needs: build
+    needs: install-deps
     runs-on: [ubuntu-latest]
     steps:
       - uses: actions/checkout@v2
       - uses: ./.github/actions/restore-cache
       - uses: ./.github/actions/setup-node
+      - uses: ./.github/actions/build-essential
       - name: Build slice machine init
         working-directory: ./packages/init
         run: npm run build
 
   build-ui:
-    needs: build
+    needs: install-deps
     runs-on: [ubuntu-latest]
     steps: 
       - uses: actions/checkout@v2
       - uses: ./.github/actions/restore-cache
       - uses: ./.github/actions/setup-node
+      - uses: ./.github/actions/build-essential
       - name: Build and export slice machine UI
         working-directory: ./packages/slice-machine
         run: npm run build && npm run export-build
 
   e2e-tests:
-    needs: build
+    needs: install-deps
     runs-on: [ubuntu-latest]
     steps: 
       - uses: actions/checkout@v2
       - uses: ./.github/actions/restore-cache
       - uses: ./.github/actions/setup-node
+      - uses: ./.github/actions/build-essential
       - name: Running End to End tests
         env:
           EMAIL: ${{ secrets.EMAIL }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,29 +4,31 @@ on: [push]
 
 jobs:
   build:
-    strategy:
-      matrix:
-        node-version: [16.x]
     runs-on: [ubuntu-latest]
     steps:
       - uses: actions/checkout@v2
-      - name: Restore cache
-        uses: actions/cache@v2
-        with:
-          path: |
-            node_modules
-            */*/node_modules
-            ~/.cache/Cypress
-          key: ${{ runner.os }}-lerna-${{ hashFiles('**/package.json') }}
-          restore-keys: |
-            ${{ runner.os }}-lerna-
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v2
-        with:
-          node-version: ${{ matrix.node-version }}
-          cache: "npm"
+      - uses: ./.github/actions/restore-cache
+      - uses: ./.github/actions/setup-node
       - name: Install dependencies
         run: npm i
+      - name: List all dependencies
+        shell: bash
+        run: npm list
+      - name: Build essential packages used by others
+        run: npm run build-essential
+
+  unit-tests:
+    needs: build
+    runs-on: [ubuntu-latest]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ./.github/actions/restore-cache
+      - uses: ./.github/actions/setup-node
+      - name: Install dependencies
+        run: npm i
+      - name: List all dependencies
+        shell: bash
+        run: npm list
       - name: Build essential packages used by others
         run: npm run build-essential
       - name: Running functional and unit tests
@@ -40,20 +42,76 @@ jobs:
           user_service_endpoint: ${{ secrets.USER_SERVICE_ENDPOINT }}
           acl_provider_endpoint: ${{ secrets.ACL_PROVIDER_ENDPOINT }}
         run: lerna run test
+  
+  dep-check:
+    needs: build
+    runs-on: [ubuntu-latest]
+    steps: 
+      - uses: actions/checkout@v2
+      - uses: ./.github/actions/restore-cache
+      - uses: ./.github/actions/setup-node
       - name: Dependency Checks
         run: npm run depcheck
+  
+  prettier:
+    needs: build
+    runs-on: [ubuntu-latest]
+    steps: 
+      - uses: actions/checkout@v2
+      - uses: ./.github/actions/restore-cache
+      - uses: ./.github/actions/setup-node
       - name: Prettier
         run: npm run prettier:check
+  
+  linting:
+    needs: build
+    runs-on: [ubuntu-latest]
+    steps: 
+      - uses: actions/checkout@v2
+      - uses: ./.github/actions/restore-cache
+      - uses: ./.github/actions/setup-node
       - name: Linting
         run: lerna run lint
+
+  audit:
+    needs: build
+    runs-on: [ubuntu-latest]
+    steps: 
+      - uses: actions/checkout@v2
+      - uses: ./.github/actions/restore-cache
+      - uses: ./.github/actions/setup-node
       - name: Audit
         run: lerna run audit
+
+  build-init:
+    needs: build
+    runs-on: [ubuntu-latest]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ./.github/actions/restore-cache
+      - uses: ./.github/actions/setup-node
       - name: Build slice machine init
         working-directory: ./packages/init
         run: npm run build
+
+  build-ui:
+    needs: build
+    runs-on: [ubuntu-latest]
+    steps: 
+      - uses: actions/checkout@v2
+      - uses: ./.github/actions/restore-cache
+      - uses: ./.github/actions/setup-node
       - name: Build and export slice machine UI
         working-directory: ./packages/slice-machine
         run: npm run build && npm run export-build
+
+  e2e-tests:
+    needs: build
+    runs-on: [ubuntu-latest]
+    steps: 
+      - uses: actions/checkout@v2
+      - uses: ./.github/actions/restore-cache
+      - uses: ./.github/actions/setup-node
       - name: Running End to End tests
         env:
           EMAIL: ${{ secrets.EMAIL }}


### PR DESCRIPTION
## Context

Tech Debt ticket: https://linear.app/prismic/issue/SM-879/[tech-debt]-spike-1-day-aadev-the-ci-can-run-parallel-jobs


## The Solution

Separating each step of the build job into different jobs that run in parallel after the installation job.

This can still be improved by looking into parallelisation of cypress e2e test since these are taking up ~80% of the total runtime 😢 

## Impact / Dependencies



## Checklist before requesting a review
- [x] I hereby declare my code ready for review.
- [ ] If it is a critical feature, I have added tests.
- [x] The CI is successful.
- [ ] If there could backward compatibility issues, it has been discussed and planned.


---

![image](https://user-images.githubusercontent.com/47107427/199206615-b7632a56-bc15-424c-a84a-1c31ff129fe9.png)