### PR TITLE
Move custom type renaming to custom types table

### DIFF
--- a/cypress/integration/customTypes/00-create.spec.js
+++ b/cypress/integration/customTypes/00-create.spec.js
@@ -36,17 +36,26 @@ describe("Custom Types specs", () => {
     cy.readFile(type).should("contains", name);
 
     //edit custom type name
-    cy.get('[data-cy="edit-custom-type"]').click();
-    cy.get("[data-cy=rename-custom-type-modal]").should("be.visible");
+    cy.visit("/");
+    cy.waitUntil(() => cy.get("[data-cy=edit-custom-type-menu]")).then(
+      () => true
+    );
+
+    cy.get('[data-cy="edit-custom-type-menu"]').click();
+
+    cy.get("[data-cy=edit-custom-type-menu-dropdown]").should("be.visible");
+
+    cy.get('[data-cy="ct-rename-menu-option"]').click();
+
     cy.get('[data-cy="custom-type-name-input"]').should("have.value", name);
     cy.get('[data-cy="custom-type-name-input"]')
       .clear()
       .type(`${name} - Edited`);
     cy.get("[data-cy=rename-custom-type-modal]").submit();
     cy.get("[data-cy=rename-custom-type-modal]").should("not.exist");
-    cy.get('[data-cy="custom-type-secondary-breadcrumb"]').contains(
-      `/ ${name} - Edited`
-    );
+
+    cy.get(`[data-cy="custom-type-${id}-label"]`).contains("Edited");
+
     cy.readFile(type).should("contains", `${name} - Edited`);
   });
 

--- a/packages/slice-machine/components/CustomTypeTable/ctPage.tsx
+++ b/packages/slice-machine/components/CustomTypeTable/ctPage.tsx
@@ -12,8 +12,7 @@ export const CustomTypeTable: React.FC<{
   customTypes: FrontEndCustomType[];
 }> = ({ customTypes }) => {
   const { modelsStatuses, authStatus, isOnline } = useModelStatus(customTypes);
-  const [renameCustomTypeName, setRenameCustomTypeName] = useState<string>("");
-  const [renameCustomTypeId, setRenameCustomTypeId] = useState<string>("");
+  const [customTypeIdToRename, setCustomTypeIdToRename] = useState<string>("");
 
   const firstColumnWidth = "27%";
   const secondColumnWidth = "27%";
@@ -91,8 +90,7 @@ export const CustomTypeTable: React.FC<{
                         displayName: "Rename",
                         onClick: (event) => {
                           event.stopPropagation();
-                          setRenameCustomTypeName(customType.local.label || "");
-                          setRenameCustomTypeId(customType.local.id);
+                          setCustomTypeIdToRename(customType.local.id);
                           openRenameCustomTypeModal();
                         },
                         dataCy: "ct-rename-menu-option",
@@ -112,8 +110,8 @@ export const CustomTypeTable: React.FC<{
         </tbody>
       </Box>
       <RenameCustomTypeModal
-        customTypeName={renameCustomTypeName}
-        customTypeId={renameCustomTypeId}
+        customTypes={customTypes}
+        customTypeId={customTypeIdToRename}
       />
     </>
   );

--- a/packages/slice-machine/components/CustomTypeTable/ctPage.tsx
+++ b/packages/slice-machine/components/CustomTypeTable/ctPage.tsx
@@ -12,7 +12,8 @@ export const CustomTypeTable: React.FC<{
   customTypes: FrontEndCustomType[];
 }> = ({ customTypes }) => {
   const { modelsStatuses, authStatus, isOnline } = useModelStatus(customTypes);
-  const [customTypeIdToRename, setCustomTypeIdToRename] = useState<string>("");
+  const [customTypeToRename, setCustomTypeToRename] =
+    useState<FrontEndCustomType>();
 
   const firstColumnWidth = "27%";
   const secondColumnWidth = "27%";
@@ -90,7 +91,7 @@ export const CustomTypeTable: React.FC<{
                         displayName: "Rename",
                         onClick: (event) => {
                           event.stopPropagation();
-                          setCustomTypeIdToRename(customType.local.id);
+                          setCustomTypeToRename(customType);
                           openRenameCustomTypeModal();
                         },
                         dataCy: "ct-rename-menu-option",
@@ -109,10 +110,7 @@ export const CustomTypeTable: React.FC<{
           ))}
         </tbody>
       </Box>
-      <RenameCustomTypeModal
-        customTypes={customTypes}
-        customTypeId={customTypeIdToRename}
-      />
+      <RenameCustomTypeModal customType={customTypeToRename} />
     </>
   );
 };

--- a/packages/slice-machine/components/CustomTypeTable/ctPage.tsx
+++ b/packages/slice-machine/components/CustomTypeTable/ctPage.tsx
@@ -88,6 +88,7 @@ export const CustomTypeTable: React.FC<{
                 </Box>
                 <Box as={"td"} style={{ width: fifthColumnWidth }}>
                   <KebabMenuDropdown
+                    dataCy="edit-custom-type-menu"
                     menuOptions={[
                       {
                         displayName: "Rename",

--- a/packages/slice-machine/components/CustomTypeTable/ctPage.tsx
+++ b/packages/slice-machine/components/CustomTypeTable/ctPage.tsx
@@ -1,15 +1,19 @@
 import { StatusBadge } from "../StatusBadge";
 import Link from "next/link";
-import React from "react";
+import React, { useState } from "react";
 import { Box, Text } from "theme-ui";
 import { FrontEndCustomType } from "@src/modules/availableCustomTypes/types";
 import { useModelStatus } from "@src/hooks/useModelStatus";
 import { KebabMenuDropdown } from "@components/KebabMenuDropdown";
+import useSliceMachineActions from "@src/modules/useSliceMachineActions";
+import { RenameCustomTypeModal } from "@components/Forms/RenameCustomTypeModal";
 
 export const CustomTypeTable: React.FC<{
   customTypes: FrontEndCustomType[];
 }> = ({ customTypes }) => {
   const { modelsStatuses, authStatus, isOnline } = useModelStatus(customTypes);
+  const [renameCustomTypeName, setRenameCustomTypeName] = useState<string>("");
+  const [renameCustomTypeId, setRenameCustomTypeId] = useState<string>("");
 
   const firstColumnWidth = "27%";
   const secondColumnWidth = "27%";
@@ -17,82 +21,100 @@ export const CustomTypeTable: React.FC<{
   const fourthColumnWidth = "20%";
   const fifthColumnWidth = "6%";
 
+  const { openRenameCustomTypeModal } = useSliceMachineActions();
+
   return (
-    <Box
-      as={"table"}
-      sx={{
-        mt: "36px",
-      }}
-    >
-      <thead>
-        <tr>
-          <Box as={"th"} sx={{ width: firstColumnWidth }}>
-            Name
-          </Box>
-          <Box as={"th"} sx={{ width: secondColumnWidth }}>
-            API ID
-          </Box>
-          <Box as={"th"} sx={{ width: thirdColumnWidth }}>
-            Type
-          </Box>
-          <Box as={"th"} sx={{ width: fourthColumnWidth }}>
-            Status
-          </Box>
-          <Box as={"th"} sx={{ width: fifthColumnWidth }} />
-        </tr>
-      </thead>
-      <tbody>
-        {customTypes.map((customType) => (
-          <Link
-            passHref
-            href={`/cts/${customType.local.id}`}
-            key={customType.local.id}
-          >
-            <tr tabIndex={0}>
-              <Box as={"td"} style={{ width: firstColumnWidth }}>
-                <Text sx={{ fontWeight: 500 }}>{customType.local.label}</Text>
-              </Box>
-              <Box as={"td"} style={{ width: secondColumnWidth }}>
-                {customType.local.id}
-              </Box>
-              <Box as={"td"} style={{ width: thirdColumnWidth }}>
-                {customType.local.repeatable
-                  ? "Repeatable Type"
-                  : "Single Type"}
-              </Box>
-              <Box as={"td"} style={{ width: fourthColumnWidth }}>
-                <StatusBadge
-                  modelType="Custom Type"
-                  modelId={customType.local.id}
-                  status={modelsStatuses.customTypes[customType.local.id]}
-                  authStatus={authStatus}
-                  isOnline={isOnline}
-                  data-for={`${customType.local.id}-tooltip`}
-                  data-tip
-                />
-              </Box>
-              <Box as={"td"} style={{ width: fifthColumnWidth }}>
-                <KebabMenuDropdown
-                  menuOptions={[
-                    {
-                      displayName: "Rename",
-                      onClick: (event) => {
-                        event.stopPropagation();
+    <>
+      <Box
+        as={"table"}
+        sx={{
+          mt: "36px",
+        }}
+      >
+        <thead>
+          <tr>
+            <Box as={"th"} sx={{ width: firstColumnWidth }}>
+              Name
+            </Box>
+            <Box as={"th"} sx={{ width: secondColumnWidth }}>
+              API ID
+            </Box>
+            <Box as={"th"} sx={{ width: thirdColumnWidth }}>
+              Type
+            </Box>
+            <Box as={"th"} sx={{ width: fourthColumnWidth }}>
+              Status
+            </Box>
+            <Box as={"th"} sx={{ width: fifthColumnWidth }} />
+          </tr>
+        </thead>
+        <tbody>
+          {customTypes.map((customType) => (
+            <Link
+              passHref
+              href={`/cts/${customType.local.id}`}
+              key={customType.local.id}
+            >
+              <tr tabIndex={0}>
+                <Box as={"td"} style={{ width: firstColumnWidth }}>
+                  <Text
+                    sx={{ fontWeight: 500 }}
+                    data-cy={`custom-type-${customType.local.id}-label`}
+                  >
+                    {customType.local.label}
+                  </Text>
+                </Box>
+                <Box as={"td"} style={{ width: secondColumnWidth }}>
+                  {customType.local.id}
+                </Box>
+                <Box as={"td"} style={{ width: thirdColumnWidth }}>
+                  {customType.local.repeatable
+                    ? "Repeatable Type"
+                    : "Single Type"}
+                </Box>
+                <Box as={"td"} style={{ width: fourthColumnWidth }}>
+                  <StatusBadge
+                    modelType="Custom Type"
+                    modelId={customType.local.id}
+                    status={modelsStatuses.customTypes[customType.local.id]}
+                    authStatus={authStatus}
+                    isOnline={isOnline}
+                    data-for={`${customType.local.id}-tooltip`}
+                    data-tip
+                  />
+                </Box>
+                <Box as={"td"} style={{ width: fifthColumnWidth }}>
+                  <KebabMenuDropdown
+                    dataCy="edit-custom-type-menu"
+                    menuOptions={[
+                      {
+                        displayName: "Rename",
+                        onClick: (event) => {
+                          event.stopPropagation();
+                          setRenameCustomTypeName(customType.local.label || "");
+                          setRenameCustomTypeId(customType.local.id);
+                          openRenameCustomTypeModal();
+                        },
+                        dataCy: "ct-rename-menu-option",
                       },
-                    },
-                    {
-                      displayName: "Delete",
-                      onClick: (event) => {
-                        event.stopPropagation();
+                      {
+                        displayName: "Delete",
+                        onClick: (event) => {
+                          event.stopPropagation();
+                        },
                       },
-                    },
-                  ]}
-                />
-              </Box>
-            </tr>
-          </Link>
-        ))}
-      </tbody>
-    </Box>
+                    ]}
+                  />
+                </Box>
+              </tr>
+            </Link>
+          ))}
+        </tbody>
+      </Box>
+      <RenameCustomTypeModal
+        customTypeName={renameCustomTypeName}
+        customTypeId={renameCustomTypeId}
+      />
+    </>
   );
 };

--- a/packages/slice-machine/components/Forms/RenameCustomTypeModal/RenameCustomTypeModal.tsx
+++ b/packages/slice-machine/components/Forms/RenameCustomTypeModal/RenameCustomTypeModal.tsx
@@ -11,17 +11,17 @@ import { selectAllCustomTypeLabels } from "@src/modules/availableCustomTypes";
 import { isLoading } from "@src/modules/loading";
 import { LoadingKeysEnum } from "@src/modules/loading/types";
 import { FrontEndCustomType } from "@src/modules/availableCustomTypes/types";
-import { useMemo } from "react";
 
 interface RenameCustomTypeModalProps {
-  customTypes: FrontEndCustomType[];
-  customTypeId: string;
+  customType?: FrontEndCustomType;
 }
 
 export const RenameCustomTypeModal: React.FC<RenameCustomTypeModalProps> = ({
-  customTypes,
-  customTypeId,
+  customType,
 }) => {
+  const customTypeName = customType?.local.label ?? "";
+  const customTypeId = customType?.local.id ?? "";
+
   const { renameCustomType, closeRenameCustomTypeModal } =
     useSliceMachineActions();
 
@@ -40,13 +40,6 @@ export const RenameCustomTypeModal: React.FC<RenameCustomTypeModalProps> = ({
     customTypeLabels: selectAllCustomTypeLabels(store),
     isRenamingCustomType: isLoading(store, LoadingKeysEnum.RENAME_CUSTOM_TYPE),
   }));
-
-  const customTypeName = useMemo(() => {
-    return (
-      customTypes.find((customType) => customType.local.id === customTypeId)
-        ?.local.label || ""
-    );
-  }, [customTypeId]);
 
   return (
     <ModalFormCard

--- a/packages/slice-machine/components/Forms/RenameCustomTypeModal/RenameCustomTypeModal.tsx
+++ b/packages/slice-machine/components/Forms/RenameCustomTypeModal/RenameCustomTypeModal.tsx
@@ -10,14 +10,16 @@ import { FormikErrors } from "formik";
 import { selectAllCustomTypeLabels } from "@src/modules/availableCustomTypes";
 import { isLoading } from "@src/modules/loading";
 import { LoadingKeysEnum } from "@src/modules/loading/types";
+import { FrontEndCustomType } from "@src/modules/availableCustomTypes/types";
+import { useMemo } from "react";
 
 interface RenameCustomTypeModalProps {
-  customTypeName: string;
+  customTypes: FrontEndCustomType[];
   customTypeId: string;
 }
 
 export const RenameCustomTypeModal: React.FC<RenameCustomTypeModalProps> = ({
-  customTypeName,
+  customTypes,
   customTypeId,
 }) => {
   const { renameCustomType, closeRenameCustomTypeModal } =
@@ -38,6 +40,13 @@ export const RenameCustomTypeModal: React.FC<RenameCustomTypeModalProps> = ({
     customTypeLabels: selectAllCustomTypeLabels(store),
     isRenamingCustomType: isLoading(store, LoadingKeysEnum.RENAME_CUSTOM_TYPE),
   }));
+
+  const customTypeName = useMemo(() => {
+    return (
+      customTypes.find((customType) => customType.local.id === customTypeId)
+        ?.local.label || ""
+    );
+  }, [customTypeId]);
 
   return (
     <ModalFormCard

--- a/packages/slice-machine/components/KebabMenuDropdown/KebabMenuList.tsx
+++ b/packages/slice-machine/components/KebabMenuDropdown/KebabMenuList.tsx
@@ -2,10 +2,11 @@ import React from "react";
 import { Box, Flex } from "theme-ui";
 import { MenuOption } from ".";
 
-const MenuItem: React.FunctionComponent<{
-  value: string;
-  onClick: (event: React.MouseEvent<HTMLDivElement>) => void;
-}> = ({ value, onClick }) => {
+const MenuItem: React.FunctionComponent<MenuOption> = ({
+  displayName,
+  onClick,
+  dataCy,
+}) => {
   return (
     <Box
       sx={{
@@ -18,8 +19,9 @@ const MenuItem: React.FunctionComponent<{
         },
       }}
       onClick={onClick}
+      data-cy={dataCy}
     >
-      {value}
+      {displayName}
     </Box>
   );
 };
@@ -27,9 +29,11 @@ const MenuItem: React.FunctionComponent<{
 export const KebabMenuList: React.FunctionComponent<{
   menuOptions: MenuOption[];
   closeMenu: () => void;
-}> = ({ menuOptions, closeMenu }) => {
+  dataCy?: string;
+}> = ({ menuOptions, closeMenu, dataCy }) => {
   return (
     <Box
+      data-cy={dataCy}
       sx={{
         py: 0,
         flexDirection: "column",
@@ -49,11 +53,12 @@ export const KebabMenuList: React.FunctionComponent<{
         {menuOptions.map((option) => {
           return (
             <MenuItem
-              value={option.displayName}
+              displayName={option.displayName}
               onClick={(event) => {
                 closeMenu();
                 option.onClick(event);
               }}
+              dataCy={option.dataCy}
             />
           );
         })}

--- a/packages/slice-machine/components/KebabMenuDropdown/index.tsx
+++ b/packages/slice-machine/components/KebabMenuDropdown/index.tsx
@@ -7,14 +7,17 @@ import { KebabMenuList } from "./KebabMenuList";
 export type MenuOption = {
   displayName: string;
   onClick: (event: React.MouseEvent<HTMLDivElement>) => void;
+  dataCy?: string;
 };
 
 type KebabMenuDropdownProps = {
   menuOptions: MenuOption[];
+  dataCy?: string;
 };
 
 export const KebabMenuDropdown: React.FC<KebabMenuDropdownProps> = ({
   menuOptions,
+  dataCy,
 }) => {
   const [isOpen, setIsOpen] = useState(false);
 
@@ -30,6 +33,7 @@ export const KebabMenuDropdown: React.FC<KebabMenuDropdownProps> = ({
           <KebabMenuList
             menuOptions={menuOptions}
             closeMenu={() => setIsOpen(false)}
+            dataCy={dataCy && `${dataCy}-dropdown`}
           />
         )}
       >
@@ -44,6 +48,7 @@ export const KebabMenuDropdown: React.FC<KebabMenuDropdownProps> = ({
             event.stopPropagation();
             setIsOpen(!isOpen);
           }}
+          data-cy={dataCy}
         >
           <BsThreeDotsVertical color="#6F6E77" size={16} />
         </Button>

--- a/packages/slice-machine/lib/builders/CustomTypeBuilder/Layout/Header/index.tsx
+++ b/packages/slice-machine/lib/builders/CustomTypeBuilder/Layout/Header/index.tsx
@@ -1,16 +1,13 @@
-import React from "react";
-import { Box, Flex, Text, useThemeUI } from "theme-ui";
+import { Box, Flex, Text } from "theme-ui";
 
 import Header from "@components/Header";
 
 import useSliceMachineActions from "@src/modules/useSliceMachineActions";
-import { MdModeEdit, MdSpaceDashboard } from "react-icons/md";
+import { MdSpaceDashboard } from "react-icons/md";
 import { useSelector } from "react-redux";
 import { SliceMachineStoreType } from "@src/redux/type";
 import { selectCurrentCustomType } from "@src/modules/selectedCustomType";
-import SliceMachineIconButton from "@components/SliceMachineIconButton";
 
-import { RenameCustomTypeModal } from "@components/Forms/RenameCustomTypeModal";
 import { isSelectedCustomTypeTouched } from "@src/modules/selectedCustomType";
 
 import { isLoading } from "@src/modules/loading";
@@ -22,9 +19,6 @@ const CustomTypeHeader = () => {
   const { currentCustomType } = useSelector((store: SliceMachineStoreType) => ({
     currentCustomType: selectCurrentCustomType(store),
   }));
-  const { openRenameCustomTypeModal } = useSliceMachineActions();
-  const { theme } = useThemeUI();
-
   const { hasPendingModifications, isSavingCustomType } = useSelector(
     (store: SliceMachineStoreType) => ({
       hasPendingModifications: isSelectedCustomTypeTouched(store),
@@ -53,24 +47,6 @@ const CustomTypeHeader = () => {
         breadrumbHref="/"
         ActionButton={
           <Flex sx={{ alignItems: "center" }}>
-            <SliceMachineIconButton
-              Icon={MdModeEdit}
-              label="Edit custom type name"
-              data-cy="edit-custom-type"
-              sx={{
-                cursor: "pointer",
-                color: theme.colors?.icons,
-                height: 40,
-                width: 40,
-              }}
-              onClick={openRenameCustomTypeModal}
-              style={{
-                color: "#4E4E55",
-                backgroundColor: "#F3F5F7",
-                border: "1px solid #3E3E4826",
-                marginRight: "8px",
-              }}
-            />
             <Button
               label="Save to File System"
               isLoading={isSavingCustomType}
@@ -81,10 +57,6 @@ const CustomTypeHeader = () => {
             />
           </Flex>
         }
-      />
-      <RenameCustomTypeModal
-        customTypeName={currentCustomType.label || ""}
-        customTypeId={currentCustomType.id}
       />
     </>
   );

--- a/packages/slice-machine/src/modules/availableCustomTypes/index.ts
+++ b/packages/slice-machine/src/modules/availableCustomTypes/index.ts
@@ -56,8 +56,7 @@ type CustomTypesActions =
   | ActionType<typeof createCustomTypeCreator>
   | ActionType<typeof renameCustomTypeCreator>
   | ActionType<typeof saveCustomTypeCreator>
-  | ActionType<typeof pushCustomTypeCreator>
-  | ActionType<typeof renameCustomTypeCreator>;
+  | ActionType<typeof pushCustomTypeCreator>;
 
 // Selectors
 export const selectAllCustomTypes = (

--- a/packages/slice-machine/src/modules/availableCustomTypes/index.ts
+++ b/packages/slice-machine/src/modules/availableCustomTypes/index.ts
@@ -56,7 +56,8 @@ type CustomTypesActions =
   | ActionType<typeof createCustomTypeCreator>
   | ActionType<typeof renameCustomTypeCreator>
   | ActionType<typeof saveCustomTypeCreator>
-  | ActionType<typeof pushCustomTypeCreator>;
+  | ActionType<typeof pushCustomTypeCreator>
+  | ActionType<typeof renameCustomTypeCreator>;
 
 // Selectors
 export const selectAllCustomTypes = (

--- a/packages/slice-machine/src/modules/selectedCustomType/actions.ts
+++ b/packages/slice-machine/src/modules/selectedCustomType/actions.ts
@@ -5,7 +5,6 @@ import {
   CustomTypeSM,
   TabField,
 } from "@slicemachine/core/build/models/CustomType";
-import { renameCustomTypeCreator } from "../availableCustomTypes";
 
 export type SelectedCustomTypeActions =
   | ActionType<typeof initCustomTypeStoreCreator>
@@ -27,8 +26,7 @@ export type SelectedCustomTypeActions =
   | ActionType<typeof replaceFieldIntoGroupCreator>
   | ActionType<typeof reorderFieldIntoGroupCreator>
   | ActionType<typeof deleteFieldIntoGroupCreator>
-  | ActionType<typeof deleteSharedSliceCreator>
-  | ActionType<typeof renameCustomTypeCreator>;
+  | ActionType<typeof deleteSharedSliceCreator>;
 
 export const initCustomTypeStoreCreator = createAction("CUSTOM_TYPE/INIT")<{
   model: CustomTypeSM;

--- a/packages/slice-machine/src/modules/selectedCustomType/reducer.ts
+++ b/packages/slice-machine/src/modules/selectedCustomType/reducer.ts
@@ -35,7 +35,6 @@ import { WidgetTypes } from "@prismicio/types-internal/lib/customtypes/widgets";
 import { SlicesSM } from "@slicemachine/core/build/models/Slices";
 import { GroupSM } from "@slicemachine/core/build/models/Group";
 import { Group } from "@lib/models/common/CustomType/group";
-import { renameCustomTypeCreator } from "../availableCustomTypes";
 
 // Reducer
 export const selectedCustomTypeReducer: Reducer<
@@ -316,22 +315,6 @@ export const selectedCustomTypeReducer: Reducer<
           groupId
         )((group: GroupSM) => Group.reorderWidget(group, start, end))
       );
-    }
-    case getType(renameCustomTypeCreator.success): {
-      if (!state) return state;
-      const newName = action.payload.newCustomTypeName;
-
-      return {
-        ...state,
-        model: {
-          ...state.model,
-          label: newName,
-        },
-        initialModel: {
-          ...state.initialModel,
-          label: newName,
-        },
-      };
     }
     default:
       return state;


### PR DESCRIPTION
## Context

Ticket: https://linear.app/prismic/issue/SM-858/[delete-ct]-aauser-i-can-rename-a-custom-type-from-the-ct-list

## The Solution

Removed the edit button in the custom type editor, added onClick functionality to the rename option of the kebab menu.


## Impact / Dependencies

Waiting on #667 

## Checklist before requesting a review
- [ ] I hereby declare my code ready for review.
- [x] If it is a critical feature, I have added tests.
- [x] The CI is successful.
- [ ] If there could backward compatibility issues, it has been discussed and planned.




## [OPT] Preview

![ezgif com-gif-maker (4)](https://user-images.githubusercontent.com/47107427/199578833-74dacbf7-3025-4e96-a6ec-b76581c363bd.gif)

---

![image](https://user-images.githubusercontent.com/47107427/199578982-68981e2f-ce71-4cc9-a346-b916342c1e50.png)