### PR TITLE
Fix slicezone shared type deletion logic

### DIFF
--- a/packages/slice-machine/lib/builders/CustomTypeBuilder/SliceZone/index.tsx
+++ b/packages/slice-machine/lib/builders/CustomTypeBuilder/SliceZone/index.tsx
@@ -110,7 +110,7 @@ const SliceZone: React.FC<SliceZoneProps> = ({
         onRemoveSharedSlice(key);
       });
     }
-  }, [notFound]);
+  }, [JSON.stringify(notFound)]);
 
   const sharedSlicesInSliceZone = slicesInSliceZone
     .filter((e) => e.type === SlicesTypes.SharedSlice)

--- a/packages/slice-machine/lib/builders/CustomTypeBuilder/SliceZone/index.tsx
+++ b/packages/slice-machine/lib/builders/CustomTypeBuilder/SliceZone/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Text, Box, Flex, Heading, Button } from "theme-ui";
 
 import ZoneHeader from "../../common/Zone/components/ZoneHeader";
@@ -100,9 +100,13 @@ const SliceZone: React.FC<SliceZoneProps> = ({
   const { modelsStatuses, authStatus, isOnline } =
     useModelStatus(frontendSlices);
 
-  const { availableSlices, slicesInSliceZone, notFound } = sliceZone
-    ? mapAvailableAndSharedSlices(sliceZone, libraries)
-    : { availableSlices: [], slicesInSliceZone: [], notFound: [] };
+  const { availableSlices, slicesInSliceZone, notFound } = useMemo(
+    () =>
+      sliceZone
+        ? mapAvailableAndSharedSlices(sliceZone, libraries)
+        : { availableSlices: [], slicesInSliceZone: [], notFound: [] },
+    [sliceZone, libraries]
+  );
 
   useEffect(() => {
     if (notFound?.length) {
@@ -110,7 +114,7 @@ const SliceZone: React.FC<SliceZoneProps> = ({
         onRemoveSharedSlice(key);
       });
     }
-  }, [JSON.stringify(notFound)]);
+  }, [notFound]);
 
   const sharedSlicesInSliceZone = slicesInSliceZone
     .filter((e) => e.type === SlicesTypes.SharedSlice)

--- a/packages/slice-machine/lib/models/common/CustomType/sliceZone.ts
+++ b/packages/slice-machine/lib/models/common/CustomType/sliceZone.ts
@@ -49,7 +49,7 @@ export const SliceZone = {
     };
   },
   removeSharedSlice(sz: SlicesSM, key: string): SlicesSM {
-    const value = sz.value.filter(({ key: k }) => k === key);
+    const value = sz.value.filter(({ key: k }) => k !== key);
 
     return {
       ...sz,

--- a/packages/slice-machine/tests/lib/models/common/CustomType/sliceZone.test.ts
+++ b/packages/slice-machine/tests/lib/models/common/CustomType/sliceZone.test.ts
@@ -1,0 +1,67 @@
+import { SliceZone } from "@lib/models/common/CustomType/sliceZone";
+import { SlicesSM } from "@slicemachine/core/build/models/Slices";
+import { SlicesTypes } from "@prismicio/types-internal/lib/customtypes/widgets/slices";
+
+const mockSliceZone: SlicesSM = {
+  key: "slices",
+  value: [
+    { key: "slice_in_zone_0", value: { type: SlicesTypes.SharedSlice } },
+    { key: "slice_in_zone_1", value: { type: SlicesTypes.SharedSlice } },
+    { key: "slice_in_zone_2", value: { type: SlicesTypes.SharedSlice } },
+  ],
+};
+
+describe("Slice Zone", () => {
+  describe("Remove shared slices", () => {
+    it("removes the correct slice", () => {
+      const keyToRemove = "slice_in_zone_1";
+
+      const result = SliceZone.removeSharedSlice(mockSliceZone, keyToRemove);
+
+      expect(result.value.map((slice) => slice.key).includes(keyToRemove)).toBe(
+        false
+      );
+      expect(result.value.length).toEqual(2);
+    });
+
+    it("removes nothing if the key does not exist", () => {
+      const keyToRemove = "invalid_key";
+
+      const result = SliceZone.removeSharedSlice(mockSliceZone, keyToRemove);
+
+      expect(result).toEqual(mockSliceZone);
+    });
+  });
+
+  describe("Replace shared slices", () => {
+    it("removes the correct slice", () => {
+      const keyToPreserve = "slice_in_zone_1";
+      const newKeys = "new_slice_in_zone";
+
+      const result = SliceZone.replaceSharedSlice(
+        mockSliceZone,
+        [newKeys],
+        [keyToPreserve]
+      );
+
+      expect(result.value.map((slice) => slice.key)).toEqual([
+        keyToPreserve,
+        newKeys,
+      ]);
+      expect(result.value.length).toEqual(2);
+    });
+  });
+
+  describe("Add shared slices", () => {
+    it("adds a new slice to the slice zone", () => {
+      const newKey = "new_slice_in_zone";
+
+      const result = SliceZone.addSharedSlice(mockSliceZone, newKey);
+
+      expect(result.value.map((slice) => slice.key)).toEqual(
+        mockSliceZone.value.map((slice) => slice.key).concat([newKey])
+      );
+      expect(result.value.length).toEqual(4);
+    });
+  });
+});


### PR DESCRIPTION
## Context

This is part of a fix for this Spike: https://linear.app/prismic/issue/SM-883/spike-1day-aauser-i-can-use-slice-machine-with-legacy-slices-in-my


## The Solution

The logic for removing a missing slice from the slice zone was reversed, and thus removing all other slices that could be displayed. This logic has now been updated and tests were added for the file. 

Also updated the dependency array for the useEffect in the slice Zone component, since this was not correctly checking that the object was equal between renders and was re-rendering infinitely.

## Checklist before requesting a review
- [ ] I hereby declare my code ready for review.
- [ ] If it is a critical feature, I have added tests.
- [ ] The CI is successful.
- [ ] If there could backward compatibility issues, it has been discussed and planned.

---

![image](https://user-images.githubusercontent.com/47107427/200538466-cac05388-74e9-4348-a84d-aea337772fd9.png)