### PR TITLE
Fix dropdown opening offscreen when at the bottom

### DIFF
--- a/packages/slice-machine/components/KebabMenuDropdown/index.tsx
+++ b/packages/slice-machine/components/KebabMenuDropdown/index.tsx
@@ -29,7 +29,7 @@ export const KebabMenuDropdown: React.FC<KebabMenuDropdownProps> = ({
         align="end"
         isOpen={isOpen}
         onClickOutside={() => setIsOpen(false)}
-        positions={["bottom"]}
+        positions={["bottom", "top"]}
         padding={2}
         content={() => (
           <KebabMenuList


### PR DESCRIPTION
## Context

Fixing this bug: https://linear.app/prismic/issue/SM-856#comment-2e48648e

## The Solution

Library allows second choice of popover positioning when the first isn't doable.

## Checklist before requesting a review
- [ ] I hereby declare my code ready for review.
- [ ] If it is a critical feature, I have added tests.
- [ ] The CI is successful.
- [ ] If there could backward compatibility issues, it has been discussed and planned.


## [OPT] Preview

<img width="1440" alt="image" src="https://user-images.githubusercontent.com/47107427/200595662-b09646c3-4242-4f7e-a4ce-0f4681946076.png">

---

<!--
A funny animal picture is welcome to close your PR!
You can find one here https://unsplash.com/s/photos/funny-animal-picture
-->


