### PR TITLE
Open delete CT modal from the CT list

### DIFF
--- a/packages/slice-machine/components/CustomTypeTable/ctPage.tsx
+++ b/packages/slice-machine/components/CustomTypeTable/ctPage.tsx
@@ -13,9 +13,7 @@ export const CustomTypeTable: React.FC<{
   customTypes: FrontEndCustomType[];
 }> = ({ customTypes }) => {
   const { modelsStatuses, authStatus, isOnline } = useModelStatus(customTypes);
-  const [customTypeToRename, setCustomTypeToRename] =
-    useState<FrontEndCustomType>();
-  const [customTypeToDelete, setCustomTypeToDelete] =
+  const [customTypeToEdit, setCustomTypeToEdit] =
     useState<FrontEndCustomType>();
 
   const firstColumnWidth = "27%";
@@ -94,7 +92,7 @@ export const CustomTypeTable: React.FC<{
                       {
                         displayName: "Rename",
                         onClick: () => {
-                          setCustomTypeToRename(customType);
+                          setCustomTypeToEdit(customType);
                           openRenameCustomTypeModal();
                         },
                         dataCy: "ct-rename-menu-option",
@@ -102,7 +100,7 @@ export const CustomTypeTable: React.FC<{
                       {
                         displayName: "Delete",
                         onClick: () => {
-                          setCustomTypeToDelete(customType);
+                          setCustomTypeToEdit(customType);
                           openDeleteCustomTypeModal();
                         },
                       },
@@ -114,8 +112,8 @@ export const CustomTypeTable: React.FC<{
           ))}
         </tbody>
       </Box>
-      <RenameCustomTypeModal customType={customTypeToRename} />
-      <DeleteCustomTypeModal customType={customTypeToDelete} />
+      <RenameCustomTypeModal customType={customTypeToEdit} />
+      <DeleteCustomTypeModal customType={customTypeToEdit} />
     </>
   );
 };

--- a/packages/slice-machine/components/CustomTypeTable/ctPage.tsx
+++ b/packages/slice-machine/components/CustomTypeTable/ctPage.tsx
@@ -1,18 +1,21 @@
 import { StatusBadge } from "../StatusBadge";
 import Link from "next/link";
-import React, { useCallback, useState } from "react";
+import React, { useState } from "react";
 import { Box, Text } from "theme-ui";
 import { FrontEndCustomType } from "@src/modules/availableCustomTypes/types";
 import { useModelStatus } from "@src/hooks/useModelStatus";
 import { KebabMenuDropdown } from "@components/KebabMenuDropdown";
 import useSliceMachineActions from "@src/modules/useSliceMachineActions";
 import { RenameCustomTypeModal } from "@components/Forms/RenameCustomTypeModal";
+import { DeleteCustomTypeModal } from "@components/DeleteCTModal";
 
 export const CustomTypeTable: React.FC<{
   customTypes: FrontEndCustomType[];
 }> = ({ customTypes }) => {
   const { modelsStatuses, authStatus, isOnline } = useModelStatus(customTypes);
   const [customTypeToRename, setCustomTypeToRename] =
+    useState<FrontEndCustomType>();
+  const [customTypeToDelete, setCustomTypeToDelete] =
     useState<FrontEndCustomType>();
 
   const firstColumnWidth = "27%";
@@ -21,10 +24,8 @@ export const CustomTypeTable: React.FC<{
   const fourthColumnWidth = "20%";
   const fifthColumnWidth = "6%";
 
-  const { openRenameCustomTypeModal } = useSliceMachineActions();
-
-  // eslint-disable-next-line
-  const noop = useCallback(() => {}, []);
+  const { openRenameCustomTypeModal, openDeleteCustomTypeModal } =
+    useSliceMachineActions();
 
   return (
     <>
@@ -100,7 +101,10 @@ export const CustomTypeTable: React.FC<{
                       },
                       {
                         displayName: "Delete",
-                        onClick: noop,
+                        onClick: () => {
+                          setCustomTypeToDelete(customType);
+                          openDeleteCustomTypeModal();
+                        },
                       },
                     ]}
                   />
@@ -111,6 +115,7 @@ export const CustomTypeTable: React.FC<{
         </tbody>
       </Box>
       <RenameCustomTypeModal customType={customTypeToRename} />
+      <DeleteCustomTypeModal customType={customTypeToDelete} />
     </>
   );
 };

--- a/packages/slice-machine/components/DeleteCTModal/index.tsx
+++ b/packages/slice-machine/components/DeleteCTModal/index.tsx
@@ -102,7 +102,7 @@ export const DeleteCustomTypeModal: React.FunctionComponent<
             />
             <Button
               label="Delete Locally"
-              variant="red"
+              variant="danger"
               onClick={() => closeDeleteCustomTypeModal()}
             />
           </Flex>

--- a/packages/slice-machine/components/DeleteCTModal/index.tsx
+++ b/packages/slice-machine/components/DeleteCTModal/index.tsx
@@ -1,0 +1,119 @@
+import SliceMachineModal from "@components/SliceMachineModal";
+import { useSelector } from "react-redux";
+import { SliceMachineStoreType } from "@src/redux/type";
+import { isModalOpen } from "@src/modules/modal";
+import { ModalKeysEnum } from "@src/modules/modal/types";
+import useSliceMachineActions from "@src/modules/useSliceMachineActions";
+import { Close, Flex, Heading, Text, useThemeUI } from "theme-ui";
+import Card from "@components/Card";
+import { FrontEndCustomType } from "@src/modules/availableCustomTypes/types";
+import { MdOutlineDelete } from "react-icons/md";
+import { Button } from "@components/Button";
+
+type ScreenshotModalProps = {
+  customType?: FrontEndCustomType;
+};
+
+export const DeleteCustomTypeModal: React.FunctionComponent<
+  ScreenshotModalProps
+> = ({ customType }) => {
+  const { isDeleteCustomTypeModalOpen } = useSelector(
+    (store: SliceMachineStoreType) => ({
+      isDeleteCustomTypeModalOpen: isModalOpen(
+        store,
+        ModalKeysEnum.DELETE_CUSTOM_TYPE
+      ),
+    })
+  );
+
+  const { closeDeleteCustomTypeModal } = useSliceMachineActions();
+
+  const { theme } = useThemeUI();
+
+  return (
+    <SliceMachineModal
+      isOpen={isDeleteCustomTypeModalOpen}
+      shouldCloseOnOverlayClick={true}
+      contentLabel={"Screenshot Preview"}
+      portalClassName={"ScreenshotPreviewModal"}
+      style={{
+        content: {
+          maxWidth: 612,
+          borderRadius: "0px",
+        },
+      }}
+    >
+      <Card
+        radius={"0px"}
+        bodySx={{
+          p: 0,
+          bg: "#FFF",
+          position: "relative",
+          height: "100%",
+          padding: 16,
+        }}
+        footerSx={{
+          p: 0,
+        }}
+        sx={{ border: "none", borderRadius: "0px" }}
+        Header={() => (
+          <Flex
+            sx={{
+              p: "16px",
+              alignItems: "center",
+              justifyContent: "space-between",
+              borderBottom: (t) => `1px solid ${String(t.colors?.borders)}`,
+            }}
+          >
+            <Flex sx={{ alignItems: "center" }}>
+              <MdOutlineDelete
+                size={20}
+                color={theme.colors?.greyIcon as string}
+              />
+              <Heading sx={{ fontSize: "14px", fontWeight: "bold", ml: 1 }}>
+                Delete Custom Type
+              </Heading>
+            </Flex>
+            <Close type="button" onClick={() => closeDeleteCustomTypeModal()} />
+          </Flex>
+        )}
+        Footer={() => (
+          <Flex
+            style={{
+              justifyContent: "flex-end",
+              height: 64,
+              alignItems: "center",
+              paddingRight: 16,
+              borderTop: "1px solid #DCDBDD",
+              backgroundColor: "white",
+            }}
+          >
+            <Button
+              label="Cancel"
+              variant="secondary"
+              onClick={() => closeDeleteCustomTypeModal()}
+              sx={{
+                mr: "10px",
+                fontWeight: "bold",
+                color: "#1A1523",
+                borderRadius: 6,
+              }}
+            />
+            <Button
+              label="Delete Locally"
+              variant="red"
+              onClick={() => closeDeleteCustomTypeModal()}
+            />
+          </Flex>
+        )}
+      >
+        <Text>
+          This action will delete the{" "}
+          <Text sx={{ fontWeight: "bold" }}>“{customType?.local.label}”</Text>{" "}
+          Custom Type in your local project. It will be deleted from your
+          repository in the next sync.
+        </Text>
+      </Card>
+    </SliceMachineModal>
+  );
+};

--- a/packages/slice-machine/components/DeleteCTModal/index.tsx
+++ b/packages/slice-machine/components/DeleteCTModal/index.tsx
@@ -42,6 +42,7 @@ export const DeleteCustomTypeModal: React.FunctionComponent<
           borderRadius: "0px",
         },
       }}
+      onRequestClose={closeDeleteCustomTypeModal}
     >
       <Card
         radius={"0px"}

--- a/packages/slice-machine/components/DeleteCTModal/index.tsx
+++ b/packages/slice-machine/components/DeleteCTModal/index.tsx
@@ -48,7 +48,7 @@ export const DeleteCustomTypeModal: React.FunctionComponent<
         radius={"0px"}
         bodySx={{
           p: 0,
-          bg: "#FFF",
+          bg: "white",
           position: "relative",
           height: "100%",
           padding: 16,
@@ -80,12 +80,12 @@ export const DeleteCustomTypeModal: React.FunctionComponent<
         )}
         Footer={() => (
           <Flex
-            style={{
+            sx={{
               justifyContent: "flex-end",
               height: 64,
               alignItems: "center",
               paddingRight: 16,
-              borderTop: "1px solid #DCDBDD",
+              borderTop: (t) => `1px solid ${String(t.colors?.darkBorders)}`,
               backgroundColor: "white",
             }}
           >
@@ -96,7 +96,7 @@ export const DeleteCustomTypeModal: React.FunctionComponent<
               sx={{
                 mr: "10px",
                 fontWeight: "bold",
-                color: "#1A1523",
+                color: "grey12",
                 borderRadius: 6,
               }}
             />

--- a/packages/slice-machine/components/ScreenshotPreviewModal/index.tsx
+++ b/packages/slice-machine/components/ScreenshotPreviewModal/index.tsx
@@ -35,6 +35,7 @@ const ScreenshotPreviewModal: React.FunctionComponent<ScreenshotModalProps> = ({
       shouldCloseOnOverlayClick={true}
       contentLabel={"Screenshot Preview"}
       portalClassName={"ScreenshotPreviewModal"}
+      onRequestClose={closeScreenshotPreviewModal}
     >
       <Card
         radius={"0px"}

--- a/packages/slice-machine/components/Simulator/index.tsx
+++ b/packages/slice-machine/components/Simulator/index.tsx
@@ -14,13 +14,13 @@ import {
 import { SliceMachineStoreType } from "@src/redux/type";
 import { selectCurrentSlice } from "@src/modules/selectedSlice/selectors";
 import Router from "next/router";
-import ScreenshotPreviewModal from "@components/ScreenshotPreviewModal";
 import { Toolbar } from "./components/Toolbar";
 import {
   ScreenSizeOptions,
   ScreenSizes,
 } from "./components/Toolbar/ScreensizeInput";
 import { ScreenDimensions } from "@lib/models/common/Screenshots";
+import ScreenshotPreviewModal from "@components/ScreenshotPreviewModal";
 
 export type SliceView = SliceViewItem[];
 export type SliceViewItem = Readonly<{ sliceID: string; variationID: string }>;

--- a/packages/slice-machine/src/modules/modal/types.ts
+++ b/packages/slice-machine/src/modules/modal/types.ts
@@ -6,6 +6,7 @@ export enum ModalKeysEnum {
   RENAME_SLICE = "RENAME_SLICE",
   SCREENSHOT_PREVIEW = "SCREENSHOT_PREVIEW",
   SCREENSHOTS = "SCREENSHOTS",
+  DELETE_CUSTOM_TYPE = "DELETE_CUSTOM_TYPE",
 }
 
 export type ModalStoreType = Record<ModalKeysEnum, boolean>;

--- a/packages/slice-machine/src/modules/useSliceMachineActions.ts
+++ b/packages/slice-machine/src/modules/useSliceMachineActions.ts
@@ -132,6 +132,11 @@ const useSliceMachineActions = () => {
   const closeScreenshotPreviewModal = () =>
     dispatch(modalCloseCreator({ modalKey: ModalKeysEnum.SCREENSHOT_PREVIEW }));
 
+  const openDeleteCustomTypeModal = () =>
+    dispatch(modalOpenCreator({ modalKey: ModalKeysEnum.DELETE_CUSTOM_TYPE }));
+  const closeDeleteCustomTypeModal = () =>
+    dispatch(modalCloseCreator({ modalKey: ModalKeysEnum.DELETE_CUSTOM_TYPE }));
+
   // Loading module
   const startLoadingReview = () =>
     dispatch(startLoadingActionCreator({ loadingKey: LoadingKeysEnum.REVIEW }));
@@ -566,6 +571,8 @@ const useSliceMachineActions = () => {
     closeRenameCustomTypeModal,
     openScreenshotPreviewModal,
     closeScreenshotPreviewModal,
+    openDeleteCustomTypeModal,
+    closeDeleteCustomTypeModal,
     openCreateSliceModal,
     closeCreateSliceModal,
     openRenameSliceModal,

--- a/packages/slice-machine/src/modules/useSliceMachineActions.ts
+++ b/packages/slice-machine/src/modules/useSliceMachineActions.ts
@@ -131,7 +131,6 @@ const useSliceMachineActions = () => {
     dispatch(modalOpenCreator({ modalKey: ModalKeysEnum.SCREENSHOT_PREVIEW }));
   const closeScreenshotPreviewModal = () =>
     dispatch(modalCloseCreator({ modalKey: ModalKeysEnum.SCREENSHOT_PREVIEW }));
-
   const openDeleteCustomTypeModal = () =>
     dispatch(modalOpenCreator({ modalKey: ModalKeysEnum.DELETE_CUSTOM_TYPE }));
   const closeDeleteCustomTypeModal = () =>

--- a/packages/slice-machine/src/theme.ts
+++ b/packages/slice-machine/src/theme.ts
@@ -44,7 +44,7 @@ const AppTheme = (): Theme =>
       },
       codeBlockBorder: "#545454",
       secondary: "#F9FAFB",
-      red: "#CB2431",
+      danger: "#CB2431",
       highlight: "hsl(10, 40%, 90%)",
       purple: "#5B3DF5",
       muted: "#F9F9FB",
@@ -319,8 +319,8 @@ const AppTheme = (): Theme =>
           outline: "none",
         },
       },
-      red: {
-        bg: "red",
+      danger: {
+        bg: "danger",
         fontFamily: "body",
         fontWeight: "bold",
         fontSize: "1",
@@ -330,16 +330,16 @@ const AppTheme = (): Theme =>
         borderRadius: "6px",
         border: `1px solid #C61926`,
         "&:hover": {
-          bg: darken("red", 0.05),
+          bg: darken("danger", 0.05),
           cursor: "pointer",
         },
         "&:focus": {
-          bg: darken("red", 0.05),
-          borderColor: darken("red", 0.15),
+          bg: darken("danger", 0.05),
+          borderColor: darken("danger", 0.15),
           outline: "none",
         },
         "&:active": {
-          bg: darken("red", 0.06),
+          bg: darken("danger", 0.06),
           outline: "none",
         },
       },

--- a/packages/slice-machine/src/theme.ts
+++ b/packages/slice-machine/src/theme.ts
@@ -44,6 +44,7 @@ const AppTheme = (): Theme =>
       },
       codeBlockBorder: "#545454",
       secondary: "#F9FAFB",
+      red: "#CB2431",
       highlight: "hsl(10, 40%, 90%)",
       purple: "#5B3DF5",
       muted: "#F9F9FB",
@@ -314,6 +315,30 @@ const AppTheme = (): Theme =>
         },
         "&:active": {
           bg: darken("secondary", 0.06),
+          outline: "none",
+        },
+      },
+      red: {
+        bg: "red",
+        fontFamily: "body",
+        fontWeight: "bold",
+        fontSize: "1",
+        color: "#F1EEFE",
+        px: "16px",
+        py: "8px",
+        borderRadius: "6px",
+        border: `1px solid #C61926`,
+        "&:hover": {
+          bg: darken("red", 0.05),
+          cursor: "pointer",
+        },
+        "&:focus": {
+          bg: darken("red", 0.05),
+          borderColor: darken("red", 0.15),
+          outline: "none",
+        },
+        "&:active": {
+          bg: darken("red", 0.06),
           outline: "none",
         },
       },

--- a/packages/slice-machine/src/theme.ts
+++ b/packages/slice-machine/src/theme.ts
@@ -55,6 +55,7 @@ const AppTheme = (): Theme =>
       grey04: "#9AA4AF",
       grey05: "#667587",
       grey07: "#F9F8F9",
+      grey12: "#1A1523",
       greyTransparent: "rgba(37, 37, 45, 0.4)",
       borders: "#E4E2E4",
       bordersFocused: "#6E56CF",


### PR DESCRIPTION
## Context

Design ticket for adding delete CT modal to the CT list: https://linear.app/prismic/issue/SM-860/[delete-ct]-aauser-i-can-see-a-modal-to-delete-a-custom-type-from-the

## The Solution

Create a new modal
Add new modal type to action

## Checklist before requesting a review
- [ ] I hereby declare my code ready for review.
- [ ] If it is a critical feature, I have added tests.
- [ ] The CI is successful.
- [ ] If there could backward compatibility issues, it has been discussed and planned.

## [OPT] Preview

![image](https://user-images.githubusercontent.com/47107427/200633085-e23a67a6-fdcc-45f8-8d89-d2543b319787.png)


---


![image](https://user-images.githubusercontent.com/47107427/200632740-6b6bb864-ccb1-4085-a50e-0b5486335d8c.png)