### PR TITLE
create API endpoint and remove files associated to a CT on delete

### DIFF
--- a/packages/slice-machine/components/DeleteCTModal/index.tsx
+++ b/packages/slice-machine/components/DeleteCTModal/index.tsx
@@ -9,6 +9,7 @@ import Card from "@components/Card";
 import { FrontEndCustomType } from "@src/modules/availableCustomTypes/types";
 import { MdOutlineDelete } from "react-icons/md";
 import { Button } from "@components/Button";
+import { deleteCustomType } from "@src/apiClient";
 
 type ScreenshotModalProps = {
   customType?: FrontEndCustomType;
@@ -103,7 +104,11 @@ export const DeleteCustomTypeModal: React.FunctionComponent<
             <Button
               label="Delete Locally"
               variant="red"
-              onClick={() => closeDeleteCustomTypeModal()}
+              // eslint-disable-next-line @typescript-eslint/no-misused-promises
+              onClick={async () => {
+                await deleteCustomType(customType?.local.id as string);
+                closeDeleteCustomTypeModal();
+              }}
             />
           </Flex>
         )}

--- a/packages/slice-machine/lib/io/CustomType.ts
+++ b/packages/slice-machine/lib/io/CustomType.ts
@@ -19,3 +19,7 @@ export function renameCustomType(path: string, newCustomTypeName: string) {
   customType.label = newCustomTypeName;
   writeCustomType(path, customType);
 }
+
+export function deleteCustomType(path: string) {
+  Files.removeDirectory(path);
+}

--- a/packages/slice-machine/lib/mock/misc/fs.ts
+++ b/packages/slice-machine/lib/mock/misc/fs.ts
@@ -1,18 +1,16 @@
 import Files from "../../utils/files";
 import { MocksConfig } from "../../models/paths";
+import { GlobalMockConfig } from "@lib/models/common/MockConfig";
 
 export const getConfig = (cwd: string) => {
   const pathToMockConfig = MocksConfig(cwd);
   if (Files.exists(pathToMockConfig)) {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-    return Files.readJson(pathToMockConfig);
+    return Files.readJson<GlobalMockConfig>(pathToMockConfig);
   }
   return {};
 };
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const writeConfig = (cwd: string, config: any) => {
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+export const writeConfig = (cwd: string, config: GlobalMockConfig) => {
   Files.write(MocksConfig(cwd), config);
 };
 
@@ -25,16 +23,13 @@ export const insert = (
   }: // eslint-disable-next-line @typescript-eslint/no-explicit-any
   { key: string; prefix: string | null; value: any }
 ) => {
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
   const config = getConfig(cwd);
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
   const withInsert = {
     ...config,
     ...(prefix
       ? {
           // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-assignment
           [prefix]: {
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
             ...config[prefix],
             // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-assignment
             [key]: value,
@@ -47,6 +42,18 @@ export const insert = (
   };
 
   writeConfig(cwd, withInsert);
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-return
   return withInsert;
+};
+
+export const remove = (
+  cwd: string,
+  { key, prefix }: { key: string; prefix: string }
+) => {
+  const config = getConfig(cwd);
+
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+  delete config[prefix][key];
+
+  writeConfig(cwd, config);
+  return config;
 };

--- a/packages/slice-machine/lib/models/common/CustomType/index.ts
+++ b/packages/slice-machine/lib/models/common/CustomType/index.ts
@@ -12,6 +12,10 @@ export interface RenameCustomTypeBody {
   newCustomTypeName: string;
 }
 
+export type DeleteCustomTypeQuery = {
+  id: string;
+};
+
 export const CustomType = {
   getSliceZones(ct: CustomTypeSM): ReadonlyArray<SlicesSM | null> {
     return ct.tabs.map((t) => t.sliceZone || null);

--- a/packages/slice-machine/lib/models/paths.ts
+++ b/packages/slice-machine/lib/models/paths.ts
@@ -7,6 +7,7 @@ export const paths = (cwd: string, prefix: string) => ({
     model: (): string =>
       path.join(paths(cwd, prefix).value(), id, "index.json"),
     mock: (): string => path.join(paths(cwd, prefix).value(), id, "mocks.json"),
+    folder: (): string => path.join(paths(cwd, prefix).value(), id),
   }),
   library: (libraryName: string) => ({
     value: (): string => path.join(paths(cwd, prefix).value(), libraryName),

--- a/packages/slice-machine/lib/utils/files.ts
+++ b/packages/slice-machine/lib/utils/files.ts
@@ -140,6 +140,9 @@ const Files = {
       });
     } catch (e) {}
   },
+  removeDirectory(src: string) {
+    fs.rmSync(src, { recursive: true, force: true });
+  },
 };
 
 export default Files;

--- a/packages/slice-machine/server/src/api/custom-types/delete.ts
+++ b/packages/slice-machine/server/src/api/custom-types/delete.ts
@@ -7,7 +7,6 @@ import { getBackendState } from "../state";
 import { RequestWithEnv } from "../http/common";
 import { DeleteCustomTypeQuery } from "../../../../lib/models/common/CustomType";
 import { remove as removeCtsFromMockConfig } from "../../../../lib/mock/misc/fs";
-import getEnv from "../services/getEnv";
 
 export default async function handler(
   req: RequestWithEnv
@@ -16,7 +15,6 @@ export default async function handler(
 > {
   const state = await getBackendState(req.errors, req.env);
   const { id } = req.query as DeleteCustomTypeQuery;
-  const { env } = await getEnv();
   const ctFolder = CustomTypesPaths(state.env.cwd).customType(id).folder();
   const customTypeAssetsFolder = GeneratedCustomTypesPaths(state.env.cwd)
     .customType(id)
@@ -25,7 +23,7 @@ export default async function handler(
   try {
     IO.CustomType.deleteCustomType(ctFolder);
   } catch (err) {
-    console.error(`[custom-type/delete] Error: ${err as string}`);
+    console.error(`[custom-type/delete] ${err as string}`);
     return {
       err: err,
       reason: "We couldn't delete your custom type. Check your terminal.",
@@ -50,7 +48,7 @@ export default async function handler(
   }
 
   try {
-    removeCtsFromMockConfig(env.cwd, { key: id, prefix: "_cts" });
+    removeCtsFromMockConfig(state.env.cwd, { key: id, prefix: "_cts" });
   } catch (err) {
     console.error(
       `[custom-type/delete] Could not delete your custom type from the mock-config.json`

--- a/packages/slice-machine/server/src/api/custom-types/delete.ts
+++ b/packages/slice-machine/server/src/api/custom-types/delete.ts
@@ -1,12 +1,14 @@
 import {
   CustomTypesPaths,
   GeneratedCustomTypesPaths,
+  MocksConfig,
 } from "../../../../lib/models/paths";
 import * as IO from "../../../../lib/io";
 import { getBackendState } from "../state";
 import { RequestWithEnv } from "../http/common";
 import { DeleteCustomTypeQuery } from "../../../../lib/models/common/CustomType";
 import { remove as removeCtsFromMockConfig } from "../../../../lib/mock/misc/fs";
+import path, { resolve } from "path";
 
 export default async function handler(
   req: RequestWithEnv
@@ -32,48 +34,64 @@ export default async function handler(
     };
   }
 
-  try {
-    IO.CustomType.deleteCustomType(customTypeAssetsFolder);
-  } catch (err) {
-    console.error(
-      `[custom-type/delete] Could not delete your custom type assets files in ${customTypeAssetsFolder}`
-    );
-    return {
-      err: err,
-      reason:
-        "Something went wrong when deleting your Custom Type. Check your terminal.",
-      status: "500",
-      type: "warning",
-    };
-  }
+  // eslint-disable-next-line @typescript-eslint/require-await
+  const deleteAssets = async () => {
+    try {
+      IO.CustomType.deleteCustomType(customTypeAssetsFolder);
+    } catch (err) {
+      console.error(
+        `[custom-type/delete] Could not delete your custom type assets files.\n`,
+        `To resolve this, manually delete the directory ${resolve(
+          customTypeAssetsFolder
+        )}`
+      );
+      throw err;
+    }
+  };
 
-  try {
-    removeCtsFromMockConfig(state.env.cwd, { key: id, prefix: "_cts" });
-  } catch (err) {
-    console.error(
-      `[custom-type/delete] Could not delete your custom type from the mock-config.json`
-    );
-    return {
-      err: err,
-      reason:
-        "Something went wrong when deleting your Custom Type. Check your terminal.",
-      status: "500",
-      type: "warning",
-    };
-  }
+  // eslint-disable-next-line @typescript-eslint/require-await
+  const updateMockConfig = async () => {
+    try {
+      removeCtsFromMockConfig(state.env.cwd, { key: id, prefix: "_cts" });
+    } catch (err) {
+      console.error(
+        `[custom-type/delete] Could not delete your custom type from the mock-config.json.\n`,
+        `To resolve this, manually remove the ${id} field in ${resolve(
+          MocksConfig(state.env.cwd)
+        )}`
+      );
+      throw err;
+    }
+  };
 
-  try {
-    IO.Types.upsert(state.env);
-  } catch (err) {
-    console.error(`[custom-type/delete] Could not update the project types.`);
-    return {
-      err: err,
-      reason:
-        "Something went wrong when deleting your Custom Type. Check your terminal.",
-      status: "500",
-      type: "warning",
-    };
-  }
+  // eslint-disable-next-line @typescript-eslint/require-await
+  const updatedTypes = async () => {
+    try {
+      IO.Types.upsert(state.env);
+    } catch (err) {
+      console.error(
+        `[custom-type/delete] Could not update the project types.\n`,
+        `You can manually delete these in ${resolve(
+          path.join(state.env.cwd, ".slicemachine", "prismicio.d.ts")
+        )}`
+      );
+      throw err;
+    }
+  };
 
-  return {};
+  const settledResults = await Promise.allSettled([
+    deleteAssets(),
+    updateMockConfig(),
+    updatedTypes(),
+  ]);
+
+  return settledResults.some((res) => res.status === "rejected")
+    ? {
+        err: {},
+        reason:
+          "Something went wrong when deleting your Custom Type. Check your terminal.",
+        status: "500",
+        type: "warning",
+      }
+    : {};
 }

--- a/packages/slice-machine/server/src/api/custom-types/delete.ts
+++ b/packages/slice-machine/server/src/api/custom-types/delete.ts
@@ -1,0 +1,81 @@
+import {
+  CustomTypesPaths,
+  GeneratedCustomTypesPaths,
+} from "../../../../lib/models/paths";
+import * as IO from "../../../../lib/io";
+import { getBackendState } from "../state";
+import { RequestWithEnv } from "../http/common";
+import { DeleteCustomTypeQuery } from "../../../../lib/models/common/CustomType";
+import { remove as removeCtsFromMockConfig } from "../../../../lib/mock/misc/fs";
+import getEnv from "../services/getEnv";
+
+export default async function handler(
+  req: RequestWithEnv
+): Promise<
+  { err: unknown; reason: string; status: string } | Record<string, unknown>
+> {
+  const state = await getBackendState(req.errors, req.env);
+  const { id } = req.query as DeleteCustomTypeQuery;
+  const { env } = await getEnv();
+  const ctFolder = CustomTypesPaths(state.env.cwd).customType(id).folder();
+  const customTypeAssetsFolder = GeneratedCustomTypesPaths(state.env.cwd)
+    .customType(id)
+    .folder();
+
+  try {
+    IO.CustomType.deleteCustomType(ctFolder);
+  } catch (err) {
+    console.error(`[custom-type/delete] Error: ${err as string}`);
+    return {
+      err: err,
+      reason: "We couldn't delete your custom type. Check your terminal.",
+      status: "500",
+      type: "error",
+    };
+  }
+
+  try {
+    IO.CustomType.deleteCustomType(customTypeAssetsFolder);
+  } catch (err) {
+    console.error(
+      `[custom-type/delete] Could not delete your custom type assets files in ${customTypeAssetsFolder}`
+    );
+    return {
+      err: err,
+      reason:
+        "Something went wrong when deleting your Custom Type. Check your terminal.",
+      status: "500",
+      type: "warning",
+    };
+  }
+
+  try {
+    removeCtsFromMockConfig(env.cwd, { key: id, prefix: "_cts" });
+  } catch (err) {
+    console.error(
+      `[custom-type/delete] Could not delete your custom type from the mock-config.json`
+    );
+    return {
+      err: err,
+      reason:
+        "Something went wrong when deleting your Custom Type. Check your terminal.",
+      status: "500",
+      type: "warning",
+    };
+  }
+
+  try {
+    IO.Types.upsert(state.env);
+  } catch (err) {
+    console.error(`[custom-type/delete] Could not update the project types.`);
+    return {
+      err: err,
+      reason:
+        "Something went wrong when deleting your Custom Type. Check your terminal.",
+      status: "500",
+      type: "warning",
+    };
+  }
+
+  return {};
+}

--- a/packages/slice-machine/server/src/api/index.ts
+++ b/packages/slice-machine/server/src/api/index.ts
@@ -17,6 +17,7 @@ import state from "./state";
 import checkSimulator from "./simulator";
 import saveCustomType from "./custom-types/save";
 import renameCustomType from "./custom-types/rename";
+import deleteCustomType from "./custom-types/delete";
 import { handler as pushCustomType } from "./custom-types/push";
 import startAuth from "./auth/start";
 import statusAuth from "./auth/status";
@@ -202,6 +203,23 @@ router.patch(
     res: express.Response
   ): Promise<Express.Response> {
     const payload = await renameCustomType(req);
+
+    if (isApiError(payload)) {
+      return res.status(payload.status).json(payload);
+    }
+
+    return res.status(200).json(payload);
+  })
+);
+
+router.delete(
+  "/custom-types/delete",
+  // eslint-disable-next-line @typescript-eslint/no-misused-promises
+  WithEnv(async function (
+    req: RequestWithEnv,
+    res: express.Response
+  ): Promise<Express.Response> {
+    const payload = await deleteCustomType(req);
 
     if (isApiError(payload)) {
       return res.status(payload.status).json(payload);

--- a/packages/slice-machine/src/apiClient.ts
+++ b/packages/slice-machine/src/apiClient.ts
@@ -59,6 +59,15 @@ export const renameCustomType = (
   );
 };
 
+export const deleteCustomType = (
+  customTypeId: string
+): Promise<AxiosResponse> => {
+  return axios.delete(
+    `/api/custom-types/delete?id=${customTypeId}`,
+    defaultAxiosConfig
+  );
+};
+
 export const pushCustomType = (
   customTypeId: string
 ): Promise<AxiosResponse> => {

--- a/packages/slice-machine/tests/server/custom-types/delete.test.ts
+++ b/packages/slice-machine/tests/server/custom-types/delete.test.ts
@@ -31,6 +31,8 @@ describe("Delete Custom Type files", () => {
   beforeEach(() => {
     console.warn = jest.fn();
     console.error = jest.fn();
+    // @ts-expect-error don't need the right type for mocking purposes
+    jest.spyOn(fs, "lstatSync").mockReturnValue(true);
   });
   afterAll(() => {
     console.warn = warn;
@@ -45,8 +47,6 @@ describe("Delete Custom Type files", () => {
         _cts: { "unwanted-ct": { name: "foo" }, "ct-2": { name: "bar" } },
       })
     );
-    // @ts-expect-error don't need the right type for mocking purposes
-    jest.spyOn(fs, "lstatSync").mockReturnValue(true);
 
     const result = await deleteCT(mockRequest);
 
@@ -129,18 +129,18 @@ describe("Delete Custom Type files", () => {
 
     const result = await deleteCT(mockRequest);
 
-    expect(mockRmSync).toHaveBeenCalled();
-    expect(mockRmSync).toHaveBeenCalled();
     expect(mockRmSync).toHaveBeenCalledTimes(2);
 
-    expect(mockReadFileSync).not.toBeCalled();
-    expect(mockWriteFileSync).not.toBeCalled();
+    expect(mockReadFileSync).toHaveBeenCalled();
+    expect(mockWriteFileSync).toHaveBeenCalled();
 
+    expect(console.error).toHaveBeenCalledTimes(1);
     expect(console.error).toHaveBeenCalledWith(
-      "[custom-type/delete] Could not delete your custom type assets files in /test/.slicemachine/assets/customtypes/unwanted-ct"
+      `[custom-type/delete] Could not delete your custom type assets files.\n`,
+      `To resolve this, manually delete the directory /test/.slicemachine/assets/customtypes/unwanted-ct`
     );
     expect(result).toStrictEqual({
-      err: Error("Couldn't remove custom type"),
+      err: {},
       reason:
         "Something went wrong when deleting your Custom Type. Check your terminal.",
       status: "500",
@@ -160,25 +160,22 @@ describe("Delete Custom Type files", () => {
         _cts: { "unwanted-ct": { name: "foo" }, "ct-2": { name: "bar" } },
       })
     );
-    // @ts-expect-error don't need the right type for mocking purposes
-    jest.spyOn(fs, "lstatSync").mockReturnValue(true);
 
     const result = await deleteCT(mockRequest);
 
-    expect(mockRmSync).toHaveBeenCalled();
-    expect(mockRmSync).toHaveBeenCalled();
     expect(mockRmSync).toHaveBeenCalledTimes(2);
 
     expect(mockReadFileSync).toBeCalled();
-
     expect(mockWriteFileSync).toBeCalled();
 
     expect(console.error).toHaveBeenCalledWith(
-      "[custom-type/delete] Could not delete your custom type from the mock-config.json"
+      `[custom-type/delete] Could not delete your custom from the mock-config.json.\n`,
+      `To resolve this, manually remove the ${CUSTOM_TYPE_TO_DELETE} field in /test/.slicemachine/mock-config.json`
     );
+    expect(console.error).toHaveBeenCalledTimes(1);
 
     expect(result).toStrictEqual({
-      err: Error("couldn't update file"),
+      err: {},
       reason:
         "Something went wrong when deleting your Custom Type. Check your terminal.",
       status: "500",

--- a/packages/slice-machine/tests/server/custom-types/delete.test.ts
+++ b/packages/slice-machine/tests/server/custom-types/delete.test.ts
@@ -1,0 +1,188 @@
+import { vol } from "memfs";
+import deleteCT from "../../../server/src/api/custom-types/delete";
+import backendEnvironment from "../../__mocks__/backendEnvironment";
+import fs from "fs";
+import { RequestWithEnv } from "server/src/api/http/common";
+
+jest.mock(`fs`, () => {
+  const { vol } = jest.requireActual("memfs");
+  return vol;
+});
+
+jest.mock("../../../server/src/api/common/LibrariesState", () => {
+  return {
+    generateState: jest.fn(),
+  };
+});
+
+describe("Delete Custom Type files", () => {
+  const CUSTOM_TYPE_TO_DELETE = "unwanted-ct";
+  const mockRequest = {
+    env: backendEnvironment,
+    errors: {},
+    query: { id: CUSTOM_TYPE_TO_DELETE },
+  } as unknown as RequestWithEnv;
+  const warn = console.warn;
+  const error = console.error;
+  afterEach(() => {
+    vol.reset();
+    jest.restoreAllMocks();
+  });
+  beforeEach(() => {
+    console.warn = jest.fn();
+    console.error = jest.fn();
+  });
+  afterAll(() => {
+    console.warn = warn;
+    console.error = error;
+  });
+
+  it("should delete all the custom type files", async () => {
+    const mockRmSync = jest.spyOn(fs, "rmSync");
+    const mockWriteFileSync = jest.spyOn(fs, "writeFileSync");
+    const mockReadFileSync = jest.spyOn(fs, "readFileSync").mockReturnValue(
+      JSON.stringify({
+        _cts: { "unwanted-ct": { name: "foo" }, "ct-2": { name: "bar" } },
+      })
+    );
+    // @ts-expect-error don't need the right type for mocking purposes
+    jest.spyOn(fs, "lstatSync").mockReturnValue(true);
+
+    const result = await deleteCT(mockRequest);
+
+    expect(mockRmSync).toHaveBeenCalledWith(
+      `/test/customtypes/${CUSTOM_TYPE_TO_DELETE}`,
+      {
+        force: true,
+        recursive: true,
+      }
+    );
+    expect(mockRmSync).toHaveBeenCalledWith(
+      `/test/.slicemachine/assets/customtypes/${CUSTOM_TYPE_TO_DELETE}`,
+      {
+        force: true,
+        recursive: true,
+      }
+    );
+    expect(mockRmSync).toHaveBeenCalledTimes(2);
+
+    expect(mockReadFileSync).toBeCalled();
+
+    expect(mockWriteFileSync).toBeCalledWith(
+      "/test/.slicemachine/mock-config.json",
+      JSON.stringify({ _cts: { "ct-2": { name: "bar" } } }, null, 2),
+      "utf8"
+    );
+
+    expect(result).toStrictEqual({});
+  });
+
+  it("should log and return an error if the custom types deletion fails", async () => {
+    const mockRmSync = jest.spyOn(fs, "rmSync").mockImplementation(() => {
+      throw new Error("Couldn't remove custom type");
+    });
+    const mockWriteFileSync = jest.spyOn(fs, "writeFileSync");
+    const mockReadFileSync = jest.spyOn(fs, "readFileSync").mockReturnValue(
+      JSON.stringify({
+        _cts: { "unwanted-ct": { name: "foo" }, "ct-2": { name: "bar" } },
+      })
+    );
+
+    const result = await deleteCT(mockRequest);
+
+    expect(mockRmSync).toHaveBeenCalledWith(
+      `/test/customtypes/${CUSTOM_TYPE_TO_DELETE}`,
+      {
+        force: true,
+        recursive: true,
+      }
+    );
+    expect(mockRmSync).toHaveBeenCalledTimes(1);
+
+    expect(mockReadFileSync).not.toBeCalled();
+    expect(mockWriteFileSync).not.toBeCalled();
+
+    expect(console.error).toHaveBeenCalledWith(
+      "[custom-type/delete] Error: Couldn't remove custom type"
+    );
+    expect(result).toStrictEqual({
+      err: Error("Couldn't remove custom type"),
+      reason: "We couldn't delete your custom type. Check your terminal.",
+      status: "500",
+      type: "error",
+    });
+  });
+
+  it("should log and return a warning if the custom type asset deletion fails", async () => {
+    const mockRmSync = jest
+      .spyOn(fs, "rmSync")
+      .mockImplementationOnce(() => {})
+      .mockImplementationOnce(() => {
+        throw new Error("Couldn't remove custom type");
+      });
+    const mockWriteFileSync = jest.spyOn(fs, "writeFileSync");
+    const mockReadFileSync = jest.spyOn(fs, "readFileSync").mockReturnValue(
+      JSON.stringify({
+        _cts: { "unwanted-ct": { name: "foo" }, "ct-2": { name: "bar" } },
+      })
+    );
+
+    const result = await deleteCT(mockRequest);
+
+    expect(mockRmSync).toHaveBeenCalled();
+    expect(mockRmSync).toHaveBeenCalled();
+    expect(mockRmSync).toHaveBeenCalledTimes(2);
+
+    expect(mockReadFileSync).not.toBeCalled();
+    expect(mockWriteFileSync).not.toBeCalled();
+
+    expect(console.error).toHaveBeenCalledWith(
+      "[custom-type/delete] Could not delete your custom type assets files in /test/.slicemachine/assets/customtypes/unwanted-ct"
+    );
+    expect(result).toStrictEqual({
+      err: Error("Couldn't remove custom type"),
+      reason:
+        "Something went wrong when deleting your Custom Type. Check your terminal.",
+      status: "500",
+      type: "warning",
+    });
+  });
+
+  it("should log and return a warning if the mock-config update fails", async () => {
+    const mockRmSync = jest.spyOn(fs, "rmSync");
+    const mockWriteFileSync = jest
+      .spyOn(fs, "writeFileSync")
+      .mockImplementationOnce(() => {
+        throw new Error("couldn't update file");
+      });
+    const mockReadFileSync = jest.spyOn(fs, "readFileSync").mockReturnValue(
+      JSON.stringify({
+        _cts: { "unwanted-ct": { name: "foo" }, "ct-2": { name: "bar" } },
+      })
+    );
+    // @ts-expect-error don't need the right type for mocking purposes
+    jest.spyOn(fs, "lstatSync").mockReturnValue(true);
+
+    const result = await deleteCT(mockRequest);
+
+    expect(mockRmSync).toHaveBeenCalled();
+    expect(mockRmSync).toHaveBeenCalled();
+    expect(mockRmSync).toHaveBeenCalledTimes(2);
+
+    expect(mockReadFileSync).toBeCalled();
+
+    expect(mockWriteFileSync).toBeCalled();
+
+    expect(console.error).toHaveBeenCalledWith(
+      "[custom-type/delete] Could not delete your custom type from the mock-config.json"
+    );
+
+    expect(result).toStrictEqual({
+      err: Error("couldn't update file"),
+      reason:
+        "Something went wrong when deleting your Custom Type. Check your terminal.",
+      status: "500",
+      type: "warning",
+    });
+  });
+});

--- a/packages/slice-machine/tests/server/custom-types/delete.test.ts
+++ b/packages/slice-machine/tests/server/custom-types/delete.test.ts
@@ -169,7 +169,7 @@ describe("Delete Custom Type files", () => {
     expect(mockWriteFileSync).toBeCalled();
 
     expect(console.error).toHaveBeenCalledWith(
-      `[custom-type/delete] Could not delete your custom from the mock-config.json.\n`,
+      `[custom-type/delete] Could not delete your custom type from the mock-config.json.\n`,
       `To resolve this, manually remove the ${CUSTOM_TYPE_TO_DELETE} field in /test/.slicemachine/mock-config.json`
     );
     expect(console.error).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
## Context

<!--
Please include either
- a ticket
    - [Link text Here](https://link-url-here.org)

- a github issue / forum thread
    - Fixes #

- a detailed description of the issue and it's implications

This part should always include acceptance criteria weither they are accessible on a link or written here directly.
-->

Adding functionality to delete custom type files in slice machine local.
Ticket here: https://linear.app/prismic/issue/SM-863/[delete-ct]-aauser-i-can-delete-a-custom-type-from-the-ct-list-only


## The Solution

Added API endpoint to server, and service which does the business logic

## Impact / Dependencies

This still requires some frontend work, since the button currently has no visible feedback (need to look at the network tab).
This will come form this ticket: https://linear.app/prismic/issue/SM-865/[delete-ct]-aauser-i-can-see-the-deleted-custom-types-disappear-from


## Checklist before requesting a review
- [x] I hereby declare my code ready for review.
- [x] If it is a critical feature, I have added tests.
- [x] The CI is successful.
- [ ] If there could backward compatibility issues, it has been discussed and planned.

---

![image](https://user-images.githubusercontent.com/47107427/201375649-2b20cd61-7093-41b0-9d42-fe983d6805c0.png)