### PR TITLE
Fix double braces in uuid field

### DIFF
--- a/packages/slice-machine/lib/builders/common/Zone/Card/components/Hints/Renderers/previous-react.tsx
+++ b/packages/slice-machine/lib/builders/common/Zone/Card/components/Hints/Renderers/previous-react.tsx
@@ -47,7 +47,7 @@ const codeByWidgetType = (
     handleLinkCode(fieldText, useKey),
 
   [Widgets.UID?.TYPE_NAME]: (fieldText: string) =>
-    `<span>{{ ${fieldText} }}</span>`,
+    `<span>{ ${fieldText} }</span>`,
 
   [Widgets.StructuredText?.TYPE_NAME]: (fieldText: string, useKey?: boolean) =>
     `<RichText render={${fieldText}} ${useKey ? appendKey("rich-text") : ""}/>`,

--- a/packages/slice-machine/lib/builders/common/Zone/Card/components/Hints/Renderers/react.tsx
+++ b/packages/slice-machine/lib/builders/common/Zone/Card/components/Hints/Renderers/react.tsx
@@ -74,7 +74,7 @@ const codeByWidgetType = (
     handleLinkCode(fieldText, useKey),
 
   [Widgets.UID?.TYPE_NAME]: (fieldText: string) =>
-    `<span>{{ ${fieldText} }}</span>`,
+    `<span>{ ${fieldText} }</span>`,
 
   [Widgets.StructuredText?.TYPE_NAME]: (fieldText: string, useKey?: boolean) =>
     `/* import { PrismicRichText } from '@prismicio/react' */


### PR DESCRIPTION
## Context

<!--
Please include either
- a ticket
    - [Link text Here](https://link-url-here.org)

- a github issue / forum thread
    - Fixes #

- a detailed description of the issue and it's implications

This part should always include acceptance criteria weither they are accessible on a link or written here directly.
-->

Issue link: https://github.com/prismicio/slice-machine/issues/690


## The Solution

Remove the double braces from the template


## Checklist before requesting a review
- [ ] I hereby declare my code ready for review.
- [ ] If it is a critical feature, I have added tests.
- [ ] The CI is successful.
- [ ] If there could backward compatibility issues, it has been discussed and planned.




## [OPT] Preview

![image](https://user-images.githubusercontent.com/47107427/202507268-d0096704-edbd-4b80-ad06-0c7ef5d9d413.png)