### PR TITLE
Fix bug in removing deleted content relationships

### DIFF
--- a/packages/slice-machine/lib/builders/common/EditModal/index.js
+++ b/packages/slice-machine/lib/builders/common/EditModal/index.js
@@ -65,7 +65,11 @@ const EditModal = ({ close, data, fields, onSave, getFieldMockConfig }) => {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
     ...createInitialValues(removeProp(FormFields, "id")),
     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
-    ...initialModelValues.config,
+    ...(maybeWidget.prepareInitialValues
+      ? // eslint-disable-next-line
+        maybeWidget.prepareInitialValues(initialModelValues.config)
+      : // eslint-disable-next-line
+        initialModelValues.config),
   };
 
   // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-assignment

--- a/packages/slice-machine/lib/models/common/widgets/ContentRelationship/Form.tsx
+++ b/packages/slice-machine/lib/models/common/widgets/ContentRelationship/Form.tsx
@@ -11,7 +11,6 @@ import { createFieldNameFromKey } from "@lib/forms";
 import { useSelector } from "react-redux";
 import { selectAllCustomTypes } from "@src/modules/availableCustomTypes";
 import { FormikProps } from "formik";
-import { useEffect } from "react";
 
 const FormFields = {
   label: DefaultFields.label,
@@ -25,11 +24,6 @@ type FormProps = {
   config: { label: string; select: string; customtypes?: string[] };
   id: string;
   // type: string; // TODO: this exists in the yup schema but this doesn't seem to be validated by formik
-};
-
-type SelectValueType = {
-  value: string;
-  label: string | null | undefined;
 };
 
 const WidgetForm = ({
@@ -46,25 +40,13 @@ const WidgetForm = ({
   }));
 
   const selectValues = formValues.config.customtypes
-    ? formValues.config.customtypes
-        .map((id) => {
-          const ct = customTypes.find(
-            (frontendCustomType) => frontendCustomType.local.id === id
-          );
-          return ct ? { value: ct.local.id, label: ct.local.label } : ct;
-        })
-        .filter((val): val is SelectValueType => val !== undefined)
+    ? formValues.config.customtypes.map((id) => {
+        const ct = customTypes.find(
+          (frontendCustomType) => frontendCustomType.local.id === id
+        );
+        return { value: ct?.local.id, label: ct?.local.label };
+      })
     : null;
-
-  // removes deleted custom type from initial values on first render
-  useEffect(
-    () =>
-      setFieldValue(
-        "config.customtypes",
-        selectValues?.map(({ value }) => value)
-      ),
-    []
-  );
 
   return (
     <FlexGrid>

--- a/packages/slice-machine/lib/models/common/widgets/ContentRelationship/Form.tsx
+++ b/packages/slice-machine/lib/models/common/widgets/ContentRelationship/Form.tsx
@@ -11,6 +11,7 @@ import { createFieldNameFromKey } from "@lib/forms";
 import { useSelector } from "react-redux";
 import { selectAllCustomTypes } from "@src/modules/availableCustomTypes";
 import { FormikProps } from "formik";
+import { useEffect } from "react";
 
 const FormFields = {
   label: DefaultFields.label,
@@ -54,6 +55,16 @@ const WidgetForm = ({
         })
         .filter((val): val is SelectValueType => val !== undefined)
     : null;
+
+  // removes deleted custom type from initial values on first render
+  useEffect(
+    () =>
+      setFieldValue(
+        "config.customtypes",
+        selectValues?.map(({ value }) => value)
+      ),
+    []
+  );
 
   return (
     <FlexGrid>

--- a/packages/slice-machine/lib/models/common/widgets/ContentRelationship/index.ts
+++ b/packages/slice-machine/lib/models/common/widgets/ContentRelationship/index.ts
@@ -7,6 +7,8 @@ import { Widget } from "../Widget";
 import { linkConfigSchema } from "../Link";
 import { Link } from "@prismicio/types-internal/lib/customtypes/widgets/nestable";
 import { WidgetTypes } from "@prismicio/types-internal/lib/customtypes/widgets";
+import { useSelector } from "react-redux";
+import { selectAllCustomTypes } from "@src/modules/availableCustomTypes";
 
 /**
  * {
@@ -60,4 +62,21 @@ export const ContentRelationshipWidget: Widget<Link, typeof schema> = {
   FormFields,
   CUSTOM_NAME: "ContentRelationship",
   Form,
+  prepareInitialValues: (initialValues) => {
+    const customTypes = useSelector(selectAllCustomTypes);
+
+    if (!initialValues.customtypes) {
+      return initialValues;
+    }
+
+    return {
+      ...initialValues,
+      // eslint-disable-next-line
+      customtypes: initialValues.customtypes.filter((ct: any) =>
+        customTypes.find(
+          (frontendCustomType) => frontendCustomType.local.id === ct
+        )
+      ),
+    };
+  },
 };

--- a/packages/slice-machine/lib/models/common/widgets/ContentRelationship/index.ts
+++ b/packages/slice-machine/lib/models/common/widgets/ContentRelationship/index.ts
@@ -48,7 +48,11 @@ const schema = yup.object().shape({
   config: contentRelationShipConfigSchema,
 });
 
-export const ContentRelationshipWidget: Widget<Link, typeof schema> = {
+export const ContentRelationshipWidget: Widget<
+  Link,
+  typeof schema,
+  { customtypes: string[] }
+> = {
   create: (label: string) => ({
     type: WidgetTypes.Link,
     config: {
@@ -71,8 +75,7 @@ export const ContentRelationshipWidget: Widget<Link, typeof schema> = {
 
     return {
       ...initialValues,
-      // eslint-disable-next-line
-      customtypes: initialValues.customtypes.filter((ct: any) =>
+      customtypes: initialValues.customtypes.filter((ct) =>
         customTypes.find(
           (frontendCustomType) => frontendCustomType.local.id === ct
         )

--- a/packages/slice-machine/lib/models/common/widgets/Widget.ts
+++ b/packages/slice-machine/lib/models/common/widgets/Widget.ts
@@ -23,6 +23,7 @@ export interface Widget<F extends TabField, S extends AnyObjectSchema> {
   CustomListItem?: (props: any) => React.ReactElement;
   // eslint-disable-next-line @typescript-eslint/ban-types, @typescript-eslint/no-explicit-any
   Form?: (props: any) => React.ReactNode;
+  prepareInitialValues?: <T extends Record<string, any>>(props: T) => T;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-explicit-any, @typescript-eslint/no-explicit-any

--- a/packages/slice-machine/lib/models/common/widgets/Widget.ts
+++ b/packages/slice-machine/lib/models/common/widgets/Widget.ts
@@ -2,7 +2,11 @@ import { WidgetTypes } from "@prismicio/types-internal/lib/customtypes/widgets";
 import { IconType } from "react-icons";
 import { AnyObjectSchema } from "yup";
 import { TabField } from "@slicemachine/core/build/models/CustomType";
-export interface Widget<F extends TabField, S extends AnyObjectSchema> {
+export interface Widget<
+  F extends TabField,
+  S extends AnyObjectSchema,
+  P = Record<string, unknown>
+> {
   TYPE_NAME: WidgetTypes;
   MockConfigForm?: {
     (): JSX.Element;
@@ -23,7 +27,7 @@ export interface Widget<F extends TabField, S extends AnyObjectSchema> {
   CustomListItem?: (props: any) => React.ReactElement;
   // eslint-disable-next-line @typescript-eslint/ban-types, @typescript-eslint/no-explicit-any
   Form?: (props: any) => React.ReactNode;
-  prepareInitialValues?: <T extends Record<string, any>>(props: T) => T;
+  prepareInitialValues?: (props: P) => P;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-explicit-any, @typescript-eslint/no-explicit-any


### PR DESCRIPTION
## Context

<!--
Please include either
- a ticket
    - [Link text Here](https://link-url-here.org)

- a github issue / forum thread
    - Fixes #

- a detailed description of the issue and it's implications

This part should always include acceptance criteria weither they are accessible on a link or written here directly.
-->

If we didn't replace a deleted CT in a content-relationship field, then the filter would not remove this from the model. 
Bug found in this ticket: https://linear.app/prismic/issue/SM-866#comment-416fe4a4


## The Solution

<!--
Highlight explanations where the complexity in your development is.
Keep in mind that the reviewer might not have as much context as you do.
This is very important to make sure the review is thorough and the reviewer understand your changes.
-->

Set the field value on first-render with a useEffect after the custom types are filtered to remove deleted ones.


## Impact / Dependencies

<!--
List all the impacts your development might have on internal and external features.
Ideally this should have been discussed prior to this development.

Link of any other PRs that are related to this development.
They should also be referenced in the ticket for reviews.
-->

NA

## Checklist before requesting a review
- [ ] I hereby declare my code ready for review.
- [ ] If it is a critical feature, I have added tests.
- [ ] The CI is successful.
- [ ] If there could backward compatibility issues, it has been discussed and planned.


## [OPT] Preview

![ezgif com-gif-maker (2)](https://user-images.githubusercontent.com/47107427/203369508-ecb0df20-3afd-44d2-8c90-6a2dbe6479bf.gif)
