### PR TITLE
fix long slice name wrapping

### DIFF
--- a/packages/slice-machine/components/DeleteSliceModal/index.tsx
+++ b/packages/slice-machine/components/DeleteSliceModal/index.tsx
@@ -103,7 +103,7 @@ export const DeleteSliceModal: React.FunctionComponent<
           </Flex>
         )}
       >
-        <Text>
+        <Text sx={{ wordWrap: "break-word" }}>
           This action will delete the{" "}
           <Text sx={{ fontWeight: "bold" }}>
             `{libName}/{sliceName}/`
@@ -114,7 +114,7 @@ export const DeleteSliceModal: React.FunctionComponent<
           Custom Types that use it.
         </Text>
         <br />
-        <Text>
+        <Text sx={{ wordWrap: "break-word" }}>
           The next time you push changes to Prismic, the{" "}
           <Text sx={{ fontWeight: "bold" }}>"{sliceName}"</Text> Slice will be
           deleted from your repository, and users will no longer be able to add


### PR DESCRIPTION
## Context

<!--
Please include either
- a ticket
    - [Link text Here](https://link-url-here.org)

- a github issue / forum thread
    - Fixes #

- a detailed description of the issue and it's implications

This part should always include acceptance criteria weither they are accessible on a link or written here directly.
-->

Long slice names were overflowing off the modal. 


## The Solution

<!--
Highlight explanations where the complexity in your development is.
Keep in mind that the reviewer might not have as much context as you do.
This is very important to make sure the review is thorough and the reviewer understand your changes.
-->

Wrap the text with css property word-wrap set to `break-word`


## Checklist before requesting a review
- [x] I hereby declare my code ready for review.
- [ ] If it is a critical feature, I have added tests.
- [ ] The CI is successful.
- [ ] If there could backward compatibility issues, it has been discussed and planned.


## [OPT] Preview

<!--
Visual aid of your work.
It can either be screenshots or a video.
This could help reviewers to get context quickly.
-->

![image](https://user-images.githubusercontent.com/47107427/203764466-5ec9aad8-363d-44c2-af65-7eff6b82c856.png)


<!--
A funny animal picture is welcome to close your PR!
You can find one here https://unsplash.com/s/photos/funny-animal-picture
-->