### PR TITLE
896 Simulator tooltip in SliceBuilder

### DIFF
--- a/cypress/integration/customTypes/00-create.spec.js
+++ b/cypress/integration/customTypes/00-create.spec.js
@@ -18,6 +18,7 @@ describe("Custom Types specs", () => {
       isOnboarded: true,
       updatesViewed: {},
       hasSeenTutorialsTooTip: true,
+      hasSeenSimulatorToolTip: false,
     });
     cy.visit("/");
 
@@ -72,6 +73,7 @@ describe("Custom Types specs", () => {
       isOnboarded: true,
       updatesViewed: {},
       hasSeenTutorialsTooTip: true,
+      hasSeenSimulatorToolTip: false,
     });
     cy.visit("/");
 

--- a/cypress/integration/customTypes/01-duplicate.spec.js
+++ b/cypress/integration/customTypes/01-duplicate.spec.js
@@ -12,6 +12,7 @@ describe("Duplicate custom types", () => {
       isOnboarded: true,
       updatesViewed: {},
       hasSeenTutorialsTooTip: true,
+      hasSeenSimulatorToolTip: true,
     });
     cy.visit("/");
     // loading spinner

--- a/cypress/integration/onboarding/00-redirects.spec.js
+++ b/cypress/integration/onboarding/00-redirects.spec.js
@@ -16,6 +16,7 @@ describe("onboarding redirects and local storage", () => {
       isOnboarded: true,
       updatesViewed: {},
       hasSeenTutorialsTooTip: true,
+      hasSeenSimulatorToolTip: true,
     });
     cy.visit("/");
     cy.location("pathname", { timeout: 5000 }).should("eq", "/");

--- a/cypress/integration/slices/00-create.spec.js
+++ b/cypress/integration/slices/00-create.spec.js
@@ -6,21 +6,6 @@ describe("Create Slices", () => {
   const sliceName = "TestSlice";
   const editedSliceName = "TestSlice2";
   const lib = "slices";
-  const pathToMock = path.join(
-    "e2e-projects",
-    "cypress-next-app",
-    ".slicemachine",
-    "assets",
-    "slices",
-    sliceName,
-    "mocks.json"
-  );
-  const pathToLibraryState = path.join(
-    "e2e-projects",
-    "cypress-next-app",
-    ".slicemachine",
-    "libraries-state.json"
-  );
 
   beforeEach(() => {
     cy.clearLocalStorageSnapshot();
@@ -36,6 +21,7 @@ describe("Create Slices", () => {
       isOnboarded: true,
       updatesViewed: {},
       hasSeenTutorialsTooTip: true,
+      hasSeenSimulatorToolTip: true,
     });
     cy.visit(`/slices`);
     cy.waitUntil(() => cy.get("[data-cy=empty-state-main-button]"));

--- a/cypress/integration/slices/01-duplicates.spec.js
+++ b/cypress/integration/slices/01-duplicates.spec.js
@@ -14,6 +14,7 @@ describe("Duplicate Slices", () => {
       isOnboarded: true,
       updatesViewed: {},
       hasSeenTutorialsTooTip: true,
+      hasSeenSimulatorToolTip: true,
     });
 
     // create first slice

--- a/cypress/integration/updates/changelog.spec.js
+++ b/cypress/integration/updates/changelog.spec.js
@@ -24,6 +24,7 @@ describe("changelog.warningBreakingChanges", () => {
         latestNonBreaking: "1.2.3",
       },
       hasSeenTutorialsTooTip: true,
+      hasSeenSimulatorToolTip: true,
     });
 
     cy.intercept("/api/state", (req) => {
@@ -53,6 +54,7 @@ describe("changelog.warningBreakingChanges", () => {
         latestNonBreaking: "1.2.3",
       },
       hasSeenTutorialsTooTip: true,
+      hasSeenSimulatorToolTip: true,
     });
 
     cy.intercept("/api/state", (req) => {

--- a/cypress/integration/updates/sidebar.spec.js
+++ b/cypress/integration/updates/sidebar.spec.js
@@ -21,6 +21,7 @@ describe("update notification", () => {
       isOnboarded: true,
       updatesViewed: {},
       hasSeenTutorialsTooTip: true,
+      hasSeenSimulatorToolTip: true,
     });
 
     cy.intercept("/api/state", (req) => {
@@ -71,6 +72,7 @@ describe("update notification", () => {
         latestNonBreaking: "1.2.3",
       },
       hasSeenTutorialsTooTip: true,
+      hasSeenSimulatorToolTip: true,
     });
 
     cy.intercept("/api/state", (req) => {
@@ -100,6 +102,7 @@ describe("update notification", () => {
         latestNonBreaking: "1.2.3",
       },
       hasSeenTutorialsTooTip: true,
+      hasSeenSimulatorToolTip: true,
     });
 
     cy.intercept("/api/state", (req) => {

--- a/cypress/integration/updates/simulator-tooltip.spec.js
+++ b/cypress/integration/updates/simulator-tooltip.spec.js
@@ -1,6 +1,7 @@
+/** This test needs to run AFTER create_slice. const values below are copied from there. */
 describe("simulator tooltip", () => {
   const lib = "slices";
-  const sliceName = "TestSlice2";
+  const sliceName = "DuplicateSlices";
   it("should display the tooltip when 'userContext.hasSeenSimulatorToolTip' is falsy and set to true when user clicks the close button", () => {
     cy.clearLocalStorage();
     cy.setupSliceMachineUserContext({

--- a/cypress/integration/updates/simulator-tooltip.spec.js
+++ b/cypress/integration/updates/simulator-tooltip.spec.js
@@ -1,0 +1,75 @@
+describe("simulator tooltip", () => {
+  const lib = "slices";
+  const sliceName = "TestSlice2";
+  it("should display the tooltip when 'userContext.hasSeenSimulatorToolTip' is falsy and set to true when user clicks the close button", () => {
+    cy.clearLocalStorage();
+    cy.setupSliceMachineUserContext({
+      hasSendAReview: true,
+      isOnboarded: true,
+      updatesViewed: {},
+      hasSeenTutorialsTooTip: true,
+      hasSeenSimulatorToolTip: false,
+    });
+
+    cy.visit(`/${lib}/${sliceName}/default`);
+
+    // There is a 5s timeout for displaying the tooltip
+    cy.wait(6000);
+
+    cy.get("[data-testid=simulator-tooltip]").should("exist");
+
+    cy.get("[data-testid=simulator-tooltip-close-button]").click();
+
+    cy.get("[data-testid=simulator-tooltip]").should("not.exist");
+
+    cy.getSliceMachineUserContext().should((data) => {
+      expect(data.hasSeenSimulatorToolTip).equal(
+        true,
+        "userContext.hasSeenSimulatorToolTip should set in local storage"
+      );
+    });
+  });
+
+  it("should not display when hasSeenSimulatorToolTip is truthy", () => {
+    cy.clearLocalStorage();
+    cy.setupSliceMachineUserContext({
+      hasSendAReview: true,
+      isOnboarded: true,
+      updatesViewed: {},
+      hasSeenTutorialsTooTip: true,
+      hasSeenSimulatorToolTip: true,
+    });
+
+    // There is a 5s timeout for displaying the tooltip
+    cy.wait(6000);
+
+    cy.get("[data-testid=simulator-tooltip]").should("not.exist");
+  });
+
+  it("should close the tooltip when the user clicks the simulator button", () => {
+    cy.clearLocalStorage();
+    cy.setupSliceMachineUserContext({
+      hasSendAReview: true,
+      isOnboarded: true,
+      updatesViewed: {},
+      hasSeenTutorialsTooTip: true,
+      hasSeenSimulatorToolTip: false,
+    });
+
+    cy.visit(`/${lib}/${sliceName}/default`);
+
+    // There is a 5s timeout for displaying the tooltip
+    cy.wait(6000);
+
+    cy.get("[data-testid=simulator-tooltip]").should("exist");
+
+    cy.get("[data-testid=simulator-open-button]").click();
+
+    cy.getSliceMachineUserContext().should((data) => {
+      expect(data.hasSeenSimulatorToolTip).equal(
+        true,
+        "userContext.hasSeenSimulatorToolTip should set in local storage"
+      );
+    });
+  });
+});

--- a/cypress/integration/updates/video-tooltip.spec.js
+++ b/cypress/integration/updates/video-tooltip.spec.js
@@ -6,6 +6,7 @@ describe("video tooltip", () => {
       isOnboarded: true,
       updatesViewed: {},
       hasSeenTutorialsTooTip: false,
+      hasSeenSimulatorToolTip: true,
     });
 
     cy.visit("/");
@@ -34,6 +35,7 @@ describe("video tooltip", () => {
       isOnboarded: true,
       updatesViewed: {},
       hasSeenTutorialsTooTip: true,
+      hasSeenSimulatorToolTip: true,
     });
 
     // There is a 5s timeout for displaying the tooltip
@@ -49,6 +51,7 @@ describe("video tooltip", () => {
       isOnboarded: true,
       updatesViewed: {},
       hasSeenTutorialsTooTip: false,
+      hasSeenSimulatorToolTip: true,
     });
 
     cy.visit("/");
@@ -79,6 +82,7 @@ describe("video tooltip", () => {
       isOnboarded: true,
       updatesViewed: {},
       hasSeenTutorialsTooTip: false,
+      hasSeenSimulatorToolTip: true,
     });
 
     cy.visit("/");

--- a/cypress/integration/user-flows/scenario_001.spec.js
+++ b/cypress/integration/user-flows/scenario_001.spec.js
@@ -1,6 +1,5 @@
 import path from "path";
 
-/** This test needs to run AFTER create_slice. const values below are copied from there. */
 describe("I am a new SM user (with Next) who wants to create a Custom Type with fields, and then save and push it to Prismic.", () => {
   const name = "My Custom Type";
   const id = "my_custom_type";

--- a/cypress/integration/user-flows/scenario_001.spec.js
+++ b/cypress/integration/user-flows/scenario_001.spec.js
@@ -10,6 +10,7 @@ describe("I am a new SM user (with Next) who wants to create a Custom Type with 
     cy.clearLocalStorageSnapshot();
     cy.cleanSliceMachineUserContext();
     cy.task("clearDir", path.join(appPath, "customtypes"));
+    cy.task("clearDir", path.join(appPath, "slices"));
     cy.task("clearDir", path.join(appPath, ".slicemachine"));
   });
 
@@ -19,7 +20,7 @@ describe("I am a new SM user (with Next) who wants to create a Custom Type with 
       isOnboarded: false,
       updatesViewed: {},
       hasSeenTutorialsTooTip: false,
-      hasSeenSimulatorToolTip: false,
+      hasSeenSimulatorToolTip: true,
     });
     cy.visit("/");
     cy.waitUntil(() => cy.get("[data-cy=get-started]"));

--- a/cypress/integration/user-flows/scenario_001.spec.js
+++ b/cypress/integration/user-flows/scenario_001.spec.js
@@ -1,5 +1,6 @@
 import path from "path";
 
+/** This test needs to run AFTER create_slice. const values below are copied from there. */
 describe("I am a new SM user (with Next) who wants to create a Custom Type with fields, and then save and push it to Prismic.", () => {
   const name = "My Custom Type";
   const id = "my_custom_type";
@@ -10,7 +11,6 @@ describe("I am a new SM user (with Next) who wants to create a Custom Type with 
     cy.clearLocalStorageSnapshot();
     cy.cleanSliceMachineUserContext();
     cy.task("clearDir", path.join(appPath, "customtypes"));
-    cy.task("clearDir", path.join(appPath, "slices"));
     cy.task("clearDir", path.join(appPath, ".slicemachine"));
   });
 
@@ -20,6 +20,7 @@ describe("I am a new SM user (with Next) who wants to create a Custom Type with 
       isOnboarded: false,
       updatesViewed: {},
       hasSeenTutorialsTooTip: false,
+      hasSeenSimulatorToolTip: false,
     });
     cy.visit("/");
     cy.waitUntil(() => cy.get("[data-cy=get-started]"));
@@ -44,6 +45,7 @@ describe("I am a new SM user (with Next) who wants to create a Custom Type with 
       isOnboarded: true,
       updatesViewed: {},
       hasSeenTutorialsTooTip: true,
+      hasSeenSimulatorToolTip: true,
     });
     cy.visit("/");
     cy.waitUntil(() => cy.get("[data-cy=empty-state-main-button]"));
@@ -67,6 +69,7 @@ describe("I am a new SM user (with Next) who wants to create a Custom Type with 
       isOnboarded: true,
       updatesViewed: {},
       hasSeenTutorialsTooTip: true,
+      hasSeenSimulatorToolTip: true,
     });
     cy.visit(`/cts/${id}`);
     cy.waitUntil(() => cy.get('[data-testid="empty-zone-add-new-field"]'));
@@ -139,6 +142,7 @@ describe("I am a new SM user (with Next) who wants to create a Custom Type with 
       isOnboarded: true,
       updatesViewed: {},
       hasSeenTutorialsTooTip: true,
+      hasSeenSimulatorToolTip: true,
     });
     cy.visit(`/changes`);
 

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -8,6 +8,7 @@ Cypress.Commands.add(
     isOnboarded, // boolean
     updatesViewed, // object
     hasSeenTutorialsTooTip, // boolean
+    hasSeenSimulatorToolTip, // boolean,
   }) => {
     return cy.setLocalStorage(
       "persist:root",
@@ -21,6 +22,7 @@ Cypress.Commands.add(
             ...updatesViewed,
           },
           hasSeenTutorialsTooTip,
+          hasSeenSimulatorToolTip,
         }),
       })
     );

--- a/cypress/support/index.d.ts
+++ b/cypress/support/index.d.ts
@@ -15,7 +15,8 @@ declare namespace Cypress {
       hasSendAReview?: boolean,
       isOnboarded?: boolean,
       viewedUpdates?: Record<string, unknown>,
-      hasSeenTutorialsTooTip?: boolean
+      hasSeenTutorialsTooTip?: boolean,
+      hasSeenSimulatorToolTip?: boolean
     ): Chainable<undefined>;
     getSliceMachineUSerContext(): Chainable<
       undefined | Record<string, unknown>

--- a/packages/slice-machine/components/AppLayout/Navigation/Menu/Navigation/VideoItem.tsx
+++ b/packages/slice-machine/components/AppLayout/Navigation/Menu/Navigation/VideoItem.tsx
@@ -63,7 +63,7 @@ const VideoItem: React.FC<VideoItemProps> = ({
           id={id}
           effect="solid"
           backgroundColor="#5B3DF5"
-          clickable={true}
+          clickable
           className={style.videoTutorialsContainer}
           afterHide={handleClose}
           offset={{

--- a/packages/slice-machine/components/Button/index.tsx
+++ b/packages/slice-machine/components/Button/index.tsx
@@ -1,21 +1,14 @@
-import React from "react";
+import React, { forwardRef } from "react";
 
-import { Button as ThemeUIButton, Spinner } from "theme-ui";
-import { ThemeUIStyleObject } from "@theme-ui/css";
+import { Button as ThemeUIButton, ButtonProps, Spinner } from "theme-ui";
 import { IconType } from "react-icons";
 
-export type ButtonProps = {
+export interface SmButtonProps extends ButtonProps {
   label: string;
   Icon?: IconType;
-  type?: "submit" | "reset" | "button";
-  form?: string;
   isLoading?: boolean;
-  disabled?: boolean;
-  onClick?: React.MouseEventHandler<HTMLButtonElement>;
-  sx?: ThemeUIStyleObject;
   "data-cy"?: string;
-  variant?: string;
-};
+}
 
 // Small helper to allow us to target spinner and icon in the CY
 const cyIdBuilder = (dataCy: string | undefined, id: string) => {
@@ -33,50 +26,56 @@ const spinnerColor = (variant: string) => {
 };
 
 // If you don't use an icon, don't forget to pass a min-width property so the button doesn't change width on loading.
-export const Button: React.FunctionComponent<ButtonProps> = ({
-  label,
-  Icon,
-  type,
-  form,
-  isLoading = false,
-  disabled = false,
-  onClick,
-  sx = {},
-  variant = "primary",
-  ...rest
-}) => (
-  <ThemeUIButton
-    sx={{
-      ...sx,
-      display: "flex",
-      alignItems: "center",
-      justifyContent: "center",
-      gap: "8px",
-      ...(isLoading ? { cursor: "wait !important" } : {}), // without important, the hover effect has priority
-    }}
-    type={type}
-    form={form}
-    disabled={disabled || isLoading}
-    onClick={!isLoading ? onClick : undefined}
-    variant={variant}
-    {...rest}
-  >
-    {isLoading ? (
-      <>
-        <Spinner
-          size={16}
-          color={spinnerColor(variant)}
-          data-cy={cyIdBuilder(rest["data-cy"], "spinner")}
-        />
-        {Icon && label}
-      </>
-    ) : (
-      <>
-        {Icon && (
-          <Icon size={16} data-cy={cyIdBuilder(rest["data-cy"], "icon")} />
-        )}
-        {label}
-      </>
-    )}
-  </ThemeUIButton>
+export const Button = forwardRef<HTMLButtonElement, SmButtonProps>(
+  (
+    {
+      label,
+      Icon,
+      type,
+      form,
+      isLoading = false,
+      disabled = false,
+      onClick,
+      sx = {},
+      variant = "primary",
+      ...rest
+    },
+    ref
+  ) => (
+    <ThemeUIButton
+      ref={ref}
+      sx={{
+        ...sx,
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        gap: "8px",
+        ...(isLoading ? { cursor: "wait !important" } : {}), // without important, the hover effect has priority
+      }}
+      type={type}
+      form={form}
+      disabled={disabled || isLoading}
+      onClick={!isLoading ? onClick : undefined}
+      variant={variant}
+      {...rest}
+    >
+      {isLoading ? (
+        <>
+          <Spinner
+            size={16}
+            color={spinnerColor(variant)}
+            data-cy={cyIdBuilder(rest["data-cy"], "spinner")}
+          />
+          {Icon && label}
+        </>
+      ) : (
+        <>
+          {Icon && (
+            <Icon size={16} data-cy={cyIdBuilder(rest["data-cy"], "icon")} />
+          )}
+          {label}
+        </>
+      )}
+    </ThemeUIButton>
+  )
 );

--- a/packages/slice-machine/components/Simulator/components/SetupModal/CodeBlock.tsx
+++ b/packages/slice-machine/components/Simulator/components/SetupModal/CodeBlock.tsx
@@ -3,7 +3,7 @@ import { Button, useThemeUI, Box } from "theme-ui";
 
 import { MdCheck, MdContentCopy } from "react-icons/md";
 
-import CodeBlock from "@components/CodeBlock";
+import CodeBlock from "../../../CodeBlock";
 
 const CodeBlockWithCopy: React.FC<{ children: string }> = ({ children }) => {
   const { theme } = useThemeUI();

--- a/packages/slice-machine/lib/builders/SliceBuilder/Header/SimulatorButton/index.tsx
+++ b/packages/slice-machine/lib/builders/SliceBuilder/Header/SimulatorButton/index.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useRef } from "react";
+import React, { RefCallback, useCallback, useRef } from "react";
 import { Box, Flex, Close, Text, Link, useThemeUI } from "theme-ui";
 import { Button } from "@components/Button";
 
@@ -33,7 +33,7 @@ const SimulatorButton: React.FC<{
     })
   );
 
-  const setRef = useCallback((node) => {
+  const setRef: RefCallback<HTMLButtonElement> = useCallback((node) => {
     if (ref.current) {
       return;
     }

--- a/packages/slice-machine/lib/builders/SliceBuilder/Header/SimulatorButton/index.tsx
+++ b/packages/slice-machine/lib/builders/SliceBuilder/Header/SimulatorButton/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React, { useCallback, useRef } from "react";
 import { Box, Flex, Close, Text, Link, useThemeUI } from "theme-ui";
 import { Button } from "@components/Button";
 
@@ -22,7 +22,7 @@ const SimulatorButton: React.FC<{
   const router = useRouter();
   const { theme } = useThemeUI();
 
-  const ref = React.createRef<HTMLButtonElement>();
+  const ref = useRef<HTMLButtonElement | null>(null);
 
   const { setSeenSimulatorToolTip } = useSliceMachineActions();
 
@@ -33,15 +33,14 @@ const SimulatorButton: React.FC<{
     })
   );
 
-  useEffect(() => {
-    if (
-      ref.current &&
-      isSimulatorAvailableForFramework &&
-      !hasSeenSimulatorTooTip
-    ) {
-      const { current } = ref;
-      setTimeout(() => ReactTooltip.show(current), 5000);
+  const setRef = useCallback((node) => {
+    if (ref.current) {
+      return;
     }
+    if (node && isSimulatorAvailableForFramework && !hasSeenSimulatorTooTip) {
+      setTimeout(() => ReactTooltip.show(node), 5000);
+    }
+    ref.current = node;
   }, []);
 
   const onCloseToolTip = () => {
@@ -56,7 +55,7 @@ const SimulatorButton: React.FC<{
     <>
       <Button
         data-tip
-        ref={ref}
+        ref={setRef}
         Icon={BsPlayCircle}
         label="Simulate Slice"
         data-testid="simulator-open-button"

--- a/packages/slice-machine/lib/builders/SliceBuilder/Header/SimulatorButton/index.tsx
+++ b/packages/slice-machine/lib/builders/SliceBuilder/Header/SimulatorButton/index.tsx
@@ -1,0 +1,174 @@
+import React, { useEffect } from "react";
+import { Box, Flex, Close, Text, Link, useThemeUI } from "theme-ui";
+import { Button } from "@components/Button";
+
+import { BsPlayCircle } from "react-icons/bs";
+import { SIMULATOR_WINDOW_ID } from "@lib/consts";
+import { useRouter } from "next/router";
+import ReactTooltip from "react-tooltip";
+import { Frameworks } from "@slicemachine/core/build/models";
+
+import style from "./style.module.css";
+import { userHasSeenSimulatorToolTip } from "@src/modules/userContext";
+import { useSelector } from "react-redux";
+import { SliceMachineStoreType } from "@src/redux/type";
+import useSliceMachineActions from "@src/modules/useSliceMachineActions";
+import { getLinkToStorybookDocs } from "@src/modules/environment";
+
+const SimulatorButton: React.FC<{
+  framework: Frameworks;
+  isSimulatorAvailableForFramework: boolean;
+}> = ({ framework, isSimulatorAvailableForFramework }) => {
+  const router = useRouter();
+  const { theme } = useThemeUI();
+
+  const ref = React.createRef<HTMLButtonElement>();
+
+  const { setSeenSimulatorToolTip } = useSliceMachineActions();
+
+  const { hasSeenSimulatorTooTip, linkToStorybookDocs } = useSelector(
+    (store: SliceMachineStoreType) => ({
+      hasSeenSimulatorTooTip: userHasSeenSimulatorToolTip(store),
+      linkToStorybookDocs: getLinkToStorybookDocs(store),
+    })
+  );
+
+  useEffect(() => {
+    if (
+      ref.current &&
+      isSimulatorAvailableForFramework &&
+      !hasSeenSimulatorTooTip
+    ) {
+      const { current } = ref;
+      setTimeout(() => ReactTooltip.show(current), 5000);
+    }
+  }, []);
+
+  const onCloseToolTip = () => {
+    setSeenSimulatorToolTip();
+    if (ref.current) {
+      const { current } = ref;
+      ReactTooltip.hide(current);
+    }
+  };
+
+  return (
+    <>
+      <Button
+        data-tip
+        ref={ref}
+        Icon={BsPlayCircle}
+        label="Simulate Slice"
+        data-cy="builder-simulate-button"
+        data-for={
+          isSimulatorAvailableForFramework
+            ? "simulator-tooltip"
+            : "simulator-not-supported"
+        }
+        onClick={() =>
+          window.open(`${router.asPath}/simulator`, SIMULATOR_WINDOW_ID)
+        }
+        disabled={!isSimulatorAvailableForFramework}
+        variant={
+          isSimulatorAvailableForFramework ? "secondary" : "disabledSecondary"
+        }
+        sx={{
+          mr: "8px",
+        }}
+      />
+      {isSimulatorAvailableForFramework ? (
+        <>
+          {!hasSeenSimulatorTooTip ? (
+            <ReactTooltip
+              clickable
+              border={false}
+              place="bottom"
+              effect="solid"
+              id="simulator-tooltip"
+              className={style.tooltip}
+              arrowColor="#5842C3"
+              afterHide={onCloseToolTip}
+              event="none"
+              textColor={String(theme.colors?.textClear)}
+            >
+              <Flex
+                sx={{
+                  alignItems: "center",
+                  justifyContent: "space-between",
+                  p: 2,
+                }}
+              >
+                <Text as="b" sx={{ color: "#FFF" }}>
+                  Simulate your slices
+                </Text>
+                <Close
+                  data-testid="video-tooltip-close-button"
+                  onClick={onCloseToolTip}
+                  sx={{
+                    width: "26px",
+                    color: "#FFF",
+                  }}
+                />
+              </Flex>
+              <Box sx={{ bg: "#FFF" }}>
+                <video
+                  width="360"
+                  height="200"
+                  controls
+                  src="https://media.geeksforgeeks.org/wp-content/uploads/20190616234019/Canvas.move_.mp4"
+                >
+                  Browser not supported
+                </video>
+                <Box sx={{ p: 2 }}>
+                  <Text>
+                    Minimize context-switching by previewing your Slice
+                    components in the simulator.
+                  </Text>
+                </Box>
+                <Flex
+                  sx={{
+                    alignItems: "center",
+                    justifyContent: "flex-end",
+                    p: 2,
+                  }}
+                >
+                  <Button
+                    label="Got it"
+                    variant="xs"
+                    sx={{ cursor: "pointer" }}
+                    onClick={onCloseToolTip}
+                  />
+                </Flex>
+              </Box>
+            </ReactTooltip>
+          ) : null}
+        </>
+      ) : (
+        <ReactTooltip
+          clickable
+          place="bottom"
+          effect="solid"
+          delayHide={500}
+          id="simulator-not-supported"
+        >
+          <Text as="b">Framework "{framework}" not supported</Text>
+          <Text as="p">
+            Slice Simulator does not support your framework yet.
+            <br />
+            You can{" "}
+            <Link
+              sx={{ color: "#FFF" }}
+              target="_blank"
+              href={linkToStorybookDocs}
+            >
+              install Storybook
+            </Link>{" "}
+            instead.
+          </Text>
+        </ReactTooltip>
+      )}
+    </>
+  );
+};
+
+export default SimulatorButton;

--- a/packages/slice-machine/lib/builders/SliceBuilder/Header/SimulatorButton/index.tsx
+++ b/packages/slice-machine/lib/builders/SliceBuilder/Header/SimulatorButton/index.tsx
@@ -59,15 +59,16 @@ const SimulatorButton: React.FC<{
         ref={ref}
         Icon={BsPlayCircle}
         label="Simulate Slice"
-        data-cy="builder-simulate-button"
+        data-testid="simulator-open-button"
         data-for={
           isSimulatorAvailableForFramework
             ? "simulator-tooltip"
             : "simulator-not-supported"
         }
-        onClick={() =>
-          window.open(`${router.asPath}/simulator`, SIMULATOR_WINDOW_ID)
-        }
+        onClick={() => {
+          onCloseToolTip();
+          window.open(`${router.asPath}/simulator`, SIMULATOR_WINDOW_ID);
+        }}
         disabled={!isSimulatorAvailableForFramework}
         variant={
           isSimulatorAvailableForFramework ? "secondary" : "disabledSecondary"
@@ -97,12 +98,13 @@ const SimulatorButton: React.FC<{
                   justifyContent: "space-between",
                   p: 2,
                 }}
+                data-testid="simulator-tooltip"
               >
                 <Text as="b" sx={{ color: "#FFF" }}>
                   Simulate your slices
                 </Text>
                 <Close
-                  data-testid="video-tooltip-close-button"
+                  data-testid="simulator-tooltip-close-button"
                   onClick={onCloseToolTip}
                   sx={{
                     width: "26px",

--- a/packages/slice-machine/lib/builders/SliceBuilder/Header/SimulatorButton/style.module.css
+++ b/packages/slice-machine/lib/builders/SliceBuilder/Header/SimulatorButton/style.module.css
@@ -1,0 +1,15 @@
+div.tooltip {
+  width: 360px;
+  background: #5842c3;
+  padding: 0;
+  border: none;
+  opacity: 1 !important;
+  filter: drop-shadow(0px 100px 80px rgba(0, 0, 0, 0.07))
+    drop-shadow(0px 41.7776px 33.4221px rgba(0, 0, 0, 0.0503198))
+    drop-shadow(0px 22.3363px 17.869px rgba(0, 0, 0, 0.0417275))
+    drop-shadow(0px 12.5216px 10.0172px rgba(0, 0, 0, 0.035))
+    drop-shadow(0px 6.6501px 5.32008px rgba(0, 0, 0, 0.0282725))
+    drop-shadow(0px 2.76726px 2.21381px rgba(0, 0, 0, 0.0196802));
+  border-radius: 6px;
+  pointer-events: auto;
+}

--- a/packages/slice-machine/lib/builders/SliceBuilder/Header/index.tsx
+++ b/packages/slice-machine/lib/builders/SliceBuilder/Header/index.tsx
@@ -14,6 +14,13 @@ import { ComponentUI } from "@lib/models/common/ComponentUI";
 import { ModelStatus } from "@lib/models/common/ModelStatus";
 import { Button } from "@components/Button";
 import { AiFillSave } from "react-icons/ai";
+import { useSelector } from "react-redux";
+import { SliceMachineStoreType } from "@src/redux/type";
+import {
+  getFramework,
+  selectIsSimulatorAvailableForFramework,
+} from "@src/modules/environment";
+import SimulatorButton from "./SimulatorButton";
 
 const Header: React.FC<{
   component: ComponentUI;
@@ -29,6 +36,14 @@ const Header: React.FC<{
 
   const { openRenameSliceModal, copyVariationSlice } = useSliceMachineActions();
   const { theme } = useThemeUI();
+
+  const { isSimulatorAvailableForFramework, framework } = useSelector(
+    (state: SliceMachineStoreType) => ({
+      isSimulatorAvailableForFramework:
+        selectIsSimulatorAvailableForFramework(state),
+      framework: getFramework(state),
+    })
+  );
 
   return (
     <Flex
@@ -97,6 +112,12 @@ const Header: React.FC<{
             </Flex>
           </Box>
           <Flex sx={{ flexDirection: "row", alignItems: "center" }}>
+            <SimulatorButton
+              framework={framework}
+              isSimulatorAvailableForFramework={
+                isSimulatorAvailableForFramework
+              }
+            />
             <SliceMachineIconButton
               Icon={MdModeEdit}
               label="Edit slice name"

--- a/packages/slice-machine/lib/builders/SliceBuilder/SideBar/index.tsx
+++ b/packages/slice-machine/lib/builders/SliceBuilder/SideBar/index.tsx
@@ -1,21 +1,15 @@
 import React from "react";
 
-import { Box, Text, Button as ThemeButton } from "theme-ui";
+import { Box, Button as ThemeButton } from "theme-ui";
 import Link from "next/link";
 
 import Card from "@components/Card";
 
 import { ScreenshotPreview } from "@components/ScreenshotPreview";
-import { useRouter } from "next/router";
 import { useSelector } from "react-redux";
 import { SliceMachineStoreType } from "@src/redux/type";
 
-import {
-  selectIsSimulatorAvailableForFramework,
-  getFramework,
-  getStorybookUrl,
-  getLinkToStorybookDocs,
-} from "@src/modules/environment";
+import { getStorybookUrl } from "@src/modules/environment";
 import { createStorybookUrl } from "@src/utils/storybook";
 import { ComponentUI } from "@lib/models/common/ComponentUI";
 import type Models from "@slicemachine/core/build/models";
@@ -23,7 +17,6 @@ import ScreenshotChangesModal from "@components/ScreenshotChangesModal";
 import { useScreenshotChangesModal } from "@src/hooks/useScreenshotChangesModal";
 import { Button } from "@components/Button";
 import { AiOutlineCamera } from "react-icons/ai";
-import { SIMULATOR_WINDOW_ID } from "@lib/consts";
 
 type SideBarProps = {
   component: ComponentUI;
@@ -34,20 +27,10 @@ const SideBar: React.FunctionComponent<SideBarProps> = ({
   component,
   variation,
 }) => {
-  const router = useRouter();
   const { screenshots } = component;
   const { openScreenshotsModal } = useScreenshotChangesModal();
 
-  const {
-    isSimulatorAvailableForFramework,
-    linkToStorybookDocs,
-    framework,
-    storybookUrl,
-  } = useSelector((state: SliceMachineStoreType) => ({
-    framework: getFramework(state),
-    linkToStorybookDocs: getLinkToStorybookDocs(state),
-    isSimulatorAvailableForFramework:
-      selectIsSimulatorAvailableForFramework(state),
+  const { storybookUrl } = useSelector((state: SliceMachineStoreType) => ({
     storybookUrl: getStorybookUrl(state),
   }));
 
@@ -83,47 +66,6 @@ const SideBar: React.FunctionComponent<SideBarProps> = ({
           }}
         />
       </Card>
-      <ThemeButton
-        data-testid="open-set-up-simulator"
-        disabled={!isSimulatorAvailableForFramework}
-        onClick={() =>
-          window.open(`${router.asPath}/simulator`, SIMULATOR_WINDOW_ID)
-        }
-        variant={
-          isSimulatorAvailableForFramework ? "secondary" : "disabledSecondary"
-        }
-        sx={{ cursor: "pointer", width: "100%", mt: 3 }}
-      >
-        Preview Slice
-      </ThemeButton>
-      {!isSimulatorAvailableForFramework && (
-        <Text
-          as="p"
-          sx={{
-            textAlign: "center",
-            mt: 3,
-            color: "grey05",
-            "::first-letter": {
-              "text-transform": "uppercase",
-            },
-          }}
-        >
-          {`Slice Simulator does not support ${
-            framework || "your"
-          } framework yet.`}
-          &nbsp;
-          {!storybookUrl ? (
-            <>
-              You can{" "}
-              <a target={"_blank"} href={linkToStorybookDocs}>
-                install Storybook
-              </a>{" "}
-              instead.
-            </>
-          ) : null}
-        </Text>
-      )}
-
       {storybookUrl && (
         <Link
           href={createStorybookUrl({

--- a/packages/slice-machine/src/modules/availableCustomTypes/index.ts
+++ b/packages/slice-machine/src/modules/availableCustomTypes/index.ts
@@ -8,7 +8,6 @@ import { withLoader } from "@src/modules/loading";
 import { LoadingKeysEnum } from "@src/modules/loading/types";
 import { renameCustomType, saveCustomType } from "@src/apiClient";
 import { modalCloseCreator } from "@src/modules/modal";
-import { ModalKeysEnum } from "@src/modules/modal/types";
 import { push } from "connected-next-router";
 import { createCustomType } from "@src/modules/availableCustomTypes/factory";
 import { openToasterCreator, ToasterType } from "@src/modules/toaster";

--- a/packages/slice-machine/src/modules/selectedSlice/sagas.ts
+++ b/packages/slice-machine/src/modules/selectedSlice/sagas.ts
@@ -13,7 +13,6 @@ import { saveSliceApiClient, renameSlice } from "@src/apiClient";
 import { openToasterCreator, ToasterType } from "@src/modules/toaster";
 import { renameSliceCreator } from "../slices";
 import { modalCloseCreator } from "../modal";
-import { ModalKeysEnum } from "../modal/types";
 import { push } from "connected-next-router";
 
 export function* saveSliceSaga({

--- a/packages/slice-machine/src/modules/simulator/index.ts
+++ b/packages/slice-machine/src/modules/simulator/index.ts
@@ -1,11 +1,6 @@
 import { Reducer } from "redux";
 import { SliceMachineStoreType } from "@src/redux/type";
-import {
-  ActionType,
-  createAction,
-  createAsyncAction,
-  getType,
-} from "typesafe-actions";
+import { ActionType, createAsyncAction, getType } from "typesafe-actions";
 import { SimulatorStoreType } from "./types";
 import {
   call,

--- a/packages/slice-machine/src/modules/slices/index.ts
+++ b/packages/slice-machine/src/modules/slices/index.ts
@@ -11,7 +11,6 @@ import { withLoader } from "@src/modules/loading";
 import { LoadingKeysEnum } from "@src/modules/loading/types";
 import { createSlice, getState } from "@src/apiClient";
 import { modalCloseCreator } from "@src/modules/modal";
-import { ModalKeysEnum } from "@src/modules/modal/types";
 import { Reducer } from "redux";
 import { SlicesStoreType } from "./types";
 import { refreshStateCreator } from "@src/modules/environment";

--- a/packages/slice-machine/src/modules/useSliceMachineActions.ts
+++ b/packages/slice-machine/src/modules/useSliceMachineActions.ts
@@ -9,6 +9,7 @@ import {
   skipReviewCreator,
   updatesViewedCreator,
   hasSeenTutorialsTooTipCreator,
+  hasSeenSimulatorToolTipCreator,
 } from "./userContext";
 import { refreshStateCreator } from "./environment";
 import {
@@ -129,6 +130,8 @@ const useSliceMachineActions = () => {
   const finishOnboarding = () => dispatch(finishOnboardingCreator());
   const setUpdatesViewed = (versions: UserContextStoreType["updatesViewed"]) =>
     dispatch(updatesViewedCreator(versions));
+  const setSeenSimulatorToolTip = () =>
+    dispatch(hasSeenSimulatorToolTipCreator());
   const setSeenTutorialsToolTip = () =>
     dispatch(hasSeenTutorialsTooTipCreator());
 
@@ -537,6 +540,7 @@ const useSliceMachineActions = () => {
     skipReview,
     setUpdatesViewed,
     setSeenTutorialsToolTip,
+    setSeenSimulatorToolTip,
     openCreateCustomTypeModal,
     openRenameCustomTypeModal,
     openScreenshotPreviewModal,

--- a/packages/slice-machine/src/modules/userContext/index.ts
+++ b/packages/slice-machine/src/modules/userContext/index.ts
@@ -19,6 +19,7 @@ const initialState: UserContextStoreType = {
     latestNonBreaking: null,
   },
   hasSeenTutorialsTooTip: false,
+  hasSeenSimulatorToolTip: false,
   authStatus: AuthStatus.UNKNOWN,
   lastSyncChange: null,
 };
@@ -40,12 +41,17 @@ export const hasSeenTutorialsTooTipCreator = createAction(
   "USER_CONTEXT/VIEW_TUTORIALS_TOOL_TIP"
 )();
 
+export const hasSeenSimulatorToolTipCreator = createAction(
+  "USER_CONTEXT/VIEW_SIMULATOR_TOOL_TIP"
+)();
+
 type userContextActions = ActionType<
   | typeof finishOnboardingCreator
   | typeof sendAReviewCreator
   | typeof skipReviewCreator
   | typeof updatesViewedCreator
   | typeof hasSeenTutorialsTooTipCreator
+  | typeof hasSeenSimulatorToolTipCreator
   | typeof refreshStateCreator
   | typeof syncChangeCreator
 >;
@@ -65,6 +71,10 @@ export const getUpdatesViewed = (
 export const userHashasSeenTutorialsTooTip = (
   state: SliceMachineStoreType
 ): boolean => state.userContext.hasSeenTutorialsTooTip || false;
+
+export const userHasSeenSimulatorToolTip = (
+  state: SliceMachineStoreType
+): boolean => state.userContext.hasSeenSimulatorToolTip || false;
 
 export const getLastSyncChange = (
   state: SliceMachineStoreType
@@ -97,6 +107,12 @@ export const userContextReducer: Reducer<
       return {
         ...state,
         hasSeenTutorialsTooTip: true,
+      };
+    }
+    case getType(hasSeenSimulatorToolTipCreator): {
+      return {
+        ...state,
+        hasSeenSimulatorToolTip: true,
       };
     }
     case getType(refreshStateCreator): {

--- a/packages/slice-machine/src/modules/userContext/types.ts
+++ b/packages/slice-machine/src/modules/userContext/types.ts
@@ -13,6 +13,7 @@ export type UserContextStoreType = {
     latestNonBreaking: string | null;
   };
   hasSeenTutorialsTooTip: boolean;
+  hasSeenSimulatorToolTip: boolean;
   authStatus: AuthStatus;
   lastSyncChange: number | null;
 };

--- a/packages/slice-machine/src/theme.ts
+++ b/packages/slice-machine/src/theme.ts
@@ -15,6 +15,7 @@ const AppTheme = (): Theme =>
       primary: "#5D40F7",
       purpleLight: "#F6F1FC",
       purpleLight01: "#6548FF1A",
+      purpleStrong: "#5842C3",
       changesWarning: {
         background: "#FFECC7",
         color: "#5C0C17",

--- a/packages/slice-machine/tests/src/modules/simulator.test.ts
+++ b/packages/slice-machine/tests/src/modules/simulator.test.ts
@@ -119,7 +119,6 @@ describe("[Simulator module]", () => {
     it("should open setup modal if checkSimulatorSetupCreator.failure action", () => {
       const saga = testSaga(failCheckSetupSaga);
 
-      saga.next().select(getFramework);
       saga.next("next").select(selectIsSimulatorAvailableForFramework);
       saga.next(true).put(checkSimulatorSetupCreator.failure(new Error()));
       saga
@@ -132,7 +131,6 @@ describe("[Simulator module]", () => {
     it("should early return if the framework doesn't support the simulator feature", () => {
       const saga = testSaga(failCheckSetupSaga);
 
-      saga.next().select(getFramework);
       saga.next("vue").select(selectIsSimulatorAvailableForFramework);
       saga.next(false).isDone();
     });


### PR DESCRIPTION
Linear: https://linear.app/prismic/issue/SM-896/aauser-in-the-slice-builder-i-see-the-preview-button-close-to-the-save

Added a tooltip displayed the first time you open the SliceBuilder