### PR TITLE
Delete slice references in custom types

### DIFF
--- a/packages/slice-machine/lib/io/Slice.ts
+++ b/packages/slice-machine/lib/io/Slice.ts
@@ -2,6 +2,10 @@ import Files from "../utils/files";
 import { SharedSlice } from "@prismicio/types-internal/lib/customtypes/widgets/slices";
 import { Slices, SliceSM } from "@slicemachine/core/build/models/Slice";
 import path from "path";
+import { getLocalCustomTypes } from "../../lib/utils/customTypes";
+import { writeCustomType } from "./CustomType";
+import { CustomTypesPaths } from "../../lib/models/paths";
+import { filterSliceFromCustomType } from "../../lib/utils/shared/customTypes";
 
 export function readSlice(path: string): SliceSM {
   const slice: SharedSlice = Files.readJson(path);
@@ -23,4 +27,15 @@ export function deleteSlice(src: string) {
   const files = Files.readDirectory(src);
   files.forEach((file) => Files.hasWritePermissions(path.join(src, file)));
   Files.removeDirectory(src);
+}
+
+export function removeSliceFromCustomTypes(sliceId: string, cwd: string) {
+  const customTypes = getLocalCustomTypes(cwd);
+  const newCTs = customTypes.map((customType) =>
+    filterSliceFromCustomType(customType, sliceId)
+  );
+  newCTs.forEach((ct) => {
+    const modelPath = CustomTypesPaths(cwd).customType(ct.id).model();
+    writeCustomType(modelPath, ct);
+  });
 }

--- a/packages/slice-machine/lib/utils/shared/customTypes.ts
+++ b/packages/slice-machine/lib/utils/shared/customTypes.ts
@@ -1,0 +1,18 @@
+import { CustomTypeSM } from "@slicemachine/core/build/models/CustomType";
+
+export const filterSliceFromCustomType = (
+  ct: CustomTypeSM,
+  sliceId: string
+): CustomTypeSM => ({
+  ...ct,
+  tabs: ct.tabs.map((tab) => {
+    if (!tab.sliceZone) return tab;
+    return {
+      ...tab,
+      sliceZone: {
+        ...tab.sliceZone,
+        value: tab.sliceZone?.value.filter((val) => val.key !== sliceId),
+      },
+    };
+  }),
+});

--- a/packages/slice-machine/server/src/api/slices/delete.ts
+++ b/packages/slice-machine/server/src/api/slices/delete.ts
@@ -11,6 +11,7 @@ import path from "path";
 import onSaveSlice from "../common/hooks/onSaveSlice";
 import { MocksConfig } from "../../../../lib/models/paths";
 import { DeleteSliceResponse } from "../../../../lib/models/common/Slice";
+import { removeSliceFromCustomTypes } from "../../../../lib/io/Slice";
 
 interface DeleteSliceBody {
   sliceId: string;
@@ -116,6 +117,18 @@ export async function deleteSlice(req: {
   };
 
   // eslint-disable-next-line @typescript-eslint/require-await
+  const updateCustomTypes = async () => {
+    try {
+      removeSliceFromCustomTypes(sliceId, env.cwd);
+    } catch (err) {
+      console.error(
+        `[slice/delete] Could not update the custom types using your slice. Check our troubleshooting guide here: ${TROUBLESHOOTING_DOCS_LINK}`
+      );
+      throw err;
+    }
+  };
+
+  // eslint-disable-next-line @typescript-eslint/require-await
   const updateTypes = async () => {
     try {
       IO.Types.upsert(env);
@@ -145,6 +158,7 @@ export async function deleteSlice(req: {
   const settledResults = await Promise.allSettled([
     deleteAssets(),
     updateMockConfig(),
+    updateCustomTypes(),
     updateTypes(),
     updateLibraries(),
   ]);

--- a/packages/slice-machine/tests/lib/utils/shared/customTypes.test.ts
+++ b/packages/slice-machine/tests/lib/utils/shared/customTypes.test.ts
@@ -1,0 +1,88 @@
+import { filterSliceFromCustomType } from "@lib/utils/shared/customTypes";
+import { SlicesTypes } from "@prismicio/types-internal/lib/customtypes/widgets/slices";
+import { CustomTypeSM } from "@slicemachine/core/build/models/CustomType";
+
+describe("Slice IO", () => {
+  const baseCustomTypeModel = {
+    id: "some_custom_type",
+    label: "SomeCustomType",
+    repeatable: false,
+    status: false,
+    tabs: [],
+  };
+  const customTypeModel: CustomTypeSM = baseCustomTypeModel;
+  customTypeModel["tabs"] = [
+    {
+      key: "tab1",
+      value: [],
+    },
+    {
+      key: "tab2",
+      value: [],
+      sliceZone: {
+        key: "slices",
+        value: [
+          {
+            key: "slice_id",
+            value: {
+              type: SlicesTypes.SharedSlice,
+            },
+          },
+          {
+            key: "slice_2",
+            value: {
+              type: SlicesTypes.SharedSlice,
+            },
+          },
+        ],
+      },
+    },
+  ];
+
+  it("should remove a slice from a custom type model", () => {
+    const sliceIdToDelete = "slice_id";
+    const result = filterSliceFromCustomType(customTypeModel, sliceIdToDelete);
+    expect(result).toStrictEqual({
+      id: "some_custom_type",
+      label: "SomeCustomType",
+      repeatable: false,
+      status: false,
+      tabs: [
+        {
+          key: "tab1",
+          value: [],
+        },
+        {
+          key: "tab2",
+          value: [],
+          sliceZone: {
+            key: "slices",
+            value: [
+              {
+                key: "slice_2",
+                value: {
+                  type: SlicesTypes.SharedSlice,
+                },
+              },
+            ],
+          },
+        },
+      ],
+    });
+  });
+
+  it("should return an unchanged model when the slice id doesn't match", () => {
+    const sliceIdToDelete = "unknown_slice";
+    const result = filterSliceFromCustomType(customTypeModel, sliceIdToDelete);
+    expect(result).toStrictEqual(customTypeModel);
+  });
+
+  it("should return an unchanged model when it doesn't contain a slicezone", () => {
+    const sliceIdToDelete = "slice_1";
+    const result = filterSliceFromCustomType(
+      baseCustomTypeModel,
+      sliceIdToDelete
+    );
+    expect(result).toStrictEqual(customTypeModel);
+  });
+});

--- a/packages/slice-machine/tests/scripts/start/index.test.ts
+++ b/packages/slice-machine/tests/scripts/start/index.test.ts
@@ -6,10 +6,7 @@ import { vol } from "memfs";
 import os from "os";
 import pkgJson from "../../../package.json";
 
-jest.mock("fs", () => {
-  const mem = jest.requireActual("memfs");
-  return mem.vol;
-});
+jest.mock("fs");
 
 afterEach(() => {
   vol.reset();

--- a/packages/slice-machine/tests/server/slices/delete.test.ts
+++ b/packages/slice-machine/tests/server/slices/delete.test.ts
@@ -71,6 +71,13 @@ const readAssetsFiles = () =>
 const readSliceFiles = () =>
   vol.readdirSync(`/test/${SLICE_TO_DELETE_LIBRARY}`);
 
+const readCustomTypeMock = () =>
+  JSON.parse(
+    vol.readFileSync("/test/customtypes/custom-type-with-slice/index.json", {
+      encoding: "utf8",
+    }) as string
+  );
+
 const MOCK_INDEX_FILE = `
 import ${SLICE_TO_DELETE_NAME} from './${SLICE_TO_DELETE_NAME}';
 import Slice2 from './Slice2';
@@ -98,6 +105,52 @@ export const components = {
 	slice-2: Slice2,
 };
 `;
+
+const CustomTypeModel = {
+  id: "custom-type-with-slice",
+  label: "Custom Type",
+  repeatable: false,
+  status: false,
+  json: {
+    Main: {
+      slices: {
+        type: "Slices",
+        fieldset: "Slice Zone",
+        config: {
+          choices: {
+            [SLICE_TO_DELETE_ID]: {
+              type: "SharedSlice",
+            },
+            "slice-2": {
+              type: "SharedSlice",
+            },
+          },
+        },
+      },
+    },
+  },
+};
+const CustomTypeModelWithoutSlice = {
+  id: "custom-type-with-slice",
+  label: "Custom Type",
+  repeatable: false,
+  status: false,
+  json: {
+    Main: {
+      slices: {
+        type: "Slices",
+        fieldset: "Slice Zone",
+        config: {
+          choices: {
+            "slice-2": {
+              type: "SharedSlice",
+            },
+          },
+        },
+      },
+    },
+  },
+};
 
 describe("Delete slice files", () => {
   const mockRequest = {
@@ -129,6 +182,8 @@ describe("Delete slice files", () => {
       [`/test/.slicemachine/assets/${SLICE_TO_DELETE_LIBRARY}/Slice2/mocks.json`]:
         JSON.stringify(otherSliceMocks),
       "/test/.slicemachine/mock-config.json": JSON.stringify(MOCK_CONFIG),
+      "/test/customtypes/custom-type-with-slice/index.json":
+        JSON.stringify(CustomTypeModel),
     });
 
     expect(readSliceFiles()).toStrictEqual([
@@ -143,6 +198,7 @@ describe("Delete slice files", () => {
         Slice2: { name: "bar" },
       },
     });
+    expect(readCustomTypeMock()).toStrictEqual(CustomTypeModel);
 
     const result = await deleteSlice(mockRequest);
 
@@ -154,6 +210,7 @@ describe("Delete slice files", () => {
         Slice2: { name: "bar" },
       },
     });
+    expect(readCustomTypeMock()).toStrictEqual(CustomTypeModelWithoutSlice);
     expect(result).toStrictEqual({});
   });
 
@@ -163,11 +220,14 @@ describe("Delete slice files", () => {
       [`/test/.slicemachine/assets/${SLICE_TO_DELETE_LIBRARY}/${SLICE_TO_DELETE_NAME}/mocks.json`]:
         JSON.stringify(SLICE_TO_DELETE_MOCKS),
       "/test/.slicemachine/mock-config.json": JSON.stringify(MOCK_CONFIG),
+      "/test/customtypes/custom-type-with-slice/index.json":
+        JSON.stringify(CustomTypeModel),
     });
 
     expect(readSliceFiles()).toStrictEqual(["test.json"]);
     expect(readAssetsFiles()).toStrictEqual([SLICE_TO_DELETE_NAME]);
     expect(readMockConfig()).toStrictEqual(MOCK_CONFIG);
+    expect(readCustomTypeMock()).toStrictEqual(CustomTypeModel);
 
     const result = await deleteSlice(mockRequest);
 
@@ -178,6 +238,7 @@ describe("Delete slice files", () => {
     expect(console.error).toHaveBeenCalledWith(
       `[slice/delete] When deleting slice: ${SLICE_TO_DELETE_ID}, the slice: ${SLICE_TO_DELETE_ID} was not found.`
     );
+    expect(readCustomTypeMock()).toStrictEqual(CustomTypeModel);
     expect(result).toStrictEqual({
       err: Error(
         `When deleting slice: ${SLICE_TO_DELETE_ID}, the slice: ${SLICE_TO_DELETE_ID} was not found.`
@@ -194,11 +255,14 @@ describe("Delete slice files", () => {
         JSON.stringify(SLICE_TO_DELETE_MOCK),
       [`/test/.slicemachine/assets/${SLICE_TO_DELETE_LIBRARY}/test.json`]: "",
       "/test/.slicemachine/mock-config.json": JSON.stringify(MOCK_CONFIG),
+      "/test/customtypes/custom-type-with-slice/index.json":
+        JSON.stringify(CustomTypeModel),
     });
 
     expect(readSliceFiles()).toStrictEqual([SLICE_TO_DELETE_NAME]);
     expect(readAssetsFiles()).toStrictEqual(["test.json"]);
     expect(readMockConfig()).toStrictEqual(MOCK_CONFIG);
+    expect(readCustomTypeMock()).toStrictEqual(CustomTypeModel);
 
     const result = await deleteSlice(mockRequest);
 
@@ -214,6 +278,7 @@ describe("Delete slice files", () => {
     expect(console.error).toHaveBeenCalledWith(
       `[slice/delete] Could not delete your slice assets files. Check our troubleshooting guide here: https://prismic.io/docs/help-center`
     );
+    expect(readCustomTypeMock()).toStrictEqual(CustomTypeModelWithoutSlice);
     expect(result).toStrictEqual({
       err: {},
       reason:
@@ -230,17 +295,21 @@ describe("Delete slice files", () => {
       [`/test/.slicemachine/assets/${SLICE_TO_DELETE_LIBRARY}/${SLICE_TO_DELETE_NAME}/mocks.json`]:
         JSON.stringify(SLICE_TO_DELETE_MOCKS),
       "/test/.slicemachine/mock-config.json": JSON.stringify({}),
+      "/test/customtypes/custom-type-with-slice/index.json":
+        JSON.stringify(CustomTypeModel),
     });
 
     expect(readSliceFiles()).toStrictEqual([SLICE_TO_DELETE_NAME]);
     expect(readAssetsFiles()).toStrictEqual([SLICE_TO_DELETE_NAME]);
     expect(readMockConfig()).toStrictEqual({});
+    expect(readCustomTypeMock()).toStrictEqual(CustomTypeModel);
 
     const result = await deleteSlice(mockRequest);
 
     expect(readSliceFiles()).toStrictEqual([]);
     expect(readAssetsFiles()).toStrictEqual([]);
     expect(readMockConfig()).toStrictEqual({});
+    expect(readCustomTypeMock()).toStrictEqual(CustomTypeModelWithoutSlice);
 
     expect(console.error).toHaveBeenCalledWith(
       `[slice/delete] Could not delete your slice from the mock-config.json in /test/.slicemachine/mock-config.json. Check our troubleshooting guide here: https://prismic.io/docs/help-center`


### PR DESCRIPTION
## Context

<!--
Please include either
- a ticket
    - [Link text Here](https://link-url-here.org)

- a github issue / forum thread
    - Fixes #

- a detailed description of the issue and it's implications

This part should always include acceptance criteria weither they are accessible on a link or written here directly.
-->

Ticket: https://linear.app/prismic/issue/SM-867/[delete-slices]-aauser-when-a-slice-is-deleted-the-custom-types-that


## The Solution

Added extra step in delete handler
Updated custom type reducer to listen to slice delete action

## Checklist before requesting a review
- [x] I hereby declare my code ready for review.
- [x] If it is a critical feature, I have added tests.
- [x] The CI is successful.
- [ ] If there could backward compatibility issues, it has been discussed and planned.




## [OPT] Preview

<!--
Visual aid of your work.
It can either be screenshots or a video.
This could help reviewers to get context quickly.
-->
![ezgif com-gif-maker (4)](https://user-images.githubusercontent.com/47107427/205035076-9d68856a-510d-4c32-a0d9-a9ada6d6cc21.gif)


---


![image](https://user-images.githubusercontent.com/47107427/205035147-9e17cdb5-a54d-4359-b043-9d5a1bfdd079.png)
