### PR TITLE
Fix CT list breaking after slice deletion

### DIFF
--- a/packages/slice-machine/src/modules/availableCustomTypes/index.ts
+++ b/packages/slice-machine/src/modules/availableCustomTypes/index.ts
@@ -195,17 +195,18 @@ export const availableCustomTypesReducer: Reducer<
       const sliceId = action.payload.sliceId;
       const newCTs = Object.entries(state)
         .map<[string, FrontEndCustomType]>(([ctName, customType]) => {
-          return [
-            ctName,
-            {
-              local: filterSliceFromCustomType(customType.local, sliceId),
-              remote: customType.remote
-                ? filterSliceFromCustomType(customType.remote, sliceId)
-                : undefined,
-            },
-          ];
+          const newCT = customType.remote
+            ? {
+                local: filterSliceFromCustomType(customType.local, sliceId),
+                remote: filterSliceFromCustomType(customType.remote, sliceId),
+              }
+            : {
+                local: filterSliceFromCustomType(customType.local, sliceId),
+              };
+
+          return [ctName, newCT];
         })
-        .reduce((acc, [name, ct]) => {
+        .reduce<AvailableCustomTypesStoreType>((acc, [name, ct]) => {
           return {
             ...acc,
             [name]: ct,

--- a/packages/slice-machine/tests/src/modules/availableCustomTypes/index.test.ts
+++ b/packages/slice-machine/tests/src/modules/availableCustomTypes/index.test.ts
@@ -26,6 +26,8 @@ import { ModalKeysEnum } from "@src/modules/modal/types";
 import { openToasterCreator, ToasterType } from "@src/modules/toaster";
 import { CustomTypeSM } from "@slicemachine/core/build/models/CustomType";
 import axios, { AxiosError } from "axios";
+import { deleteSliceCreator } from "@src/modules/slices";
+import { SlicesTypes } from "@prismicio/types-internal/lib/customtypes/widgets/slices";
 
 const dummyCustomTypesState: AvailableCustomTypesStoreType = {};
 
@@ -187,6 +189,89 @@ describe("[Available Custom types module]", () => {
       delete expectState[customTypeIdToDelete];
 
       expect(result).toEqual(expectState);
+    });
+
+    it("should update the custom types state given SLICES/DELETE.SUCCESS action", () => {
+      const sliceToDeleteId = "slice_id";
+      const mockCustomTypeToUpdate: CustomTypeSM = {
+        id: "id",
+        label: "lama",
+        repeatable: false,
+        status: true,
+        tabs: [
+          {
+            key: "Main",
+            value: [],
+            sliceZone: {
+              key: "slices",
+              value: [
+                {
+                  key: sliceToDeleteId,
+                  value: {
+                    type: SlicesTypes.SharedSlice,
+                  },
+                },
+                {
+                  key: "slice_2",
+                  value: {
+                    type: SlicesTypes.SharedSlice,
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      };
+
+      const originalState = { ...dummyCustomTypesState };
+
+      originalState["id"] = {
+        local: mockCustomTypeToUpdate,
+      };
+      const action = deleteSliceCreator.success({
+        sliceId: sliceToDeleteId,
+        sliceName: "slice_name",
+        libName: "lib",
+      });
+
+      const result = availableCustomTypesReducer(
+        originalState,
+        action
+      ) as AvailableCustomTypesStoreType;
+
+      expect(
+        Object.values(result).flatMap((localAndRemote) => {
+          return Object.values(localAndRemote);
+        })
+      ).not.toContain(undefined);
+
+      expect(result).toEqual({
+        id: {
+          local: {
+            id: "id",
+            label: "lama",
+            repeatable: false,
+            status: true,
+            tabs: [
+              {
+                key: "Main",
+                value: [],
+                sliceZone: {
+                  key: "slices",
+                  value: [
+                    {
+                      key: "slice_2",
+                      value: {
+                        type: SlicesTypes.SharedSlice,
+                      },
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        },
+      });
     });
   });
 


### PR DESCRIPTION
## Context

<!--
Please include either
- a ticket
    - [Link text Here](https://link-url-here.org)

- a github issue / forum thread
    - Fixes #

- a detailed description of the issue and it's implications

This part should always include acceptance criteria weither they are accessible on a link or written here directly.
-->

Fixing this issue: https://linear.app/prismic/issue/SM-867#comment-658ba61b


## The Solution

<!--
Highlight explanations where the complexity in your development is.
Keep in mind that the reviewer might not have as much context as you do.
This is very important to make sure the review is thorough and the reviewer understand your changes.
-->

CT filtering in reducer was creating undefined values in the remote customtypes. This caused values map to fail on the label selector

## Checklist before requesting a review
- [ ] I hereby declare my code ready for review.
- [ ] If it is a critical feature, I have added tests.
- [ ] The CI is successful.
- [ ] If there could backward compatibility issues, it has been discussed and planned.




## [OPT] Preview

![ezgif com-gif-maker (5)](https://user-images.githubusercontent.com/47107427/205327340-08e96e71-ce64-4b05-ac15-2fc1670fc446.gif)



---


![image](https://user-images.githubusercontent.com/47107427/205327048-e61c4ea6-adf5-41a0-9e38-31f80fc24ef8.png)