### PR TITLE
Track editor widget usage

### DIFF
--- a/packages/slice-machine/components/Simulator/index.tsx
+++ b/packages/slice-machine/components/Simulator/index.tsx
@@ -57,6 +57,7 @@ export default function Simulator() {
 
   useEffect(() => {
     void Tracker.get().trackOpenSliceSimulator(framework, version);
+    Tracker.get().editor.startNewSession();
   }, []);
 
   if (!component || !variation) {
@@ -132,6 +133,11 @@ const SimulatorForSlice: React.FC<SimulatorForSliceProps> = ({
 
   const [isDisplayEditor, toggleIsDisplayEditor] = useState(true);
 
+  function onContentChange(content: SharedSliceContent) {
+    Tracker.get().editor.trackWidgetUsed();
+    setContent(content);
+  }
+
   return (
     <Flex sx={{ flexDirection: "column", height: "100vh" }}>
       <Header
@@ -206,7 +212,9 @@ const SimulatorForSlice: React.FC<SimulatorForSliceProps> = ({
             <ThemeProvider mode="light">
               <SharedSliceEditor
                 content={editorContent}
-                onContentChange={(c) => setContent(c as SharedSliceContent)}
+                onContentChange={(c) =>
+                  onContentChange(c as SharedSliceContent)
+                }
                 sharedSlice={sharedSlice}
               />
             </ThemeProvider>

--- a/packages/slice-machine/src/tracking/client.ts
+++ b/packages/slice-machine/src/tracking/client.ts
@@ -296,6 +296,22 @@ export class SMTracker {
 
     return this.#trackEvent(payload);
   }
+
+  #startedNewEditorSession = false;
+  editor = {
+    startNewSession: () => {
+      this.#startedNewEditorSession = true;
+    },
+    trackWidgetUsed: () => {
+      if (!this.#startedNewEditorSession) return;
+
+      this.#startedNewEditorSession = false;
+
+      void this.#trackEvent({
+        name: EventNames.EditorWidgetUsed,
+      });
+    },
+  };
 }
 
 const Tracker = (() => {

--- a/packages/slice-machine/src/tracking/types.ts
+++ b/packages/slice-machine/src/tracking/types.ts
@@ -24,6 +24,8 @@ export enum EventNames {
 
   ScreenshotTaken = "SliceMachine Screenshot Taken",
   ChangesPushed = "SliceMachine Changes Pushed",
+
+  EditorWidgetUsed = "Editor Widget Used",
 }
 
 type BaseTrackingEvent = {
@@ -190,6 +192,10 @@ export interface ChangesPushed extends BaseTrackingEvent {
   };
 }
 
+export interface EditorWidgetUsed extends BaseTrackingEvent {
+  name: EventNames.EditorWidgetUsed;
+}
+
 export type TrackingEvents =
   | PageView
   | IdentifyUser
@@ -208,7 +214,8 @@ export type TrackingEvents =
   | SliceSimulatorOpen
   | SliceSimulatorSetup
   | ScreenshotTaken
-  | ChangesPushed;
+  | ChangesPushed
+  | EditorWidgetUsed;
 
 export function isTrackingEvent(
   payload: TrackingEvents


### PR DESCRIPTION
[Ticket](https://linear.app/prismic/issue/EDT-331/editor-widget-analytics-in-slice-simulator)

