### PR TITLE
rename build-essential to old name so alpha deployments work

### DIFF
--- a/.github/actions/build-essential/action.yml
+++ b/.github/actions/build-essential/action.yml
@@ -5,4 +5,4 @@ runs:
   steps:
     - name: Build essential packages used by others
       shell: bash
-      run: npm run build:essential
+      run: npm run build-essential

--- a/.github/workflows/deploy-alpha.yml
+++ b/.github/workflows/deploy-alpha.yml
@@ -30,7 +30,7 @@ jobs:
           git checkout .
       - name: Build packages used by others
         run: |
-          npm run build:essential
+          npm run build-essential
       - name: Version And Publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "postinstall": "lerna bootstrap && npm install --prefix e2e-projects/next",
     "bootstrap": "lerna bootstrap",
     "build": "lerna run build",
-    "build:essential": "npm run build --prefix packages/core && npm run build --prefix packages/client",
+    "build-essential": "npm run build --prefix packages/core && npm run build --prefix packages/client",
     "start:slice-machine": "npm run start --prefix packages/slice-machine",
     "audit": "lerna run audit",
     "lint": "lerna run lint",


### PR DESCRIPTION
## Context

<!--
Please include either
- a ticket
    - [Link text Here](https://link-url-here.org)

- a github issue / forum thread
    - Fixes #

- a detailed description of the issue and it's implications

This part should always include acceptance criteria weither they are accessible on a link or written here directly.
-->

Alpha deployments of dev-delete failing because the script name in the branch is different from the deploy-alpha workflow in master. Need to rename to align it and unblock this. https://github.com/prismicio/slice-machine/actions/runs/3650523830/jobs/6166610976

## Checklist before requesting a review
- [ ] I hereby declare my code ready for review.
- [ ] If it is a critical feature, I have added tests.
- [ ] The CI is successful.
- [ ] If there could backward compatibility issues, it has been discussed and planned.


---


![image](https://user-images.githubusercontent.com/47107427/207023958-d2f7f6b2-8279-4fc1-a224-e61db02c4b54.png)