### PR TITLE
fix(cypress): flaky E2E test

### DIFF
--- a/cypress/integration/user-flows/scenario_001.spec.js
+++ b/cypress/integration/user-flows/scenario_001.spec.js
@@ -71,6 +71,9 @@ describe("I am a new SM user (with Next) who wants to create a Custom Type with 
     cy.visit(`/cts/${id}`);
     cy.waitUntil(() => cy.get('[data-testid="empty-zone-add-new-field"]'));
 
+    // TODO: removing this delay will make the test flaky (because of the useServerState hook).
+    cy.wait(5_000);
+
     // Add UID
     cy.get('[data-testid="empty-zone-add-new-field"]').first().click();
     cy.get("[data-cy=UID]").click();


### PR DESCRIPTION
## Context

Linear issue: [SM-915 [Spike] Investigate flaky tests](https://linear.app/prismic/issue/SM-915/[spike]-investigate-flaky-tests).

## The Solution

Added a `cy.wait` so that the `Formik` component gets unmounted and then remounted before Cypress starts to `cy.type`. Without this `cy.wait`, the `Formik` component gets unmounted and then remounted while Cypress runs `cy.type` and so the test fails.

This is a temporary workaround while we wait for: [SM-932 useServerState shouldn't unmount the whole app](https://linear.app/prismic/issue/SM-932/useserverstate-shouldnt-unmount-the-whole-app-will-make-e2e-tests-non).

## Checklist before requesting a review
- [x] I hereby declare my code ready for review.
- [ ] If it is a critical feature, I have added tests.
- [x] The CI is successful.
- [ ] If there could backward compatibility issues, it has been discussed and planned.