### PR TITLE
Sort Document cards by number of associated docs

### DIFF
--- a/packages/slice-machine/components/DeleteDocumentsDrawer/AssociatedDocumentsCard.tsx
+++ b/packages/slice-machine/components/DeleteDocumentsDrawer/AssociatedDocumentsCard.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Flex, Text, Card, Link } from "theme-ui";
 
-type CustomtypeDocuments = {
+export type CustomtypeDocuments = {
   ctName: string;
   numberOfDocuments: number;
   link: string;

--- a/packages/slice-machine/components/DeleteDocumentsDrawer/DeleteDocumentsDrawerOverLimit.tsx
+++ b/packages/slice-machine/components/DeleteDocumentsDrawer/DeleteDocumentsDrawerOverLimit.tsx
@@ -10,9 +10,11 @@ import { SliceMachineStoreType } from "@src/redux/type";
 import { ModalKeysEnum } from "@src/modules/modal/types";
 import { isModalOpen } from "@src/modules/modal";
 import { AssociatedDocumentsCard } from "./AssociatedDocumentsCard";
+import { sortDocumentCards } from ".";
 
 // TODO: replace with actual API response
 const AssociatedDocuments = [
+  { ctName: "Feature", numberOfDocuments: 6, link: "https://prismic.io/" },
   { ctName: "Legals", numberOfDocuments: 2030, link: "https://prismic.io/" },
 ];
 
@@ -116,7 +118,7 @@ const DeleteDocumentsDrawerOverLimit: React.FunctionComponent = () => {
           manually and then try deleting the Custom Types again.
         </Text>
 
-        {AssociatedDocuments.map((ctDocuments) => (
+        {sortDocumentCards(AssociatedDocuments).map((ctDocuments) => (
           <AssociatedDocumentsCard ctDocuments={ctDocuments} isOverLimit />
         ))}
       </Card>

--- a/packages/slice-machine/components/DeleteDocumentsDrawer/index.tsx
+++ b/packages/slice-machine/components/DeleteDocumentsDrawer/index.tsx
@@ -22,8 +22,10 @@ import {
   CustomtypeDocuments,
 } from "./AssociatedDocumentsCard";
 
-export const sortDocumentCards = (documents: CustomtypeDocuments[]) =>
-  documents.sort(
+export const sortDocumentCards = (
+  documents: Readonly<Array<CustomtypeDocuments>>
+) =>
+  [...documents].sort(
     (doc1, doc2) => doc2.numberOfDocuments - doc1.numberOfDocuments
   );
 

--- a/packages/slice-machine/components/DeleteDocumentsDrawer/index.tsx
+++ b/packages/slice-machine/components/DeleteDocumentsDrawer/index.tsx
@@ -17,7 +17,15 @@ import { useSelector } from "react-redux";
 import { SliceMachineStoreType } from "@src/redux/type";
 import { ModalKeysEnum } from "@src/modules/modal/types";
 import { isModalOpen } from "@src/modules/modal";
-import { AssociatedDocumentsCard } from "./AssociatedDocumentsCard";
+import {
+  AssociatedDocumentsCard,
+  CustomtypeDocuments,
+} from "./AssociatedDocumentsCard";
+
+export const sortDocumentCards = (documents: CustomtypeDocuments[]) =>
+  documents.sort(
+    (doc1, doc2) => doc2.numberOfDocuments - doc1.numberOfDocuments
+  );
 
 // TODO: replace with actual API response
 const AssociatedDocuments = [
@@ -171,7 +179,7 @@ const DeleteDocumentsDrawer: React.FunctionComponent = () => {
           broken links in your repository.
         </Text>
 
-        {AssociatedDocuments.map((ctDocuments) => (
+        {sortDocumentCards(AssociatedDocuments).map((ctDocuments) => (
           <AssociatedDocumentsCard ctDocuments={ctDocuments} />
         ))}
       </Card>


### PR DESCRIPTION
## Context

We want the CT-document cards in the panel to be sorted by the number of associated documents.
Bug found here: https://linear.app/prismic/issue/SM-886#comment-ddf471ea

## The Solution

Sort them on the UI side (this might be changed later when the API is implemented) 


## Checklist before requesting a review
- [ ] I hereby declare my code ready for review.
- [ ] If it is a critical feature, I have added tests.
- [ ] The CI is successful.
- [ ] If there could backward compatibility issues, it has been discussed and planned.




## [OPT] Preview

<img width="1440" alt="image" src="https://user-images.githubusercontent.com/47107427/207582432-23555394-ed6d-47c1-9e05-a4584b8c1eeb.png">