### PR TITLE
set editor width to 33% when open

### DIFF
--- a/packages/slice-machine/components/Simulator/components/FailedConnect/index.tsx
+++ b/packages/slice-machine/components/Simulator/components/FailedConnect/index.tsx
@@ -37,7 +37,7 @@ const FailedConnect = () => (
       <br /> If that doesn't work, see the&nbsp;
       <Link
         target="_blank"
-        href="https://prismic.io"
+        href="https://prismic.io/docs/slice-machine"
         sx={{
           color: "link",
         }}

--- a/packages/slice-machine/components/Simulator/index.tsx
+++ b/packages/slice-machine/components/Simulator/index.tsx
@@ -237,7 +237,7 @@ const Simulator: ComponentWithSliceProps = ({ slice, variation }) => {
         >
           <Flex
             sx={{
-              width: "100%",
+              flex: 2,
               height: "100%",
               flexDirection: "column",
             }}
@@ -296,6 +296,7 @@ const Simulator: ComponentWithSliceProps = ({ slice, variation }) => {
                   ? {
                       marginLeft: "16px",
                       visibility: "visible",
+                      flex: 1,
                     }
                   : {
                       marginLeft: "0px",


### PR DESCRIPTION
## Context

https://linear.app/prismic/issue/SM-936/slice-simulator-editor-width-expandsshrinks-while-typing


## The Solution

Fix the width fo the editor container when open


## Impact / Dependencies

-


## Checklist before requesting a review
- [x] I hereby declare my code ready for review.
- [x] If it is a critical feature, I have added tests.
- [ ] The CI is successful.
- [x] If there could backward compatibility issues, it has been discussed and planned.




## [OPT] Preview

<img width="1512" alt="image" src="https://user-images.githubusercontent.com/1148164/207913984-c8b0f29b-7b0d-4638-bc7e-6f44fd06f03f.png">
<img width="1511" alt="image" src="https://user-images.githubusercontent.com/1148164/207914118-3381a0f7-a6dd-478f-ac5b-242cd8e566c1.png">
