### PR TITLE
fix editor width

### DIFF
--- a/packages/slice-machine/components/Simulator/index.tsx
+++ b/packages/slice-machine/components/Simulator/index.tsx
@@ -237,9 +237,9 @@ const Simulator: ComponentWithSliceProps = ({ slice, variation }) => {
         >
           <Flex
             sx={{
-              flex: 2,
               height: "100%",
               flexDirection: "column",
+              flex: 1,
             }}
           >
             <Toolbar
@@ -296,7 +296,7 @@ const Simulator: ComponentWithSliceProps = ({ slice, variation }) => {
                   ? {
                       marginLeft: "16px",
                       visibility: "visible",
-                      flex: 1,
+                      width: "496px",
                     }
                   : {
                       marginLeft: "0px",


### PR DESCRIPTION
## Context

https://linear.app/prismic/issue/SM-936/slice-simulator-editor-width-expandsshrinks-while-typing





## The Solution

Realised it does not look good with smaller screens, decided with Benjamin to fix it





## Impact / Dependencies





## Checklist before requesting a review
- [ ] I hereby declare my code ready for review.
- [ ] If it is a critical feature, I have added tests.
- [ ] The CI is successful.
- [ ] If there could backward compatibility issues, it has been discussed and planned.




## [OPT] Preview

<img width="211" alt="image" src="https://user-images.githubusercontent.com/1148164/207921748-9e866301-27db-4efa-90c0-40b8dab20eed.png">

