### PR TITLE
Fix simulator templates

### DIFF
--- a/packages/slice-machine/components/Simulator/components/SetupModal/steps/next.tsx
+++ b/packages/slice-machine/components/Simulator/components/SetupModal/steps/next.tsx
@@ -14,7 +14,6 @@ const CreatePageInstructions = {
   code: `import { SliceSimulator } from "@prismicio/slice-simulator-react";
 import { SliceZone } from "@prismicio/react";
 
-import state from "../.slicemachine/libraries-state.json";
 import { components } from "../slices";
 
 const SliceSimulatorPage = () => (
@@ -22,7 +21,7 @@ const SliceSimulatorPage = () => (
     sliceZone={({ slices }) => (
       <SliceZone slices={slices} components={components} />
     )}
-    state={state}
+    state={{}}
   />
 );
 

--- a/packages/slice-machine/components/Simulator/components/SetupModal/steps/nuxt.tsx
+++ b/packages/slice-machine/components/Simulator/components/SetupModal/steps/nuxt.tsx
@@ -21,7 +21,7 @@ const NuxtConfigInstructions = `// Modules: https://go.nuxtjs.dev/config-modules
   modules: [["@nuxtjs/prismic", {
     endpoint: smConfig.apiEndpoint|| ""
   }]],
-  
+
   // Build Configuration: https://go.nuxtjs.dev/config-build
   build: {
     transpile: ["@prismicio/vue"]
@@ -38,18 +38,16 @@ const SliceSimulatorPageCreationInstruction = `<template>
 import { SliceSimulator } from "@prismicio/slice-simulator-vue";
 import { components } from "~/slices"
 
-import state from "~/.slicemachine/libraries-state.json";
-
 export default {
   components: {
     SliceSimulator,
   },
   data() {
-    return { state, components };
+    return { state: {}, components };
   }
 }
 </script>
-  
+
   `;
 
 const UpdateNuxtConfig: React.FunctionComponent<DefaultStepCompProps> = () => {

--- a/packages/slice-machine/components/Simulator/components/SetupModal/steps/previousNext.tsx
+++ b/packages/slice-machine/components/Simulator/components/SetupModal/steps/previousNext.tsx
@@ -14,17 +14,15 @@ import {
 const CreatePageInstructions = {
   code: `import { SliceSimulator } from "@prismicio/slice-simulator-react";
   import SliceZone from "next-slicezone";
-  
-  import state from "../.slicemachine/libraries-state.json";
-  
+
   import * as Slices from "../slices";
   const resolver = ({ sliceName }) => Slices[sliceName];
-  
+
   const SliceSimulatorPage = () => (<SliceSimulator
   \tsliceZone={(props) => <SliceZone {...props} resolver={resolver} />}
-  \tstate={state}
+  \tstate={{}}
   />);
-  
+
   export default SliceSimulatorPage;`,
   instructions: (
     <>

--- a/packages/slice-machine/components/Simulator/components/SetupModal/steps/previousNuxt.tsx
+++ b/packages/slice-machine/components/Simulator/components/SetupModal/steps/previousNuxt.tsx
@@ -21,7 +21,7 @@ const NuxtConfigInstructions = `// Modules: https://go.nuxtjs.dev/config-modules
   modules: [["@nuxtjs/prismic", {
     endpoint: smConfig.apiEndpoint|| ""
   }], ["nuxt-sm"]],
-  
+
   // Build Configuration: https://go.nuxtjs.dev/config-build
   build: {
     transpile: ["vue-slicezone", "nuxt-sm"]
@@ -33,20 +33,18 @@ const SliceSimulatorPageCreationInstruction = `<template>
       <SliceZone v-bind="props" />
     </SliceSimulator>
   </template>
-  
+
   <script>
   import { SliceSimulator } from "@prismicio/slice-simulator-vue";
   import SliceZone from "vue-slicezone";
-  
-  import state from "~/.slicemachine/libraries-state.json";
-  
+
   export default {
     components: {
       SliceSimulator,
       SliceZone
     },
     data() {
-      return { state };
+      return { state: {} };
     }
   }
   </script>


### PR DESCRIPTION
## Context

Since we removed `libraries-state.json` the simulator templates for each techno shouldn’t reference it anymore.
Currently slice simulator must contain a state so we provide an empty state to keep to compatibility otherwise it breaks.
Ticket: https://linear.app/prismic/issue/SM-934/simulator-troubleshooting-code-snippet-points-to-unexisting