### PR TITLE
call changelog only when the app starts

### DIFF
--- a/packages/slice-machine/components/App/index.tsx
+++ b/packages/slice-machine/components/App/index.tsx
@@ -14,6 +14,7 @@ import { useSelector } from "react-redux";
 import { SliceMachineStoreType } from "@src/redux/type";
 import { getLibraries } from "@src/modules/slices";
 import useSMTracker from "@src/hooks/useSMTracker";
+import { useChangelog } from "@src/hooks/useChangelog";
 
 type Props = Readonly<{
   children?: ReactNode;
@@ -27,6 +28,7 @@ const SliceMachineApp: FC<Props> = ({ children }) => {
   useSMTracker();
   useOnboardingRedirection();
   useServerState();
+  useChangelog();
 
   return (
     <>

--- a/packages/slice-machine/lib/models/common/Environment.ts
+++ b/packages/slice-machine/lib/models/common/Environment.ts
@@ -11,7 +11,6 @@ export interface BackendEnvironment {
   prismicData: PrismicData;
   manifest: Models.Manifest;
   repo: string;
-  changelog: PackageChangelog;
   mockConfig: CustomTypeMockConfig;
   framework: Models.Frameworks;
   baseUrl: string;
@@ -23,7 +22,7 @@ export interface FrontEndEnvironment {
   intercomHash?: string;
   manifest: Models.Manifest;
   repo: string;
-  changelog: PackageChangelog;
+  changelog?: PackageChangelog;
   packageManager: PackageManager;
   mockConfig: CustomTypeMockConfig;
   framework: Models.Frameworks;

--- a/packages/slice-machine/server/src/api/changelog.ts
+++ b/packages/slice-machine/server/src/api/changelog.ts
@@ -1,0 +1,7 @@
+import { getPackageChangelog } from "../../../lib/env/versions";
+
+declare let appRoot: string;
+
+export default async function handler() {
+  return await getPackageChangelog(appRoot);
+}

--- a/packages/slice-machine/server/src/api/custom-types/save.ts
+++ b/packages/slice-machine/server/src/api/custom-types/save.ts
@@ -13,7 +13,7 @@ import { SaveCustomTypeBody } from "../../../../lib/models/common/CustomType";
 import * as IO from "../../../../lib/io";
 
 export default async function handler(req: { body: SaveCustomTypeBody }) {
-  const { env } = await getEnv();
+  const { env } = getEnv();
   const { model, mockConfig } = req.body;
 
   const mockPath = GeneratedCustomTypesPaths(env.cwd)

--- a/packages/slice-machine/server/src/api/http/common.ts
+++ b/packages/slice-machine/server/src/api/http/common.ts
@@ -13,7 +13,7 @@ export function WithEnv(
   handler: (req: RequestWithEnv, res: express.Response) => Promise<any>
 ) {
   return async function (req: express.Request, res: express.Response) {
-    const { env, errors } = await getEnv();
+    const { env, errors } = getEnv();
 
     const reqWithEnv = (() => {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-explicit-any

--- a/packages/slice-machine/server/src/api/index.ts
+++ b/packages/slice-machine/server/src/api/index.ts
@@ -30,6 +30,7 @@ import {
 import { SaveCustomTypeBody } from "../../../lib/models/common/CustomType";
 import { isApiError } from "../../../lib/models/server/ApiResult";
 import tracking from "./tracking";
+import changelog from "./changelog";
 
 router.use(
   "/__preview",
@@ -296,6 +297,19 @@ router.post(
       .catch(() => null)
       .then(() => res.json());
   })
+);
+
+router.get(
+  "/changelog",
+  // eslint-disable-next-line @typescript-eslint/no-misused-promises
+  async function (
+    _req: express.Request,
+    res: express.Response
+  ): Promise<Express.Response> {
+    const payload = await changelog();
+
+    return res.status(200).json(payload);
+  }
 );
 
 // eslint-disable-next-line @typescript-eslint/no-misused-promises, @typescript-eslint/require-await

--- a/packages/slice-machine/server/src/api/screenshots/custom-screenshots.ts
+++ b/packages/slice-machine/server/src/api/screenshots/custom-screenshots.ts
@@ -16,12 +16,12 @@ import {
 } from "../../../../lib/models/common/Screenshots";
 import { hash } from "@slicemachine/core/build/utils/str";
 
-export default async function handler(
+export default function handler(
   file: TmpFile,
   body: CustomScreenshotRequest
-): Promise<ScreenshotUI> {
+): ScreenshotUI {
   const { libraryName, sliceName, variationId } = body;
-  const { env } = await getEnv();
+  const { env } = getEnv();
 
   const maybeCustomScreenshot = resolvePathsToScreenshot({
     paths: [env.cwd],

--- a/packages/slice-machine/server/src/api/screenshots/screenshots.ts
+++ b/packages/slice-machine/server/src/api/screenshots/screenshots.ts
@@ -38,7 +38,7 @@ export default async function handler({
   variationId,
   screenDimensions,
 }: ScreenshotRequest): Promise<ScreenshotResponse> {
-  const { env } = await getEnv();
+  const { env } = getEnv();
 
   const maybeErr = validateEnv(
     env.framework,

--- a/packages/slice-machine/server/src/api/services/getEnv.ts
+++ b/packages/slice-machine/server/src/api/services/getEnv.ts
@@ -4,7 +4,6 @@ import { Framework } from "@slicemachine/core/build/node-utils";
 
 import type { BackendEnvironment } from "../../../../lib/models/common/Environment";
 import type { ConfigErrors } from "../../../../lib/models/server/ServerState";
-import { getPackageChangelog } from "../../../../lib/env/versions";
 import { getConfig as getMockConfig } from "../../../../lib/mock/misc/fs";
 import handleManifest, {
   ManifestState,
@@ -13,9 +12,6 @@ import handleManifest, {
 
 import getPrismicData from "../../../../lib/env/getPrismicData";
 import getApplicationMode from "../../../../lib/env/getApplicationMode";
-
-// variable declared globally on the index.ts, is the cwd to SM dependency
-declare let appRoot: string;
 
 function validate(config: Models.Manifest): ConfigErrors {
   const errors: ConfigErrors = {};
@@ -51,9 +47,10 @@ function extractRepo(apiEndpoint: Models.Manifest["apiEndpoint"]): string {
   }
 }
 
-export default async function getEnv(
-  maybeCustomCwd?: string
-): Promise<{ errors: ConfigErrors; env: BackendEnvironment }> {
+export default function getEnv(maybeCustomCwd?: string): {
+  errors: ConfigErrors;
+  env: BackendEnvironment;
+} {
   const cwd = maybeCustomCwd || process.env.CWD || process.cwd();
   if (!cwd) {
     const message =
@@ -81,8 +78,6 @@ export default async function getEnv(
     throw new Error(message);
   }
 
-  const smChangelog = await getPackageChangelog(appRoot);
-
   const maybeErrors = validate(manifestInfo.content);
 
   const repository = extractRepo(manifestInfo.content.apiEndpoint);
@@ -103,7 +98,6 @@ export default async function getEnv(
       repo: repository,
       manifest: manifestInfo.content,
       prismicData: prismicData.value,
-      changelog: smChangelog,
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       mockConfig,
       framework: Framework.defineFramework({

--- a/packages/slice-machine/server/src/api/slices/index.ts
+++ b/packages/slice-machine/server/src/api/slices/index.ts
@@ -20,6 +20,6 @@ export const getSlices = async (
 };
 
 export default async function handler() {
-  const { env } = await getEnv();
+  const { env } = getEnv();
   return await getSlices(env.client);
 }

--- a/packages/slice-machine/src/apiClient.ts
+++ b/packages/slice-machine/src/apiClient.ts
@@ -14,6 +14,7 @@ import {
   ScreenshotResponse,
 } from "../lib/models/common/Screenshots";
 import { ComponentUI, ScreenshotUI } from "@lib/models/common/ComponentUI";
+import { PackageChangelog } from "@lib/models/common/versions";
 
 const defaultAxiosConfig = {
   withCredentials: true,
@@ -147,3 +148,9 @@ export const checkAuthStatus = (): Promise<CheckAuthStatusResponse> =>
 export const checkSimulatorSetup = (): Promise<
   AxiosResponse<SimulatorCheckResponse>
 > => axios.get(`/api/simulator/check`);
+
+export const getChangelogApiClient = (): Promise<PackageChangelog> => {
+  return axios
+    .get<PackageChangelog>(`/api/changelog`, defaultAxiosConfig)
+    .then((response) => response.data);
+};

--- a/packages/slice-machine/src/hooks/useChangelog.ts
+++ b/packages/slice-machine/src/hooks/useChangelog.ts
@@ -1,0 +1,11 @@
+import { useEffect } from "react";
+
+import useSliceMachineActions from "@src/modules/useSliceMachineActions";
+
+export const useChangelog = () => {
+  const { getChangelog } = useSliceMachineActions();
+
+  useEffect(() => {
+    getChangelog();
+  }, []);
+};

--- a/packages/slice-machine/src/modules/environment/index.ts
+++ b/packages/slice-machine/src/modules/environment/index.ts
@@ -1,6 +1,11 @@
 import { Reducer } from "redux";
 import { EnvironmentStoreType } from "./types";
-import { ActionType, createAction, getType } from "typesafe-actions";
+import {
+  ActionType,
+  createAction,
+  createAsyncAction,
+  getType,
+} from "typesafe-actions";
 import { SliceMachineStoreType } from "@src/redux/type";
 import { FrontEndEnvironment } from "@models/common/Environment";
 import { Frameworks } from "@slicemachine/core/build/models/Framework";
@@ -12,6 +17,10 @@ import { SliceSM } from "@slicemachine/core/build/models";
 import { CustomTypeSM } from "@slicemachine/core/build/models/CustomType";
 import ErrorWithStatus from "@lib/models/common/ErrorWithStatus";
 import { AuthStatus } from "../userContext/types";
+import { getChangelogApiClient } from "@src/apiClient";
+import { call, fork, put, takeLatest } from "redux-saga/effects";
+import { withLoader } from "../loading";
+import { LoadingKeysEnum } from "../loading/types";
 
 // Action Creators
 export const refreshStateCreator = createAction("STATE/REFRESH.RESPONSE")<{
@@ -23,7 +32,22 @@ export const refreshStateCreator = createAction("STATE/REFRESH.RESPONSE")<{
   clientError?: ErrorWithStatus;
 }>();
 
-type EnvironmentActions = ActionType<typeof refreshStateCreator>;
+// Actions Creators
+export const getChangelogCreator = createAsyncAction(
+  "CHANGELOG.REQUEST",
+  "CHANGELOG.RESPONSE",
+  "CHANGELOG.FAILURE"
+)<
+  undefined,
+  {
+    changelog: PackageChangelog;
+  },
+  undefined
+>();
+
+type EnvironmentActions = ActionType<
+  typeof refreshStateCreator | typeof getChangelogCreator
+>;
 
 // Selectors
 export const getEnvironment = (
@@ -55,10 +79,15 @@ export const selectIsSimulatorAvailableForFramework = (
   return simulatorIsSupported(store.environment.framework);
 };
 
-export const getChangelog = (
-  store: SliceMachineStoreType
-): PackageChangelog => {
-  return store.environment.changelog;
+export const getChangelog = (store: SliceMachineStoreType) => {
+  return (
+    store.environment?.changelog ?? {
+      currentVersion: "",
+      updateAvailable: false,
+      latestNonBreakingVersion: null,
+      versions: [],
+    }
+  );
 };
 
 export const getPackageManager = (
@@ -68,8 +97,8 @@ export const getPackageManager = (
 };
 
 export const getCurrentVersion = (store: SliceMachineStoreType): string => {
-  const { currentVersion } = getChangelog(store);
-  return currentVersion;
+  const changelog = getChangelog(store);
+  return changelog?.currentVersion;
 };
 
 export const getIsTrackingAvailable = (
@@ -143,7 +172,34 @@ export const environmentReducer: Reducer<
         ...state,
         ...action.payload.env,
       };
+    case getType(getChangelogCreator.success):
+      return { ...state, changelog: action.payload.changelog };
     default:
       return state;
   }
 };
+
+export function* getChangelogSaga(): Generator<
+  unknown,
+  void,
+  PackageChangelog
+> {
+  try {
+    const changelog = yield call(getChangelogApiClient);
+    yield put(getChangelogCreator.success({ changelog }));
+  } catch {
+    yield put(getChangelogCreator.failure());
+  }
+}
+
+function* watchChangelog() {
+  yield takeLatest(
+    getType(getChangelogCreator.request),
+    withLoader(getChangelogSaga, LoadingKeysEnum.CHANGELOG)
+  );
+}
+
+// Saga Exports
+export function* watchChangelogSagas() {
+  yield fork(watchChangelog);
+}

--- a/packages/slice-machine/src/modules/environment/index.ts
+++ b/packages/slice-machine/src/modules/environment/index.ts
@@ -81,7 +81,7 @@ export const selectIsSimulatorAvailableForFramework = (
 
 export const getChangelog = (store: SliceMachineStoreType) => {
   return (
-    store.environment?.changelog ?? {
+    store.environment.changelog ?? {
       currentVersion: "",
       updateAvailable: false,
       latestNonBreakingVersion: null,

--- a/packages/slice-machine/src/modules/loading/types.ts
+++ b/packages/slice-machine/src/modules/loading/types.ts
@@ -15,4 +15,5 @@ export enum LoadingKeysEnum {
   SAVE_SLICE = "SAVE_SLICE",
   PUSH_SLICE = "PUSH_SLICE",
   CHANGES_PUSH = "CHANGES_PUSH",
+  CHANGELOG = "CHANGELOG",
 }

--- a/packages/slice-machine/src/modules/useSliceMachineActions.ts
+++ b/packages/slice-machine/src/modules/useSliceMachineActions.ts
@@ -10,7 +10,7 @@ import {
   updatesViewedCreator,
   hasSeenTutorialsTooTipCreator,
 } from "./userContext";
-import { refreshStateCreator } from "./environment";
+import { getChangelogCreator, refreshStateCreator } from "./environment";
 import {
   openSetupDrawerCreator,
   closeSetupDrawerCreator,
@@ -502,6 +502,10 @@ const useSliceMachineActions = () => {
     );
   };
 
+  const getChangelog = () => {
+    dispatch(getChangelogCreator.request());
+  };
+
   return {
     checkSimulatorSetup,
     connectToSimulatorFailure,
@@ -572,6 +576,7 @@ const useSliceMachineActions = () => {
     closeRenameSliceModal,
     openToaster,
     pushChanges,
+    getChangelog,
   };
 };
 

--- a/packages/slice-machine/src/redux/saga.ts
+++ b/packages/slice-machine/src/redux/saga.ts
@@ -8,6 +8,7 @@ import { watchSliceSagas } from "@src/modules/slices";
 import { watchToasterSagas } from "@src/modules/toaster";
 import { screenshotsSagas } from "@src/modules/screenshots/sagas";
 import { watchChangesPushSagas } from "@src/modules/pushChangesSaga";
+import { watchChangelogSagas } from "@src/modules/environment";
 
 // Single entry point to start all Sagas at once
 export default function* rootSaga() {
@@ -19,4 +20,5 @@ export default function* rootSaga() {
   yield fork(screenshotsSagas);
   yield fork(selectedSliceSagas);
   yield fork(watchChangesPushSagas);
+  yield fork(watchChangelogSagas);
 }

--- a/packages/slice-machine/tests/server/services/getEnv.test.js
+++ b/packages/slice-machine/tests/server/services/getEnv.test.js
@@ -31,12 +31,14 @@ describe("getEnv", () => {
     process.env = env;
   });
 
-  test("it throws if no sm.json file is found", async () => {
+  test("it throws if no sm.json file is found", () => {
     fs.use(Volume.fromJSON({}, TMP));
-    await expect(getEnv(TMP)).rejects.toThrow();
+    expect(() => {
+      getEnv(TMP);
+    }).toThrow("Could not find manifest file (./sm.json).");
   });
 
-  test("it throws if no package.json file is found", async () => {
+  test("it throws if no package.json file is found", () => {
     fs.use(
       Volume.fromJSON(
         {
@@ -45,7 +47,9 @@ describe("getEnv", () => {
         TMP
       )
     );
-    await expect(getEnv(TMP)).rejects.toThrow();
+    expect(() => {
+      getEnv(TMP);
+    }).toThrow("Cannot read properties of undefined (reading 'includes')");
   });
 
   test.skip("it fails because api endpoint is missing", async () => {
@@ -317,6 +321,8 @@ describe("getEnv", () => {
       )
     );
 
-    await expect(getEnv(TMP)).rejects.toThrow();
+    expect(() => {
+      getEnv(TMP);
+    }).toThrow("Unknown application mode for https://api-1.fake.io/api/v2");
   });
 });

--- a/packages/slice-machine/tests/src/modules/environment.test.ts
+++ b/packages/slice-machine/tests/src/modules/environment.test.ts
@@ -2,10 +2,13 @@ import "@testing-library/jest-dom";
 
 import {
   environmentReducer,
+  getChangelog,
+  getChangelogCreator,
   refreshStateCreator,
 } from "@src/modules/environment";
 import { EnvironmentStoreType } from "@src/modules/environment/types";
 import { dummyServerState } from "./__mocks__/serverState";
+import { SliceMachineStoreType } from "@src/redux/type";
 
 const dummyEnvironmentState: EnvironmentStoreType = dummyServerState.env;
 
@@ -36,6 +39,46 @@ describe("[Environment module]", () => {
       expect(environmentReducer(dummyEnvironmentState, action)).toEqual({
         ...dummyEnvironmentState,
         repo: "newUrl",
+      });
+    });
+
+    it("should update the environment state given CHANGELOG.RESPONSE action", () => {
+      const newChangeLog = {
+        currentVersion: "1.0.0",
+        updateAvailable: true,
+        latestNonBreakingVersion: "0.1.2",
+        versions: [],
+      };
+      const action = getChangelogCreator.success({
+        changelog: newChangeLog,
+      });
+
+      expect(environmentReducer(dummyEnvironmentState, action)).toEqual({
+        ...dummyEnvironmentState,
+        changelog: newChangeLog,
+      });
+    });
+  });
+
+  describe("[Selector]", () => {
+    it("returns the changelog currently in the store", () => {
+      const sliceMachineStore = {
+        environment: dummyEnvironmentState,
+      } as SliceMachineStoreType;
+      const result = getChangelog(sliceMachineStore);
+      expect(result).toEqual(dummyEnvironmentState.changelog);
+    });
+
+    it("returns the default changelog when there isn't one in the store", () => {
+      const sliceMachineStore = {
+        environment: {},
+      } as SliceMachineStoreType;
+      const result = getChangelog(sliceMachineStore);
+      expect(result).toEqual({
+        currentVersion: "",
+        latestNonBreakingVersion: null,
+        updateAvailable: false,
+        versions: [],
       });
     });
   });


### PR DESCRIPTION
## Context

Ticket: https://linear.app/prismic/issue/SM-916/[spike]-aauser-i-should-always-be-able-to-access-the-sm-changelog

## The Solution

Remove the change log call from the general getEnv function.
Create an API route which returns the change log from github
Call this to set the CL in the redux store on start or refresh

## Checklist before requesting a review
- [ ] I hereby declare my code ready for review.
- [ ] If it is a critical feature, I have added tests.
- [ ] The CI is successful.
- [ ] If there could backward compatibility issues, it has been discussed and planned.




## [OPT] Preview

<!--
Visual aid of your work.
It can either be screenshots or a video.
This could help reviewers to get context quickly.
-->


---


![image](https://user-images.githubusercontent.com/47107427/208144166-a828cd16-d1c9-4304-a647-aebc34fcda1c.png)