### PR TITLE
Disable save mock button when there is a problem loading the simulator and fix header

### DIFF
--- a/packages/slice-machine/components/Simulator/components/Header/index.tsx
+++ b/packages/slice-machine/components/Simulator/components/Header/index.tsx
@@ -142,7 +142,7 @@ const Header: React.FunctionComponent<PropTypes> = ({
           data-cy="save-mock"
           onClick={onSaveMock}
           label="Save mock content"
-          disabled={savingMock}
+          disabled={savingMock || actionsDisabled}
           sx={{
             padding: "8px 16px",
             borderRadius: "6px",

--- a/packages/slice-machine/components/Simulator/components/Header/index.tsx
+++ b/packages/slice-machine/components/Simulator/components/Header/index.tsx
@@ -54,7 +54,7 @@ const Header: React.FunctionComponent<PropTypes> = ({
   return (
     <Flex
       sx={{
-        p: "16px 16px 16px 24px",
+        p: "16px",
         display: "flex",
         bg: "grey07",
         gridTemplateRows: "1fr",


### PR DESCRIPTION
## Context

Ticket: https://linear.app/prismic/issue/SM-948/save-mock-button-should-be-disabled-when-the-user-cannot-interact-with
Ticket for header: https://linear.app/prismic/issue/SM-947/incorrect-padding-on-header-in-slice-simulator

## The Solution

<!--
Highlight explanations where the complexity in your development is.
Keep in mind that the reviewer might not have as much context as you do.
This is very important to make sure the review is thorough and the reviewer understand your changes.
-->




## Impact / Dependencies

<!--
List all the impacts your development might have on internal and external features.
Ideally this should have been discussed prior to this development.

Link of any other PRs that are related to this development.
They should also be referenced in the ticket for reviews.
-->




## Checklist before requesting a review
- [ ] I hereby declare my code ready for review.
- [ ] If it is a critical feature, I have added tests.
- [ ] The CI is successful.
- [ ] If there could backward compatibility issues, it has been discussed and planned.




## [OPT] Preview

<img width="1440" alt="image" src="https://user-images.githubusercontent.com/47107427/208702230-a794cfa3-483b-4643-8f12-6fc772dd29d6.png">



<!--
A funny animal picture is welcome to close your PR!
You can find one here https://unsplash.com/s/photos/funny-animal-picture
-->