### PR TITLE
fix: iframe scaling

### DIFF
--- a/packages/slice-machine/components/Header/index.tsx
+++ b/packages/slice-machine/components/Header/index.tsx
@@ -1,17 +1,13 @@
 import NextLink from "next/link";
-import {
-  type FC,
-  type ReactElement,
-  useCallback,
-  useRef,
-  useState,
-} from "react";
+import { type FC, type ReactElement, useState } from "react";
 import {
   type ThemeUIStyleObject,
   Flex,
   Box,
   Link as ThemeLink,
 } from "theme-ui";
+
+import { useElementSize } from "@src/hooks/useElementSize";
 
 type HeaderProps = {
   link: {
@@ -28,23 +24,12 @@ type HeaderProps = {
 
 const Header: FC<HeaderProps> = ({ link, subtitle, Actions, sx }) => {
   const [overflowing, setOverflowing] = useState(false);
-  const resizeObserverRef = useRef<ResizeObserver>();
-  const subtitleRef = useCallback(
-    (element: HTMLDivElement | null) => {
-      if (element === null) {
-        resizeObserverRef.current?.disconnect();
-      } else {
-        resizeObserverRef.current = new ResizeObserver(() => {
-          setOverflowing(
-            subtitle ? element.offsetWidth < element.scrollWidth : false
-          );
-        });
-        resizeObserverRef.current.observe(element);
-      }
+  const subtitleRef = useElementSize<HTMLElement>(
+    (_size, element) => {
+      setOverflowing(!!subtitle && element.offsetWidth < element.scrollWidth);
     },
     [subtitle]
   );
-
   return (
     <Flex
       sx={{

--- a/packages/slice-machine/components/Simulator/components/IframeRenderer/index.tsx
+++ b/packages/slice-machine/components/Simulator/components/IframeRenderer/index.tsx
@@ -115,7 +115,7 @@ const IframeRenderer: React.FunctionComponent<IframeRendererProps> = ({
         display: "flex",
         height: "100%",
         justifyContent: "center",
-        overflowY: "hidden",
+        overflow: "hidden",
         ...(dryRun ? { display: "none" } : {}),
       }}
     >

--- a/packages/slice-machine/components/Simulator/components/IframeRenderer/index.tsx
+++ b/packages/slice-machine/components/Simulator/components/IframeRenderer/index.tsx
@@ -93,10 +93,7 @@ const IframeRenderer: React.FunctionComponent<IframeRendererProps> = ({
       });
   }, [client, apiContent, simulatorUrl]);
 
-  const [viewportSize, setViewportSize] = useState<ScreenDimensions>({
-    height: 0,
-    width: 0,
-  });
+  const [viewportSize, setViewportSize] = useState<ScreenDimensions>();
   const viewportRef = useElementSize(({ blockSize, inlineSize }) => {
     setViewportSize({ height: blockSize, width: inlineSize });
   }, []);
@@ -131,7 +128,9 @@ const IframeRenderer: React.FunctionComponent<IframeRendererProps> = ({
             minHeight: `${iframeSize.height}px`,
             minWidth: `${iframeSize.width}px`,
             overflowY: "auto",
-            transform: `scale(${getScaling(iframeSize, viewportSize)})`,
+            ...(viewportSize
+              ? { transform: `scale(${getScaling(iframeSize, viewportSize)})` }
+              : { display: "none" }),
           }}
         />
       ) : null}

--- a/packages/slice-machine/components/Simulator/components/IframeRenderer/index.tsx
+++ b/packages/slice-machine/components/Simulator/components/IframeRenderer/index.tsx
@@ -140,16 +140,14 @@ const IframeRenderer: React.FunctionComponent<IframeRendererProps> = ({
   );
 };
 
-function getScaling(
+export function getScaling(
   { height: iframeHeight, width: iframeWidth }: ScreenDimensions,
   { height: viewportHeight, width: viewportWidth }: ScreenDimensions
 ): number {
-  const widthDiff = iframeWidth - viewportWidth;
-  const heightDiff = iframeHeight - viewportHeight;
-  if (iframeWidth > viewportWidth && widthDiff > heightDiff) {
-    return viewportWidth / iframeWidth;
-  } else if (iframeHeight > viewportHeight && heightDiff > widthDiff) {
-    return viewportHeight / iframeHeight;
+  if (iframeWidth > viewportWidth || iframeHeight > viewportHeight) {
+    return iframeWidth - viewportWidth > iframeHeight - viewportHeight
+      ? viewportWidth / iframeWidth
+      : viewportHeight / iframeHeight;
   } else {
     return 1;
   }

--- a/packages/slice-machine/components/Simulator/components/IframeRenderer/index.tsx
+++ b/packages/slice-machine/components/Simulator/components/IframeRenderer/index.tsx
@@ -1,9 +1,9 @@
 import { RefCallback, useCallback, useEffect, useRef, useState } from "react";
 
-import { Box, Flex } from "theme-ui";
-import { ThemeUIStyleObject } from "@theme-ui/css";
+import { Flex } from "theme-ui";
 
 import { SimulatorClient } from "@prismicio/slice-simulator-com";
+import { useElementSize } from "@src/hooks/useElementSize";
 import useSliceMachineActions from "@src/modules/useSliceMachineActions";
 import { ScreenDimensions } from "@lib/models/common/Screenshots";
 
@@ -51,17 +51,15 @@ type IframeRendererProps = {
   screenDimensions: ScreenDimensions;
   simulatorUrl: string | undefined;
   dryRun?: boolean;
-  sx?: ThemeUIStyleObject;
 };
 
 const IframeRenderer: React.FunctionComponent<IframeRendererProps> = ({
   apiContent,
-  screenDimensions,
+  screenDimensions: iframeSize,
   simulatorUrl,
   dryRun = false,
-  sx,
 }) => {
-  const [client, refCallback] = useSimulatorClient();
+  const [client, iframeRef] = useSimulatorClient();
 
   const { connectToSimulatorSuccess, connectToSimulatorFailure } =
     useSliceMachineActions();
@@ -95,63 +93,66 @@ const IframeRenderer: React.FunctionComponent<IframeRendererProps> = ({
       });
   }, [client, apiContent, simulatorUrl]);
 
+  const [viewportSize, setViewportSize] = useState<ScreenDimensions>({
+    height: 0,
+    width: 0,
+  });
+  const viewportRef = useElementSize(({ blockSize, inlineSize }) => {
+    setViewportSize({ height: blockSize, width: inlineSize });
+  }, []);
+
   return (
-    <Box
+    <Flex
+      ref={viewportRef}
       sx={{
-        height: "100%",
-        backgroundColor: "white",
+        alignItems: "center",
+        backgroundColor: "headSection",
+        backgroundImage: "url(/pattern.png)",
+        backgroundRepeat: "repeat",
+        backgroundSize: "10px",
         border: (t) => `1px solid ${String(t.colors?.darkBorder)}`,
         borderRadius: 8,
-        overflow: "hidden",
-        ...(dryRun
-          ? {
-              position: "absolute",
-              top: "0",
-              width: "0",
-              height: "0",
-            }
-          : {}),
-        ...sx,
+        display: "flex",
+        height: "100%",
+        justifyContent: "center",
+        overflowY: "hidden",
+        ...(dryRun ? { display: "none" } : {}),
       }}
     >
-      <Flex
-        sx={{
-          backgroundImage: "url(/pattern.png)",
-          backgroundColor: "headSection",
-          backgroundRepeat: "repeat",
-          backgroundSize: "10px",
-          mx: "auto",
-          flexDirection: "column",
-          justifyContent: "center",
-          overflow: "auto",
-        }}
-      >
-        <Flex
-          sx={{
-            justifyContent: "center",
-            margin: "0 auto",
-            alignContent: "center",
-            width: screenDimensions.width,
-            height: screenDimensions.height,
+      {simulatorUrl ? (
+        <iframe
+          id="__iframe-renderer"
+          ref={iframeRef}
+          src={simulatorUrl}
+          style={{
+            border: "none",
+            maxHeight: `${iframeSize.height}px`,
+            maxWidth: `${iframeSize.width}px`,
+            minHeight: `${iframeSize.height}px`,
+            minWidth: `${iframeSize.width}px`,
+            overflowY: "auto",
+            transform: `scale(${getScaling(iframeSize, viewportSize)})`,
           }}
-        >
-          {client?.connected ? <div id="__iframe-ready" /> : null}
-          {simulatorUrl ? (
-            <iframe
-              id="__iframe-renderer"
-              ref={refCallback}
-              src={simulatorUrl}
-              style={{
-                border: "none",
-                width: "100%",
-                height: "100%",
-              }}
-            />
-          ) : null}
-        </Flex>
-      </Flex>
-    </Box>
+        />
+      ) : null}
+      {client?.connected ? <div id="__iframe-ready" /> : null}
+    </Flex>
   );
 };
+
+function getScaling(
+  { height: iframeHeight, width: iframeWidth }: ScreenDimensions,
+  { height: viewportHeight, width: viewportWidth }: ScreenDimensions
+): number {
+  const widthDiff = iframeWidth - viewportWidth;
+  const heightDiff = iframeHeight - viewportHeight;
+  if (iframeWidth > viewportWidth && widthDiff > heightDiff) {
+    return viewportWidth / iframeWidth;
+  } else if (iframeHeight > viewportHeight && heightDiff > widthDiff) {
+    return viewportHeight / iframeHeight;
+  } else {
+    return 1;
+  }
+}
 
 export default IframeRenderer;

--- a/packages/slice-machine/jest.config.js
+++ b/packages/slice-machine/jest.config.js
@@ -14,6 +14,7 @@ module.exports = {
     "^lib/(.*)$": "<rootDir>/lib/$1",
     "^tests/(.*)$": "<rootDir>/tests/$1",
   },
+  setupFiles: ["<rootDir>/tests/jest-setup.js"],
   testPathIgnorePatterns: ["<rootDir>/node_modules/", "<rootDir>/.next/"],
   transform: {
     "^.+\\.(js|jsx|ts|tsx)$": [

--- a/packages/slice-machine/pages/[lib]/[sliceName]/[variation]/screenshot.tsx
+++ b/packages/slice-machine/pages/[lib]/[sliceName]/[variation]/screenshot.tsx
@@ -44,9 +44,6 @@ const Screenshot: ComponentWithSliceProps = ({ slice, variation }) => {
       }}
     >
       <IframeRenderer
-        sx={{
-          height: "100%",
-        }}
         simulatorUrl={simulatorUrl}
         apiContent={apiContent}
         screenDimensions={ScreenSizes[ScreenSizeOptions.DESKTOP]}

--- a/packages/slice-machine/pages/[lib]/[sliceName]/[variation]/screenshot.tsx
+++ b/packages/slice-machine/pages/[lib]/[sliceName]/[variation]/screenshot.tsx
@@ -1,8 +1,4 @@
 import IframeRenderer from "@components/Simulator/components/IframeRenderer";
-import {
-  ScreenSizeOptions,
-  ScreenSizes,
-} from "@components/Simulator/components/Toolbar/ScreensizeInput";
 
 import useEditorContentOnce from "@src/hooks/useEditorContent";
 import {
@@ -12,7 +8,7 @@ import {
 import { selectSimulatorUrl } from "@src/modules/environment";
 import { SliceMachineStoreType } from "@src/redux/type";
 import { FC, ReactNode } from "react";
-
+import { useRouter } from "next/router";
 import { useSelector } from "react-redux";
 import { Box } from "theme-ui";
 
@@ -24,6 +20,9 @@ const Screenshot: ComponentWithSliceProps = ({ slice, variation }) => {
   const { simulatorUrl } = useSelector((store: SliceMachineStoreType) => ({
     simulatorUrl: selectSimulatorUrl(store),
   }));
+  const router = useRouter();
+  const screenWidth = Number(router.query.screenWidth);
+  const screenHeight = Number(router.query.screenHeight);
 
   const { apiContent } = useEditorContentOnce({
     slice,
@@ -46,7 +45,10 @@ const Screenshot: ComponentWithSliceProps = ({ slice, variation }) => {
       <IframeRenderer
         simulatorUrl={simulatorUrl}
         apiContent={apiContent}
-        screenDimensions={ScreenSizes[ScreenSizeOptions.DESKTOP]}
+        screenDimensions={{
+          width: screenWidth,
+          height: screenHeight,
+        }}
       />
     </Box>
   );

--- a/packages/slice-machine/server/src/api/screenshots/generate.ts
+++ b/packages/slice-machine/server/src/api/screenshots/generate.ts
@@ -53,7 +53,7 @@ async function generateForVariation(
   screenDimensions: ScreenDimensions,
   href: string
 ): Promise<ScreenshotUI> {
-  const screenshotUrl = `${env.baseUrl}/${href}/${sliceName}/${variationId}/screenshot`;
+  const screenshotUrl = `${env.baseUrl}/${href}/${sliceName}/${variationId}/screenshot?screenWidth=${screenDimensions.width}&screenHeight=${screenDimensions.height}`;
 
   const pathToFile = NodeUtils.GeneratedPaths(env.cwd)
     .library(libraryName)

--- a/packages/slice-machine/server/src/api/screenshots/puppeteer.ts
+++ b/packages/slice-machine/server/src/api/screenshots/puppeteer.ts
@@ -58,12 +58,9 @@ const generateScreenshot = async (
   try {
     Files.mkdir(path.dirname(pathToFile), { recursive: true });
 
-    await page.goto(
-      `${screenshotUrl}?screenWidth=${screenDimensions.width}&screenHeight=${screenDimensions.height}`,
-      {
-        waitUntil: "load",
-      }
-    );
+    await page.goto(screenshotUrl, {
+      waitUntil: "load",
+    });
 
     await page.waitForSelector("#__iframe-ready", { timeout: 10000 });
     const element = await page.$("#__iframe-renderer");

--- a/packages/slice-machine/server/src/api/screenshots/puppeteer.ts
+++ b/packages/slice-machine/server/src/api/screenshots/puppeteer.ts
@@ -58,9 +58,12 @@ const generateScreenshot = async (
   try {
     Files.mkdir(path.dirname(pathToFile), { recursive: true });
 
-    await page.goto(screenshotUrl, {
-      waitUntil: "load",
-    });
+    await page.goto(
+      `${screenshotUrl}?screenWidth=${screenDimensions.width}&screenHeight=${screenDimensions.height}`,
+      {
+        waitUntil: "load",
+      }
+    );
 
     await page.waitForSelector("#__iframe-ready", { timeout: 10000 });
     const element = await page.$("#__iframe-renderer");

--- a/packages/slice-machine/src/hooks/useElementSize.ts
+++ b/packages/slice-machine/src/hooks/useElementSize.ts
@@ -5,17 +5,17 @@ import {
   useRef,
 } from "react";
 
-export function useElementSize(
-  callback: (size: ResizeObserverSize) => void,
+export function useElementSize<E extends Element>(
+  callback: (size: ResizeObserverSize, element: E) => void,
   deps: DependencyList
-): RefCallback<Element> {
+): RefCallback<E> {
   const resizeObserverRef = useRef<ResizeObserver>();
-  return useCallback((element: Element | null) => {
+  return useCallback((element: E | null) => {
     resizeObserverRef.current?.disconnect();
     if (element === null) return;
     resizeObserverRef.current = new ResizeObserver(([entry]) => {
       const { height, width } = entry.contentRect;
-      callback({ blockSize: height, inlineSize: width });
+      callback({ blockSize: height, inlineSize: width }, element);
     });
     resizeObserverRef.current.observe(element);
   }, deps);

--- a/packages/slice-machine/src/hooks/useElementSize.ts
+++ b/packages/slice-machine/src/hooks/useElementSize.ts
@@ -1,0 +1,22 @@
+import {
+  type DependencyList,
+  type RefCallback,
+  useCallback,
+  useRef,
+} from "react";
+
+export function useElementSize(
+  callback: (size: ResizeObserverSize) => void,
+  deps: DependencyList
+): RefCallback<Element> {
+  const resizeObserverRef = useRef<ResizeObserver>();
+  return useCallback((element: Element | null) => {
+    resizeObserverRef.current?.disconnect();
+    if (element === null) return;
+    resizeObserverRef.current = new ResizeObserver(([entry]) => {
+      const { height, width } = entry.contentRect;
+      callback({ blockSize: height, inlineSize: width });
+    });
+    resizeObserverRef.current.observe(element);
+  }, deps);
+}

--- a/packages/slice-machine/tests/components/IframeRenderer.spec.ts
+++ b/packages/slice-machine/tests/components/IframeRenderer.spec.ts
@@ -1,0 +1,14 @@
+import { getScaling } from "@components/Simulator/components/IframeRenderer";
+
+const VIEWPORT_SIZE = { width: 100, height: 100 };
+
+describe("getScaling", () => {
+  it("prevents the iframe from overflowing the viewport", () => {
+    expect(getScaling({ width: 50, height: 50 }, VIEWPORT_SIZE)).toBe(1);
+    expect(getScaling({ width: 200, height: 50 }, VIEWPORT_SIZE)).toBe(0.5);
+    expect(getScaling({ width: 200, height: 150 }, VIEWPORT_SIZE)).toBe(0.5);
+    expect(getScaling({ width: 50, height: 200 }, VIEWPORT_SIZE)).toBe(0.5);
+    expect(getScaling({ width: 150, height: 200 }, VIEWPORT_SIZE)).toBe(0.5);
+    expect(getScaling({ width: 200, height: 200 }, VIEWPORT_SIZE)).toBe(0.5);
+  });
+});

--- a/packages/slice-machine/tests/jest-setup.js
+++ b/packages/slice-machine/tests/jest-setup.js
@@ -1,0 +1,7 @@
+if (typeof window === "object") {
+  window.ResizeObserver = jest.fn().mockReturnValue({
+    disconnect: jest.fn(),
+    observe: jest.fn(),
+    unobserve: jest.fn(),
+  });
+}

--- a/packages/slice-machine/tests/pages/cts.spec.tsx
+++ b/packages/slice-machine/tests/pages/cts.spec.tsx
@@ -30,14 +30,6 @@ const server = setupServer(
   })
 );
 
-const ResizeObserverMock = jest
-  .fn<(fn: ResizeObserverCallback) => ResizeObserver>()
-  .mockImplementation(() => ({
-    disconnect: jest.fn(),
-    observe: jest.fn(),
-    unobserve: jest.fn(),
-  }));
-
 beforeAll(() => server.listen());
 afterEach(() => server.resetHandlers());
 afterAll(() => server.close());
@@ -55,7 +47,6 @@ describe("Custom Type Builder", () => {
 
   beforeEach(async () => {
     mockRouter.setCurrentUrl("/");
-    window.ResizeObserver = ResizeObserverMock;
   });
 
   const libraries = [

--- a/packages/slice-machine/tsconfig.json
+++ b/packages/slice-machine/tsconfig.json
@@ -30,7 +30,6 @@
       "@builders/*": ["lib/builders/*"],
       "@models/*": ["lib/models/*"],
       "@src/*": ["src/*"],
-      "@hooks/*": ["hooks/*"],
       "@components/*": ["components/*"]
     },
     "incremental": true


### PR DESCRIPTION
## Context

Corresponding Linear issue: [SM-946 Slice Simulator v2 - App preview not scrollable](https://linear.app/prismic/issue/SM-946/slice-simulator-v2-app-preview-not-scrollable).

## The Solution

1. Correctly scale the iframe based on the requested screen dimensions.
2. Introduce the `useElementSize` hook and call it in `packages/slice-machine/components/Header/index.tsx`.
3. Mock `ResizeObserver` in `packages/slice-machine/tests/jest-setup.js`.
4. Remove unused `@hooks/*` alias from `packages/slice-machine/tsconfig.json`.

## Checklist before requesting a review
- [x] I hereby declare my code ready for review.
- [ ] If it is a critical feature, I have added tests.
- [x] The CI is successful.
- [ ] If there could backward compatibility issues, it has been discussed and planned.