### PR TITLE
add cursor not-allowed to screenshot button disabled state

### DIFF
--- a/packages/slice-machine/components/Simulator/components/Toolbar/index.tsx
+++ b/packages/slice-machine/components/Simulator/components/Toolbar/index.tsx
@@ -168,6 +168,7 @@ export const Toolbar: React.FC<ToolbarProps> = ({
           },
           "&:disabled": {
             color: "#908E96",
+            cursor: "not-allowed",
           },
         }}
       />


### PR DESCRIPTION
## Context

Ticket: https://linear.app/prismic/issue/SM-949/the-take-screenshot-button-is-not-disabled-confusing-the-user

## The Solution

<!--
Highlight explanations where the complexity in your development is.
Keep in mind that the reviewer might not have as much context as you do.
This is very important to make sure the review is thorough and the reviewer understand your changes.
-->

Base button states were overriding the disabled state for the screenshot button. Have added the cursor style to the `sx` prop of the same.


## Impact / Dependencies

<!--
List all the impacts your development might have on internal and external features.
Ideally this should have been discussed prior to this development.

Link of any other PRs that are related to this development.
They should also be referenced in the ticket for reviews.
-->




## Checklist before requesting a review
- [ ] I hereby declare my code ready for review.
- [ ] If it is a critical feature, I have added tests.
- [ ] The CI is successful.
- [ ] If there could backward compatibility issues, it has been discussed and planned.




## [OPT] Preview

https://user-images.githubusercontent.com/47107427/209105279-d72246f4-23c9-432d-8c05-fbcc436308f4.mov



<!--
A funny animal picture is welcome to close your PR!
You can find one here https://unsplash.com/s/photos/funny-animal-picture
-->