### PR TITLE
Update latest version in changelog page when the versions change

### DIFF
--- a/packages/slice-machine/components/Changelog/index.tsx
+++ b/packages/slice-machine/components/Changelog/index.tsx
@@ -15,13 +15,15 @@ export default function Changelog() {
     })
   );
 
+  const latestVersion = changelog.versions[0] || null;
+
   const [selectedVersion, setSelectedVersion] = useState<PackageVersion | null>(
-    changelog.versions[0] || null
+    latestVersion
   );
 
   useEffect(() => {
-    setSelectedVersion(changelog.versions[0]);
-  }, [JSON.stringify(changelog)]);
+    setSelectedVersion(latestVersion);
+  }, [latestVersion]);
 
   return (
     <Flex

--- a/packages/slice-machine/components/Changelog/index.tsx
+++ b/packages/slice-machine/components/Changelog/index.tsx
@@ -19,10 +19,10 @@ export default function Changelog() {
     })
   );
 
-  const latestVersion = changelog.versions[0] || null;
+  const latestVersion = changelog.versions[0];
 
   const [selectedVersion, setSelectedVersion] = useState<PackageVersion | null>(
-    latestVersion
+    latestVersion || null
   );
 
   useEffect(() => {

--- a/packages/slice-machine/components/Changelog/index.tsx
+++ b/packages/slice-machine/components/Changelog/index.tsx
@@ -2,7 +2,7 @@ import { Flex } from "theme-ui";
 import { useSelector } from "react-redux";
 import { SliceMachineStoreType } from "@src/redux/type";
 import { getChangelog, getPackageManager } from "@src/modules/environment";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { PackageVersion } from "@models/common/versions";
 import { Navigation } from "./navigation";
 import { VersionDetails, ReleaseWarning } from "./versionDetails";
@@ -15,10 +15,13 @@ export default function Changelog() {
     })
   );
 
-  // Null is when no version are found (edge case)
   const [selectedVersion, setSelectedVersion] = useState<PackageVersion | null>(
     changelog.versions[0] || null
   );
+
+  useEffect(() => {
+    setSelectedVersion(changelog.versions[0]);
+  }, [JSON.stringify(changelog)]);
 
   return (
     <Flex

--- a/packages/slice-machine/components/Changelog/index.tsx
+++ b/packages/slice-machine/components/Changelog/index.tsx
@@ -6,12 +6,16 @@ import { useEffect, useState } from "react";
 import { PackageVersion } from "@models/common/versions";
 import { Navigation } from "./navigation";
 import { VersionDetails, ReleaseWarning } from "./versionDetails";
+import { isLoading } from "@src/modules/loading";
+import { LoadingKeysEnum } from "@src/modules/loading/types";
+import LoadingPage from "@components/LoadingPage";
 
 export default function Changelog() {
-  const { changelog, packageManager } = useSelector(
+  const { changelog, packageManager, isChangelogLoading } = useSelector(
     (store: SliceMachineStoreType) => ({
       changelog: getChangelog(store),
       packageManager: getPackageManager(store),
+      isChangelogLoading: isLoading(store, LoadingKeysEnum.CHANGELOG),
     })
   );
 
@@ -25,7 +29,7 @@ export default function Changelog() {
     setSelectedVersion(latestVersion);
   }, [latestVersion]);
 
-  return (
+  return !isChangelogLoading ? (
     <Flex
       sx={{
         maxWidth: "1224px",
@@ -60,5 +64,7 @@ export default function Changelog() {
         />
       )}
     </Flex>
+  ) : (
+    <LoadingPage />
   );
 }


### PR DESCRIPTION
## Context

Issue in ticket: https://linear.app/prismic/issue/SM-916#comment-e223c409
When navigating directly to /changelog, the list in the column updates but the latest version displayed on the right does not as this was wrapped in a usestate. Not we update the state when the changelog changes.


## Checklist before requesting a review
- [ ] I hereby declare my code ready for review.
- [ ] If it is a critical feature, I have added tests.
- [ ] The CI is successful.
- [ ] If there could backward compatibility issues, it has been discussed and planned.




## [OPT] Preview

<!--
Visual aid of your work.
It can either be screenshots or a video.
This could help reviewers to get context quickly.
-->

![ezgif com-gif-maker (8)](https://user-images.githubusercontent.com/47107427/209110764-40a967aa-335b-4c8d-bc3d-1fc711d9b412.gif)



<!--
A funny animal picture is welcome to close your PR!
You can find one here https://unsplash.com/s/photos/funny-animal-picture
-->