### PR TITLE
fix(slice-machine-ui): add source maps to .npmignore

### DIFF
--- a/packages/slice-machine/.npmignore
+++ b/packages/slice-machine/.npmignore
@@ -26,3 +26,7 @@ tests/project/node_modules
 
 # prov
 /api-dump
+
+# source maps
+/build/**/*.map
+/out/**/*.map


### PR DESCRIPTION
## Context

Corresponding Linear issue: [SM-958 (SPIKE 1Day)slice-machine-ui package size doubled between 0.5.2 and 0.6.0](https://linear.app/prismic/issue/SM-958/spike-1dayslice-machine-ui-package-size-doubled-between-052-and-060).

## The Solution

Add `.map` files located in `packages/slice-machine/build` and `packages/slice-machine/out` to `packages/slice-machine/.npmignore`.

## Impact / Dependencies

N/A

## Checklist before requesting a review
- [x] I hereby declare my code ready for review.
- [ ] If it is a critical feature, I have added tests.
- [x] The CI is successful.
- [ ] If there could backward compatibility issues, it has been discussed and planned.