### PR TITLE
explicitly log pupeteer errors

### DIFF
--- a/packages/slice-machine/lib/models/common/Screenshots.ts
+++ b/packages/slice-machine/lib/models/common/Screenshots.ts
@@ -12,12 +12,22 @@ export interface ScreenshotRequest {
   href: string;
 }
 
-export interface ScreenshotResponse {
-  err: Error | null;
-  reason: string | null;
-  warning?: string | null;
-  screenshot: ScreenshotUI | null;
-}
+type ScreenshotErrorResponse = {
+  err: Error;
+  reason: string;
+};
+
+type ScreenshotSuccessResponse = {
+  screenshot: ScreenshotUI;
+};
+
+export type ScreenshotResponse =
+  | ScreenshotErrorResponse
+  | ScreenshotSuccessResponse;
+
+export const isError = (
+  response: ScreenshotResponse
+): response is ScreenshotErrorResponse => "err" in response;
 
 export type TmpFile = File & { path: string };
 export interface CustomScreenshotRequest {

--- a/packages/slice-machine/server/src/api/index.ts
+++ b/packages/slice-machine/server/src/api/index.ts
@@ -27,6 +27,7 @@ import sentryHandler, { plainTextBodyParser } from "./sentry";
 
 import { RequestWithEnv, WithEnv } from "./http/common";
 import {
+  isError,
   ScreenshotRequest,
   ScreenshotResponse,
 } from "../../../lib/models/common/Screenshots";
@@ -88,7 +89,7 @@ router.post(
     res: express.Response
   ): Promise<Express.Response> {
     const payload = await screenshot(req.body);
-    if (payload.err) {
+    if (isError(payload)) {
       return res.status(400).json(payload);
     }
     return res.status(200).json(payload);

--- a/packages/slice-machine/server/src/api/screenshots/generate.ts
+++ b/packages/slice-machine/server/src/api/screenshots/generate.ts
@@ -12,7 +12,7 @@ import { ScreenDimensions } from "../../../../lib/models/common/Screenshots";
 import { hash } from "@slicemachine/core/build/utils/str";
 
 export interface ScreenshotResults {
-  screenshot: ScreenshotUI | null;
+  screenshot: ScreenshotUI;
 }
 
 export async function generateScreenshotAndRemoveCustom(
@@ -23,26 +23,20 @@ export async function generateScreenshotAndRemoveCustom(
   screenDimensions: ScreenDimensions,
   href: string
 ): Promise<ScreenshotResults> {
-  try {
-    const result = await generateForVariation(
-      env,
-      libraryName,
-      sliceName,
-      variationId,
-      screenDimensions,
-      href
-    );
+  const result = await generateForVariation(
+    env,
+    libraryName,
+    sliceName,
+    variationId,
+    screenDimensions,
+    href
+  );
 
-    removeCustomScreenshot(env, libraryName, sliceName, variationId);
+  removeCustomScreenshot(env, libraryName, sliceName, variationId);
 
-    return {
-      screenshot: result,
-    };
-  } catch {
-    return {
-      screenshot: null,
-    };
-  }
+  return {
+    screenshot: result,
+  };
 }
 
 async function generateForVariation(

--- a/packages/slice-machine/server/src/api/screenshots/puppeteer.ts
+++ b/packages/slice-machine/server/src/api/screenshots/puppeteer.ts
@@ -26,14 +26,26 @@ export default {
         defaultViewport: null,
       });
     }
-    const puppeteerBrowser = await puppeteerBrowserPromise;
+
+    let puppeteerBrowser: puppeteer.Browser;
+
+    try {
+      puppeteerBrowser = await puppeteerBrowserPromise;
+    } catch (e) {
+      console.error(
+        "Could not load pupeteer. Try re-installing your dependencies (`npm i`) to fix the issue"
+      );
+      console.error(e);
+      throw e;
+    }
 
     return generateScreenshot(
       puppeteerBrowser,
       screenshotUrl,
       pathToFile,
       screenDimensions
-    ).catch(() => {
+    ).catch((error) => {
+      console.error(error);
       throw new Error(
         `Unable to generate screenshot for this page: ${screenshotUrl}`
       );

--- a/packages/slice-machine/server/src/api/screenshots/puppeteer.ts
+++ b/packages/slice-machine/server/src/api/screenshots/puppeteer.ts
@@ -35,7 +35,6 @@ export default {
       console.error(
         "Could not load pupeteer. Try re-installing your dependencies (`npm i`) to fix the issue"
       );
-      console.error(e);
       throw e;
     }
 
@@ -44,12 +43,7 @@ export default {
       screenshotUrl,
       pathToFile,
       screenDimensions
-    ).catch((error) => {
-      console.error(error);
-      throw new Error(
-        `Unable to generate screenshot for this page: ${screenshotUrl}`
-      );
-    });
+    );
   },
 };
 

--- a/packages/slice-machine/server/src/api/screenshots/screenshots.ts
+++ b/packages/slice-machine/server/src/api/screenshots/screenshots.ts
@@ -1,3 +1,5 @@
+import * as Sentry from "@sentry/node";
+
 import getEnv from "../services/getEnv";
 import { generateScreenshotAndRemoveCustom } from "./generate";
 import {
@@ -17,7 +19,6 @@ export function validateEnv(
     return {
       err: new Error(reason),
       reason,
-      screenshot: null,
     };
   }
   if (!simulatorUrl) {
@@ -27,7 +28,6 @@ export function validateEnv(
     return {
       err: new Error(reason),
       reason,
-      screenshot: null,
     };
   }
 }
@@ -59,30 +59,15 @@ export default async function handler({
       href
     );
 
-    // We display an error if no screenshot has been taken
-    if (!screenshot) {
-      const message = `Could not generate screenshot for variation ${variationId}`;
-      return {
-        err: new Error(message),
-        reason: message,
-        warning: null,
-        screenshot,
-      };
-    }
-
     return {
-      err: null,
-      reason: null,
       screenshot,
     };
-  } catch (e) {
-    const crashMessage =
-      "Could not generate screenshots for this slice, upload manually a screenshot";
+  } catch (error) {
+    console.error(error);
+    Sentry.captureException(error);
     return {
-      err: new Error(crashMessage),
-      reason: crashMessage,
-      warning: null,
-      screenshot: null,
+      err: error as Error,
+      reason: "Could not generate screenshot",
     };
   }
 }

--- a/packages/slice-machine/src/modules/screenshots/sagas.ts
+++ b/packages/slice-machine/src/modules/screenshots/sagas.ts
@@ -18,6 +18,7 @@ import {
 } from "@src/apiClient";
 import { openToasterCreator, ToasterType } from "@src/modules/toaster";
 import Tracker from "@src/tracking/client";
+import { isError } from "@lib/models/common/Screenshots";
 
 export function* generateSliceScreenshotSaga({
   payload,
@@ -33,7 +34,7 @@ export function* generateSliceScreenshotSaga({
     })) as SagaReturnType<typeof generateSliceScreenshotApiClient>;
 
     // If screenshot is null, then no screenshots were taken
-    if (!response.data.screenshot) {
+    if (isError(response.data)) {
       throw Error("No screenshot saved");
     }
 


### PR DESCRIPTION
## Context

https://linear.app/prismic/issue/SM-913/aauser-i-want-to-see-the-error-that-causes-screenshot-failure


## The Solution

Explicitly log error cases when they happen in our pupeteer module



## Impact / Dependencies

-


## Checklist before requesting a review
- [ ] I hereby declare my code ready for review.
- [ ] If it is a critical feature, I have added tests.
- [ ] The CI is successful.
- [ ] If there could backward compatibility issues, it has been discussed and planned.




## [OPT] Preview

<img width="1341" alt="image" src="https://user-images.githubusercontent.com/1148164/210604820-23f5547e-4739-429c-baac-c926b4b1c4c9.png">
<img width="772" alt="image" src="https://user-images.githubusercontent.com/1148164/210605015-7c341f40-6779-4914-96c7-516f89e9e6d7.png">
