### PR TITLE
fix crash when editing a select widget options

### DIFF
--- a/packages/slice-machine/components/FormFields/Array.js
+++ b/packages/slice-machine/components/FormFields/Array.js
@@ -31,7 +31,7 @@ const FormFieldArray = ({
       refs.current[len - 1].focus();
     }
     setPrevLen(len);
-  }, [refs.current.length]);
+  }, [refs.current.length, focusOnNewEntry, prevLen]);
 
   return (
     <Fragment>

--- a/packages/slice-machine/components/FormFields/CheckboxControl.js
+++ b/packages/slice-machine/components/FormFields/CheckboxControl.js
@@ -1,21 +1,26 @@
 import { useState, useEffect } from "react";
-import { useFormikContext } from "formik";
 
 import { FormFieldCheckbox } from "./";
 
+/**
+ * This components allows to set/unset the value of an arbitrary field via checking/unchecking the box
+ *
+ * field: the controlled Formik field that we want to manipulate
+ * label: a function of text displayed next to the checkbox. Can be either a string or a function
+ * controlledValue: the value of the field being controlled
+ * setControlledValue: function to update the value of the controlled value in Formik
+ * buildControlledValue: function to build the new value based on the current controlled value and the state of the checkbox
+ *
+ */
 const CheckboxControl = ({
   field,
-  helpers,
   label,
   defaultValue,
   onChange,
-  getFieldControl,
-  setControlFromField,
+  controlledValue,
+  setControlledValue,
+  buildControlledValue,
 }) => {
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-  const { values } = useFormikContext();
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call
-  const fieldControl = getFieldControl(values);
   // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-assignment
   const [isChecked, setCheck] = useState(
     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
@@ -24,13 +29,15 @@ const CheckboxControl = ({
 
   useEffect(() => {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-    helpers.setValue(
-      setControlFromField
-        ? // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-call
-          setControlFromField(fieldControl, isChecked)
-        : fieldControl
-    );
-  }, [isChecked, fieldControl]);
+    buildControlledValue
+      ? // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+        setControlledValue(buildControlledValue(controlledValue))
+      : // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+        setControlledValue(buildControlledValue);
+    // Adding the missing dependency to this hook triggers an infinite loop
+    // We decided to leave it for now, waiting for a bigger refactor
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isChecked, controlledValue, buildControlledValue]);
 
   return (
     <FormFieldCheckbox
@@ -44,7 +51,7 @@ const CheckboxControl = ({
       onChange={(value) => setCheck(value) && onChange && onChange(value)}
       label={
         // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call
-        typeof label === "function" ? label(fieldControl, isChecked) : label
+        typeof label === "function" ? label(controlledValue, isChecked) : label
       }
     />
   );

--- a/packages/slice-machine/lib/models/common/widgets/Select/FormFields.js
+++ b/packages/slice-machine/lib/models/common/widgets/Select/FormFields.js
@@ -1,10 +1,22 @@
 import * as yup from "yup";
+import { useFormikContext } from "formik";
+
 import { FormFieldCheckboxControl } from "components/FormFields";
 
 import { FormTypes } from "@lib/forms/types";
 
 import { DefaultFields } from "@lib/forms/defaults";
 import { FormFieldArray } from "components/FormFields";
+
+const label = (controlledValue) =>
+  `use first value as default ${
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/restrict-template-expressions, @typescript-eslint/no-unsafe-member-access
+    controlledValue ? `("${controlledValue}")` : ""
+  }`;
+
+const buildControlledValue = (controlledValue, isChecked) =>
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-member-access
+  isChecked ? controlledValue : undefined;
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
 const FormFields = {
@@ -30,25 +42,25 @@ const FormFields = {
         },
       });
     },
-    component: (props) => (
-      <FormFieldCheckboxControl
-        {...props}
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
-        defaultValue={props.field.value}
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-member-access
-        getFieldControl={(formValues) => formValues.config?.options}
-        setControlFromField={(options, isChecked) =>
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-member-access
-          isChecked ? options.length && options[0] : undefined
-        }
-        label={(options) =>
-          `use first value as default ${
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/restrict-template-expressions, @typescript-eslint/no-unsafe-member-access
-            options.length ? `("${options[0]}")` : ""
-          }`
-        }
-      />
-    ),
+    component: (props) => {
+      // eslint-disable-next-line react-hooks/rules-of-hooks, @typescript-eslint/no-unsafe-assignment
+      const { values } = useFormikContext();
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment
+      const controlledValue = values.config?.options[0];
+      return (
+        <FormFieldCheckboxControl
+          {...props}
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
+          defaultValue={props.field.value}
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
+          controlledValue={controlledValue}
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment
+          setControlledValue={props.helpers.setValue}
+          buildControlledValue={buildControlledValue}
+          label={label}
+        />
+      );
+    },
   },
   options: {
     yupType: "array",


### PR DESCRIPTION
## Context

https://linear.app/prismic/issue/SM-959/[spike]-aauser-i-can-type-text-fast-in-the-slice-select-option-field


## The Solution

Change the code around the effect to prevent the infinite loop


## Impact / Dependencies

Updating Formik to the latest version



## Checklist before requesting a review
- [ ] I hereby declare my code ready for review.
- [ ] If it is a critical feature, I have added tests.
- [ ] The CI is successful.
- [ ] If there could backward compatibility issues, it has been discussed and planned.




## [OPT] Preview


https://user-images.githubusercontent.com/1148164/211049649-ea258611-98a8-43ec-a3da-70ef947f03a9.mov



