### PR TITLE
Wait for all images to load in simulator iframe before taking a screenshot

### DIFF
--- a/packages/slice-machine/server/src/api/screenshots/puppeteer.ts
+++ b/packages/slice-machine/server/src/api/screenshots/puppeteer.ts
@@ -65,6 +65,15 @@ const generateScreenshot = async (
     await page.waitForSelector("#__iframe-ready", { timeout: 10000 });
     const element = await page.$("#__iframe-renderer");
 
+    const iframe = page.frames().find((f) => f.name() === "__iframe-renderer");
+    const images = iframe ? await iframe.$$("img") : [];
+
+    await Promise.all(
+      images.map(async (img) => {
+        await iframe?.waitForFunction((img) => img.complete, {}, img);
+      })
+    );
+
     if (element) {
       await element.screenshot({
         path: pathToFile,


### PR DESCRIPTION
## Context

Linear ticket: https://linear.app/prismic/issue/SM-881/aauser-i-see-all-the-images-when-i-take-a-screenshot-from-the-preview


## The Solution

Check images inside iframe and wait for all to be ready, before proceeding with screenshot code.

## Impact / Dependencies

Since we are waiting a little longer for images to load, we of course are sacrificing some performance. You can see the results of the before and after of this optimisation in the image here (this is taking 50 screenshots of the _CategoryPreviewWithImageBackgrounds_ slice in the example project):

<img width="410" alt="image" src="https://user-images.githubusercontent.com/47107427/211346152-36fb12d4-e7d9-43f8-8289-f00107a1f204.png">


## Checklist before requesting a review
- [ ] I hereby declare my code ready for review.
- [ ] If it is a critical feature, I have added tests.
- [ ] The CI is successful.
- [ ] If there could backward compatibility issues, it has been discussed and planned.


---


![image](https://user-images.githubusercontent.com/47107427/211346384-039f927e-4587-4b45-adbf-c35ae1fbe70b.png)
