### PR TITLE
Fix: don't allow duplicate CT tab IDs

### DIFF
--- a/packages/slice-machine/lib/builders/CustomTypeBuilder/TabModal/update.tsx
+++ b/packages/slice-machine/lib/builders/CustomTypeBuilder/TabModal/update.tsx
@@ -88,7 +88,7 @@ const CreateCustomtypeForm = ({
         title,
       }}
     >
-      {({ errors, values, setFieldValue }) => (
+      {({ errors, values, setFieldValue, isValid }) => (
         <Box>
           <Box sx={{ px: 4, py: 4 }}>
             <InputBox
@@ -103,12 +103,12 @@ const CreateCustomtypeForm = ({
               }}
               onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
                 setFieldValue("id", e.target.value);
-                setFieldValue("actionType", ActionType.UPDATE);
               }}
             />
             <Button
               type="button"
               sx={{ mt: 3, width: "100%" }}
+              disabled={!isValid}
               onClick={() => {
                 if (values.id && values.id.length) {
                   onSubmit({


### PR DESCRIPTION
## Context

Ticket: https://linear.app/prismic/issue/SM-953/[spike]-aauser-i-should-not-be-able-to-create-duplicate-custom-type


## The Solution

There was a redundant update to the actionType field value which caused the old value of the field to be used for the duplicate name check. Have now removed this and disable the button when the form is not valid.

## Impact / Dependencies

<!--
List all the impacts your development might have on internal and external features.
Ideally this should have been discussed prior to this development.

Link of any other PRs that are related to this development.
They should also be referenced in the ticket for reviews.
-->




## Checklist before requesting a review
- [ ] I hereby declare my code ready for review.
- [ ] If it is a critical feature, I have added tests.
- [ ] The CI is successful.
- [ ] If there could backward compatibility issues, it has been discussed and planned.




## [OPT] Preview

<!--
Visual aid of your work.
It can either be screenshots or a video.
This could help reviewers to get context quickly.
-->

https://user-images.githubusercontent.com/47107427/211613840-2405fc01-8d47-4589-905d-5857d532bbfb.mov


---


![image](https://user-images.githubusercontent.com/47107427/211613943-c32d6152-f5a6-4bac-b03b-7d95a2925d91.png)
