### PR TITLE
Fix slice widget drag and drop to top position

### DIFF
--- a/cypress/e2e/slices/00-create.cy.js
+++ b/cypress/e2e/slices/00-create.cy.js
@@ -105,4 +105,30 @@ describe("Create Slices", () => {
       .its("content.text")
       .should("equal", "🎉");
   });
+
+  it("allows drag n drop to the top position", () => {
+    // inspired by https://github.com/atlassian/react-beautiful-dnd/blob/master/cypress/integration/reorder.spec.js
+    // could not get it to work with mouse events
+
+    // TODO: use faster fixtures
+    cy.createSlice(lib, sliceId, sliceName);
+
+    cy.get('ul[data-cy="slice-non-repeatable-zone"] > li')
+      .eq(1)
+      .contains("Description");
+
+    cy.get("[data-rbd-draggable-id='list-item-description'] button")
+      .first()
+      .focus()
+      .trigger("keydown", { keyCode: 32 });
+    cy.get("[data-rbd-draggable-id='list-item-description'] button")
+      .first()
+      .trigger("keydown", { keyCode: 38, force: true })
+      .wait(1 * 1000)
+      .trigger("keydown", { keyCode: 32, force: true });
+
+    cy.get('ul[data-cy="slice-non-repeatable-zone"] > li')
+      .eq(0)
+      .contains("Description");
+  });
 });

--- a/packages/slice-machine/.eslintrc.json
+++ b/packages/slice-machine/.eslintrc.json
@@ -17,5 +17,9 @@
     "plugin:jest/recommended",
     "eslint-config-prettier"
   ],
-  "ignorePatterns": ["build", "templates", "**/tests/**", "helpers/**"]
+  "ignorePatterns": ["build", "templates", "**/tests/**", "helpers/**"],
+  "rules": {
+    "@typescript-eslint/prefer-nullish-coalescing": "warn",
+    "@typescript-eslint/strict-boolean-expressions": "warn"
+  }
 }

--- a/packages/slice-machine/lib/builders/SliceBuilder/FieldZones/index.tsx
+++ b/packages/slice-machine/lib/builders/SliceBuilder/FieldZones/index.tsx
@@ -130,7 +130,7 @@ const FieldZones: React.FunctionComponent<FieldZonesProps> = ({
         variation.id,
         widgetArea,
         result.source.index,
-        (result.destination && result.destination.index) || undefined
+        result.destination?.index ?? undefined
       );
     };
 


### PR DESCRIPTION
## Context

https://linear.app/prismic/issue/SM-986/spike-1day-aauser-i-want-to-be-able-to-move-a-slice-field-to-the-top


## The Solution

Prevent the `0` position from being defaulted to `undefined`


## Impact / Dependencies

Added new eslint rules that highlight and help prevent this type of error. Currently only as warning as there are ~400 instances in the code. If added can help us during code reviews to not introduce new ones

- https://typescript-eslint.io/rules/prefer-nullish-coalescing/
- https://typescript-eslint.io/rules/strict-boolean-expressions/




## Checklist before requesting a review
- [ ] I hereby declare my code ready for review.
- [ ] If it is a critical feature, I have added tests.
- [ ] The CI is successful.
- [ ] If there could backward compatibility issues, it has been discussed and planned.




## [OPT] Preview


https://user-images.githubusercontent.com/1148164/212310062-69563971-01e0-4ed0-ac95-06c5cb4d67e9.mov

