### PR TITLE
consistent "log in" wording across the slice machine ui

### DIFF
--- a/packages/slice-machine/components/AuthInstructions/index.js
+++ b/packages/slice-machine/components/AuthInstructions/index.js
@@ -22,7 +22,7 @@ const AuthInstructions = () => (
           borderBottom: (t) => `1px solid ${t.colors?.borders}`,
         }}
       >
-        <Heading as="h3">Login to Prismic</Heading>
+        <Heading as="h3">Log in to Prismic</Heading>
       </Flex>
     )}
   >

--- a/packages/slice-machine/components/ChangesEmptyPage/AuthErrorPage.tsx
+++ b/packages/slice-machine/components/ChangesEmptyPage/AuthErrorPage.tsx
@@ -25,10 +25,10 @@ export const AuthErrorPage = () => {
           Could not access your repository
         </Text>
         <Text sx={{ fontSize: "13px", lineHeight: "24px" }}>
-          You need to login to Prismic in order to push your changes.
+          You need to log in to Prismic in order to push your changes.
         </Text>
         <Button sx={{ mt: "24px" }} onClick={() => openLoginModal()}>
-          Login to Prismic
+          Log in to Prismic
         </Button>
       </Flex>
     </Flex>

--- a/packages/slice-machine/components/LoginModal/index.tsx
+++ b/packages/slice-machine/components/LoginModal/index.tsx
@@ -77,7 +77,7 @@ const LoginModal: React.FunctionComponent = () => {
       closeModals();
     } catch (e) {
       stopLoadingLogin();
-      openToaster("Logging fail", ToasterType.ERROR);
+      openToaster("Login failed", ToasterType.ERROR);
     }
   };
 
@@ -157,7 +157,7 @@ const LoginModal: React.FunctionComponent = () => {
             {isLoginLoading ? (
               <Spinner color="#FFF" size={16} />
             ) : (
-              <>Signin to Prismic</>
+              <>Log in to Prismic</>
             )}
           </Button>
         </Flex>


### PR DESCRIPTION
## Context

https://linear.app/prismic/issue/SM-901/aauser-i-see-consistent-wording-to-log-in-to-prismic


## The Solution


## Impact / Dependencies



## Checklist before requesting a review
- [ ] I hereby declare my code ready for review.
- [ ] If it is a critical feature, I have added tests.
- [ ] The CI is successful.
- [ ] If there could backward compatibility issues, it has been discussed and planned.




## [OPT] Preview

<!--
Visual aid of your work.
It can either be screenshots or a video.
This could help reviewers to get context quickly.
-->




<!--
A funny animal picture is welcome to close your PR!
You can find one here https://unsplash.com/s/photos/funny-animal-picture
-->