### PR TITLE
add e2e test for the tooltips

### DIFF
--- a/cypress/e2e/slices/00-create.cy.js
+++ b/cypress/e2e/slices/00-create.cy.js
@@ -35,7 +35,19 @@ describe("Create Slices", () => {
     cy.get("#variation-add").submit();
 
     cy.contains("button", "Simulate Slice").should("have.attr", "disabled");
+    cy.contains("button", "Simulate Slice").realHover();
+    cy.get("#simulator-button-tooltip").should("be.visible");
+    cy.get("#simulator-button-tooltip").should(
+      "contain",
+      "Save your work in order to simulate"
+    );
     cy.contains("button", "Update screenshot").should("have.attr", "disabled");
+    cy.contains("button", "Update screenshot").realHover();
+    cy.get("#update-screenshot-button-tooltip").should("be.visible");
+    cy.get("#update-screenshot-button-tooltip").should(
+      "contain",
+      "Save your work in order to update the screenshot"
+    );
 
     cy.location("pathname", { timeout: 20000 }).should(
       "eq",

--- a/cypress/support/e2e.js
+++ b/cypress/support/e2e.js
@@ -20,3 +20,5 @@ import "./commands";
 // require('./commands')
 
 import "./assertions";
+
+import "cypress-real-events";

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "dependencies": {
         "cypress": "^12.1.0",
         "cypress-localstorage-commands": "^1.7.0",
+        "cypress-real-events": "^1.7.6",
         "cypress-wait-until": "^1.7.2",
         "start-server-and-test": "^1.14.0"
       },
@@ -5006,6 +5007,14 @@
       },
       "peerDependencies": {
         "cypress": ">=2.1.0"
+      }
+    },
+    "node_modules/cypress-real-events": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/cypress-real-events/-/cypress-real-events-1.7.6.tgz",
+      "integrity": "sha512-yP6GnRrbm6HK5q4DH6Nnupz37nOfZu/xn1xFYqsE2o4G73giPWQOdu6375QYpwfU1cvHNCgyD2bQ2hPH9D7NMw==",
+      "peerDependencies": {
+        "cypress": "^4.x || ^5.x || ^6.x || ^7.x || ^8.x || ^9.x || ^10.x || ^11.x || ^12.x"
       }
     },
     "node_modules/cypress-wait-until": {
@@ -17443,6 +17452,12 @@
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/cypress-localstorage-commands/-/cypress-localstorage-commands-1.7.0.tgz",
       "integrity": "sha512-4v4FrDRPimMStWmiGikyN7OmO2rH0MLI7DMk76dBpb9/sJqCDwa7fAHTUDx6avUEDmO7TFQFgaT3OQTr1HqasQ==",
+      "requires": {}
+    },
+    "cypress-real-events": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/cypress-real-events/-/cypress-real-events-1.7.6.tgz",
+      "integrity": "sha512-yP6GnRrbm6HK5q4DH6Nnupz37nOfZu/xn1xFYqsE2o4G73giPWQOdu6375QYpwfU1cvHNCgyD2bQ2hPH9D7NMw==",
       "requires": {}
     },
     "cypress-wait-until": {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   "dependencies": {
     "cypress": "^12.1.0",
     "cypress-localstorage-commands": "^1.7.0",
+    "cypress-real-events": "^1.7.6",
     "cypress-wait-until": "^1.7.2",
     "start-server-and-test": "^1.14.0"
   },

--- a/packages/slice-machine/lib/builders/SliceBuilder/Header/SimulatorButton/index.tsx
+++ b/packages/slice-machine/lib/builders/SliceBuilder/Header/SimulatorButton/index.tsx
@@ -128,10 +128,9 @@ const SimulatorOnboardingTooltip: React.FC<{
 
 const NeedToSaveTooltip: React.FC = () => (
   <ReactTooltip
-    clickable
     place="bottom"
     effect="solid"
-    delayHide={100}
+    delayHide={500}
     id="simulator-button-tooltip"
   >
     Save your work in order to simulate

--- a/packages/slice-machine/lib/builders/SliceBuilder/Header/SimulatorButton/index.tsx
+++ b/packages/slice-machine/lib/builders/SliceBuilder/Header/SimulatorButton/index.tsx
@@ -128,6 +128,7 @@ const SimulatorOnboardingTooltip: React.FC<{
 
 const NeedToSaveTooltip: React.FC = () => (
   <ReactTooltip
+    clickable
     place="bottom"
     effect="solid"
     delayHide={500}

--- a/packages/slice-machine/lib/builders/SliceBuilder/SideBar/index.tsx
+++ b/packages/slice-machine/lib/builders/SliceBuilder/SideBar/index.tsx
@@ -27,6 +27,7 @@ type SideBarProps = {
 
 const NeedToSaveTooltip: React.FC = () => (
   <ReactTooltip
+    clickable
     place="bottom"
     effect="solid"
     delayHide={500}

--- a/packages/slice-machine/lib/builders/SliceBuilder/SideBar/index.tsx
+++ b/packages/slice-machine/lib/builders/SliceBuilder/SideBar/index.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import { Box, Button as ThemeButton } from "theme-ui";
+import { Box, Button as ThemeButton, Flex } from "theme-ui";
 import Link from "next/link";
 
 import Card from "@components/Card";
@@ -27,10 +27,9 @@ type SideBarProps = {
 
 const NeedToSaveTooltip: React.FC = () => (
   <ReactTooltip
-    clickable
     place="bottom"
     effect="solid"
-    delayHide={100}
+    delayHide={500}
     id="update-screenshot-button-tooltip"
   >
     Save your work in order to update the screenshot
@@ -62,10 +61,13 @@ const SideBar: React.FunctionComponent<SideBarProps> = ({
         bodySx={{ p: 0 }}
         Footer={() => (
           <>
-            <span
+            <Flex
               data-tip
               data-tip-disable={false}
               data-for={"update-screenshot-button-tooltip"}
+              sx={{
+                width: "fit-content",
+              }}
             >
               <Button
                 onClick={openScreenshotsModal}
@@ -76,7 +78,7 @@ const SideBar: React.FunctionComponent<SideBarProps> = ({
                 label="Update screenshot"
                 disabled={isTouched}
               />
-            </span>
+            </Flex>
             {isTouched && <NeedToSaveTooltip />}
           </>
         )}

--- a/packages/slice-machine/lib/builders/SliceBuilder/SideBar/index.tsx
+++ b/packages/slice-machine/lib/builders/SliceBuilder/SideBar/index.tsx
@@ -73,7 +73,7 @@ const SideBar: React.FunctionComponent<SideBarProps> = ({
                 sx={{ fontWeight: "bold" }}
                 Icon={AiOutlineCamera}
                 iconFill="#1A1523"
-                label="Update screenshot!!!"
+                label="Update screenshot"
                 disabled={isTouched}
               />
             </span>


### PR DESCRIPTION
## Context

https://linear.app/prismic/issue/SM-704/aau-when-i-create-a-new-variation-i-see-the-screenshots-and-preview


## The Solution


## Impact / Dependencies


## Checklist before requesting a review
- [ ] I hereby declare my code ready for review.
- [ ] If it is a critical feature, I have added tests.
- [ ] The CI is successful.
- [ ] If there could backward compatibility issues, it has been discussed and planned.


## [OPT] Preview

https://user-images.githubusercontent.com/1148164/212725821-a13e0a78-ed43-4b54-9631-eddd08d72437.mov

