### PR TITLE
Sm 963/mocks with variations

### DIFF
--- a/packages/slice-machine/lib/mock/Slice.ts
+++ b/packages/slice-machine/lib/mock/Slice.ts
@@ -65,13 +65,16 @@ export default function MockSlice(
   sliceDiff?: SliceDiff | undefined
 ): ComponentMocks {
   const sliceMockConfig = buildSliceMockConfig(sliceModel, legacyMockConfig);
+
   return sliceMockConfig.map((sc) => {
     if (!sliceDiff) return SharedSliceMock.generate(sliceModel, sc);
 
     const variationMock = previousMocks?.find(
       (m) => m.variation === sc.variation
     );
-    if (!variationMock) return SharedSliceMock.generate(sliceModel, sc);
+    if (!variationMock) {
+      return SharedSliceMock.generate(sliceModel, sc);
+    }
 
     const patched = SharedSliceMock.patch(
       sliceDiff,
@@ -79,8 +82,12 @@ export default function MockSlice(
       variationMock,
       sc
     );
-    if (!patched.ok || !patched.result)
-      return SharedSliceMock.generate(sliceModel, sc);
+
+    if (!patched.ok || !patched.result) {
+      // odd case here where patched is false with the error "Error: The model of the content with variation default has not changed.", but here it would be regenerated
+      // return SharedSliceMock.generate(sliceModel, sc);
+      return variationMock;
+    }
 
     return patched.result;
   });

--- a/packages/slice-machine/lib/mock/Slice.ts
+++ b/packages/slice-machine/lib/mock/Slice.ts
@@ -83,10 +83,12 @@ export default function MockSlice(
       sc
     );
 
-    if (!patched.ok || !patched.result) {
-      // odd case here where patched is false with the error "Error: The model of the content with variation default has not changed.", but here it would be regenerated
-      // return SharedSliceMock.generate(sliceModel, sc);
+    if (!patched.ok) {
       return variationMock;
+    }
+
+    if (!patched.result) {
+      return SharedSliceMock.generate(sliceModel, sc);
     }
 
     return patched.result;

--- a/packages/slice-machine/tests/lib/mock/Slice.test.ts
+++ b/packages/slice-machine/tests/lib/mock/Slice.test.ts
@@ -229,7 +229,7 @@ describe("MockSlice", () => {
   //   expect(isRight(result)).toBeTruthy();
   // });
 
-  test.only("when i add a variation to a slice it should the old mock content should be kept", () => {
+  test("when i add a variation to a slice it should the old mock content should be kept", () => {
     const sliceModel: SharedSlice = {
       id: "testing",
       type: "SharedSlice",
@@ -386,7 +386,7 @@ describe("MockSlice", () => {
                 content: {
                   text: "Woo",
                 },
-                direction: "ltr",
+                // direction: "ltr",
               },
             ],
           },

--- a/packages/slice-machine/tests/lib/mock/Slice.test.ts
+++ b/packages/slice-machine/tests/lib/mock/Slice.test.ts
@@ -1,12 +1,17 @@
 import "@testing-library/jest-dom";
 import { WidgetTypes } from "@prismicio/types-internal/lib/customtypes/widgets";
-import { SlicesTypes } from "@prismicio/types-internal/lib/customtypes/widgets/slices";
+import {
+  SharedSlice,
+  SlicesTypes,
+} from "@prismicio/types-internal/lib/customtypes/widgets/slices";
 import { Slices, SliceSM } from "@slicemachine/core/build/models";
 import { isRight } from "fp-ts/lib/Either";
 import MockSlice from "../../../lib/mock/Slice";
 // import allFieldSliceModel from "../../../tests/__mocks__/sliceModel";
 import { GeoPointContent } from "@prismicio/types-internal/lib/documents/widgets/nestable";
 import { LinkContent } from "@prismicio/types-internal/lib/documents/widgets/nestable/Link";
+import { SharedSliceContent } from "@prismicio/types-internal/lib/content";
+import { SliceDiff } from "@prismicio/types-internal/lib/customtypes/diff";
 
 jest.mock("lorem-ipsum", () => {
   return {
@@ -223,4 +228,198 @@ describe("MockSlice", () => {
   //   const result = SliceMock.decode(mock);
   //   expect(isRight(result)).toBeTruthy();
   // });
+
+  test.only("when i add a variation to a slice it should the old mock content should be kept", () => {
+    const sliceModel: SharedSlice = {
+      id: "testing",
+      type: "SharedSlice",
+      name: "Testing",
+      description: "Testing",
+      variations: [
+        {
+          id: "default",
+          name: "Default",
+          docURL: "...",
+          version: "sktwi1xtmkfgx8626",
+          description: "Testing",
+          primary: {
+            title: {
+              type: "StructuredText",
+              config: {
+                single: "heading1",
+                label: "Title",
+                placeholder: "This is where it all begins...",
+              },
+            },
+            description: {
+              type: "StructuredText",
+              config: {
+                single: "paragraph",
+                label: "Description",
+                placeholder: "A nice description of your feature",
+              },
+            },
+          },
+          items: {},
+          imageUrl:
+            "https://images.prismic.io/slice-machine/621a5ec4-0387-4bc5-9860-2dd46cbc07cd_default_ss.png?auto=compress,format",
+        },
+        {
+          id: "foo",
+          name: "Foo",
+          docURL: "...",
+          version: "sktwi1xtmkfgx8626",
+          description: "Testing",
+          primary: {
+            title: {
+              type: "StructuredText",
+              config: {
+                single: "heading1",
+                label: "Title",
+                placeholder: "This is where it all begins...",
+              },
+            },
+            description: {
+              type: "StructuredText",
+              config: {
+                single: "paragraph",
+                label: "Description",
+                placeholder: "A nice description of your feature",
+              },
+            },
+          },
+          items: {},
+          imageUrl:
+            "https://images.prismic.io/slice-machine/621a5ec4-0387-4bc5-9860-2dd46cbc07cd_default_ss.png?auto=compress,format",
+        },
+      ],
+    };
+    const legacyMockConfig = {};
+    const previousMocks: SharedSliceContent[] = [
+      {
+        __TYPE__: "SharedSliceContent",
+        variation: "default",
+        primary: {
+          title: {
+            __TYPE__: "StructuredTextContent",
+            value: [
+              {
+                type: "heading1",
+                content: {
+                  text: "Test Heading",
+                  // "spans": []
+                },
+                // "direction": "ltr"
+              },
+            ],
+          },
+          description: {
+            __TYPE__: "StructuredTextContent",
+            value: [
+              {
+                type: "paragraph",
+                content: {
+                  text: "Some text on the default slice.",
+                },
+              },
+            ],
+          },
+        },
+        items: [
+          {
+            __TYPE__: "GroupItemContent",
+            value: [],
+          },
+        ],
+      },
+    ];
+    const sliceDiff: SliceDiff = {
+      op: "updated",
+      value: {
+        variations: {
+          foo: {
+            op: "added",
+            value: {
+              id: "foo",
+              name: "Foo",
+              docURL: "...",
+              version: "sktwi1xtmkfgx8626",
+              description: "Testing",
+              primary: {
+                title: {
+                  type: "StructuredText",
+                  config: {
+                    single: "heading1",
+                    label: "Title",
+                    placeholder: "This is where it all begins...",
+                  },
+                },
+                description: {
+                  type: "StructuredText",
+                  config: {
+                    single: "paragraph",
+                    label: "Description",
+                    placeholder: "A nice description of your feature",
+                  },
+                },
+              },
+              items: {},
+              imageUrl:
+                "https://images.prismic.io/slice-machine/621a5ec4-0387-4bc5-9860-2dd46cbc07cd_default_ss.png?auto=compress,format",
+            },
+          },
+        },
+      },
+    };
+
+    const wanted = [
+      ...previousMocks,
+      {
+        __TYPE__: "SharedSliceContent",
+        variation: "foo",
+        primary: {
+          title: {
+            __TYPE__: "StructuredTextContent",
+            value: [
+              {
+                type: "heading1",
+                content: {
+                  text: "Woo",
+                },
+                direction: "ltr",
+              },
+            ],
+          },
+          description: {
+            __TYPE__: "StructuredTextContent",
+            value: [
+              {
+                type: "paragraph",
+                content: {
+                  text: "Some text.",
+                },
+              },
+            ],
+          },
+        },
+        items: [
+          {
+            __TYPE__: "GroupItemContent",
+            value: [],
+          },
+        ],
+      },
+    ];
+
+    const results = MockSlice(
+      sliceModel,
+      legacyMockConfig,
+      previousMocks,
+      sliceDiff
+    );
+
+    // check the content is unchanged
+    expect(results[0]).toEqual(previousMocks[0]);
+    expect(results).toEqual(wanted);
+  });
 });


### PR DESCRIPTION
## Context
ticket: https://linear.app/prismic/issue/SM-963/%5Bspike%5D-adding-new-slice-variation-resets-editor-mocks-of-the-existing

Adding new Slice variation resets editor mocks of the existing variations

Scenario

Create a Slice 

Open the Simulator, set mocks on the Default variation and save them

Got to the slice page, create a new slice variation, save

Refresh the simulator

Actual behaviour

Mocks are re-generated on the Default variation

Expected behaviour

Mocks of the Default variation are preserved

<!--
Please include either
- a ticket
    - [Link text Here](https://link-url-here.org)

- a github issue / forum thread
    - Fixes #

- a detailed description of the issue and it's implications

This part should always include acceptance criteria weither they are accessible on a link or written here directly.
-->




## The Solution

return the variation mock :)




## Checklist before requesting a review
- [x] I hereby declare my code ready for review.
- [x] If it is a critical feature, I have added tests.
- [x] The CI is successful.
- [ ] If there could backward compatibility issues, it has been discussed and planned.




## [OPT] Preview

<!--
Visual aid of your work.
It can either be screenshots or a video.
This could help reviewers to get context quickly.
-->




<!--
A funny animal picture is welcome to close your PR!
You can find one here https://unsplash.com/s/photos/funny-animal-picture
-->
![82060872_598821160679421_6173575182179455260_n](https://user-images.githubusercontent.com/7499570/212923148-6ebc5723-89d4-43d2-9268-41c84db6159f.jpg)
