### PR TITLE
prevent rerender loop in screenshot

### DIFF
--- a/packages/slice-machine/pages/[lib]/[sliceName]/[variation]/screenshot.tsx
+++ b/packages/slice-machine/pages/[lib]/[sliceName]/[variation]/screenshot.tsx
@@ -29,7 +29,7 @@ const Screenshot: ComponentWithSliceProps = ({ slice, variation }) => {
     variationID: variation.id,
   });
 
-  if (!simulatorUrl) {
+  if (simulatorUrl === undefined) {
     return null;
   }
 

--- a/packages/slice-machine/src/hooks/useEditorContent.ts
+++ b/packages/slice-machine/src/hooks/useEditorContent.ts
@@ -1,3 +1,4 @@
+import { useMemo } from "react";
 import { ComponentUI } from "@lib/models/common/ComponentUI";
 import { defaultSharedSliceContent } from "@src/utils/editor";
 import { renderSliceMock } from "@prismicio/mocks";
@@ -15,10 +16,10 @@ function useEditorContentOnce({
     slice.mock?.find((m) => m.variation === variationID) ||
     defaultSharedSliceContent(variationID);
 
-  const apiContent = {
+  const apiContent = useMemo(() => ({
     ...(renderSliceMock(Slices.fromSM(slice.model), editorContent) as object),
     id: slice.model.id,
-  };
+  }), []);
 
   return { editorContent, apiContent };
 }

--- a/packages/slice-machine/src/hooks/useEditorContent.ts
+++ b/packages/slice-machine/src/hooks/useEditorContent.ts
@@ -19,7 +19,7 @@ function useEditorContentOnce({
   const apiContent = useMemo(() => ({
     ...(renderSliceMock(Slices.fromSM(slice.model), editorContent) as object),
     id: slice.model.id,
-  }), []);
+  }), [slice.model]);
 
   return { editorContent, apiContent };
 }

--- a/packages/slice-machine/src/hooks/useEditorContent.ts
+++ b/packages/slice-machine/src/hooks/useEditorContent.ts
@@ -16,10 +16,13 @@ function useEditorContentOnce({
     slice.mock?.find((m) => m.variation === variationID) ||
     defaultSharedSliceContent(variationID);
 
-  const apiContent = useMemo(() => ({
-    ...(renderSliceMock(Slices.fromSM(slice.model), editorContent) as object),
-    id: slice.model.id,
-  }), [slice.model]);
+  const apiContent = useMemo(
+    () => ({
+      ...(renderSliceMock(Slices.fromSM(slice.model), editorContent) as object),
+      id: slice.model.id,
+    }),
+    [slice.model, editorContent]
+  );
 
   return { editorContent, apiContent };
 }


### PR DESCRIPTION
Fixes https://linear.app/prismic/issue/SM-983/[performance]-screenshot-page-renders-continuously-causing-high-cpu