### PR TITLE
WIP use dev server in local e2e tests for hot reload

### DIFF
--- a/cypress.config.js
+++ b/cypress.config.js
@@ -1,5 +1,7 @@
 const { defineConfig } = require("cypress");
 
+const SERVER_PORT = process.env.SERVER_PORT;
+
 module.exports = defineConfig({
   viewportWidth: 1920,
   viewportHeight: 1080,
@@ -12,6 +14,6 @@ module.exports = defineConfig({
     setupNodeEvents(on, config) {
       return require("./cypress/plugins/index.js")(on, config);
     },
-    baseUrl: "http://localhost:9999",
+    baseUrl: `http://localhost:${SERVER_PORT}`,
   },
 });

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "pretty": "prettier --write .",
     "prettier:check": "prettier --check .",
     "test": "lerna run test --stream -- -- --collectCoverage=false",
+    "test:e2e:fast": "SERVER_PORT=9997 start-server-and-test 'npm run dev-cypress --prefix packages/slice-machine' http://localhost:3001 'npm run dev-server-cypress --prefix packages/slice-machine' http://localhost:9997 'cypress open'",
     "test:e2e": "npm run cypress-setup && start-server-and-test 'npm run dev --prefix e2e-projects/cypress-next-app' http://localhost:3000 'NO_SENTRY=1 npm run slicemachine --prefix e2e-projects/cypress-next-app' http://localhost:9999 'cypress run'",
     "test:e2e:dev": "npm run cypress-setup && start-server-and-test 'npm run dev --prefix e2e-projects/cypress-next-app' http://localhost:3000 'NO_SENTRY=1 npm run slicemachine --prefix e2e-projects/cypress-next-app' http://localhost:9999 'cypress open'",    
     "::changeset": "npm run changeset add && git add .changeset && git commit -m '[release:changelog] update changeset'; echo 'We commited your changeset. You should defo push this master ✌️'",

--- a/packages/slice-machine/package.json
+++ b/packages/slice-machine/package.json
@@ -13,7 +13,7 @@
   },
   "scripts": {
     "dev": "concurrently \"next dev\" \"npm run dev --prefix ../../e2e-projects/next\"",
-    "dev-cypress": "concurrently \"next dev\" \"npm run dev --prefix ../../e2e-projects/cypress-next-app\"",
+    "dev-cypress": "concurrently \"next dev -p 3001\" \"npm run dev --prefix ../../e2e-projects/cypress-next-app\"",
     "test": "jest",
     "watch-test": "jest --watch",
     "config": "tsc --showConfig",
@@ -21,7 +21,7 @@
     "postinstall": "node postinstall",
     "prepublishOnly": "npm run bundle",
     "dev-server": "cross-env PORT=9999 CWD=../../e2e-projects/next ENV=SM NO_SENTRY=1 concurrently \"rollup -w -c ./rollup-server.config.js\" \"nodemon --inspect -e ts,js --watch server --watch lib --ignore build/ build/server/index.js\"",
-    "dev-server-cypress": "cross-env PORT=9999 CWD=../../e2e-projects/cypress-next-app ENV=SM NO_SENTRY=1 concurrently \"rollup -w -c ./rollup-server.config.js\" \"nodemon -e ts,js --watch server --watch lib --ignore build/ build/server/index.js\"",
+    "dev-server-cypress": "cross-env PORT=9997 NEXT_PORT=3001 CWD=../../e2e-projects/cypress-next-app ENV=SM NO_SENTRY=1 concurrently \"rollup -w -c ./rollup-server.config.js\" \"nodemon -e ts,js --watch server --watch lib --ignore build/ build/server/index.js\"",
     "prod-server": "cross-env PORT=9999 CWD=../../e2e-projects/next concurrently \"rollup -w -c ./rollup-server.config.js\" \"nodemon -e ts,js --watch server --watch lib --ignore build/ build/server/index.js\"",
     "build": "npm run build-scripts && npm run build-server && npm run build-next-app",
     "build-scripts": "tsc --project scripts/tsconfig.json",

--- a/packages/slice-machine/server/src/index.ts
+++ b/packages/slice-machine/server/src/index.ts
@@ -44,9 +44,10 @@ app.use("/api", api);
 // For local env (SM), all the requests are forwarded to the next dev server
 // For production, all the requests are forwarded to the next build directory
 if (process.env.ENV === "SM") {
+  const NEXT_PORT = process.env.NEXT_PORT ?? "3000";
   const proxy = createProxyMiddleware({
     changeOrigin: true,
-    target: "http://localhost:3000",
+    target: `http://localhost:${NEXT_PORT}`,
     ws: true,
   });
   app.use(proxy);


### PR DESCRIPTION
## Context

As part of a bigger improvement around e2e test DX here: https://www.notion.so/prismic/Slice-Machine-E2E-tests-c57f7e45524947ffa669d349417fc80b

This specific PR is targeting **As a developer, I can easily run e2e tests locally** with the following features:

- E2E tests can be run on the cypress project without having to kill your other dev servers (they are configured to run on ports 3001 and 9997).
- This is done with only 1 command, and the test suite now takes roughly **20 seconds to start**
- These are dev servers started with this command, meaning that we get hot reload of the code and don’t need to bundle the app to get new changes.

## The Solution

The demo `test:e2e:fast` script starts the dev server on 9997 and the example project on 3001.

You can see the old and new flow for starting e2e tests here:
![Prismic - 5s - Cypress dev - after](https://user-images.githubusercontent.com/47107427/214895649-69c6005f-551d-4dfe-8ee7-1c5b739fc84c.png)

## Impact / Dependencies

We still need to add an option (either a flag or CLI) for forcing the refresh of the e2e project. This would need to be run only when the project is deleted for some reason (e.g. cloned the project to a new repo), or CI.

## Checklist before requesting a review
- [ ] I hereby declare my code ready for review.
- [ ] If it is a critical feature, I have added tests.
- [ ] The CI is successful.
- [ ] If there could backward compatibility issues, it has been discussed and planned.



![image](https://user-images.githubusercontent.com/47107427/214895533-830ea668-1739-41b5-9227-cfdd9383f2f0.png)
