### PR TITLE
fix flaky e2e custom screenshots test

### DIFF
--- a/cypress/e2e/user-flows/scenario_custom_screenshots.cy.js
+++ b/cypress/e2e/user-flows/scenario_custom_screenshots.cy.js
@@ -77,6 +77,8 @@ describe("I am an existing SM user and I want to upload screenshots on variation
   it("Error displayed when non-image files are uploaded", () => {
     slicePage.goTo(slice.library, slice.name);
     slicePage.addVariation("Error handling");
+    cy.saveSliceModifications();
+
     slicePage.openScreenshotModal();
     cy.contains("Select file").selectFile(
       {

--- a/cypress/e2e/user-flows/scenario_custom_screenshots.cy.js
+++ b/cypress/e2e/user-flows/scenario_custom_screenshots.cy.js
@@ -3,12 +3,12 @@ import { SliceCard } from "../../pages/slices/sliceCard";
 import { SlicePage } from "../../pages/slices/slicePage";
 import { Menu } from "../../pages/Menu";
 
-describe.skip("I am an existing SM user and I want to upload screenshots on variations of an existing Slice", () => {
+describe("I am an existing SM user and I want to upload screenshots on variations of an existing Slice", () => {
   const random = Date.now();
 
   const slice = {
-    id: `test_screenshots${random}`,
-    name: `TestScreenshots${random}`,
+    id: `test_custom_screenshots${random}`,
+    name: `TestCustomScreenshots${random}`,
     library: "slices",
   };
 

--- a/cypress/e2e/user-flows/scenario_custom_screenshots.cy.js
+++ b/cypress/e2e/user-flows/scenario_custom_screenshots.cy.js
@@ -1,7 +1,8 @@
 import { ScreenshotModal } from "../../pages/slices/screenshotModal";
 import { SliceCard } from "../../pages/slices/sliceCard";
 import { SlicePage } from "../../pages/slices/slicePage";
-import { Menu } from "../../pages/Menu";
+import { ChangesPage } from "../../pages/changesPage";
+import { Menu } from "../../pages/menu";
 
 describe("I am an existing SM user and I want to upload screenshots on variations of an existing Slice", () => {
   const random = Date.now();
@@ -51,12 +52,14 @@ describe("I am an existing SM user and I want to upload screenshots on variation
     cy.saveSliceModifications();
 
     const menu = new Menu();
+    const changes = new ChangesPage();
     const sliceCard = new SliceCard(slice.name);
 
     menu.navigateTo("Slices");
     sliceCard.imagePreview.isSameImageAs(defaultScreenshot);
 
     menu.navigateTo("Changes");
+    changes.screenshotsButton.should("be.visible");
     sliceCard.content.should("include.text", "1/2 screenshots missing");
     sliceCard.imagePreview.isSameImageAs(defaultScreenshot);
 

--- a/cypress/e2e/user-flows/scenario_custom_screenshots.cy.js
+++ b/cypress/e2e/user-flows/scenario_custom_screenshots.cy.js
@@ -27,10 +27,9 @@ describe.skip("I am an existing SM user and I want to upload screenshots on vari
 
   beforeEach("Start from the Slice page", () => {
     cy.setSliceMachineUserContext({});
-    slicePage.goTo(slice.library, slice.name);
   });
 
-  it("Upload and replace a screenshot on the default variation", () => {
+  it("Upload and replace custom screenshots", () => {
     // Upload custom screenshot on default variation
     slicePage.imagePreview.should("not.exist");
     slicePage.openScreenshotModal();
@@ -76,6 +75,7 @@ describe.skip("I am an existing SM user and I want to upload screenshots on vari
   });
 
   it("Error displayed when non-image files are uploaded", () => {
+    slicePage.goTo(slice.library, slice.name);
     slicePage.addVariation("Error handling");
     slicePage.openScreenshotModal();
     cy.contains("Select file").selectFile(

--- a/cypress/e2e/user-flows/scenario_custom_screenshots.cy.js
+++ b/cypress/e2e/user-flows/scenario_custom_screenshots.cy.js
@@ -23,6 +23,8 @@ describe("I am an existing SM user and I want to upload screenshots on variation
   before("Cleanup local data and create a new slice", () => {
     cy.clearProject();
     cy.setSliceMachineUserContext({});
+    // Push all local changes in case there are deleted slices
+    cy.pushLocalChanges();
     cy.createSlice(slice.library, slice.id, slice.name);
   });
 

--- a/cypress/e2e/user-flows/transactional-push.cy.js
+++ b/cypress/e2e/user-flows/transactional-push.cy.js
@@ -1,5 +1,5 @@
 import { SlicePage } from "../../pages/slices/slicePage";
-import { Menu } from "../../pages/Menu";
+import { Menu } from "../../pages/menu";
 
 describe("I am an existing SM user and I want to push local changes", () => {
   const random = Date.now();

--- a/cypress/pages/Menu.js
+++ b/cypress/pages/Menu.js
@@ -1,5 +1,10 @@
 export class Menu {
+  /**
+   * @param {('Custom Types'|'Slices'|'Changes')} label - The menu item to click
+   */
   navigateTo(label) {
-    return cy.get("aside").contains(label).click();
+    cy.get("aside").contains(label).click();
+    cy.get("main a").contains(label);
+    return this;
   }
 }

--- a/cypress/pages/changesPage.js
+++ b/cypress/pages/changesPage.js
@@ -1,0 +1,5 @@
+export class ChangesPage {
+  get screenshotsButton() {
+    return cy.get("button").contains("Update all screenshots");
+  }
+}

--- a/cypress/pages/menu.js
+++ b/cypress/pages/menu.js
@@ -3,8 +3,6 @@ export class Menu {
    * @param {('Custom Types'|'Slices'|'Changes')} label - The menu item to click
    */
   navigateTo(label) {
-    cy.get("aside").contains(label).click();
-    cy.get("main a").contains(label);
-    return this;
+    return cy.get("aside").contains(label).click();
   }
 }


### PR DESCRIPTION
## Context

https://linear.app/prismic/issue/SM-1001/[spike]-upload-screenshots-e2e-test-is-flaky

The Slice screenshot was sometimes disappearing right after being successfully uploaded and displayed, making the test fail. I could not reproduce when interacting with the browser as a human. 


## The Solution

- I noticed that not reloading the Slice page after having created the slice solved the issue. i.e. not calling `slicePage.goTo(library, name)`
- Moved the test to the `slices` folder with a comprehensive name
- Used `md5` instead of `sha256` to compute the image hash as `sha256` seemed unnecessary (not linked to the flakiness)

## Impact / Dependencies

## Checklist before requesting a review
- [ ] I hereby declare my code ready for review.
- [x] If it is a critical feature, I have added tests.
- [ ] The CI is successful.
- [x] If there could backward compatibility issues, it has been discussed and planned.

![image](https://images.unsplash.com/photo-1560743641-3914f2c45636?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=200&q=80)
