### PR TITLE
fix error toast continuously showing on the changes page

### DIFF
--- a/packages/slice-machine/components/DeleteDocumentsDrawer/HardDeleteDocumentsDrawer.tsx
+++ b/packages/slice-machine/components/DeleteDocumentsDrawer/HardDeleteDocumentsDrawer.tsx
@@ -25,6 +25,8 @@ export const HardDeleteDocumentsDrawer: React.FunctionComponent = () => {
 
   const { pushChanges, closeModals, openToaster } = useSliceMachineActions();
 
+  if (!isDeleteDocumentsDrawerOpen) return null;
+
   if (!modalData?.details.customTypes) {
     openToaster("No change data", ToasterType.ERROR);
     return null;

--- a/packages/slice-machine/components/DeleteDocumentsDrawer/SoftDeleteDocumentsDrawer.tsx
+++ b/packages/slice-machine/components/DeleteDocumentsDrawer/SoftDeleteDocumentsDrawer.tsx
@@ -54,6 +54,8 @@ export const SoftDeleteDocumentsDrawer: React.FunctionComponent = () => {
 
   const { pushChanges, closeModals, openToaster } = useSliceMachineActions();
 
+  if (!isDeleteDocumentsDrawerOpen) return null;
+
   if (!modalData?.details.customTypes) {
     openToaster("No change data", ToasterType.ERROR);
     return null;


### PR DESCRIPTION
## Context

The No change data toast kept being shown on the changes page since we lost the early return when the modal shouldn't have been open.


## The Solution

<!--
Highlight explanations where the complexity in your development is.
Keep in mind that the reviewer might not have as much context as you do.
This is very important to make sure the review is thorough and the reviewer understand your changes.
-->




## Impact / Dependencies

<!--
List all the impacts your development might have on internal and external features.
Ideally this should have been discussed prior to this development.

Link of any other PRs that are related to this development.
They should also be referenced in the ticket for reviews.
-->




## Checklist before requesting a review
- [ ] I hereby declare my code ready for review.
- [ ] If it is a critical feature, I have added tests.
- [ ] The CI is successful.
- [ ] If there could backward compatibility issues, it has been discussed and planned.




## [OPT] Preview

<!--
Visual aid of your work.
It can either be screenshots or a video.
This could help reviewers to get context quickly.
-->




<!--
A funny animal picture is welcome to close your PR!
You can find one here https://unsplash.com/s/photos/funny-animal-picture
-->