### PR TITLE
Don't show references error for legacy slice

### DIFF
--- a/packages/slice-machine/server/src/api/pushChanges/checkCustomTypes.ts
+++ b/packages/slice-machine/server/src/api/pushChanges/checkCustomTypes.ts
@@ -15,7 +15,8 @@ export function getCustomTypesWithInvalidReferences(
       ct.tabs.some((tab) =>
         tab.sliceZone?.value.some(
           (z) =>
-            !localSliceIds.includes(z.key) && z.value.type !== SlicesTypes.Slice
+            !localSliceIds.includes(z.key) &&
+            z.value.type === SlicesTypes.SharedSlice
         )
       )
     )

--- a/packages/slice-machine/server/src/api/pushChanges/checkCustomTypes.ts
+++ b/packages/slice-machine/server/src/api/pushChanges/checkCustomTypes.ts
@@ -1,5 +1,6 @@
 import type { CustomTypeSM } from "@slicemachine/core/build/models/CustomType";
 import type { Component, Library } from "@slicemachine/core/build/models";
+import { SlicesTypes } from "@prismicio/types-internal/lib/customtypes/widgets/slices";
 
 export function getCustomTypesWithInvalidReferences(
   localCustomTypes: CustomTypeSM[],
@@ -12,7 +13,10 @@ export function getCustomTypesWithInvalidReferences(
   return localCustomTypes
     .filter((ct) =>
       ct.tabs.some((tab) =>
-        tab.sliceZone?.value.some((z) => !localSliceIds.includes(z.key))
+        tab.sliceZone?.value.some(
+          (z) =>
+            !localSliceIds.includes(z.key) && z.value.type !== SlicesTypes.Slice
+        )
       )
     )
     .map((ct) => ({


### PR DESCRIPTION
## Context

Issue: https://linear.app/prismic/issue/SM-994#comment-6a542572


## The Solution

We check that the slice is not a legacy slice when checking if the slices is in the local libraries.


## Impact / Dependencies

<!--
List all the impacts your development might have on internal and external features.
Ideally this should have been discussed prior to this development.

Link of any other PRs that are related to this development.
They should also be referenced in the ticket for reviews.
-->




## Checklist before requesting a review
- [ ] I hereby declare my code ready for review.
- [ ] If it is a critical feature, I have added tests.
- [ ] The CI is successful.
- [ ] If there could backward compatibility issues, it has been discussed and planned.




## [OPT] Preview

![image](https://user-images.githubusercontent.com/47107427/218814780-a01d9644-1b04-46ef-80d0-c31a0dff4876.png)