### PR TITLE
Cleanup selected CT store when exiting the CT page

### DIFF
--- a/packages/slice-machine/pages/cts/[ct].tsx
+++ b/packages/slice-machine/pages/cts/[ct].tsx
@@ -49,10 +49,21 @@ const CustomTypeBuilderWithRouter = () => {
     })
   );
 
+  const { cleanupCustomTypeStore } = useSliceMachineActions();
+
   useEffect(() => {
     if (!selectedCustomType || !hasLocal(selectedCustomType))
       void router.replace("/");
   }, [selectedCustomType, router]);
+
+  useEffect(() => {
+    router.events.on("routeChangeStart", cleanupCustomTypeStore);
+
+    return () => {
+      cleanupCustomTypeStore();
+      router.events.off("routeChangeStart", cleanupCustomTypeStore);
+    };
+  }, []);
 
   if (!selectedCustomType || !hasLocal(selectedCustomType)) {
     return null;

--- a/packages/slice-machine/pages/cts/[ct].tsx
+++ b/packages/slice-machine/pages/cts/[ct].tsx
@@ -57,12 +57,11 @@ const CustomTypeBuilderWithRouter = () => {
   }, [selectedCustomType, router]);
 
   useEffect(() => {
-    router.events.on("routeChangeStart", cleanupCustomTypeStore);
-
     return () => {
       cleanupCustomTypeStore();
-      router.events.off("routeChangeStart", cleanupCustomTypeStore);
     };
+    // we don't want to re-run this effect when the cleanupCustomTypeStore is redefined
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   if (!selectedCustomType || !hasLocal(selectedCustomType)) {

--- a/packages/slice-machine/src/modules/selectedCustomType/actions.ts
+++ b/packages/slice-machine/src/modules/selectedCustomType/actions.ts
@@ -8,6 +8,7 @@ import {
 
 export type SelectedCustomTypeActions =
   | ActionType<typeof initCustomTypeStoreCreator>
+  | ActionType<typeof cleanupCustomTypeStoreCreator>
   | ActionType<typeof saveCustomTypeCreator>
   | ActionType<typeof updateFieldMockConfigCreator>
   | ActionType<typeof deleteFieldMockConfigCreator>
@@ -33,6 +34,10 @@ export const initCustomTypeStoreCreator = createAction("CUSTOM_TYPE/INIT")<{
   remoteModel: CustomTypeSM | undefined;
   mockConfig: CustomTypeMockConfig;
 }>();
+
+export const cleanupCustomTypeStoreCreator = createAction(
+  "CUSTOM_TYPE/CLEANUP"
+)();
 
 // Async actions
 export const saveCustomTypeCreator = createAsyncAction(

--- a/packages/slice-machine/src/modules/selectedCustomType/reducer.ts
+++ b/packages/slice-machine/src/modules/selectedCustomType/reducer.ts
@@ -6,6 +6,7 @@ import {
   updateTabCreator,
   SelectedCustomTypeActions,
   initCustomTypeStoreCreator,
+  cleanupCustomTypeStoreCreator,
   addFieldCreator,
   deleteTabCreator,
   createSliceZoneCreator,
@@ -42,6 +43,8 @@ export const selectedCustomTypeReducer: Reducer<
   SelectedCustomTypeActions
 > = (state = null, action) => {
   switch (action.type) {
+    case getType(cleanupCustomTypeStoreCreator):
+      return null;
     case getType(initCustomTypeStoreCreator):
       return {
         ...state,

--- a/packages/slice-machine/src/modules/useSliceMachineActions.ts
+++ b/packages/slice-machine/src/modules/useSliceMachineActions.ts
@@ -50,6 +50,7 @@ import {
   deleteGroupFieldMockConfigCreator,
   deleteFieldMockConfigCreator,
   updateFieldMockConfigCreator,
+  cleanupCustomTypeStoreCreator,
 } from "./selectedCustomType";
 import { CustomTypeMockConfig } from "@models/common/MockConfig";
 import {
@@ -174,6 +175,8 @@ const useSliceMachineActions = () => {
     remoteModel: CustomTypeSM | undefined,
     mockConfig: CustomTypeMockConfig
   ) => dispatch(initCustomTypeStoreCreator({ model, mockConfig, remoteModel }));
+  const cleanupCustomTypeStore = () =>
+    dispatch(cleanupCustomTypeStoreCreator());
   const saveCustomType = () => dispatch(saveCustomTypeCreator.request());
   const createCustomTypeTab = (tabId: string) =>
     dispatch(createTabCreator({ tabId }));
@@ -514,6 +517,7 @@ const useSliceMachineActions = () => {
     renameCustomType,
     deleteCustomType,
     initCustomTypeStore,
+    cleanupCustomTypeStore,
     saveCustomType,
     createCustomTypeTab,
     updateCustomTypeTab,

--- a/packages/slice-machine/tests/src/modules/selectedCustomType/reducer.test.ts
+++ b/packages/slice-machine/tests/src/modules/selectedCustomType/reducer.test.ts
@@ -13,6 +13,7 @@ import {
   replaceFieldCreator,
   replaceSharedSliceCreator,
   updateTabCreator,
+  cleanupCustomTypeStoreCreator,
 } from "@src/modules/selectedCustomType";
 import { SelectedCustomTypeStoreType } from "@src/modules/selectedCustomType/types";
 import * as widgets from "@models/common/widgets/withGroup";
@@ -40,6 +41,15 @@ describe("[Selected Custom type module]", () => {
       expect(
         selectedCustomTypeReducer(dummyCustomTypesState, { type: "NO.MATCH" })
       ).toEqual(dummyCustomTypesState);
+    });
+
+    it("should reset the custom type state given CUSTOM_TYPE/CLEANUP action", () => {
+      expect(
+        selectedCustomTypeReducer(
+          dummyCustomTypesState,
+          cleanupCustomTypeStoreCreator()
+        )
+      ).toEqual(null);
     });
 
     it("should update the custom type state given CUSTOM_TYPE/INIT action", () => {


### PR DESCRIPTION
## Context

Linear ticket with bug: https://linear.app/prismic/issue/SM-1033/aauser-i-want-to-see-the-legacy-slice-migration-link-only-on-ct-using


## The Solution

The problem is that after you have just visited a custom type with legacy slices, this CT is still loaded in the `selectedCustomType` store. So when you open another one, the page is initially rendered with the info of the one in the store (since this is what the selector returns). 

This isn't a problem for most of the content on the page (this behaviour is not new) since the subsequent re-render happens to fast that you don't notice the change. But since the warning toast remains on the page for a few seconds, it becomes a problem.

<img width="884" alt="image" src="https://user-images.githubusercontent.com/47107427/219026562-b3e630e3-e065-4c00-ab72-2d1274fedde1.png">


## Impact / Dependencies

<!--
List all the impacts your development might have on internal and external features.
Ideally this should have been discussed prior to this development.

Link of any other PRs that are related to this development.
They should also be referenced in the ticket for reviews.
-->




## Checklist before requesting a review
- [ ] I hereby declare my code ready for review.
- [ ] If it is a critical feature, I have added tests.
- [ ] The CI is successful.
- [ ] If there could backward compatibility issues, it has been discussed and planned.




## [OPT] Preview


https://user-images.githubusercontent.com/47107427/219027282-9c8556f7-b3b0-4a4b-8828-ef437bdc3f36.mov

