### PR TITLE
fix iframe connection

### DIFF
--- a/packages/slice-machine/src/modules/simulator/index.ts
+++ b/packages/slice-machine/src/modules/simulator/index.ts
@@ -12,7 +12,6 @@ import {
   race,
   take,
   delay,
-  CallEffect,
   SagaReturnType,
 } from "redux-saga/effects";
 import {
@@ -199,21 +198,22 @@ function* connectToSimulatorIframe() {
   yield put(connectToSimulatorIframeCreator.request());
   // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
   const {
-    timeout,
-    iframeCheckKO,
+    iframeCheckOk
   }: {
-    iframeCheckKO: ReturnType<typeof connectToSimulatorIframeCreator.failure>;
-    timeout: CallEffect<true>;
+    iframeCheckOk: ReturnType<typeof connectToSimulatorIframeCreator.success>;
   } = yield race({
     iframeCheckOk: take(getType(connectToSimulatorIframeCreator.success)),
     iframeCheckKO: take(getType(connectToSimulatorIframeCreator.failure)),
-    timeout: delay(5000),
+    timeout: delay(20000),
   });
-  if (timeout || iframeCheckKO) {
-    yield put(connectToSimulatorIframeCreator.failure());
+
+  if(iframeCheckOk) {
+    yield put(connectToSimulatorIframeCreator.success());
     return;
   }
-  yield put(connectToSimulatorIframeCreator.success());
+
+  yield put(connectToSimulatorIframeCreator.failure());
+  
 }
 
 export function* failCheckSetupSaga() {


### PR DESCRIPTION
## Context

We implemented the `slice-simulator` page on a `Next.JS` app that loads global app data on each page load to configure some internal resources. The issue is that this data loading takes some time and when we try to simulate a slice on the `slice-machine-ui`, it redirects to the page that loads the `slice-simulator` Iframe and it always fails to connect the iframe.

## The Solution

Reviewing the code, we found that the `connectToSimulatorIframe` function inside `packages/slice-machine/src/modules/simulator/index.ts` has a static timeout value, and it put to race 3 events (timeout, iframeCheckKO, and iframeCheckOk) and it keeps only the first winner to run the remaining function code. If the winner is `timeout` or `iframeCheckKO` it put the iframe connection in what it looks like a `failure status` if none of these is the winner then put the iframe connection in what it looks like a `success status`. 

_**What we changed:**_

1) We increased the static timeout value from 5000 to 20000. In addition we think it will be good to have this timeout value available in the sm.json file to be configured.

2) We removed the piece that receives the `timeout` and `iframeCheckKO` events if some of these wins the race.

3) We added the piece that receives the `iframeCheckOk` event if it wins the race.

4) We changed the condition that was saying ` if timeout or iframeCheckKO lets fail else lets success ` to ` if iframeCheckOk lets success else lets fail `

5) We removed the unused import `CallEffect`

After these changes the `slice-simulator` worked consistently for all our team members.

## Checklist before requesting a review
- [x] I hereby declare my code ready for review.
- [ ] If it is a critical feature, I have added tests.
- [ ] The CI is successful.
- [ ] If there could backward compatibility issues, it has been discussed and planned.
