### PR TITLE
Disallow library names beginning with @

### DIFF
--- a/packages/start-slicemachine/src/StartSliceMachineProcess.ts
+++ b/packages/start-slicemachine/src/StartSliceMachineProcess.ts
@@ -156,12 +156,28 @@ export class StartSliceMachineProcess {
 	/**
 	 * Validates the project's config and content models.
 	 *
+	 * @throws Throws if a Library name is invalid.
 	 * @throws Throws if a Slice model is invalid.
 	 * @throws Throws if a Custom Type model is invalid.
 	 */
 	private async _validateProject(): Promise<void> {
 		// Validate Slice Machine config.
 		await this._sliceMachineManager.project.loadSliceMachineConfig();
+
+		const allProjectLibraries =
+			await this._sliceMachineManager.slices.readAllSliceLibraries();
+		const invalidLibraryNames = allProjectLibraries.libraries.reduce<string[]>(
+			(acc, library) =>
+				library.libraryID.startsWith("@") ? [...acc, library.libraryID] : acc,
+			[],
+		);
+		if (invalidLibraryNames.length > 0) {
+			throw new Error(
+				`The following Slice libraries have invalid names: ${invalidLibraryNames.join(
+					", ",
+				)}. Slice libraries must not start with an "@" character.`,
+			);
+		}
 
 		// Validate Slice models.
 		const allSlices = await this._sliceMachineManager.slices.readAllSlices();


### PR DESCRIPTION
## Context

Ticket: https://linear.app/prismic/issue/SMX-107/aauser-i-want-to-get-notified-that-my-libraryid-cannot-start-with

## The Solution

Add an additional check in validate project in start-slicemachine for the library names.

## Impact / Dependencies

<!--
List all the impacts your development might have on internal and external features.
Ideally this should have been discussed prior to this development.

Link of any other PRs that are related to this development.
They should also be referenced in the ticket for reviews.
-->




## Checklist before requesting a review
- [ ] I hereby declare my code ready for review.
- [ ] If it is a critical feature, I have added tests.
- [ ] The CI is successful.
- [ ] If there could backward compatibility issues, it has been discussed and planned.




## [OPT] Preview


<img width="702" alt="image" src="https://user-images.githubusercontent.com/47107427/225945459-88aeedf8-8281-4f0a-8928-91568698ab13.png">



<!--
A funny animal picture is welcome to close your PR!
You can find one here https://unsplash.com/s/photos/funny-animal-picture
-->