### PR TITLE
fix(slice-machine-ui): consistently display custom types and slices

### DIFF
--- a/packages/manager/src/managers/SliceMachineManager.ts
+++ b/packages/manager/src/managers/SliceMachineManager.ts
@@ -328,7 +328,15 @@ export class SliceMachineManager {
 			);
 		}
 
-		return libraries;
+		// Preserve library order from config file
+		return libraries.sort((library1, library2) => {
+			const libraryIndex1 =
+				sliceMachineConfig.libraries?.indexOf(library1.name) || 0;
+			const libraryIndex2 =
+				sliceMachineConfig.libraries?.indexOf(library2.name) || 0;
+
+			return Math.sign(libraryIndex1 - libraryIndex2);
+		});
 	}
 
 	private async _getCustomTypes(): Promise<

--- a/packages/slice-machine/pages/index.tsx
+++ b/packages/slice-machine/pages/index.tsx
@@ -30,6 +30,16 @@ const CustomTypes: React.FunctionComponent = () => {
     })
   );
 
+  const sortedCustomTypes = customTypes.sort((customType1, customType2) => {
+    if (customType1.local.id > customType2.local.id) {
+      return 1;
+    } else if (customType1.local.id < customType2.local.id) {
+      return -1;
+    }
+
+    return 0;
+  });
+
   return (
     <Container sx={{ flex: 1, display: "flex", flexDirection: "column" }}>
       <Header
@@ -42,7 +52,7 @@ const CustomTypes: React.FunctionComponent = () => {
           href: "/",
         }}
         Actions={
-          customTypes.length > 0
+          sortedCustomTypes.length > 0
             ? [
                 <Button
                   key="create-custom-type"
@@ -58,7 +68,7 @@ const CustomTypes: React.FunctionComponent = () => {
             : []
         }
       />
-      {customTypes.length === 0 ? (
+      {sortedCustomTypes.length === 0 ? (
         <Flex
           sx={{
             flex: 1,
@@ -91,7 +101,7 @@ const CustomTypes: React.FunctionComponent = () => {
           />
         </Flex>
       ) : (
-        <CustomTypeTable customTypes={customTypes} />
+        <CustomTypeTable customTypes={sortedCustomTypes} />
       )}
       <CreateCustomTypeModal />
     </Container>

--- a/packages/slice-machine/pages/index.tsx
+++ b/packages/slice-machine/pages/index.tsx
@@ -31,13 +31,7 @@ const CustomTypes: React.FunctionComponent = () => {
   );
 
   const sortedCustomTypes = customTypes.sort((customType1, customType2) => {
-    if (customType1.local.id > customType2.local.id) {
-      return 1;
-    } else if (customType1.local.id < customType2.local.id) {
-      return -1;
-    }
-
-    return 0;
+    return customType1.local.id.localeCompare(customType2.local.id);
   });
 
   return (

--- a/packages/slice-machine/pages/slices.tsx
+++ b/packages/slice-machine/pages/slices.tsx
@@ -70,7 +70,22 @@ const SlicesIndex: React.FunctionComponent = () => {
     createSlice(sliceName, from);
   };
 
-  const localLibraries: LibraryUI[] = libraries.filter((l) => l.isLocal);
+  const localLibraries: LibraryUI[] = libraries.filter(
+    (library) => library.isLocal
+  );
+  const sortedLibraries: LibraryUI[] = libraries.map((library) => {
+    // Sort slices
+    library.components = [...library.components].sort((slice1, slice2) => {
+      if (slice1.model.name > slice2.model.name) {
+        return 1;
+      } else if (slice1.model.name < slice2.model.name) {
+        return -1;
+      }
+
+      return 0;
+    });
+    return library;
+  });
 
   const { modelsStatuses, authStatus, isOnline } = useModelStatus({
     slices: frontendSlices,
@@ -123,7 +138,7 @@ const SlicesIndex: React.FunctionComponent = () => {
                 : []
             }
           />
-          {libraries && (
+          {sortedLibraries && (
             <Flex
               sx={{
                 flex: 1,
@@ -163,7 +178,7 @@ const SlicesIndex: React.FunctionComponent = () => {
                   />
                 </Flex>
               ) : (
-                libraries.map((lib) => {
+                sortedLibraries.map((lib) => {
                   const { name, isLocal, components } = lib;
                   return (
                     <Flex

--- a/packages/slice-machine/pages/slices.tsx
+++ b/packages/slice-machine/pages/slices.tsx
@@ -76,13 +76,7 @@ const SlicesIndex: React.FunctionComponent = () => {
   const sortedLibraries: LibraryUI[] = libraries.map((library) => {
     // Sort slices
     library.components = [...library.components].sort((slice1, slice2) => {
-      if (slice1.model.name > slice2.model.name) {
-        return 1;
-      } else if (slice1.model.name < slice2.model.name) {
-        return -1;
-      }
-
-      return 0;
+      return slice1.model.name.localeCompare(slice2.model.name);
     });
     return library;
   });


### PR DESCRIPTION
## Context

SMX-106

## The Solution

This PR ensures custom types and slices are displayed consistently within the UI lists.

I think it makes more sense to keep the sorting on the component level, this way the component is in control of its own display ordering, that's why I implemented most of the sorting on each page rather than on the manager itself.


## Impact / Dependencies

<!--
List all the impacts your development might have on internal and external features.
Ideally this should have been discussed prior to this development.

Link of any other PRs that are related to this development.
They should also be referenced in the ticket for reviews.
-->




## Checklist before requesting a review
- [x] I hereby declare my code ready for review.
- [ ] If it is a critical feature, I have added tests.
- [x] The CI is successful.
- [ ] If there could backward compatibility issues, it has been discussed and planned.




## [OPT] Preview

<!--
Visual aid of your work.
It can either be screenshots or a video.
This could help reviewers to get context quickly.
-->




<!--
A funny animal picture is welcome to close your PR!
You can find one here https://unsplash.com/s/photos/funny-animal-picture
-->