### PR TITLE
fix: output telemetry logs only in DEV

### DIFF
--- a/packages/manager/package.json
+++ b/packages/manager/package.json
@@ -47,7 +47,7 @@
 	],
 	"scripts": {
 		"build": "vite build",
-		"dev": "vite build --watch",
+		"dev": "vite build --watch --mode development",
 		"format": "prettier --write .",
 		"lint": "eslint --ext .js,.ts .",
 		"prepublishOnly": "npm run build",

--- a/packages/manager/src/managers/telemetry/TelemetryManager.ts
+++ b/packages/manager/src/managers/telemetry/TelemetryManager.ts
@@ -123,7 +123,7 @@ export class TelemetryManager extends BaseManager {
 			this._segmentClient.track(
 				payload as Parameters<typeof this._segmentClient.track>[0],
 				(maybeError?: Error) => {
-					if (maybeError) {
+					if (maybeError && import.meta.env.DEV) {
 						// TODO: Not sure how we want to deal with that
 						console.warn(
 							`An error occurred during Segment tracking`,
@@ -159,7 +159,7 @@ export class TelemetryManager extends BaseManager {
 
 			// TODO: Make sure client fails gracefully when no internet connection
 			this._segmentClient.identify(payload, (maybeError?: Error) => {
-				if (maybeError) {
+				if (maybeError && import.meta.env.DEV) {
 					// TODO: Not sure how we want to deal with that
 					console.warn(`An error occurred during Segment identify`, maybeError);
 				}
@@ -196,7 +196,7 @@ export class TelemetryManager extends BaseManager {
 			this._segmentClient.group(
 				payload as Parameters<typeof this._segmentClient.group>[0],
 				(maybeError?: Error) => {
-					if (maybeError) {
+					if (maybeError && import.meta.env.DEV) {
 						// TODO: Not sure how we want to deal with that
 						console.warn(`An error occurred during Segment group`, maybeError);
 					}

--- a/packages/manager/tsconfig.json
+++ b/packages/manager/tsconfig.json
@@ -13,7 +13,7 @@
 
 		"forceConsistentCasingInFileNames": true,
 		"lib": ["esnext"],
-		"types": ["node"]
+		"types": ["node", "vite/client"]
 	},
 	"exclude": ["node_modules", "dist"]
 }

--- a/packages/start-slicemachine/package.json
+++ b/packages/start-slicemachine/package.json
@@ -26,7 +26,7 @@
 	],
 	"scripts": {
 		"build": "vite build",
-		"dev": "vite build --watch",
+		"dev": "vite build --watch --mode development",
 		"format": "prettier --write .",
 		"lint": "eslint --ext .js,.ts .",
 		"prepublishOnly": "npm run build",

--- a/packages/start-slicemachine/package.json
+++ b/packages/start-slicemachine/package.json
@@ -26,7 +26,7 @@
 	],
 	"scripts": {
 		"build": "vite build",
-		"dev": "vite build --watch --mode development",
+		"dev": "vite build --watch",
 		"format": "prettier --write .",
 		"lint": "eslint --ext .js,.ts .",
 		"prepublishOnly": "npm run build",

--- a/packages/start-slicemachine/src/bin/start-slicemachine.ts
+++ b/packages/start-slicemachine/src/bin/start-slicemachine.ts
@@ -1,5 +1,5 @@
 // Automatically restart the process ONLY when Vite is in development mode.
-if (import.meta.env.MODE === "development") {
+if (import.meta.env.DEV) {
 	Promise.all([import("node:url"), import("nodemon")]).then(
 		([url, nodemon]) => {
 			const relativePath = (path: string) =>


### PR DESCRIPTION
## Context

Fixes an issue, related to SMX-81, where telemetry logs where always output.

## The Solution

1. Output telemetry logs only in development mode (using `import.meta.env.mode`).

## Checklist before requesting a review
- [x] I hereby declare my code ready for review.
- [ ] If it is a critical feature, I have added tests.
- [ ] The CI is successful.
- [ ] If there could backward compatibility issues, it has been discussed and planned.