### PR TITLE
fix(start-slicemachine): `/api/auth` endpoint response (SMX-128)

### DIFF
--- a/packages/manager/src/auth/createPrismicAuthManagerMiddleware.ts
+++ b/packages/manager/src/auth/createPrismicAuthManagerMiddleware.ts
@@ -65,6 +65,8 @@ export const createPrismicAuthManagerMiddleware = (
 	return defineNodeMiddleware(async (req, res) => {
 		const event = createEvent(req, res);
 
-		return await router.handler(event);
+		await router.handler(event);
+
+		res.end();
 	});
 };


### PR DESCRIPTION
## Context

SMX-128

## The Solution

H3 has some convenience response inference mechanism which work only within an H3 app (e.g. returning an object from an event handler will automatically assume it's the response body and JSON stringify it)

Since we migrated from H3 to Express on the init command, this highlighted a bug where we never closed the response from the `/api/auth` middleware. This PR fixes that.


## Impact / Dependencies

<!--
List all the impacts your development might have on internal and external features.
Ideally this should have been discussed prior to this development.

Link of any other PRs that are related to this development.
They should also be referenced in the ticket for reviews.
-->




## Checklist before requesting a review
- [ ] I hereby declare my code ready for review.
- [ ] If it is a critical feature, I have added tests.
- [ ] The CI is successful.
- [ ] If there could backward compatibility issues, it has been discussed and planned.




## [OPT] Preview

<!--
Visual aid of your work.
It can either be screenshots or a video.
This could help reviewers to get context quickly.
-->




<!--
A funny animal picture is welcome to close your PR!
You can find one here https://unsplash.com/s/photos/funny-animal-picture
-->