### PR TITLE
feat: automatically clean hosted screenshots

### DIFF
--- a/packages/init/test/__testutils__/mockAWSACLAPI.ts
+++ b/packages/init/test/__testutils__/mockAWSACLAPI.ts
@@ -27,6 +27,7 @@ type MockAWSACLAPIConfig = {
 					contentType?: string;
 				}[];
 		  };
+	deleteFolderEndpoint?: { expectedSliceIDs: string[] };
 };
 
 type MockAWSACLAPIReturnType = {
@@ -139,6 +140,22 @@ export const mockAWSACLAPI = (
 					return res(ctx.status(401));
 				}
 			}),
+		);
+	}
+
+	if (config?.deleteFolderEndpoint) {
+		ctx.msw.use(
+			rest.post(
+				new URL("delete-folder", endpoint).toString(),
+				async (req, res, ctx) => {
+					const { sliceId } = await req.json<{ sliceId: string }>();
+					if (config.deleteFolderEndpoint?.expectedSliceIDs.includes(sliceId)) {
+						return res(ctx.status(200));
+					} else {
+						return res(ctx.status(401));
+					}
+				},
+			),
 		);
 	}
 

--- a/packages/manager/src/managers/prismicRepository/PrismicRepositoryManager.ts
+++ b/packages/manager/src/managers/prismicRepository/PrismicRepositoryManager.ts
@@ -297,7 +297,7 @@ export class PrismicRepositoryManager extends BaseManager {
 								});
 
 								if (!model) {
-									throw Error(`Could not find model  ${change.id}`);
+									throw Error(`Could not find model ${change.id}`);
 								}
 
 								const modelWithScreenshots =
@@ -318,6 +318,10 @@ export class PrismicRepositoryManager extends BaseManager {
 								};
 							}
 							case "DELETED":
+								await this.screenshots.deleteScreenshotFolder({
+									sliceID: change.id,
+								});
+
 								return {
 									id: change.id,
 									payload: { id: change.id },

--- a/packages/manager/test/SliceMachineManager-screenshots-deleteScreenshotFolder.test.ts
+++ b/packages/manager/test/SliceMachineManager-screenshots-deleteScreenshotFolder.test.ts
@@ -1,0 +1,58 @@
+import { expect, it } from "vitest";
+
+import { createPrismicAuthLoginResponse } from "./__testutils__/createPrismicAuthLoginResponse";
+import { createTestPlugin } from "./__testutils__/createTestPlugin";
+import { createTestProject } from "./__testutils__/createTestProject";
+import { mockAWSACLAPI } from "./__testutils__/mockAWSACLAPI";
+import { mockPrismicAuthAPI } from "./__testutils__/mockPrismicAuthAPI";
+import { mockPrismicUserAPI } from "./__testutils__/mockPrismicUserAPI";
+
+import { createSliceMachineManager } from "../src";
+
+it("deletes a screenshot folder from S3", async (ctx) => {
+	const adapter = createTestPlugin();
+	const cwd = await createTestProject({ adapter });
+	const manager = createSliceMachineManager({
+		nativePlugins: { [adapter.meta.name]: adapter },
+		cwd,
+	});
+
+	mockPrismicUserAPI(ctx);
+	mockPrismicAuthAPI(ctx);
+
+	await manager.user.login(createPrismicAuthLoginResponse());
+
+	mockAWSACLAPI(ctx, {
+		deleteFolderEndpoint: { expectedSliceIDs: ["6DMD8c7iweHQ8F9mtC5ho"] },
+	});
+
+	await expect(
+		manager.screenshots.deleteScreenshotFolder({
+			sliceID: "6DMD8c7iweHQ8F9mtC5ho",
+		}),
+	).resolves.toBeUndefined();
+});
+
+it("throws if the folder deletion was unsuccessful", async (ctx) => {
+	const adapter = createTestPlugin();
+	const cwd = await createTestProject({ adapter });
+	const manager = createSliceMachineManager({
+		nativePlugins: { [adapter.meta.name]: adapter },
+		cwd,
+	});
+
+	mockPrismicUserAPI(ctx);
+	mockPrismicAuthAPI(ctx);
+
+	await manager.user.login(createPrismicAuthLoginResponse());
+
+	mockAWSACLAPI(ctx, {
+		deleteFolderEndpoint: { expectedSliceIDs: ["6DMD8c7iweHQ8F9mtC5ho"] },
+	});
+
+	await expect(
+		manager.screenshots.deleteScreenshotFolder({
+			sliceID: "yeoOt6laxWwzMAXJvxxfV",
+		}),
+	).rejects.toThrow(/Unable to delete screenshot folder/i);
+});

--- a/packages/manager/test/__testutils__/mockAWSACLAPI.ts
+++ b/packages/manager/test/__testutils__/mockAWSACLAPI.ts
@@ -27,6 +27,7 @@ type MockAWSACLAPIConfig = {
 					contentType?: string;
 				}[];
 		  };
+	deleteFolderEndpoint?: { expectedSliceIDs: string[] };
 };
 
 type MockAWSACLAPIReturnType = {
@@ -139,6 +140,22 @@ export const mockAWSACLAPI = (
 					return res(ctx.status(401));
 				}
 			}),
+		);
+	}
+
+	if (config?.deleteFolderEndpoint) {
+		ctx.msw.use(
+			rest.post(
+				new URL("delete-folder", endpoint).toString(),
+				async (req, res, ctx) => {
+					const { sliceId } = await req.json<{ sliceId: string }>();
+					if (config.deleteFolderEndpoint?.expectedSliceIDs.includes(sliceId)) {
+						return res(ctx.status(200));
+					} else {
+						return res(ctx.status(401));
+					}
+				},
+			),
 		);
 	}
 

--- a/packages/slice-machine/test/__testutils__/mockAWSACLAPI.ts
+++ b/packages/slice-machine/test/__testutils__/mockAWSACLAPI.ts
@@ -27,6 +27,7 @@ type MockAWSACLAPIConfig = {
           contentType?: string;
         }[];
       };
+  deleteFolderEndpoint?: { expectedSliceIDs: string[] };
 };
 
 type MockAWSACLAPIReturnType = {
@@ -139,6 +140,22 @@ export const mockAWSACLAPI = (
           return res(ctx.status(401));
         }
       })
+    );
+  }
+
+  if (config?.deleteFolderEndpoint) {
+    ctx.msw.use(
+      rest.post(
+        new URL("delete-folder", endpoint).toString(),
+        async (req, res, ctx) => {
+          const { sliceId } = await req.json<{ sliceId: string }>();
+          if (config.deleteFolderEndpoint?.expectedSliceIDs.includes(sliceId)) {
+            return res(ctx.status(200));
+          } else {
+            return res(ctx.status(401));
+          }
+        }
+      )
     );
   }
 


### PR DESCRIPTION
## Context

Completes SMX-126: Delete hosted screenshots of deleted slices.

## The Solution

1. Add `deleteScreenshotFolder` in `ScreenshotsManager`.
2. Use `ScreenshotsManager.deleteScreenshotFolder` in `PrismicRepositoryManager.pushChanges`.

## Checklist before requesting a review
- [x] I hereby declare my code ready for review.
- [x] If it is a critical feature, I have added tests.
- [ ] The CI is successful.
- [ ] If there could backward compatibility issues, it has been discussed and planned.