### PR TITLE
Store mocks as array of variations (SMX-132)

### DIFF
--- a/e2e-projects/next/customtypes/blog-page/mocks.json
+++ b/e2e-projects/next/customtypes/blog-page/mocks.json
@@ -1,0 +1,332 @@
+[
+  {
+    "uid": {
+      "__TYPE__": "UIDContent",
+      "value": "bigger"
+    },
+    "title": {
+      "__TYPE__": "StructuredTextContent",
+      "value": [
+        {
+          "type": "heading1",
+          "content": {
+            "text": "Television"
+          }
+        }
+      ]
+    },
+    "category": {
+      "__TYPE__": "StructuredTextContent",
+      "value": [
+        {
+          "type": "heading1",
+          "content": {
+            "text": "Handsome"
+          }
+        }
+      ]
+    },
+    "description": {
+      "__TYPE__": "StructuredTextContent",
+      "value": [
+        {
+          "type": "paragraph",
+          "content": {
+            "text": "Esse fugiat ex ut reprehenderit nulla magna mollit mollit. Culpa voluptate elit et est irure enim."
+          }
+        }
+      ]
+    },
+    "slices": {
+      "__TYPE__": "SliceContentType",
+      "value": [
+        {
+          "key": "content_section_centered$d236c8d8-f90b-48f4-b839-bb32dcdf77c4",
+          "name": "content_section_centered",
+          "widget": {
+            "__TYPE__": "SharedSliceContent",
+            "variation": "default-slice",
+            "primary": {
+              "description": {
+                "__TYPE__": "StructuredTextContent",
+                "value": [
+                  {
+                    "type": "paragraph",
+                    "content": {
+                      "text": "Ut laboris ex officia consequat incididunt ipsum consequat cupidatat pariatur do nostrud nisi magna magna. Ut labore sunt minim laboris laboris consectetur elit non ex sint."
+                    }
+                  }
+                ]
+              }
+            },
+            "items": [
+              {
+                "__TYPE__": "GroupItemContent",
+                "value": []
+              }
+            ]
+          }
+        },
+        {
+          "key": "content_section_centered_embed$2fc83327-d5a3-46d8-88af-0d0099ae848b",
+          "name": "content_section_centered_embed",
+          "widget": {
+            "__TYPE__": "SharedSliceContent",
+            "variation": "default-slice",
+            "primary": {
+              "EmbedItem": {
+                "embed_url": "https://twitter.com/timbenniks/status/1304146886832594944",
+                "author_name": "Tim Benniks",
+                "author_url": "https://twitter.com/timbenniks",
+                "html": "<blockquote class=\"twitter-tweet\"><p lang=\"en\" dir=\"ltr\">I’ve been diving deep on <a href=\"https://twitter.com/prismicio?ref_src=twsrc%5Etfw\">@prismicio</a> <a href=\"https://twitter.com/hashtag/slicemachine?src=hash&amp;ref_src=twsrc%5Etfw\">#slicemachine</a> today. I made all my own components and I used custom slices. It works like a charm with <a href=\"https://twitter.com/nuxt_js?ref_src=twsrc%5Etfw\">@nuxt_js</a>. Also\": I’m coding with this view. <a href=\"https://t.co/F0I8X9gz39\">pic.twitter.com/F0I8X9gz39</a></p>&mdash; Tim Benniks (@timbenniks) <a href=\"https://twitter.com/timbenniks/status/1304146886832594944?ref_src=twsrc%5Etfw\">September 10, 2020</a></blockquote>\n<script async src=\"https://platform.twitter.com/widgets.js\" charset=\"utf-8\"></script>\n",
+                "width": 550,
+                "height": null,
+                "type": "rich",
+                "cache_age": "3153600000",
+                "provider_name": "Twitter",
+                "provider_url": "http://www.twitter.com/",
+                "version": "1.0",
+                "all": {
+                  "embed_url": "https://twitter.com/timbenniks/status/1304146886832594944",
+                  "author_name": "Tim Benniks",
+                  "author_url": "https://twitter.com/timbenniks",
+                  "html": "<blockquote class=\"twitter-tweet\"><p lang=\"en\" dir=\"ltr\">I’ve been diving deep on <a href=\"https://twitter.com/prismicio?ref_src=twsrc%5Etfw\">@prismicio</a> <a href=\"https://twitter.com/hashtag/slicemachine?src=hash&amp;ref_src=twsrc%5Etfw\">#slicemachine</a> today. I made all my own components and I used custom slices. It works like a charm with <a href=\"https://twitter.com/nuxt_js?ref_src=twsrc%5Etfw\">@nuxt_js</a>. Also\": I’m coding with this view. <a href=\"https://t.co/F0I8X9gz39\">pic.twitter.com/F0I8X9gz39</a></p>&mdash; Tim Benniks (@timbenniks) <a href=\"https://twitter.com/timbenniks/status/1304146886832594944?ref_src=twsrc%5Etfw\">September 10, 2020</a></blockquote>\n<script async src=\"https://platform.twitter.com/widgets.js\" charset=\"utf-8\"></script>\n",
+                  "width": 550,
+                  "height": null,
+                  "type": "rich",
+                  "cache_age": "3153600000",
+                  "provider_name": "Twitter",
+                  "provider_url": "http://www.twitter.com/",
+                  "version": "1.0"
+                },
+                "__TYPE__": "EmbedContent"
+              }
+            },
+            "items": [
+              {
+                "__TYPE__": "GroupItemContent",
+                "value": []
+              }
+            ]
+          }
+        },
+        {
+          "key": "content_section_centered_image$02074faa-b018-4d29-85fe-06eeaea9c0e7",
+          "name": "content_section_centered_image",
+          "widget": {
+            "__TYPE__": "SharedSliceContent",
+            "variation": "default-slice",
+            "primary": {
+              "description": {
+                "__TYPE__": "StructuredTextContent",
+                "value": [
+                  {
+                    "type": "paragraph",
+                    "content": {
+                      "text": "Voluptate ea Lorem elit sit dolor officia veniam. Commodo voluptate adipisicing nostrud commodo aliqua cupidatat commodo ad in ea qui. Incididunt labore duis ea aliquip laborum sunt cupidatat aute mollit proident dolore qui reprehenderit voluptate et."
+                    }
+                  }
+                ]
+              },
+              "image": {
+                "__TYPE__": "ImageContent",
+                "origin": {
+                  "id": "main",
+                  "url": "https://images.unsplash.com/photo-1498050108023-c5249f4df085",
+                  "width": 3882,
+                  "height": 2584
+                },
+                "url": "https://images.unsplash.com/photo-1498050108023-c5249f4df085",
+                "width": 3882,
+                "height": 2584,
+                "edit": {
+                  "zoom": 1,
+                  "crop": {
+                    "x": 0,
+                    "y": 0
+                  },
+                  "background": "transparent"
+                },
+                "thumbnails": {}
+              }
+            },
+            "items": [
+              {
+                "__TYPE__": "GroupItemContent",
+                "value": []
+              }
+            ]
+          }
+        },
+        {
+          "key": "separator$91fe04a6-e225-43e0-be0d-2c9e554be4d8",
+          "name": "separator",
+          "widget": {
+            "__TYPE__": "SharedSliceContent",
+            "variation": "default-slice",
+            "primary": {},
+            "items": [
+              {
+                "__TYPE__": "GroupItemContent",
+                "value": []
+              }
+            ]
+          }
+        },
+        {
+          "key": "content_section_two_columns_with_image$f31d0d15-4271-4e2a-8bb9-a84441df6c49",
+          "name": "content_section_two_columns_with_image",
+          "widget": {
+            "__TYPE__": "SharedSliceContent",
+            "variation": "default-slice",
+            "primary": {
+              "title": {
+                "__TYPE__": "StructuredTextContent",
+                "value": [
+                  {
+                    "type": "heading1",
+                    "content": {
+                      "text": "Memory"
+                    }
+                  }
+                ]
+              },
+              "description": {
+                "__TYPE__": "StructuredTextContent",
+                "value": [
+                  {
+                    "type": "paragraph",
+                    "content": {
+                      "text": "Est sit nulla exercitation proident reprehenderit."
+                    }
+                  }
+                ]
+              },
+              "superTitle": {
+                "__TYPE__": "FieldContent",
+                "value": "private",
+                "type": "Text"
+              },
+              "text": {
+                "__TYPE__": "StructuredTextContent",
+                "value": [
+                  {
+                    "type": "paragraph",
+                    "content": {
+                      "text": "Commodo sunt aute aliqua exercitation magna ipsum sunt sunt consequat adipisicing consectetur."
+                    }
+                  }
+                ]
+              },
+              "image": {
+                "__TYPE__": "ImageContent",
+                "origin": {
+                  "id": "main",
+                  "url": "https://images.unsplash.com/photo-1600861194802-a2b11076bc51",
+                  "width": 2545,
+                  "height": 2545
+                },
+                "url": "https://images.unsplash.com/photo-1600861194802-a2b11076bc51",
+                "width": 2545,
+                "height": 2545,
+                "edit": {
+                  "zoom": 1,
+                  "crop": {
+                    "x": 0,
+                    "y": 0
+                  },
+                  "background": "transparent"
+                },
+                "thumbnails": {}
+              },
+              "caption": {
+                "__TYPE__": "StructuredTextContent",
+                "value": [
+                  {
+                    "type": "paragraph",
+                    "content": {
+                      "text": "Excepteur dolore occaecat consectetur deserunt qui aliqua eu."
+                    }
+                  }
+                ]
+              }
+            },
+            "items": [
+              {
+                "__TYPE__": "GroupItemContent",
+                "value": []
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "meta_title": {
+      "__TYPE__": "FieldContent",
+      "value": "drive",
+      "type": "Text"
+    },
+    "meta_description": {
+      "__TYPE__": "FieldContent",
+      "value": "balloon",
+      "type": "Text"
+    },
+    "canonicalLink": {
+      "__TYPE__": "LinkContent",
+      "value": {
+        "__TYPE__": "ExternalLink",
+        "url": "http://google.com"
+      }
+    },
+    "social_cards": {
+      "__TYPE__": "GroupContentType",
+      "value": [
+        {
+          "__TYPE__": "GroupItemContent",
+          "value": [
+            [
+              "social_card_image",
+              {
+                "__TYPE__": "ImageContent",
+                "origin": {
+                  "id": "main",
+                  "url": "https://images.unsplash.com/photo-1587653915936-5623ea0b949a",
+                  "width": 4000,
+                  "height": 4000
+                },
+                "url": "https://images.unsplash.com/photo-1587653915936-5623ea0b949a",
+                "width": 4000,
+                "height": 4000,
+                "edit": {
+                  "zoom": 1,
+                  "crop": {
+                    "x": 0,
+                    "y": 0
+                  },
+                  "background": "transparent"
+                },
+                "thumbnails": {}
+              }
+            ],
+            [
+              "social_card_title",
+              {
+                "__TYPE__": "FieldContent",
+                "value": "nothing",
+                "type": "Text"
+              }
+            ],
+            [
+              "social_card_description",
+              {
+                "__TYPE__": "FieldContent",
+                "value": "pour",
+                "type": "Text"
+              }
+            ]
+          ]
+        }
+      ]
+    }
+  }
+]

--- a/e2e-projects/next/customtypes/footer/mocks.json
+++ b/e2e-projects/next/customtypes/footer/mocks.json
@@ -1,0 +1,69 @@
+[
+  {
+    "newsletter_title": {
+      "__TYPE__": "FieldContent",
+      "value": "provide",
+      "type": "Text"
+    },
+    "newsletter_description": {
+      "__TYPE__": "FieldContent",
+      "value": "central",
+      "type": "Text"
+    },
+    "newsletter_button": {
+      "__TYPE__": "FieldContent",
+      "value": "copper",
+      "type": "Text"
+    },
+    "copyright": {
+      "__TYPE__": "FieldContent",
+      "value": "limited",
+      "type": "Text"
+    },
+    "body": {
+      "__TYPE__": "SliceContentType",
+      "value": [
+        {
+          "key": "footer_column$14c973b2-84db-4c4a-971f-d56ca3567851",
+          "name": "footer_column",
+          "widget": {
+            "__TYPE__": "SharedSliceContent",
+            "variation": "default-slice",
+            "primary": {
+              "section_title": {
+                "__TYPE__": "FieldContent",
+                "value": "author",
+                "type": "Text"
+              }
+            },
+            "items": [
+              {
+                "__TYPE__": "GroupItemContent",
+                "value": [
+                  [
+                    "link",
+                    {
+                      "__TYPE__": "LinkContent",
+                      "value": {
+                        "__TYPE__": "DocumentLink",
+                        "id": "mock_document_id"
+                      }
+                    }
+                  ],
+                  [
+                    "link_label",
+                    {
+                      "__TYPE__": "FieldContent",
+                      "value": "both",
+                      "type": "Text"
+                    }
+                  ]
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+]

--- a/e2e-projects/next/customtypes/home-page/mocks.json
+++ b/e2e-projects/next/customtypes/home-page/mocks.json
@@ -1,0 +1,960 @@
+[
+  {
+    "slices": {
+      "__TYPE__": "SliceContentType",
+      "value": [
+        {
+          "key": "category_preview_with_image_backgrounds$0144105f-2b99-42cf-b051-db9a43bbc820",
+          "name": "category_preview_with_image_backgrounds",
+          "widget": {
+            "__TYPE__": "SharedSliceContent",
+            "variation": "default-slice",
+            "primary": {
+              "title": {
+                "__TYPE__": "StructuredTextContent",
+                "value": [
+                  {
+                    "type": "heading1",
+                    "content": {
+                      "text": "Activity"
+                    }
+                  }
+                ]
+              },
+              "linkLabel": {
+                "__TYPE__": "FieldContent",
+                "value": "constantly",
+                "type": "Text"
+              },
+              "link": {
+                "__TYPE__": "LinkContent",
+                "value": {
+                  "__TYPE__": "DocumentLink",
+                  "id": "mock_document_id"
+                }
+              },
+              "imageLeft": {
+                "__TYPE__": "ImageContent",
+                "origin": {
+                  "id": "main",
+                  "url": "https://images.unsplash.com/photo-1541807084-5c52b6b3adef",
+                  "width": 4000,
+                  "height": 6000
+                },
+                "url": "https://images.unsplash.com/photo-1541807084-5c52b6b3adef?rect=0%2C1000%2C4000%2C4000&w=592&h=592",
+                "width": 592,
+                "height": 592,
+                "edit": {
+                  "zoom": 1,
+                  "crop": {
+                    "x": 0,
+                    "y": 1000
+                  },
+                  "background": "transparent"
+                },
+                "thumbnails": {
+                  "mobile": {
+                    "origin": {
+                      "id": "mobile",
+                      "url": "https://images.unsplash.com/photo-1551739440-5dd934d3a94a",
+                      "width": 3456,
+                      "height": 4320
+                    },
+                    "url": "https://images.unsplash.com/photo-1551739440-5dd934d3a94a?rect=0%2C1296%2C3456%2C1728&w=560&h=280",
+                    "width": 560,
+                    "height": 280,
+                    "edit": {
+                      "zoom": 1,
+                      "crop": {
+                        "x": 0,
+                        "y": 1296
+                      },
+                      "background": "transparent"
+                    }
+                  }
+                }
+              },
+              "imageLeftTitle": {
+                "__TYPE__": "FieldContent",
+                "value": "basket",
+                "type": "Text"
+              },
+              "imageLeftCta": {
+                "__TYPE__": "FieldContent",
+                "value": "enter",
+                "type": "Text"
+              },
+              "leftImageLink": {
+                "__TYPE__": "LinkContent",
+                "value": {
+                  "__TYPE__": "DocumentLink",
+                  "id": "mock_document_id"
+                }
+              },
+              "imageTopRight": {
+                "__TYPE__": "ImageContent",
+                "origin": {
+                  "id": "main",
+                  "url": "https://images.unsplash.com/photo-1586952518485-11b180e92764",
+                  "width": 4172,
+                  "height": 4000
+                },
+                "url": "https://images.unsplash.com/photo-1586952518485-11b180e92764?rect=0%2C1013%2C4172%2C1973&w=592&h=280",
+                "width": 592,
+                "height": 280,
+                "edit": {
+                  "zoom": 1,
+                  "crop": {
+                    "x": 0,
+                    "y": 1013
+                  },
+                  "background": "transparent"
+                },
+                "thumbnails": {}
+              },
+              "imageTopRightTitle": {
+                "__TYPE__": "FieldContent",
+                "value": "such",
+                "type": "Text"
+              },
+              "imageTopRightCta": {
+                "__TYPE__": "FieldContent",
+                "value": "freedom",
+                "type": "Text"
+              },
+              "topRightImageLink": {
+                "__TYPE__": "LinkContent",
+                "value": {
+                  "__TYPE__": "DocumentLink",
+                  "id": "mock_document_id"
+                }
+              },
+              "imageBottomRight": {
+                "__TYPE__": "ImageContent",
+                "origin": {
+                  "id": "main",
+                  "url": "https://images.unsplash.com/photo-1587905069134-008460d7a636",
+                  "width": 3935,
+                  "height": 5894
+                },
+                "url": "https://images.unsplash.com/photo-1587905069134-008460d7a636?rect=0%2C2016%2C3935%2C1861&w=592&h=280",
+                "width": 592,
+                "height": 280,
+                "edit": {
+                  "zoom": 1,
+                  "crop": {
+                    "x": 0,
+                    "y": 2016
+                  },
+                  "background": "transparent"
+                },
+                "thumbnails": {}
+              },
+              "imageBottomRightTitle": {
+                "__TYPE__": "FieldContent",
+                "value": "answer",
+                "type": "Text"
+              },
+              "imageBottomRightCta": {
+                "__TYPE__": "FieldContent",
+                "value": "border",
+                "type": "Text"
+              },
+              "bottomRightImageLink": {
+                "__TYPE__": "LinkContent",
+                "value": {
+                  "__TYPE__": "DocumentLink",
+                  "id": "mock_document_id"
+                }
+              }
+            },
+            "items": [
+              {
+                "__TYPE__": "GroupItemContent",
+                "value": []
+              }
+            ]
+          }
+        },
+        {
+          "key": "category_preview_with_scrolling_cards$6702e21b-c3f3-4d5f-8ee3-68ce31b2eb5c",
+          "name": "category_preview_with_scrolling_cards",
+          "widget": {
+            "__TYPE__": "SharedSliceContent",
+            "variation": "default-slice",
+            "primary": {
+              "title": {
+                "__TYPE__": "StructuredTextContent",
+                "value": [
+                  {
+                    "type": "heading1",
+                    "content": {
+                      "text": "Potatoes"
+                    }
+                  }
+                ]
+              },
+              "CTA": {
+                "__TYPE__": "FieldContent",
+                "value": "seed",
+                "type": "Text"
+              },
+              "CTALink": {
+                "__TYPE__": "LinkContent",
+                "value": {
+                  "__TYPE__": "DocumentLink",
+                  "id": "mock_document_id"
+                }
+              }
+            },
+            "items": [
+              {
+                "__TYPE__": "GroupItemContent",
+                "value": [
+                  [
+                    "image",
+                    {
+                      "__TYPE__": "ImageContent",
+                      "origin": {
+                        "id": "main",
+                        "url": "https://images.unsplash.com/photo-1587614295999-6c1c13675117",
+                        "width": 3810,
+                        "height": 5715
+                      },
+                      "url": "https://images.unsplash.com/photo-1587614295999-6c1c13675117?rect=0%2C136%2C3810%2C5443&w=224&h=320",
+                      "width": 224,
+                      "height": 320,
+                      "edit": {
+                        "zoom": 1,
+                        "crop": {
+                          "x": 0,
+                          "y": 136
+                        },
+                        "background": "transparent"
+                      },
+                      "thumbnails": {}
+                    }
+                  ],
+                  [
+                    "title",
+                    {
+                      "__TYPE__": "FieldContent",
+                      "value": "went",
+                      "type": "Text"
+                    }
+                  ],
+                  [
+                    "link",
+                    {
+                      "__TYPE__": "LinkContent",
+                      "value": {
+                        "__TYPE__": "DocumentLink",
+                        "id": "mock_document_id"
+                      }
+                    }
+                  ]
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "key": "hero_banner$97f12789-3da7-4a59-ac9c-260044616010",
+          "name": "hero_banner",
+          "widget": {
+            "__TYPE__": "SharedSliceContent",
+            "variation": "default-slice",
+            "primary": {
+              "title": {
+                "__TYPE__": "FieldContent",
+                "value": "thick",
+                "type": "Text"
+              },
+              "description": {
+                "__TYPE__": "FieldContent",
+                "value": "mass",
+                "type": "Text"
+              },
+              "image": {
+                "__TYPE__": "ImageContent",
+                "origin": {
+                  "id": "main",
+                  "url": "https://images.unsplash.com/photo-1515378791036-0648a3ef77b2",
+                  "width": 5616,
+                  "height": 3744
+                },
+                "url": "https://images.unsplash.com/photo-1515378791036-0648a3ef77b2?rect=0%2C981%2C5616%2C1782&w=1024&h=325",
+                "width": 1024,
+                "height": 325,
+                "edit": {
+                  "zoom": 1,
+                  "crop": {
+                    "x": 0,
+                    "y": 981
+                  },
+                  "background": "transparent"
+                },
+                "thumbnails": {
+                  "mobile": {
+                    "origin": {
+                      "id": "mobile",
+                      "url": "https://images.unsplash.com/photo-1587613865763-4b8b0d19e8ab",
+                      "width": 12288,
+                      "height": 16384
+                    },
+                    "url": "https://images.unsplash.com/photo-1587613865763-4b8b0d19e8ab?rect=0%2C3994%2C12288%2C8397&w=600&h=410",
+                    "width": 600,
+                    "height": 410,
+                    "edit": {
+                      "zoom": 1,
+                      "crop": {
+                        "x": 0,
+                        "y": 3994
+                      },
+                      "background": "transparent"
+                    }
+                  }
+                }
+              },
+              "cta": {
+                "__TYPE__": "FieldContent",
+                "value": "apartment",
+                "type": "Text"
+              },
+              "CTALink": {
+                "__TYPE__": "LinkContent",
+                "value": {
+                  "__TYPE__": "DocumentLink",
+                  "id": "mock_document_id"
+                }
+              }
+            },
+            "items": [
+              {
+                "__TYPE__": "GroupItemContent",
+                "value": []
+              }
+            ]
+          }
+        },
+        {
+          "key": "product_list_with_cta$f503c8f2-a948-48f7-a1fe-79fe34bc24f9",
+          "name": "product_list_with_cta",
+          "widget": {
+            "__TYPE__": "SharedSliceContent",
+            "variation": "default-slice",
+            "primary": {
+              "title": {
+                "__TYPE__": "StructuredTextContent",
+                "value": [
+                  {
+                    "type": "heading1",
+                    "content": {
+                      "text": "Bottom"
+                    }
+                  }
+                ]
+              },
+              "description": {
+                "__TYPE__": "StructuredTextContent",
+                "value": [
+                  {
+                    "type": "paragraph",
+                    "content": {
+                      "text": "Minim ad nulla eu est cupidatat ut. Proident tempor laborum velit et eu occaecat ullamco duis excepteur irure ut quis."
+                    }
+                  }
+                ]
+              },
+              "link": {
+                "__TYPE__": "LinkContent",
+                "value": {
+                  "__TYPE__": "DocumentLink",
+                  "id": "mock_document_id"
+                }
+              }
+            },
+            "items": [
+              {
+                "__TYPE__": "GroupItemContent",
+                "value": [
+                  [
+                    "topProduct",
+                    {
+                      "__TYPE__": "IntegrationFieldsContent",
+                      "value": "integration-field-product-id"
+                    }
+                  ],
+                  [
+                    "productLink",
+                    {
+                      "__TYPE__": "LinkContent",
+                      "value": {
+                        "__TYPE__": "DocumentLink",
+                        "id": "mock_document_id"
+                      }
+                    }
+                  ]
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "key": "promo_section_fading_background_testimonials$cbe07c31-9a1f-4b15-9ac8-c4df436572d5",
+          "name": "promo_section_fading_background_testimonials",
+          "widget": {
+            "__TYPE__": "SharedSliceContent",
+            "variation": "default-slice",
+            "primary": {
+              "title": {
+                "__TYPE__": "StructuredTextContent",
+                "value": [
+                  {
+                    "type": "heading1",
+                    "content": {
+                      "text": "Claws"
+                    }
+                  }
+                ]
+              },
+              "description": {
+                "__TYPE__": "StructuredTextContent",
+                "value": [
+                  {
+                    "type": "paragraph",
+                    "content": {
+                      "text": "Laborum est sit et dolore nisi velit id consectetur amet adipisicing sit aute anim."
+                    }
+                  }
+                ]
+              },
+              "cta": {
+                "__TYPE__": "FieldContent",
+                "value": "porch",
+                "type": "Text"
+              },
+              "link": {
+                "__TYPE__": "LinkContent",
+                "value": {
+                  "__TYPE__": "DocumentLink",
+                  "id": "mock_document_id"
+                }
+              },
+              "quotesTitle": {
+                "__TYPE__": "FieldContent",
+                "value": "ready",
+                "type": "Text"
+              },
+              "image": {
+                "__TYPE__": "ImageContent",
+                "origin": {
+                  "id": "main",
+                  "url": "https://images.unsplash.com/photo-1589321578146-4c1ba445cc88",
+                  "width": 3168,
+                  "height": 4752
+                },
+                "url": "https://images.unsplash.com/photo-1589321578146-4c1ba445cc88?rect=0%2C1131%2C3168%2C2491&w=1216&h=956",
+                "width": 1216,
+                "height": 956,
+                "edit": {
+                  "zoom": 1,
+                  "crop": {
+                    "x": 0,
+                    "y": 1131
+                  },
+                  "background": "transparent"
+                },
+                "thumbnails": {}
+              }
+            },
+            "items": [
+              {
+                "__TYPE__": "GroupItemContent",
+                "value": [
+                  [
+                    "quote",
+                    {
+                      "__TYPE__": "FieldContent",
+                      "value": "track",
+                      "type": "Text"
+                    }
+                  ],
+                  [
+                    "attribution",
+                    {
+                      "__TYPE__": "FieldContent",
+                      "value": "stone",
+                      "type": "Text"
+                    }
+                  ]
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "key": "promo_section_image_tiles$4b723a52-8822-49a8-a640-f902757eafd2",
+          "name": "promo_section_image_tiles",
+          "widget": {
+            "__TYPE__": "SharedSliceContent",
+            "variation": "default-slice",
+            "primary": {
+              "title": {
+                "__TYPE__": "FieldContent",
+                "value": "paragraph",
+                "type": "Text"
+              },
+              "subtitle": {
+                "__TYPE__": "FieldContent",
+                "value": "transportation",
+                "type": "Text"
+              },
+              "linkLabel": {
+                "__TYPE__": "FieldContent",
+                "value": "dog",
+                "type": "Text"
+              },
+              "link": {
+                "__TYPE__": "LinkContent",
+                "value": {
+                  "__TYPE__": "DocumentLink",
+                  "id": "mock_document_id"
+                }
+              },
+              "backgroundColor": {
+                "__TYPE__": "FieldContent",
+                "value": "#93de4d",
+                "type": "Color"
+              },
+              "image1": {
+                "__TYPE__": "ImageContent",
+                "origin": {
+                  "id": "main",
+                  "url": "https://images.unsplash.com/photo-1504198070170-4ca53bb1c1fa",
+                  "width": 2747,
+                  "height": 4120
+                },
+                "url": "https://images.unsplash.com/photo-1504198070170-4ca53bb1c1fa?rect=0%2C62%2C2747%2C3996&w=176&h=256",
+                "width": 176,
+                "height": 256,
+                "edit": {
+                  "zoom": 1,
+                  "crop": {
+                    "x": 0,
+                    "y": 62
+                  },
+                  "background": "transparent"
+                },
+                "thumbnails": {}
+              },
+              "image2": {
+                "__TYPE__": "ImageContent",
+                "origin": {
+                  "id": "main",
+                  "url": "https://images.unsplash.com/photo-1498050108023-c5249f4df085",
+                  "width": 3882,
+                  "height": 2584
+                },
+                "url": "https://images.unsplash.com/photo-1498050108023-c5249f4df085?rect=1053%2C0%2C1777%2C2584&w=176&h=256",
+                "width": 176,
+                "height": 256,
+                "edit": {
+                  "zoom": 1,
+                  "crop": {
+                    "x": 1053,
+                    "y": 0
+                  },
+                  "background": "transparent"
+                },
+                "thumbnails": {}
+              },
+              "image3": {
+                "__TYPE__": "ImageContent",
+                "origin": {
+                  "id": "main",
+                  "url": "https://images.unsplash.com/photo-1448932223592-d1fc686e76ea",
+                  "width": 3500,
+                  "height": 2338
+                },
+                "url": "https://images.unsplash.com/photo-1448932223592-d1fc686e76ea?rect=946%2C0%2C1607%2C2338&w=176&h=256",
+                "width": 176,
+                "height": 256,
+                "edit": {
+                  "zoom": 1,
+                  "crop": {
+                    "x": 946,
+                    "y": 0
+                  },
+                  "background": "transparent"
+                },
+                "thumbnails": {}
+              },
+              "image4": {
+                "__TYPE__": "ImageContent",
+                "origin": {
+                  "id": "main",
+                  "url": "https://images.unsplash.com/photo-1493119508027-2b584f234d6c",
+                  "width": 3424,
+                  "height": 3424
+                },
+                "url": "https://images.unsplash.com/photo-1493119508027-2b584f234d6c?rect=535%2C0%2C2354%2C3424&w=176&h=256",
+                "width": 176,
+                "height": 256,
+                "edit": {
+                  "zoom": 1,
+                  "crop": {
+                    "x": 535,
+                    "y": 0
+                  },
+                  "background": "transparent"
+                },
+                "thumbnails": {}
+              },
+              "image5": {
+                "__TYPE__": "ImageContent",
+                "origin": {
+                  "id": "main",
+                  "url": "https://images.unsplash.com/photo-1607582278043-57198ac8da43",
+                  "width": 4024,
+                  "height": 4024
+                },
+                "url": "https://images.unsplash.com/photo-1607582278043-57198ac8da43?rect=629%2C0%2C2767%2C4024&w=176&h=256",
+                "width": 176,
+                "height": 256,
+                "edit": {
+                  "zoom": 1,
+                  "crop": {
+                    "x": 629,
+                    "y": 0
+                  },
+                  "background": "transparent"
+                },
+                "thumbnails": {}
+              },
+              "image6": {
+                "__TYPE__": "ImageContent",
+                "origin": {
+                  "id": "main",
+                  "url": "https://images.unsplash.com/photo-1600804931749-2da4ce26c869",
+                  "width": 3199,
+                  "height": 3199
+                },
+                "url": "https://images.unsplash.com/photo-1600804931749-2da4ce26c869?rect=500%2C0%2C2199%2C3199&w=176&h=256",
+                "width": 176,
+                "height": 256,
+                "edit": {
+                  "zoom": 1,
+                  "crop": {
+                    "x": 500,
+                    "y": 0
+                  },
+                  "background": "transparent"
+                },
+                "thumbnails": {}
+              },
+              "image7": {
+                "__TYPE__": "ImageContent",
+                "origin": {
+                  "id": "main",
+                  "url": "https://images.unsplash.com/photo-1537498425277-c283d32ef9db",
+                  "width": 4380,
+                  "height": 2895
+                },
+                "url": "https://images.unsplash.com/photo-1537498425277-c283d32ef9db?rect=1195%2C0%2C1990%2C2895&w=176&h=256",
+                "width": 176,
+                "height": 256,
+                "edit": {
+                  "zoom": 1,
+                  "crop": {
+                    "x": 1195,
+                    "y": 0
+                  },
+                  "background": "transparent"
+                },
+                "thumbnails": {}
+              },
+              "personalisationid": {
+                "__TYPE__": "FieldContent",
+                "value": "heart",
+                "type": "Text"
+              },
+              "intent": {
+                "__TYPE__": "IntegrationFieldsContent",
+                "value": "integration-field-product-id"
+              }
+            },
+            "items": [
+              {
+                "__TYPE__": "GroupItemContent",
+                "value": []
+              }
+            ]
+          }
+        },
+        {
+          "key": "promo_section_with_background_image$cb376f2a-b434-4f0e-89c1-d6e1a1f396bb",
+          "name": "promo_section_with_background_image",
+          "widget": {
+            "__TYPE__": "SharedSliceContent",
+            "variation": "default-slice",
+            "primary": {
+              "title": {
+                "__TYPE__": "StructuredTextContent",
+                "value": [
+                  {
+                    "type": "heading1",
+                    "content": {
+                      "text": "Seems"
+                    }
+                  }
+                ]
+              },
+              "description": {
+                "__TYPE__": "StructuredTextContent",
+                "value": [
+                  {
+                    "type": "paragraph",
+                    "content": {
+                      "text": "Dolore sint elit labore."
+                    }
+                  }
+                ]
+              },
+              "image": {
+                "__TYPE__": "ImageContent",
+                "origin": {
+                  "id": "main",
+                  "url": "https://images.unsplash.com/photo-1606248897732-2c5ffe759c04",
+                  "width": 4000,
+                  "height": 4000
+                },
+                "url": "https://images.unsplash.com/photo-1606248897732-2c5ffe759c04?rect=0%2C1207%2C4000%2C1586&w=1216&h=482",
+                "width": 1216,
+                "height": 482,
+                "edit": {
+                  "zoom": 1,
+                  "crop": {
+                    "x": 0,
+                    "y": 1207
+                  },
+                  "background": "transparent"
+                },
+                "thumbnails": {
+                  "mobile": {
+                    "origin": {
+                      "id": "mobile",
+                      "url": "https://images.unsplash.com/photo-1499951360447-b19be8fe80f5",
+                      "width": 5848,
+                      "height": 3899
+                    },
+                    "url": "https://images.unsplash.com/photo-1499951360447-b19be8fe80f5?rect=262%2C0%2C5325%2C3899&w=605&h=443",
+                    "width": 605,
+                    "height": 443,
+                    "edit": {
+                      "zoom": 1,
+                      "crop": {
+                        "x": 262,
+                        "y": 0
+                      },
+                      "background": "transparent"
+                    }
+                  }
+                }
+              },
+              "link": {
+                "__TYPE__": "LinkContent",
+                "value": {
+                  "__TYPE__": "DocumentLink",
+                  "id": "mock_document_id"
+                }
+              },
+              "linkLabel": {
+                "__TYPE__": "FieldContent",
+                "value": "program",
+                "type": "Text"
+              }
+            },
+            "items": [
+              {
+                "__TYPE__": "GroupItemContent",
+                "value": []
+              }
+            ]
+          }
+        },
+        {
+          "key": "contact_section_split_two_tone$6d32397b-10fb-43c2-a51b-293341f1b03e",
+          "name": "contact_section_split_two_tone",
+          "widget": {
+            "__TYPE__": "SharedSliceContent",
+            "variation": "default-slice",
+            "primary": {
+              "title": {
+                "__TYPE__": "StructuredTextContent",
+                "value": [
+                  {
+                    "type": "paragraph",
+                    "content": {
+                      "text": "In nisi ex velit non magna. Minim ipsum officia nostrud sunt. Laborum minim dolore qui veniam adipisicing consequat est nostrud consectetur."
+                    }
+                  }
+                ]
+              },
+              "description": {
+                "__TYPE__": "StructuredTextContent",
+                "value": [
+                  {
+                    "type": "paragraph",
+                    "content": {
+                      "text": "Sit exercitation Lorem exercitation aliquip incididunt esse Lorem do ipsum consequat. Ullamco ullamco nisi culpa officia cillum nulla culpa ad anim consequat ipsum. Aute veniam tempor elit quis commodo tempor."
+                    }
+                  }
+                ]
+              },
+              "address": {
+                "__TYPE__": "StructuredTextContent",
+                "value": [
+                  {
+                    "type": "paragraph",
+                    "content": {
+                      "text": "Nulla aliqua elit ut ad incididunt non. Labore adipisicing commodo aliquip duis."
+                    }
+                  }
+                ]
+              },
+              "phone": {
+                "__TYPE__": "FieldContent",
+                "value": "locate",
+                "type": "Text"
+              },
+              "email": {
+                "__TYPE__": "FieldContent",
+                "value": "quite",
+                "type": "Text"
+              },
+              "careerText": {
+                "__TYPE__": "StructuredTextContent",
+                "value": [
+                  {
+                    "type": "paragraph",
+                    "content": {
+                      "text": "Velit commodo velit est."
+                    }
+                  }
+                ]
+              },
+              "careerLink": {
+                "__TYPE__": "LinkContent",
+                "value": {
+                  "__TYPE__": "ExternalLink",
+                  "url": "https://slicemachine.dev"
+                }
+              },
+              "CareerLinkText": {
+                "__TYPE__": "FieldContent",
+                "value": "day",
+                "type": "Text"
+              },
+              "cta": {
+                "__TYPE__": "FieldContent",
+                "value": "reach",
+                "type": "Text"
+              }
+            },
+            "items": [
+              {
+                "__TYPE__": "GroupItemContent",
+                "value": [
+                  [
+                    "field",
+                    {
+                      "__TYPE__": "FieldContent",
+                      "value": "deeply",
+                      "type": "Text"
+                    }
+                  ],
+                  [
+                    "fieldPlaceholder",
+                    {
+                      "__TYPE__": "FieldContent",
+                      "value": "torn",
+                      "type": "Text"
+                    }
+                  ]
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "meta_title": {
+      "__TYPE__": "FieldContent",
+      "value": "college",
+      "type": "Text"
+    },
+    "meta_description": {
+      "__TYPE__": "FieldContent",
+      "value": "discuss",
+      "type": "Text"
+    },
+    "canonicalLink": {
+      "__TYPE__": "LinkContent",
+      "value": {
+        "__TYPE__": "ExternalLink",
+        "url": "http://google.com"
+      }
+    },
+    "social_cards": {
+      "__TYPE__": "GroupContentType",
+      "value": [
+        {
+          "__TYPE__": "GroupItemContent",
+          "value": [
+            [
+              "social_card_image",
+              {
+                "__TYPE__": "ImageContent",
+                "origin": {
+                  "id": "main",
+                  "url": "https://images.unsplash.com/photo-1496181133206-80ce9b88a853",
+                  "width": 5243,
+                  "height": 3495
+                },
+                "url": "https://images.unsplash.com/photo-1496181133206-80ce9b88a853",
+                "width": 5243,
+                "height": 3495,
+                "edit": {
+                  "zoom": 1,
+                  "crop": {
+                    "x": 0,
+                    "y": 0
+                  },
+                  "background": "transparent"
+                },
+                "thumbnails": {}
+              }
+            ],
+            [
+              "social_card_title",
+              {
+                "__TYPE__": "FieldContent",
+                "value": "history",
+                "type": "Text"
+              }
+            ],
+            [
+              "social_card_description",
+              {
+                "__TYPE__": "FieldContent",
+                "value": "finish",
+                "type": "Text"
+              }
+            ]
+          ]
+        }
+      ]
+    }
+  }
+]

--- a/e2e-projects/next/customtypes/menu-tab/mocks.json
+++ b/e2e-projects/next/customtypes/menu-tab/mocks.json
@@ -1,0 +1,54 @@
+[
+  {
+    "title": {
+      "__TYPE__": "FieldContent",
+      "value": "eager",
+      "type": "Text"
+    },
+    "slices": {
+      "__TYPE__": "SliceContentType",
+      "value": [
+        {
+          "key": "menu_sub_tab$98a35086-4307-46ff-9604-b2de9bc303ba",
+          "name": "menu_sub_tab",
+          "widget": {
+            "__TYPE__": "SharedSliceContent",
+            "variation": "default-slice",
+            "primary": {
+              "sectionTitle": {
+                "__TYPE__": "FieldContent",
+                "value": "those",
+                "type": "Text"
+              }
+            },
+            "items": [
+              {
+                "__TYPE__": "GroupItemContent",
+                "value": [
+                  [
+                    "subSectionTitle",
+                    {
+                      "__TYPE__": "FieldContent",
+                      "value": "cup",
+                      "type": "Text"
+                    }
+                  ],
+                  [
+                    "subSectionLink",
+                    {
+                      "__TYPE__": "LinkContent",
+                      "value": {
+                        "__TYPE__": "DocumentLink",
+                        "id": "mock_document_id"
+                      }
+                    }
+                  ]
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+]

--- a/e2e-projects/next/customtypes/menu/mocks.json
+++ b/e2e-projects/next/customtypes/menu/mocks.json
@@ -1,48 +1,50 @@
-{
-  "topPromoBanner": {
-    "__TYPE__": "FieldContent",
-    "value": "social",
-    "type": "Text"
-  },
-  "logo": {
-    "__TYPE__": "ImageContent",
-    "origin": {
-      "id": "main",
-      "url": "https://images.unsplash.com/photo-1579931794097-0ad001e51edb",
-      "width": 3958,
-      "height": 3958
+[
+  {
+    "topPromoBanner": {
+      "__TYPE__": "FieldContent",
+      "value": "equally",
+      "type": "Text"
     },
-    "url": "https://images.unsplash.com/photo-1579931794097-0ad001e51edb?rect=0%2C0%2C3958%2C3958&w=64&h=64",
-    "width": 64,
-    "height": 64,
-    "edit": {
-      "zoom": 1,
-      "crop": {
-        "x": 0,
-        "y": 0
+    "logo": {
+      "__TYPE__": "ImageContent",
+      "origin": {
+        "id": "main",
+        "url": "https://images.unsplash.com/photo-1593642532973-d31b6557fa68",
+        "width": 8640,
+        "height": 8640
       },
-      "background": "transparent"
+      "url": "https://images.unsplash.com/photo-1593642532973-d31b6557fa68?rect=0%2C0%2C8640%2C8640&w=64&h=64",
+      "width": 64,
+      "height": 64,
+      "edit": {
+        "zoom": 1,
+        "crop": {
+          "x": 0,
+          "y": 0
+        },
+        "background": "transparent"
+      },
+      "thumbnails": {}
     },
-    "thumbnails": {}
-  },
-  "menuTabs": {
-    "__TYPE__": "GroupContentType",
-    "value": [
-      {
-        "__TYPE__": "GroupItemContent",
-        "value": [
-          [
-            "menuTab",
-            {
-              "__TYPE__": "LinkContent",
-              "value": {
-                "__TYPE__": "DocumentLink",
-                "id": "mock_document_id"
+    "menuTabs": {
+      "__TYPE__": "GroupContentType",
+      "value": [
+        {
+          "__TYPE__": "GroupItemContent",
+          "value": [
+            [
+              "menuTab",
+              {
+                "__TYPE__": "LinkContent",
+                "value": {
+                  "__TYPE__": "DocumentLink",
+                  "id": "mock_document_id"
+                }
               }
-            }
+            ]
           ]
-        ]
-      }
-    ]
+        }
+      ]
+    }
   }
-}
+]

--- a/e2e-projects/next/customtypes/page/mocks.json
+++ b/e2e-projects/next/customtypes/page/mocks.json
@@ -1,0 +1,1103 @@
+[
+  {
+    "uid": {
+      "__TYPE__": "UIDContent",
+      "value": "west"
+    },
+    "slices": {
+      "__TYPE__": "SliceContentType",
+      "value": [
+        {
+          "key": "promo_section_image_tiles$f078b794-92ce-4ec4-bb47-8da4a584934a",
+          "name": "promo_section_image_tiles",
+          "widget": {
+            "__TYPE__": "SharedSliceContent",
+            "variation": "default-slice",
+            "primary": {
+              "title": {
+                "__TYPE__": "FieldContent",
+                "value": "jet",
+                "type": "Text"
+              },
+              "subtitle": {
+                "__TYPE__": "FieldContent",
+                "value": "planning",
+                "type": "Text"
+              },
+              "linkLabel": {
+                "__TYPE__": "FieldContent",
+                "value": "morning",
+                "type": "Text"
+              },
+              "link": {
+                "__TYPE__": "LinkContent",
+                "value": {
+                  "__TYPE__": "DocumentLink",
+                  "id": "mock_document_id"
+                }
+              },
+              "backgroundColor": {
+                "__TYPE__": "FieldContent",
+                "value": "#3d52c5",
+                "type": "Color"
+              },
+              "image1": {
+                "__TYPE__": "ImageContent",
+                "origin": {
+                  "id": "main",
+                  "url": "https://images.unsplash.com/photo-1571126770897-2d612d1f7b89",
+                  "width": 3456,
+                  "height": 3456
+                },
+                "url": "https://images.unsplash.com/photo-1571126770897-2d612d1f7b89?rect=540%2C0%2C2376%2C3456&w=176&h=256",
+                "width": 176,
+                "height": 256,
+                "edit": {
+                  "zoom": 1,
+                  "crop": {
+                    "x": 540,
+                    "y": 0
+                  },
+                  "background": "transparent"
+                },
+                "thumbnails": {}
+              },
+              "image2": {
+                "__TYPE__": "ImageContent",
+                "origin": {
+                  "id": "main",
+                  "url": "https://images.unsplash.com/photo-1589652717521-10c0d092dea9",
+                  "width": 4752,
+                  "height": 3168
+                },
+                "url": "https://images.unsplash.com/photo-1589652717521-10c0d092dea9?rect=1287%2C0%2C2178%2C3168&w=176&h=256",
+                "width": 176,
+                "height": 256,
+                "edit": {
+                  "zoom": 1,
+                  "crop": {
+                    "x": 1287,
+                    "y": 0
+                  },
+                  "background": "transparent"
+                },
+                "thumbnails": {}
+              },
+              "image3": {
+                "__TYPE__": "ImageContent",
+                "origin": {
+                  "id": "main",
+                  "url": "https://images.unsplash.com/photo-1576662712957-9c79ae1280f8",
+                  "width": 3456,
+                  "height": 3456
+                },
+                "url": "https://images.unsplash.com/photo-1576662712957-9c79ae1280f8?rect=540%2C0%2C2376%2C3456&w=176&h=256",
+                "width": 176,
+                "height": 256,
+                "edit": {
+                  "zoom": 1,
+                  "crop": {
+                    "x": 540,
+                    "y": 0
+                  },
+                  "background": "transparent"
+                },
+                "thumbnails": {}
+              },
+              "image4": {
+                "__TYPE__": "ImageContent",
+                "origin": {
+                  "id": "main",
+                  "url": "https://images.unsplash.com/photo-1541807084-5c52b6b3adef",
+                  "width": 4000,
+                  "height": 6000
+                },
+                "url": "https://images.unsplash.com/photo-1541807084-5c52b6b3adef?rect=0%2C91%2C4000%2C5818&w=176&h=256",
+                "width": 176,
+                "height": 256,
+                "edit": {
+                  "zoom": 1,
+                  "crop": {
+                    "x": 0,
+                    "y": 91
+                  },
+                  "background": "transparent"
+                },
+                "thumbnails": {}
+              },
+              "image5": {
+                "__TYPE__": "ImageContent",
+                "origin": {
+                  "id": "main",
+                  "url": "https://images.unsplash.com/photo-1571126770897-2d612d1f7b89",
+                  "width": 3456,
+                  "height": 3456
+                },
+                "url": "https://images.unsplash.com/photo-1571126770897-2d612d1f7b89?rect=540%2C0%2C2376%2C3456&w=176&h=256",
+                "width": 176,
+                "height": 256,
+                "edit": {
+                  "zoom": 1,
+                  "crop": {
+                    "x": 540,
+                    "y": 0
+                  },
+                  "background": "transparent"
+                },
+                "thumbnails": {}
+              },
+              "image6": {
+                "__TYPE__": "ImageContent",
+                "origin": {
+                  "id": "main",
+                  "url": "https://images.unsplash.com/photo-1498050108023-c5249f4df085",
+                  "width": 3882,
+                  "height": 2584
+                },
+                "url": "https://images.unsplash.com/photo-1498050108023-c5249f4df085?rect=1053%2C0%2C1777%2C2584&w=176&h=256",
+                "width": 176,
+                "height": 256,
+                "edit": {
+                  "zoom": 1,
+                  "crop": {
+                    "x": 1053,
+                    "y": 0
+                  },
+                  "background": "transparent"
+                },
+                "thumbnails": {}
+              },
+              "image7": {
+                "__TYPE__": "ImageContent",
+                "origin": {
+                  "id": "main",
+                  "url": "https://images.unsplash.com/photo-1504198070170-4ca53bb1c1fa",
+                  "width": 2747,
+                  "height": 4120
+                },
+                "url": "https://images.unsplash.com/photo-1504198070170-4ca53bb1c1fa?rect=0%2C62%2C2747%2C3996&w=176&h=256",
+                "width": 176,
+                "height": 256,
+                "edit": {
+                  "zoom": 1,
+                  "crop": {
+                    "x": 0,
+                    "y": 62
+                  },
+                  "background": "transparent"
+                },
+                "thumbnails": {}
+              },
+              "personalisationid": {
+                "__TYPE__": "FieldContent",
+                "value": "metal",
+                "type": "Text"
+              },
+              "intent": {
+                "__TYPE__": "IntegrationFieldsContent",
+                "value": "integration-field-product-id"
+              }
+            },
+            "items": [
+              {
+                "__TYPE__": "GroupItemContent",
+                "value": []
+              }
+            ]
+          }
+        },
+        {
+          "key": "promo_section_full_width_with_overlapping_image_tiles$58ea175a-ddac-4787-b067-2cdd97525b71",
+          "name": "promo_section_full_width_with_overlapping_image_tiles",
+          "widget": {
+            "__TYPE__": "SharedSliceContent",
+            "variation": "default-slice",
+            "primary": {
+              "title1": {
+                "__TYPE__": "StructuredTextContent",
+                "value": [
+                  {
+                    "type": "heading1",
+                    "content": {
+                      "text": "Round"
+                    }
+                  }
+                ]
+              },
+              "title2": {
+                "__TYPE__": "StructuredTextContent",
+                "value": [
+                  {
+                    "type": "heading1",
+                    "content": {
+                      "text": "Excited"
+                    }
+                  }
+                ]
+              },
+              "image1": {
+                "__TYPE__": "ImageContent",
+                "origin": {
+                  "id": "main",
+                  "url": "https://images.unsplash.com/photo-1531771686035-25f47595c87a",
+                  "width": 3024,
+                  "height": 3778
+                },
+                "url": "https://images.unsplash.com/photo-1531771686035-25f47595c87a?rect=0%2C377%2C3024%2C3024&w=288&h=288",
+                "width": 288,
+                "height": 288,
+                "edit": {
+                  "zoom": 1,
+                  "crop": {
+                    "x": 0,
+                    "y": 377
+                  },
+                  "background": "transparent"
+                },
+                "thumbnails": {}
+              },
+              "image2": {
+                "__TYPE__": "ImageContent",
+                "origin": {
+                  "id": "main",
+                  "url": "https://images.unsplash.com/photo-1587653915936-5623ea0b949a",
+                  "width": 4000,
+                  "height": 4000
+                },
+                "url": "https://images.unsplash.com/photo-1587653915936-5623ea0b949a?rect=0%2C0%2C4000%2C4000&w=288&h=288",
+                "width": 288,
+                "height": 288,
+                "edit": {
+                  "zoom": 1,
+                  "crop": {
+                    "x": 0,
+                    "y": 0
+                  },
+                  "background": "transparent"
+                },
+                "thumbnails": {}
+              },
+              "image3": {
+                "__TYPE__": "ImageContent",
+                "origin": {
+                  "id": "main",
+                  "url": "https://images.unsplash.com/photo-1499951360447-b19be8fe80f5",
+                  "width": 5848,
+                  "height": 3899
+                },
+                "url": "https://images.unsplash.com/photo-1499951360447-b19be8fe80f5?rect=975%2C0%2C3899%2C3899&w=288&h=288",
+                "width": 288,
+                "height": 288,
+                "edit": {
+                  "zoom": 1,
+                  "crop": {
+                    "x": 975,
+                    "y": 0
+                  },
+                  "background": "transparent"
+                },
+                "thumbnails": {}
+              },
+              "image4": {
+                "__TYPE__": "ImageContent",
+                "origin": {
+                  "id": "main",
+                  "url": "https://images.unsplash.com/photo-1471897488648-5eae4ac6686b",
+                  "width": 3560,
+                  "height": 5340
+                },
+                "url": "https://images.unsplash.com/photo-1471897488648-5eae4ac6686b?rect=0%2C890%2C3560%2C3560&w=288&h=288",
+                "width": 288,
+                "height": 288,
+                "edit": {
+                  "zoom": 1,
+                  "crop": {
+                    "x": 0,
+                    "y": 890
+                  },
+                  "background": "transparent"
+                },
+                "thumbnails": {}
+              },
+              "image5": {
+                "__TYPE__": "ImageContent",
+                "origin": {
+                  "id": "main",
+                  "url": "https://images.unsplash.com/photo-1448932223592-d1fc686e76ea",
+                  "width": 3500,
+                  "height": 2338
+                },
+                "url": "https://images.unsplash.com/photo-1448932223592-d1fc686e76ea?rect=581%2C0%2C2338%2C2338&w=288&h=288",
+                "width": 288,
+                "height": 288,
+                "edit": {
+                  "zoom": 1,
+                  "crop": {
+                    "x": 581,
+                    "y": 0
+                  },
+                  "background": "transparent"
+                },
+                "thumbnails": {}
+              },
+              "image6": {
+                "__TYPE__": "ImageContent",
+                "origin": {
+                  "id": "main",
+                  "url": "https://images.unsplash.com/photo-1496181133206-80ce9b88a853",
+                  "width": 5243,
+                  "height": 3495
+                },
+                "url": "https://images.unsplash.com/photo-1496181133206-80ce9b88a853?rect=874%2C0%2C3495%2C3495&w=288&h=288",
+                "width": 288,
+                "height": 288,
+                "edit": {
+                  "zoom": 1,
+                  "crop": {
+                    "x": 874,
+                    "y": 0
+                  },
+                  "background": "transparent"
+                },
+                "thumbnails": {}
+              },
+              "ctaLink": {
+                "__TYPE__": "LinkContent",
+                "value": {
+                  "__TYPE__": "DocumentLink",
+                  "id": "mock_document_id"
+                }
+              },
+              "linkLabel": {
+                "__TYPE__": "FieldContent",
+                "value": "rough",
+                "type": "Text"
+              }
+            },
+            "items": [
+              {
+                "__TYPE__": "GroupItemContent",
+                "value": []
+              }
+            ]
+          }
+        },
+        {
+          "key": "promo_section_with_background_image$b81566ab-15ea-4f78-8374-f4b1176e6785",
+          "name": "promo_section_with_background_image",
+          "widget": {
+            "__TYPE__": "SharedSliceContent",
+            "variation": "default-slice",
+            "primary": {
+              "title": {
+                "__TYPE__": "StructuredTextContent",
+                "value": [
+                  {
+                    "type": "heading1",
+                    "content": {
+                      "text": "Safety"
+                    }
+                  }
+                ]
+              },
+              "description": {
+                "__TYPE__": "StructuredTextContent",
+                "value": [
+                  {
+                    "type": "paragraph",
+                    "content": {
+                      "text": "Officia enim Lorem ipsum officia anim eu sint nostrud nostrud. Incididunt Lorem sunt enim dolore velit esse dolore velit non."
+                    }
+                  }
+                ]
+              },
+              "image": {
+                "__TYPE__": "ImageContent",
+                "origin": {
+                  "id": "main",
+                  "url": "https://images.unsplash.com/photo-1560457079-9a6532ccb118",
+                  "width": 4160,
+                  "height": 3120
+                },
+                "url": "https://images.unsplash.com/photo-1560457079-9a6532ccb118?rect=0%2C736%2C4160%2C1649&w=1216&h=482",
+                "width": 1216,
+                "height": 482,
+                "edit": {
+                  "zoom": 1,
+                  "crop": {
+                    "x": 0,
+                    "y": 736
+                  },
+                  "background": "transparent"
+                },
+                "thumbnails": {
+                  "mobile": {
+                    "origin": {
+                      "id": "mobile",
+                      "url": "https://images.unsplash.com/photo-1571126770897-2d612d1f7b89",
+                      "width": 3456,
+                      "height": 3456
+                    },
+                    "url": "https://images.unsplash.com/photo-1571126770897-2d612d1f7b89?rect=0%2C463%2C3456%2C2531&w=605&h=443",
+                    "width": 605,
+                    "height": 443,
+                    "edit": {
+                      "zoom": 1,
+                      "crop": {
+                        "x": 0,
+                        "y": 463
+                      },
+                      "background": "transparent"
+                    }
+                  }
+                }
+              },
+              "link": {
+                "__TYPE__": "LinkContent",
+                "value": {
+                  "__TYPE__": "DocumentLink",
+                  "id": "mock_document_id"
+                }
+              },
+              "linkLabel": {
+                "__TYPE__": "FieldContent",
+                "value": "rubber",
+                "type": "Text"
+              }
+            },
+            "items": [
+              {
+                "__TYPE__": "GroupItemContent",
+                "value": []
+              }
+            ]
+          }
+        },
+        {
+          "key": "promo_section_fading_background_testimonials$0af93c5d-9f6c-4675-8d2a-8c67b79c4634",
+          "name": "promo_section_fading_background_testimonials",
+          "widget": {
+            "__TYPE__": "SharedSliceContent",
+            "variation": "default-slice",
+            "primary": {
+              "title": {
+                "__TYPE__": "StructuredTextContent",
+                "value": [
+                  {
+                    "type": "heading1",
+                    "content": {
+                      "text": "Arrange"
+                    }
+                  }
+                ]
+              },
+              "description": {
+                "__TYPE__": "StructuredTextContent",
+                "value": [
+                  {
+                    "type": "paragraph",
+                    "content": {
+                      "text": "Nisi officia aute dolore non irure do laboris fugiat veniam esse. Eu eiusmod excepteur enim velit officia in nulla magna ea tempor irure reprehenderit ipsum et esse. Nostrud quis eu qui in ipsum ipsum ex ad eiusmod."
+                    }
+                  }
+                ]
+              },
+              "cta": {
+                "__TYPE__": "FieldContent",
+                "value": "grow",
+                "type": "Text"
+              },
+              "link": {
+                "__TYPE__": "LinkContent",
+                "value": {
+                  "__TYPE__": "DocumentLink",
+                  "id": "mock_document_id"
+                }
+              },
+              "quotesTitle": {
+                "__TYPE__": "FieldContent",
+                "value": "today",
+                "type": "Text"
+              },
+              "image": {
+                "__TYPE__": "ImageContent",
+                "origin": {
+                  "id": "main",
+                  "url": "https://images.unsplash.com/photo-1537498425277-c283d32ef9db",
+                  "width": 4380,
+                  "height": 2895
+                },
+                "url": "https://images.unsplash.com/photo-1537498425277-c283d32ef9db?rect=349%2C0%2C3682%2C2895&w=1216&h=956",
+                "width": 1216,
+                "height": 956,
+                "edit": {
+                  "zoom": 1,
+                  "crop": {
+                    "x": 349,
+                    "y": 0
+                  },
+                  "background": "transparent"
+                },
+                "thumbnails": {}
+              }
+            },
+            "items": [
+              {
+                "__TYPE__": "GroupItemContent",
+                "value": [
+                  [
+                    "quote",
+                    {
+                      "__TYPE__": "FieldContent",
+                      "value": "idea",
+                      "type": "Text"
+                    }
+                  ],
+                  [
+                    "attribution",
+                    {
+                      "__TYPE__": "FieldContent",
+                      "value": "chose",
+                      "type": "Text"
+                    }
+                  ]
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "key": "category_preview_with_scrolling_cards$b432e802-fe44-40fe-a1c4-70cd0b23f07e",
+          "name": "category_preview_with_scrolling_cards",
+          "widget": {
+            "__TYPE__": "SharedSliceContent",
+            "variation": "default-slice",
+            "primary": {
+              "title": {
+                "__TYPE__": "StructuredTextContent",
+                "value": [
+                  {
+                    "type": "heading1",
+                    "content": {
+                      "text": "Service"
+                    }
+                  }
+                ]
+              },
+              "CTA": {
+                "__TYPE__": "FieldContent",
+                "value": "excellent",
+                "type": "Text"
+              },
+              "CTALink": {
+                "__TYPE__": "LinkContent",
+                "value": {
+                  "__TYPE__": "DocumentLink",
+                  "id": "mock_document_id"
+                }
+              }
+            },
+            "items": [
+              {
+                "__TYPE__": "GroupItemContent",
+                "value": [
+                  [
+                    "image",
+                    {
+                      "__TYPE__": "ImageContent",
+                      "origin": {
+                        "id": "main",
+                        "url": "https://images.unsplash.com/photo-1591012911207-0dbac31f37da",
+                        "width": 4000,
+                        "height": 4000
+                      },
+                      "url": "https://images.unsplash.com/photo-1591012911207-0dbac31f37da?rect=600%2C0%2C2800%2C4000&w=224&h=320",
+                      "width": 224,
+                      "height": 320,
+                      "edit": {
+                        "zoom": 1,
+                        "crop": {
+                          "x": 600,
+                          "y": 0
+                        },
+                        "background": "transparent"
+                      },
+                      "thumbnails": {}
+                    }
+                  ],
+                  [
+                    "title",
+                    {
+                      "__TYPE__": "FieldContent",
+                      "value": "hollow",
+                      "type": "Text"
+                    }
+                  ],
+                  [
+                    "link",
+                    {
+                      "__TYPE__": "LinkContent",
+                      "value": {
+                        "__TYPE__": "DocumentLink",
+                        "id": "mock_document_id"
+                      }
+                    }
+                  ]
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "key": "external_video_slice$c0080c52-a58b-4029-b9e2-4964987fc3eb",
+          "name": "external_video_slice",
+          "widget": {
+            "__TYPE__": "SharedSliceContent",
+            "variation": "default-slice",
+            "primary": {
+              "video": {
+                "__TYPE__": "IntegrationFieldsContent",
+                "value": "integration-field-product-id"
+              }
+            },
+            "items": [
+              {
+                "__TYPE__": "GroupItemContent",
+                "value": []
+              }
+            ]
+          }
+        },
+        {
+          "key": "header_section_simple_centered$25d8b292-b7b0-498f-b4f6-7e14470cd6a1",
+          "name": "header_section_simple_centered",
+          "widget": {
+            "__TYPE__": "SharedSliceContent",
+            "variation": "default-slice",
+            "primary": {
+              "title": {
+                "__TYPE__": "StructuredTextContent",
+                "value": [
+                  {
+                    "type": "heading1",
+                    "content": {
+                      "text": "Condition"
+                    }
+                  }
+                ]
+              },
+              "description": {
+                "__TYPE__": "StructuredTextContent",
+                "value": [
+                  {
+                    "type": "paragraph",
+                    "content": {
+                      "text": "Magna do laborum qui veniam labore laborum dolore officia ad dolor culpa laboris deserunt sit amet. Non sint duis ullamco et ad quis excepteur pariatur ullamco ut duis sit reprehenderit enim id. Tempor sint amet labore enim non anim quis est eu eiusmod Lorem."
+                    }
+                  }
+                ]
+              }
+            },
+            "items": []
+          }
+        },
+        {
+          "key": "category_preview_with_image_backgrounds$9bf82871-e888-4281-91bf-20e1407980f5",
+          "name": "category_preview_with_image_backgrounds",
+          "widget": {
+            "__TYPE__": "SharedSliceContent",
+            "variation": "default-slice",
+            "primary": {
+              "title": {
+                "__TYPE__": "StructuredTextContent",
+                "value": [
+                  {
+                    "type": "heading1",
+                    "content": {
+                      "text": "Mighty"
+                    }
+                  }
+                ]
+              },
+              "linkLabel": {
+                "__TYPE__": "FieldContent",
+                "value": "leaving",
+                "type": "Text"
+              },
+              "link": {
+                "__TYPE__": "LinkContent",
+                "value": {
+                  "__TYPE__": "DocumentLink",
+                  "id": "mock_document_id"
+                }
+              },
+              "imageLeft": {
+                "__TYPE__": "ImageContent",
+                "origin": {
+                  "id": "main",
+                  "url": "https://images.unsplash.com/photo-1486312338219-ce68d2c6f44d",
+                  "width": 4076,
+                  "height": 2712
+                },
+                "url": "https://images.unsplash.com/photo-1486312338219-ce68d2c6f44d?rect=682%2C0%2C2712%2C2712&w=592&h=592",
+                "width": 592,
+                "height": 592,
+                "edit": {
+                  "zoom": 1,
+                  "crop": {
+                    "x": 682,
+                    "y": 0
+                  },
+                  "background": "transparent"
+                },
+                "thumbnails": {
+                  "mobile": {
+                    "origin": {
+                      "id": "mobile",
+                      "url": "https://images.unsplash.com/photo-1560762484-813fc97650a0",
+                      "width": 3344,
+                      "height": 2509
+                    },
+                    "url": "https://images.unsplash.com/photo-1560762484-813fc97650a0?rect=0%2C419%2C3344%2C1672&w=560&h=280",
+                    "width": 560,
+                    "height": 280,
+                    "edit": {
+                      "zoom": 1,
+                      "crop": {
+                        "x": 0,
+                        "y": 419
+                      },
+                      "background": "transparent"
+                    }
+                  }
+                }
+              },
+              "imageLeftTitle": {
+                "__TYPE__": "FieldContent",
+                "value": "exclaimed",
+                "type": "Text"
+              },
+              "imageLeftCta": {
+                "__TYPE__": "FieldContent",
+                "value": "began",
+                "type": "Text"
+              },
+              "leftImageLink": {
+                "__TYPE__": "LinkContent",
+                "value": {
+                  "__TYPE__": "DocumentLink",
+                  "id": "mock_document_id"
+                }
+              },
+              "imageTopRight": {
+                "__TYPE__": "ImageContent",
+                "origin": {
+                  "id": "main",
+                  "url": "https://images.unsplash.com/photo-1600804931749-2da4ce26c869",
+                  "width": 3199,
+                  "height": 3199
+                },
+                "url": "https://images.unsplash.com/photo-1600804931749-2da4ce26c869?rect=0%2C843%2C3199%2C1513&w=592&h=280",
+                "width": 592,
+                "height": 280,
+                "edit": {
+                  "zoom": 1,
+                  "crop": {
+                    "x": 0,
+                    "y": 843
+                  },
+                  "background": "transparent"
+                },
+                "thumbnails": {}
+              },
+              "imageTopRightTitle": {
+                "__TYPE__": "FieldContent",
+                "value": "progress",
+                "type": "Text"
+              },
+              "imageTopRightCta": {
+                "__TYPE__": "FieldContent",
+                "value": "jungle",
+                "type": "Text"
+              },
+              "topRightImageLink": {
+                "__TYPE__": "LinkContent",
+                "value": {
+                  "__TYPE__": "DocumentLink",
+                  "id": "mock_document_id"
+                }
+              },
+              "imageBottomRight": {
+                "__TYPE__": "ImageContent",
+                "origin": {
+                  "id": "main",
+                  "url": "https://images.unsplash.com/photo-1544731612-de7f96afe55f",
+                  "width": 6000,
+                  "height": 4000
+                },
+                "url": "https://images.unsplash.com/photo-1544731612-de7f96afe55f?rect=0%2C581%2C6000%2C2838&w=592&h=280",
+                "width": 592,
+                "height": 280,
+                "edit": {
+                  "zoom": 1,
+                  "crop": {
+                    "x": 0,
+                    "y": 581
+                  },
+                  "background": "transparent"
+                },
+                "thumbnails": {}
+              },
+              "imageBottomRightTitle": {
+                "__TYPE__": "FieldContent",
+                "value": "reason",
+                "type": "Text"
+              },
+              "imageBottomRightCta": {
+                "__TYPE__": "FieldContent",
+                "value": "final",
+                "type": "Text"
+              },
+              "bottomRightImageLink": {
+                "__TYPE__": "LinkContent",
+                "value": {
+                  "__TYPE__": "DocumentLink",
+                  "id": "mock_document_id"
+                }
+              }
+            },
+            "items": [
+              {
+                "__TYPE__": "GroupItemContent",
+                "value": []
+              }
+            ]
+          }
+        },
+        {
+          "key": "hero_banner$02a3620a-a275-450f-8cf2-a98f454c7bea",
+          "name": "hero_banner",
+          "widget": {
+            "__TYPE__": "SharedSliceContent",
+            "variation": "default-slice",
+            "primary": {
+              "title": {
+                "__TYPE__": "FieldContent",
+                "value": "twice",
+                "type": "Text"
+              },
+              "description": {
+                "__TYPE__": "FieldContent",
+                "value": "everywhere",
+                "type": "Text"
+              },
+              "image": {
+                "__TYPE__": "ImageContent",
+                "origin": {
+                  "id": "main",
+                  "url": "https://images.unsplash.com/photo-1515378960530-7c0da6231fb1",
+                  "width": 5616,
+                  "height": 3744
+                },
+                "url": "https://images.unsplash.com/photo-1515378960530-7c0da6231fb1?rect=0%2C981%2C5616%2C1782&w=1024&h=325",
+                "width": 1024,
+                "height": 325,
+                "edit": {
+                  "zoom": 1,
+                  "crop": {
+                    "x": 0,
+                    "y": 981
+                  },
+                  "background": "transparent"
+                },
+                "thumbnails": {
+                  "mobile": {
+                    "origin": {
+                      "id": "mobile",
+                      "url": "https://images.unsplash.com/photo-1601933973783-43cf8a7d4c5f",
+                      "width": 6597,
+                      "height": 4398
+                    },
+                    "url": "https://images.unsplash.com/photo-1601933973783-43cf8a7d4c5f?rect=80%2C0%2C6436%2C4398&w=600&h=410",
+                    "width": 600,
+                    "height": 410,
+                    "edit": {
+                      "zoom": 1,
+                      "crop": {
+                        "x": 80,
+                        "y": 0
+                      },
+                      "background": "transparent"
+                    }
+                  }
+                }
+              },
+              "cta": {
+                "__TYPE__": "FieldContent",
+                "value": "wild",
+                "type": "Text"
+              },
+              "CTALink": {
+                "__TYPE__": "LinkContent",
+                "value": {
+                  "__TYPE__": "DocumentLink",
+                  "id": "mock_document_id"
+                }
+              }
+            },
+            "items": [
+              {
+                "__TYPE__": "GroupItemContent",
+                "value": []
+              }
+            ]
+          }
+        },
+        {
+          "key": "chart_slice$cc49bc0e-8880-45a7-9cd5-c1f0d9e0156d",
+          "name": "chart_slice",
+          "widget": {
+            "__TYPE__": "SharedSliceContent",
+            "variation": "default-slice",
+            "primary": {
+              "title": {
+                "__TYPE__": "StructuredTextContent",
+                "value": [
+                  {
+                    "type": "heading1",
+                    "content": {
+                      "text": "General"
+                    }
+                  }
+                ]
+              },
+              "description": {
+                "__TYPE__": "StructuredTextContent",
+                "value": [
+                  {
+                    "type": "paragraph",
+                    "content": {
+                      "text": "Ea qui consectetur laborum occaecat commodo nulla consectetur reprehenderit ea magna ad ad non. Minim velit minim amet aliqua exercitation laboris id ea ea aliqua cillum in sunt minim voluptate. Irure quis nulla consectetur reprehenderit dolor ipsum deserunt magna."
+                    }
+                  }
+                ]
+              },
+              "additionalInfoTitle": {
+                "__TYPE__": "StructuredTextContent",
+                "value": [
+                  {
+                    "type": "paragraph",
+                    "content": {
+                      "text": "Voluptate aliquip ipsum enim aliqua. Sit amet cupidatat laborum deserunt officia nisi."
+                    }
+                  }
+                ]
+              },
+              "additionalInfo": {
+                "__TYPE__": "StructuredTextContent",
+                "value": [
+                  {
+                    "type": "paragraph",
+                    "content": {
+                      "text": "Ex Lorem consequat anim reprehenderit sunt adipisicing nisi sunt mollit commodo dolor ut irure esse magna."
+                    }
+                  }
+                ]
+              }
+            },
+            "items": [
+              {
+                "__TYPE__": "GroupItemContent",
+                "value": [
+                  [
+                    "percentageShare",
+                    {
+                      "__TYPE__": "FieldContent",
+                      "value": "35",
+                      "type": "Number"
+                    }
+                  ],
+                  [
+                    "entityLabel",
+                    {
+                      "__TYPE__": "FieldContent",
+                      "value": "then",
+                      "type": "Text"
+                    }
+                  ]
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "meta_title": {
+      "__TYPE__": "FieldContent",
+      "value": "taught",
+      "type": "Text"
+    },
+    "meta_description": {
+      "__TYPE__": "FieldContent",
+      "value": "window",
+      "type": "Text"
+    },
+    "canonicalLink": {
+      "__TYPE__": "LinkContent",
+      "value": {
+        "__TYPE__": "ExternalLink",
+        "url": "http://twitter.com"
+      }
+    },
+    "social_cards": {
+      "__TYPE__": "GroupContentType",
+      "value": [
+        {
+          "__TYPE__": "GroupItemContent",
+          "value": [
+            [
+              "social_card_image",
+              {
+                "__TYPE__": "ImageContent",
+                "origin": {
+                  "id": "main",
+                  "url": "https://images.unsplash.com/photo-1547082299-de196ea013d6",
+                  "width": 4272,
+                  "height": 2848
+                },
+                "url": "https://images.unsplash.com/photo-1547082299-de196ea013d6",
+                "width": 4272,
+                "height": 2848,
+                "edit": {
+                  "zoom": 1,
+                  "crop": {
+                    "x": 0,
+                    "y": 0
+                  },
+                  "background": "transparent"
+                },
+                "thumbnails": {}
+              }
+            ],
+            [
+              "social_card_title",
+              {
+                "__TYPE__": "FieldContent",
+                "value": "dear",
+                "type": "Text"
+              }
+            ],
+            [
+              "social_card_description",
+              {
+                "__TYPE__": "FieldContent",
+                "value": "example",
+                "type": "Text"
+              }
+            ]
+          ]
+        }
+      ]
+    }
+  }
+]

--- a/e2e-projects/next/slices/ecommerce/CategoryPreviewWithImageBackgrounds/mocks.json
+++ b/e2e-projects/next/slices/ecommerce/CategoryPreviewWithImageBackgrounds/mocks.json
@@ -1,1 +1,189 @@
-[{"__TYPE__":"SharedSliceContent","variation":"default-slice","primary":{"linkLabel":{"__TYPE__":"FieldContent","value":"speed","type":"Text"},"title":{"__TYPE__":"StructuredTextContent","value":[{"type":"heading1","content":{"text":"Higher"}}]},"link":{"__TYPE__":"LinkContent","value":{"id":"mock_document_id","__TYPE__":"DocumentLink"}},"imageLeft":{"__TYPE__":"ImageContent","url":"https://images.unsplash.com/photo-1551739440-5dd934d3a94a?fit=crop&w=592&h=592","origin":{"id":"main","url":"https://images.unsplash.com/photo-1551739440-5dd934d3a94a","width":592,"height":592},"width":592,"height":592,"edit":{"zoom":1,"crop":{"x":0,"y":0},"background":"transparent"},"thumbnails":{"mobile":{"url":"https://images.unsplash.com/photo-1515378791036-0648a3ef77b2?fit=crop&w=560&h=280","origin":{"id":"mobile","url":"https://images.unsplash.com/photo-1515378791036-0648a3ef77b2","width":560,"height":280},"width":560,"height":280,"edit":{"zoom":1,"crop":{"x":0,"y":0},"background":"transparent"}}}},"imageLeftTitle":{"__TYPE__":"FieldContent","value":"rate","type":"Text"},"imageLeftCta":{"__TYPE__":"FieldContent","value":"funny","type":"Text"},"leftImageLink":{"__TYPE__":"LinkContent","value":{"id":"mock_document_id","__TYPE__":"DocumentLink"}},"imageTopRight":{"__TYPE__":"ImageContent","url":"https://images.unsplash.com/photo-1600861194802-a2b11076bc51?fit=crop&w=592&h=280","origin":{"id":"main","url":"https://images.unsplash.com/photo-1600861194802-a2b11076bc51","width":592,"height":280},"width":592,"height":280,"edit":{"zoom":1,"crop":{"x":0,"y":0},"background":"transparent"},"thumbnails":{}},"imageTopRightTitle":{"__TYPE__":"FieldContent","value":"soil","type":"Text"},"imageTopRightCta":{"__TYPE__":"FieldContent","value":"printed","type":"Text"},"topRightImageLink":{"__TYPE__":"LinkContent","value":{"id":"mock_document_id","__TYPE__":"DocumentLink"}},"imageBottomRight":{"__TYPE__":"ImageContent","url":"https://images.unsplash.com/photo-1607582278043-57198ac8da43?fit=crop&w=592&h=280","origin":{"id":"main","url":"https://images.unsplash.com/photo-1607582278043-57198ac8da43","width":592,"height":280},"width":592,"height":280,"edit":{"zoom":1,"crop":{"x":0,"y":0},"background":"transparent"},"thumbnails":{}},"imageBottomRightTitle":{"__TYPE__":"FieldContent","value":"smile","type":"Text"},"imageBottomRightCta":{"__TYPE__":"FieldContent","value":"exchange","type":"Text"},"bottomRightImageLink":{"__TYPE__":"LinkContent","value":{"id":"mock_document_id","__TYPE__":"DocumentLink"}}},"items":[{"__TYPE__":"GroupItemContent","value":[]}]}]
+[
+  {
+    "__TYPE__": "SharedSliceContent",
+    "variation": "another-variation",
+    "primary": {
+      "title": {
+        "__TYPE__": "StructuredTextContent",
+        "value": [
+          {
+            "type": "heading1",
+            "content": {
+              "text": "Together"
+            }
+          }
+        ]
+      }
+    },
+    "items": []
+  },
+  {
+    "__TYPE__": "SharedSliceContent",
+    "variation": "default-slice",
+    "primary": {
+      "title": {
+        "__TYPE__": "StructuredTextContent",
+        "value": [
+          {
+            "type": "heading1",
+            "content": {
+              "text": "Exact"
+            }
+          }
+        ]
+      },
+      "linkLabel": {
+        "__TYPE__": "FieldContent",
+        "value": "likely",
+        "type": "Text"
+      },
+      "link": {
+        "__TYPE__": "LinkContent",
+        "value": {
+          "__TYPE__": "DocumentLink",
+          "id": "mock_document_id"
+        }
+      },
+      "imageLeft": {
+        "__TYPE__": "ImageContent",
+        "origin": {
+          "id": "main",
+          "url": "https://images.unsplash.com/photo-1587905069134-008460d7a636",
+          "width": 3935,
+          "height": 5894
+        },
+        "url": "https://images.unsplash.com/photo-1587905069134-008460d7a636?rect=0%2C980%2C3935%2C3935&w=592&h=592",
+        "width": 592,
+        "height": 592,
+        "edit": {
+          "zoom": 1,
+          "crop": {
+            "x": 0,
+            "y": 980
+          },
+          "background": "transparent"
+        },
+        "thumbnails": {
+          "mobile": {
+            "origin": {
+              "id": "mobile",
+              "url": "https://images.unsplash.com/photo-1596195689404-24d8a8d1c6ea",
+              "width": 5000,
+              "height": 4613
+            },
+            "url": "https://images.unsplash.com/photo-1596195689404-24d8a8d1c6ea?rect=0%2C1057%2C5000%2C2500&w=560&h=280",
+            "width": 560,
+            "height": 280,
+            "edit": {
+              "zoom": 1,
+              "crop": {
+                "x": 0,
+                "y": 1057
+              },
+              "background": "transparent"
+            }
+          }
+        }
+      },
+      "imageLeftTitle": {
+        "__TYPE__": "FieldContent",
+        "value": "feel",
+        "type": "Text"
+      },
+      "imageLeftCta": {
+        "__TYPE__": "FieldContent",
+        "value": "means",
+        "type": "Text"
+      },
+      "leftImageLink": {
+        "__TYPE__": "LinkContent",
+        "value": {
+          "__TYPE__": "DocumentLink",
+          "id": "mock_document_id"
+        }
+      },
+      "imageTopRight": {
+        "__TYPE__": "ImageContent",
+        "origin": {
+          "id": "main",
+          "url": "https://images.unsplash.com/photo-1537498425277-c283d32ef9db",
+          "width": 4380,
+          "height": 2895
+        },
+        "url": "https://images.unsplash.com/photo-1537498425277-c283d32ef9db?rect=0%2C412%2C4380%2C2072&w=592&h=280",
+        "width": 592,
+        "height": 280,
+        "edit": {
+          "zoom": 1,
+          "crop": {
+            "x": 0,
+            "y": 412
+          },
+          "background": "transparent"
+        },
+        "thumbnails": {}
+      },
+      "imageTopRightTitle": {
+        "__TYPE__": "FieldContent",
+        "value": "principle",
+        "type": "Text"
+      },
+      "imageTopRightCta": {
+        "__TYPE__": "FieldContent",
+        "value": "lunch",
+        "type": "Text"
+      },
+      "topRightImageLink": {
+        "__TYPE__": "LinkContent",
+        "value": {
+          "__TYPE__": "DocumentLink",
+          "id": "mock_document_id"
+        }
+      },
+      "imageBottomRight": {
+        "__TYPE__": "ImageContent",
+        "origin": {
+          "id": "main",
+          "url": "https://images.unsplash.com/photo-1547394765-185e1e68f34e",
+          "width": 6000,
+          "height": 4000
+        },
+        "url": "https://images.unsplash.com/photo-1547394765-185e1e68f34e?rect=0%2C581%2C6000%2C2838&w=592&h=280",
+        "width": 592,
+        "height": 280,
+        "edit": {
+          "zoom": 1,
+          "crop": {
+            "x": 0,
+            "y": 581
+          },
+          "background": "transparent"
+        },
+        "thumbnails": {}
+      },
+      "imageBottomRightTitle": {
+        "__TYPE__": "FieldContent",
+        "value": "vast",
+        "type": "Text"
+      },
+      "imageBottomRightCta": {
+        "__TYPE__": "FieldContent",
+        "value": "plain",
+        "type": "Text"
+      },
+      "bottomRightImageLink": {
+        "__TYPE__": "LinkContent",
+        "value": {
+          "__TYPE__": "DocumentLink",
+          "id": "mock_document_id"
+        }
+      }
+    },
+    "items": [
+      {
+        "__TYPE__": "GroupItemContent",
+        "value": []
+      }
+    ]
+  }
+]

--- a/e2e-projects/next/slices/ecommerce/CategoryPreviewWithImageBackgrounds/model.json
+++ b/e2e-projects/next/slices/ecommerce/CategoryPreviewWithImageBackgrounds/model.json
@@ -5,6 +5,24 @@
   "description": "CategoryPreviewWithImageBackgrounds",
   "variations": [
     {
+      "id": "another-variation",
+      "name": "Another variation",
+      "docURL": "...",
+      "version": "sktwi1xtmkfgx8626",
+      "description": "CategoryPreviewWithImageBackgrounds",
+      "primary": {
+        "title": {
+          "type": "StructuredText",
+          "config": {
+            "label": "Title",
+            "placeholder": "This is where it all begins...",
+            "allowTargetBlank": true,
+            "single": "heading1"
+          }
+        }
+      }
+    },
+    {
       "id": "default-slice",
       "name": "Default slice",
       "docURL": "...",

--- a/e2e-projects/next/slices/marketing/BlogSectionThreeColumnCards/mocks.json
+++ b/e2e-projects/next/slices/marketing/BlogSectionThreeColumnCards/mocks.json
@@ -1,117 +1,119 @@
-{
-  "__TYPE__": "SharedSliceContent",
-  "variation": "default-slice",
-  "primary": {
-    "title": {
-      "__TYPE__": "StructuredTextContent",
-      "value": [
-        {
-          "type": "heading1",
-          "content": {
-            "text": "Thumb"
-          }
-        }
-      ]
-    },
-    "description": {
-      "__TYPE__": "StructuredTextContent",
-      "value": [
-        {
-          "type": "paragraph",
-          "content": {
-            "text": "Consectetur sit nulla esse fugiat fugiat reprehenderit ipsum culpa amet id ad voluptate fugiat deserunt. Incididunt quis anim voluptate."
-          }
-        }
-      ]
-    }
-  },
-  "items": [
-    {
-      "__TYPE__": "GroupItemContent",
-      "value": [
-        [
-          "article",
+[
+  {
+    "__TYPE__": "SharedSliceContent",
+    "variation": "default-slice",
+    "primary": {
+      "title": {
+        "__TYPE__": "StructuredTextContent",
+        "value": [
           {
-            "__TYPE__": "LinkContent",
-            "value": {
-              "__TYPE__": "DocumentLink",
-              "id": "mock_document_id"
+            "type": "heading1",
+            "content": {
+              "text": "Diameter"
             }
           }
-        ],
-        [
-          "image",
+        ]
+      },
+      "description": {
+        "__TYPE__": "StructuredTextContent",
+        "value": [
           {
-            "__TYPE__": "ImageContent",
-            "origin": {
-              "id": "main",
-              "url": "https://images.unsplash.com/photo-1587613865763-4b8b0d19e8ab",
-              "width": 12288,
-              "height": 16384
-            },
-            "url": "https://images.unsplash.com/photo-1587613865763-4b8b0d19e8ab",
-            "width": 12288,
-            "height": 16384,
-            "edit": {
-              "zoom": 1,
-              "crop": {
-                "x": 0,
-                "y": 0
-              },
-              "background": "transparent"
-            },
-            "thumbnails": {}
-          }
-        ],
-        [
-          "author",
-          {
-            "__TYPE__": "FieldContent",
-            "value": "river",
-            "type": "Text"
-          }
-        ],
-        [
-          "authorImage",
-          {
-            "__TYPE__": "ImageContent",
-            "origin": {
-              "id": "main",
-              "url": "https://images.unsplash.com/photo-1607582278038-6bebbd4d7b72",
-              "width": 4010,
-              "height": 4010
-            },
-            "url": "https://images.unsplash.com/photo-1607582278038-6bebbd4d7b72",
-            "width": 4010,
-            "height": 4010,
-            "edit": {
-              "zoom": 1,
-              "crop": {
-                "x": 0,
-                "y": 0
-              },
-              "background": "transparent"
-            },
-            "thumbnails": {}
-          }
-        ],
-        [
-          "date",
-          {
-            "__TYPE__": "FieldContent",
-            "type": "Date",
-            "value": "2013-11-24"
-          }
-        ],
-        [
-          "minutesToRead",
-          {
-            "__TYPE__": "FieldContent",
-            "value": "94",
-            "type": "Number"
+            "type": "paragraph",
+            "content": {
+              "text": "Consequat eiusmod nostrud commodo ipsum deserunt cupidatat consequat esse adipisicing in mollit proident dolore. Aute in ex cupidatat labore labore tempor ad id."
+            }
           }
         ]
-      ]
-    }
-  ]
-}
+      }
+    },
+    "items": [
+      {
+        "__TYPE__": "GroupItemContent",
+        "value": [
+          [
+            "article",
+            {
+              "__TYPE__": "LinkContent",
+              "value": {
+                "__TYPE__": "DocumentLink",
+                "id": "mock_document_id"
+              }
+            }
+          ],
+          [
+            "image",
+            {
+              "__TYPE__": "ImageContent",
+              "origin": {
+                "id": "main",
+                "url": "https://images.unsplash.com/photo-1587905069134-008460d7a636",
+                "width": 3935,
+                "height": 5894
+              },
+              "url": "https://images.unsplash.com/photo-1587905069134-008460d7a636",
+              "width": 3935,
+              "height": 5894,
+              "edit": {
+                "zoom": 1,
+                "crop": {
+                  "x": 0,
+                  "y": 0
+                },
+                "background": "transparent"
+              },
+              "thumbnails": {}
+            }
+          ],
+          [
+            "author",
+            {
+              "__TYPE__": "FieldContent",
+              "value": "western",
+              "type": "Text"
+            }
+          ],
+          [
+            "authorImage",
+            {
+              "__TYPE__": "ImageContent",
+              "origin": {
+                "id": "main",
+                "url": "https://images.unsplash.com/photo-1448932223592-d1fc686e76ea",
+                "width": 3500,
+                "height": 2338
+              },
+              "url": "https://images.unsplash.com/photo-1448932223592-d1fc686e76ea",
+              "width": 3500,
+              "height": 2338,
+              "edit": {
+                "zoom": 1,
+                "crop": {
+                  "x": 0,
+                  "y": 0
+                },
+                "background": "transparent"
+              },
+              "thumbnails": {}
+            }
+          ],
+          [
+            "date",
+            {
+              "__TYPE__": "FieldContent",
+              "type": "Date",
+              "value": "2021-03-24"
+            }
+          ],
+          [
+            "minutesToRead",
+            {
+              "__TYPE__": "FieldContent",
+              "value": "83",
+              "type": "Number"
+            }
+          ]
+        ]
+      }
+    ]
+  }
+]

--- a/e2e-projects/next/slices/marketing/ContactSectionSplitTwoTone/mocks.json
+++ b/e2e-projects/next/slices/marketing/ContactSectionSplitTwoTone/mocks.json
@@ -1,100 +1,102 @@
-{
-  "__TYPE__": "SharedSliceContent",
-  "variation": "default-slice",
-  "primary": {
-    "title": {
-      "__TYPE__": "StructuredTextContent",
-      "value": [
-        {
-          "type": "paragraph",
-          "content": {
-            "text": "Aute minim qui culpa aliqua. Commodo proident enim ad sint nulla."
-          }
-        }
-      ]
-    },
-    "description": {
-      "__TYPE__": "StructuredTextContent",
-      "value": [
-        {
-          "type": "paragraph",
-          "content": {
-            "text": "Est veniam nisi commodo reprehenderit irure officia laboris irure exercitation fugiat deserunt Lorem proident eiusmod deserunt. Officia eiusmod veniam deserunt amet sit non non occaecat."
-          }
-        }
-      ]
-    },
-    "address": {
-      "__TYPE__": "StructuredTextContent",
-      "value": [
-        {
-          "type": "paragraph",
-          "content": {
-            "text": "Non non et veniam ea aute proident cillum non cillum do laboris ut esse sunt. In consequat dolor Lorem in fugiat. Sit tempor consequat officia exercitation tempor."
-          }
-        }
-      ]
-    },
-    "phone": {
-      "__TYPE__": "FieldContent",
-      "value": "surface",
-      "type": "Text"
-    },
-    "email": {
-      "__TYPE__": "FieldContent",
-      "value": "soft",
-      "type": "Text"
-    },
-    "careerText": {
-      "__TYPE__": "StructuredTextContent",
-      "value": [
-        {
-          "type": "paragraph",
-          "content": {
-            "text": "Culpa voluptate velit in occaecat. Incididunt magna anim qui in voluptate ipsum dolor quis ullamco officia et cillum commodo."
-          }
-        }
-      ]
-    },
-    "careerLink": {
-      "__TYPE__": "LinkContent",
-      "value": {
-        "__TYPE__": "ExternalLink",
-        "url": "http://google.com"
-      }
-    },
-    "CareerLinkText": {
-      "__TYPE__": "FieldContent",
-      "value": "mother",
-      "type": "Text"
-    },
-    "cta": {
-      "__TYPE__": "FieldContent",
-      "value": "screen",
-      "type": "Text"
-    }
-  },
-  "items": [
-    {
-      "__TYPE__": "GroupItemContent",
-      "value": [
-        [
-          "field",
+[
+  {
+    "__TYPE__": "SharedSliceContent",
+    "variation": "default-slice",
+    "primary": {
+      "title": {
+        "__TYPE__": "StructuredTextContent",
+        "value": [
           {
-            "__TYPE__": "FieldContent",
-            "value": "travel",
-            "type": "Text"
-          }
-        ],
-        [
-          "fieldPlaceholder",
-          {
-            "__TYPE__": "FieldContent",
-            "value": "travel",
-            "type": "Text"
+            "type": "paragraph",
+            "content": {
+              "text": "Occaecat non magna cupidatat tempor eu officia et labore."
+            }
           }
         ]
-      ]
-    }
-  ]
-}
+      },
+      "description": {
+        "__TYPE__": "StructuredTextContent",
+        "value": [
+          {
+            "type": "paragraph",
+            "content": {
+              "text": "Anim sit sint deserunt. Exercitation qui quis ut deserunt eu. Cupidatat consectetur eu velit dolor esse magna Lorem cillum cillum est."
+            }
+          }
+        ]
+      },
+      "address": {
+        "__TYPE__": "StructuredTextContent",
+        "value": [
+          {
+            "type": "paragraph",
+            "content": {
+              "text": "Laboris qui elit incididunt enim cupidatat consequat. Et non excepteur nostrud sunt amet culpa proident irure laboris ullamco sint magna nostrud enim. Nulla duis ut ullamco aliqua tempor exercitation ex minim."
+            }
+          }
+        ]
+      },
+      "phone": {
+        "__TYPE__": "FieldContent",
+        "value": "drink",
+        "type": "Text"
+      },
+      "email": {
+        "__TYPE__": "FieldContent",
+        "value": "owner",
+        "type": "Text"
+      },
+      "careerText": {
+        "__TYPE__": "StructuredTextContent",
+        "value": [
+          {
+            "type": "paragraph",
+            "content": {
+              "text": "Proident velit veniam incididunt ullamco sint minim sint veniam sit mollit."
+            }
+          }
+        ]
+      },
+      "careerLink": {
+        "__TYPE__": "LinkContent",
+        "value": {
+          "__TYPE__": "ExternalLink",
+          "url": "http://google.com"
+        }
+      },
+      "CareerLinkText": {
+        "__TYPE__": "FieldContent",
+        "value": "cheese",
+        "type": "Text"
+      },
+      "cta": {
+        "__TYPE__": "FieldContent",
+        "value": "answer",
+        "type": "Text"
+      }
+    },
+    "items": [
+      {
+        "__TYPE__": "GroupItemContent",
+        "value": [
+          [
+            "field",
+            {
+              "__TYPE__": "FieldContent",
+              "value": "compare",
+              "type": "Text"
+            }
+          ],
+          [
+            "fieldPlaceholder",
+            {
+              "__TYPE__": "FieldContent",
+              "value": "push",
+              "type": "Text"
+            }
+          ]
+        ]
+      }
+    ]
+  }
+]

--- a/e2e-projects/next/slices/marketing/ContentSectionCentered/mocks.json
+++ b/e2e-projects/next/slices/marketing/ContentSectionCentered/mocks.json
@@ -1,23 +1,25 @@
-{
-  "__TYPE__": "SharedSliceContent",
-  "variation": "default-slice",
-  "primary": {
-    "description": {
-      "__TYPE__": "StructuredTextContent",
-      "value": [
-        {
-          "type": "paragraph",
-          "content": {
-            "text": "Excepteur aliqua ex fugiat veniam. Cupidatat dolor ea irure veniam sit laboris laborum irure pariatur nostrud. Labore consectetur sunt est cillum dolor sint sunt duis."
+[
+  {
+    "__TYPE__": "SharedSliceContent",
+    "variation": "default-slice",
+    "primary": {
+      "description": {
+        "__TYPE__": "StructuredTextContent",
+        "value": [
+          {
+            "type": "paragraph",
+            "content": {
+              "text": "Commodo sunt elit veniam fugiat esse quis qui."
+            }
           }
-        }
-      ]
-    }
-  },
-  "items": [
-    {
-      "__TYPE__": "GroupItemContent",
-      "value": []
-    }
-  ]
-}
+        ]
+      }
+    },
+    "items": [
+      {
+        "__TYPE__": "GroupItemContent",
+        "value": []
+      }
+    ]
+  }
+]

--- a/e2e-projects/next/slices/marketing/ContentSectionCenteredEmbed/mocks.json
+++ b/e2e-projects/next/slices/marketing/ContentSectionCenteredEmbed/mocks.json
@@ -1,39 +1,41 @@
-{
-  "__TYPE__": "SharedSliceContent",
-  "variation": "default-slice",
-  "primary": {
-    "EmbedItem": {
-      "embed_url": "https://twitter.com/prismicio/status/1354835716430319617",
-      "author_name": "Prismic",
-      "author_url": "https://twitter.com/prismicio",
-      "html": "<blockquote class=\"twitter-tweet\"><p lang=\"en\" dir=\"ltr\">Does anyone want to create a wildly popular website for discussing &#39;Wall Street Bets&#39; using Prismic?<br><br>It may or may not have to look a lot like <a href=\"https://twitter.com/hashtag/reddit?src=hash&amp;ref_src=twsrc%5Etfw\">#reddit</a> and we won&#39;t make it private.<br><br>Just asking for some friends...</p>&mdash; Prismic (@prismicio) <a href=\"https://twitter.com/prismicio/status/1354835716430319617?ref_src=twsrc%5Etfw\">January 28, 2021</a></blockquote>\n<script async src=\"https://platform.twitter.com/widgets.js\" charset=\"utf-8\"></script>\n",
-      "width": 550,
-      "height": null,
-      "type": "rich",
-      "cache_age": "3153600000",
-      "provider_name": "Twitter",
-      "provider_url": "http://www.twitter.com/",
-      "version": "1.0",
-      "all": {
-        "embed_url": "https://twitter.com/prismicio/status/1354835716430319617",
+[
+  {
+    "__TYPE__": "SharedSliceContent",
+    "variation": "default-slice",
+    "primary": {
+      "EmbedItem": {
+        "embed_url": "https://twitter.com/prismicio/status/1356293316158095361",
         "author_name": "Prismic",
         "author_url": "https://twitter.com/prismicio",
-        "html": "<blockquote class=\"twitter-tweet\"><p lang=\"en\" dir=\"ltr\">Does anyone want to create a wildly popular website for discussing &#39;Wall Street Bets&#39; using Prismic?<br><br>It may or may not have to look a lot like <a href=\"https://twitter.com/hashtag/reddit?src=hash&amp;ref_src=twsrc%5Etfw\">#reddit</a> and we won&#39;t make it private.<br><br>Just asking for some friends...</p>&mdash; Prismic (@prismicio) <a href=\"https://twitter.com/prismicio/status/1354835716430319617?ref_src=twsrc%5Etfw\">January 28, 2021</a></blockquote>\n<script async src=\"https://platform.twitter.com/widgets.js\" charset=\"utf-8\"></script>\n",
+        "html": "<blockquote class=\"twitter-tweet\"><p lang=\"en\" dir=\"ltr\">Gatsby is a popular choice for Prismic users and we work hard on delivering a CMS that plays to its strengths.<br><br>But, what makes <a href=\"https://twitter.com/GatsbyJS?ref_src=twsrc%5Etfw\">@GatsbyJS</a> so popular?<br><br>Here are some of <a href=\"https://twitter.com/mxstbr?ref_src=twsrc%5Etfw\">@mxstbr</a>&#39;s thoughts on Gatsby&#39;s success and how they&#39;re improving developer experience.<a href=\"https://t.co/ZjCPvsWWUD\">https://t.co/ZjCPvsWWUD</a> <a href=\"https://t.co/EQqzJpeNKl\">pic.twitter.com/EQqzJpeNKl</a></p>&mdash; Prismic (@prismicio) <a href=\"https://twitter.com/prismicio/status/1356293316158095361?ref_src=twsrc%5Etfw\">February 1, 2021</a></blockquote>\n<script async src=\"https://platform.twitter.com/widgets.js\" charset=\"utf-8\"></script>\n",
         "width": 550,
         "height": null,
         "type": "rich",
         "cache_age": "3153600000",
         "provider_name": "Twitter",
         "provider_url": "http://www.twitter.com/",
-        "version": "1.0"
-      },
-      "__TYPE__": "EmbedContent"
-    }
-  },
-  "items": [
-    {
-      "__TYPE__": "GroupItemContent",
-      "value": []
-    }
-  ]
-}
+        "version": "1.0",
+        "all": {
+          "embed_url": "https://twitter.com/prismicio/status/1356293316158095361",
+          "author_name": "Prismic",
+          "author_url": "https://twitter.com/prismicio",
+          "html": "<blockquote class=\"twitter-tweet\"><p lang=\"en\" dir=\"ltr\">Gatsby is a popular choice for Prismic users and we work hard on delivering a CMS that plays to its strengths.<br><br>But, what makes <a href=\"https://twitter.com/GatsbyJS?ref_src=twsrc%5Etfw\">@GatsbyJS</a> so popular?<br><br>Here are some of <a href=\"https://twitter.com/mxstbr?ref_src=twsrc%5Etfw\">@mxstbr</a>&#39;s thoughts on Gatsby&#39;s success and how they&#39;re improving developer experience.<a href=\"https://t.co/ZjCPvsWWUD\">https://t.co/ZjCPvsWWUD</a> <a href=\"https://t.co/EQqzJpeNKl\">pic.twitter.com/EQqzJpeNKl</a></p>&mdash; Prismic (@prismicio) <a href=\"https://twitter.com/prismicio/status/1356293316158095361?ref_src=twsrc%5Etfw\">February 1, 2021</a></blockquote>\n<script async src=\"https://platform.twitter.com/widgets.js\" charset=\"utf-8\"></script>\n",
+          "width": 550,
+          "height": null,
+          "type": "rich",
+          "cache_age": "3153600000",
+          "provider_name": "Twitter",
+          "provider_url": "http://www.twitter.com/",
+          "version": "1.0"
+        },
+        "__TYPE__": "EmbedContent"
+      }
+    },
+    "items": [
+      {
+        "__TYPE__": "GroupItemContent",
+        "value": []
+      }
+    ]
+  }
+]

--- a/e2e-projects/next/slices/marketing/ContentSectionCenteredImage/mocks.json
+++ b/e2e-projects/next/slices/marketing/ContentSectionCenteredImage/mocks.json
@@ -1,44 +1,46 @@
-{
-  "__TYPE__": "SharedSliceContent",
-  "variation": "default-slice",
-  "primary": {
-    "description": {
-      "__TYPE__": "StructuredTextContent",
-      "value": [
-        {
-          "type": "paragraph",
-          "content": {
-            "text": "Et dolore ex enim sit ipsum nulla mollit pariatur. Sit consequat est nulla sunt id deserunt fugiat. Reprehenderit eiusmod incididunt irure irure amet laborum id esse."
+[
+  {
+    "__TYPE__": "SharedSliceContent",
+    "variation": "default-slice",
+    "primary": {
+      "description": {
+        "__TYPE__": "StructuredTextContent",
+        "value": [
+          {
+            "type": "paragraph",
+            "content": {
+              "text": "Officia esse labore voluptate ullamco. Minim consequat exercitation officia magna mollit culpa tempor nostrud aute aliquip."
+            }
           }
-        }
-      ]
-    },
-    "image": {
-      "__TYPE__": "ImageContent",
-      "origin": {
-        "id": "main",
-        "url": "https://images.unsplash.com/photo-1496181133206-80ce9b88a853",
-        "width": 5243,
-        "height": 3495
+        ]
       },
-      "url": "https://images.unsplash.com/photo-1496181133206-80ce9b88a853",
-      "width": 5243,
-      "height": 3495,
-      "edit": {
-        "zoom": 1,
-        "crop": {
-          "x": 0,
-          "y": 0
+      "image": {
+        "__TYPE__": "ImageContent",
+        "origin": {
+          "id": "main",
+          "url": "https://images.unsplash.com/photo-1589321578146-4c1ba445cc88",
+          "width": 3168,
+          "height": 4752
         },
-        "background": "transparent"
-      },
-      "thumbnails": {}
-    }
-  },
-  "items": [
-    {
-      "__TYPE__": "GroupItemContent",
-      "value": []
-    }
-  ]
-}
+        "url": "https://images.unsplash.com/photo-1589321578146-4c1ba445cc88",
+        "width": 3168,
+        "height": 4752,
+        "edit": {
+          "zoom": 1,
+          "crop": {
+            "x": 0,
+            "y": 0
+          },
+          "background": "transparent"
+        },
+        "thumbnails": {}
+      }
+    },
+    "items": [
+      {
+        "__TYPE__": "GroupItemContent",
+        "value": []
+      }
+    ]
+  }
+]

--- a/e2e-projects/next/slices/marketing/ContentSectionTwoColumnsWithImage/mocks.json
+++ b/e2e-projects/next/slices/marketing/ContentSectionTwoColumnsWithImage/mocks.json
@@ -1,82 +1,84 @@
-{
-  "__TYPE__": "SharedSliceContent",
-  "variation": "default-slice",
-  "primary": {
-    "title": {
-      "__TYPE__": "StructuredTextContent",
-      "value": [
-        {
-          "type": "heading1",
-          "content": {
-            "text": "Worry"
+[
+  {
+    "__TYPE__": "SharedSliceContent",
+    "variation": "default-slice",
+    "primary": {
+      "title": {
+        "__TYPE__": "StructuredTextContent",
+        "value": [
+          {
+            "type": "heading1",
+            "content": {
+              "text": "Apple"
+            }
           }
-        }
-      ]
-    },
-    "description": {
-      "__TYPE__": "StructuredTextContent",
-      "value": [
-        {
-          "type": "paragraph",
-          "content": {
-            "text": "Laboris sunt laborum ea elit sint fugiat officia esse dolore veniam labore est id adipisicing do. Laboris adipisicing Lorem cupidatat enim duis adipisicing eiusmod deserunt eiusmod quis elit quis enim cillum exercitation. Cillum laboris consequat eu eu culpa minim aliqua ex."
-          }
-        }
-      ]
-    },
-    "superTitle": {
-      "__TYPE__": "FieldContent",
-      "value": "very",
-      "type": "Text"
-    },
-    "text": {
-      "__TYPE__": "StructuredTextContent",
-      "value": [
-        {
-          "type": "paragraph",
-          "content": {
-            "text": "Velit labore ipsum sit id voluptate consequat est voluptate do incididunt incididunt quis."
-          }
-        }
-      ]
-    },
-    "image": {
-      "__TYPE__": "ImageContent",
-      "origin": {
-        "id": "main",
-        "url": "https://images.unsplash.com/photo-1587613865763-4b8b0d19e8ab",
-        "width": 12288,
-        "height": 16384
+        ]
       },
-      "url": "https://images.unsplash.com/photo-1587613865763-4b8b0d19e8ab",
-      "width": 12288,
-      "height": 16384,
-      "edit": {
-        "zoom": 1,
-        "crop": {
-          "x": 0,
-          "y": 0
+      "description": {
+        "__TYPE__": "StructuredTextContent",
+        "value": [
+          {
+            "type": "paragraph",
+            "content": {
+              "text": "Incididunt eu laboris exercitation nostrud ad duis sunt in consequat sunt amet excepteur laborum. Deserunt exercitation magna magna occaecat in incididunt."
+            }
+          }
+        ]
+      },
+      "superTitle": {
+        "__TYPE__": "FieldContent",
+        "value": "wealth",
+        "type": "Text"
+      },
+      "text": {
+        "__TYPE__": "StructuredTextContent",
+        "value": [
+          {
+            "type": "paragraph",
+            "content": {
+              "text": "Mollit officia aliquip aute aliquip duis nisi excepteur mollit est ipsum. Anim et aliqua consectetur labore minim est sit magna deserunt amet in proident eiusmod non."
+            }
+          }
+        ]
+      },
+      "image": {
+        "__TYPE__": "ImageContent",
+        "origin": {
+          "id": "main",
+          "url": "https://images.unsplash.com/photo-1586952518485-11b180e92764",
+          "width": 4172,
+          "height": 4000
         },
-        "background": "transparent"
+        "url": "https://images.unsplash.com/photo-1586952518485-11b180e92764",
+        "width": 4172,
+        "height": 4000,
+        "edit": {
+          "zoom": 1,
+          "crop": {
+            "x": 0,
+            "y": 0
+          },
+          "background": "transparent"
+        },
+        "thumbnails": {}
       },
-      "thumbnails": {}
-    },
-    "caption": {
-      "__TYPE__": "StructuredTextContent",
-      "value": [
-        {
-          "type": "paragraph",
-          "content": {
-            "text": "Ipsum aliqua amet minim qui labore. Eu ex aliquip pariatur laboris aute ullamco aliqua proident culpa. Consectetur deserunt excepteur non sint laborum aute ad."
+      "caption": {
+        "__TYPE__": "StructuredTextContent",
+        "value": [
+          {
+            "type": "paragraph",
+            "content": {
+              "text": "Ad cupidatat ex in occaecat excepteur sint."
+            }
           }
-        }
-      ]
-    }
-  },
-  "items": [
-    {
-      "__TYPE__": "GroupItemContent",
-      "value": []
-    }
-  ]
-}
+        ]
+      }
+    },
+    "items": [
+      {
+        "__TYPE__": "GroupItemContent",
+        "value": []
+      }
+    ]
+  }
+]

--- a/e2e-projects/next/slices/marketing/FeaturedSectionCentered22/mocks.json
+++ b/e2e-projects/next/slices/marketing/FeaturedSectionCentered22/mocks.json
@@ -1,87 +1,89 @@
-{
-  "__TYPE__": "SharedSliceContent",
-  "variation": "default-slice",
-  "primary": {
-    "title": {
-      "__TYPE__": "StructuredTextContent",
-      "value": [
-        {
-          "type": "heading1",
-          "content": {
-            "text": "Spend"
-          }
-        }
-      ]
-    },
-    "description": {
-      "__TYPE__": "StructuredTextContent",
-      "value": [
-        {
-          "type": "paragraph",
-          "content": {
-            "text": "Ullamco dolore nulla laboris veniam officia dolore laboris est consectetur est nostrud veniam duis. Ex veniam esse magna tempor Lorem aliqua aliqua."
-          }
-        }
-      ]
-    }
-  },
-  "items": [
-    {
-      "__TYPE__": "GroupItemContent",
-      "value": [
-        [
-          "icon",
+[
+  {
+    "__TYPE__": "SharedSliceContent",
+    "variation": "default-slice",
+    "primary": {
+      "title": {
+        "__TYPE__": "StructuredTextContent",
+        "value": [
           {
-            "__TYPE__": "ImageContent",
-            "origin": {
-              "id": "main",
-              "url": "https://images.unsplash.com/photo-1547394765-185e1e68f34e",
-              "width": 6000,
-              "height": 4000
-            },
-            "url": "https://images.unsplash.com/photo-1547394765-185e1e68f34e?rect=1000%2C0%2C4000%2C4000&w=48&h=48",
-            "width": 48,
-            "height": 48,
-            "edit": {
-              "zoom": 1,
-              "crop": {
-                "x": 1000,
-                "y": 0
-              },
-              "background": "transparent"
-            },
-            "thumbnails": {}
-          }
-        ],
-        [
-          "title",
-          {
-            "__TYPE__": "StructuredTextContent",
-            "value": [
-              {
-                "type": "paragraph",
-                "content": {
-                  "text": "Id laborum nulla exercitation dolore anim exercitation proident commodo. Velit id culpa nostrud. Duis labore do irure id aliquip aliquip exercitation magna."
-                }
-              }
-            ]
-          }
-        ],
-        [
-          "description",
-          {
-            "__TYPE__": "StructuredTextContent",
-            "value": [
-              {
-                "type": "paragraph",
-                "content": {
-                  "text": "Aliquip incididunt incididunt ut nostrud ut magna."
-                }
-              }
-            ]
+            "type": "heading1",
+            "content": {
+              "text": "Union"
+            }
           }
         ]
-      ]
-    }
-  ]
-}
+      },
+      "description": {
+        "__TYPE__": "StructuredTextContent",
+        "value": [
+          {
+            "type": "paragraph",
+            "content": {
+              "text": "Esse aute laborum ad sint velit aliquip nulla. Anim nostrud Lorem culpa et."
+            }
+          }
+        ]
+      }
+    },
+    "items": [
+      {
+        "__TYPE__": "GroupItemContent",
+        "value": [
+          [
+            "icon",
+            {
+              "__TYPE__": "ImageContent",
+              "origin": {
+                "id": "main",
+                "url": "https://images.unsplash.com/photo-1587614295999-6c1c13675117",
+                "width": 3810,
+                "height": 5715
+              },
+              "url": "https://images.unsplash.com/photo-1587614295999-6c1c13675117?rect=0%2C953%2C3810%2C3810&w=48&h=48",
+              "width": 48,
+              "height": 48,
+              "edit": {
+                "zoom": 1,
+                "crop": {
+                  "x": 0,
+                  "y": 953
+                },
+                "background": "transparent"
+              },
+              "thumbnails": {}
+            }
+          ],
+          [
+            "title",
+            {
+              "__TYPE__": "StructuredTextContent",
+              "value": [
+                {
+                  "type": "paragraph",
+                  "content": {
+                    "text": "Sunt mollit duis nisi sit ex tempor nisi do excepteur. Do amet occaecat quis ex culpa pariatur fugiat eu Lorem incididunt eu mollit magna. Qui laboris ad ullamco ipsum exercitation amet."
+                  }
+                }
+              ]
+            }
+          ],
+          [
+            "description",
+            {
+              "__TYPE__": "StructuredTextContent",
+              "value": [
+                {
+                  "type": "paragraph",
+                  "content": {
+                    "text": "Excepteur est elit cillum."
+                  }
+                }
+              ]
+            }
+          ]
+        ]
+      }
+    ]
+  }
+]

--- a/e2e-projects/next/slices/marketing/HeaderSectionSimpleCentered/mocks.json
+++ b/e2e-projects/next/slices/marketing/HeaderSectionSimpleCentered/mocks.json
@@ -1,29 +1,31 @@
-{
-  "__TYPE__": "SharedSliceContent",
-  "variation": "default-slice",
-  "primary": {
-    "title": {
-      "__TYPE__": "StructuredTextContent",
-      "value": [
-        {
-          "type": "heading1",
-          "content": {
-            "text": "Organized"
+[
+  {
+    "__TYPE__": "SharedSliceContent",
+    "variation": "default-slice",
+    "primary": {
+      "title": {
+        "__TYPE__": "StructuredTextContent",
+        "value": [
+          {
+            "type": "heading1",
+            "content": {
+              "text": "Opposite"
+            }
           }
-        }
-      ]
+        ]
+      },
+      "description": {
+        "__TYPE__": "StructuredTextContent",
+        "value": [
+          {
+            "type": "paragraph",
+            "content": {
+              "text": "Velit aliquip et ullamco tempor. Sit commodo exercitation id. Dolore proident irure in dolore voluptate sit laborum voluptate nostrud amet minim deserunt."
+            }
+          }
+        ]
+      }
     },
-    "description": {
-      "__TYPE__": "StructuredTextContent",
-      "value": [
-        {
-          "type": "paragraph",
-          "content": {
-            "text": "Occaecat eiusmod enim ad eu Lorem consequat minim laboris tempor minim aliqua aute cillum incididunt. Nisi consequat qui nisi ipsum nisi amet mollit."
-          }
-        }
-      ]
-    }
-  },
-  "items": []
-}
+    "items": []
+  }
+]

--- a/e2e-projects/next/slices/marketing/HeroSectionSplit/mocks.json
+++ b/e2e-projects/next/slices/marketing/HeroSectionSplit/mocks.json
@@ -1,90 +1,92 @@
-{
-  "__TYPE__": "SharedSliceContent",
-  "variation": "default-slice",
-  "primary": {
-    "title1": {
-      "__TYPE__": "StructuredTextContent",
-      "value": [
-        {
-          "type": "heading1",
-          "content": {
-            "text": "Bring"
+[
+  {
+    "__TYPE__": "SharedSliceContent",
+    "variation": "default-slice",
+    "primary": {
+      "title1": {
+        "__TYPE__": "StructuredTextContent",
+        "value": [
+          {
+            "type": "heading1",
+            "content": {
+              "text": "Clothing"
+            }
           }
-        }
-      ]
-    },
-    "title2": {
-      "__TYPE__": "StructuredTextContent",
-      "value": [
-        {
-          "type": "heading1",
-          "content": {
-            "text": "Secret"
+        ]
+      },
+      "title2": {
+        "__TYPE__": "StructuredTextContent",
+        "value": [
+          {
+            "type": "heading1",
+            "content": {
+              "text": "Earth"
+            }
           }
-        }
-      ]
-    },
-    "description": {
-      "__TYPE__": "StructuredTextContent",
-      "value": [
-        {
-          "type": "paragraph",
-          "content": {
-            "text": "Ut dolor do reprehenderit voluptate anim incididunt ipsum tempor in consequat laborum aliquip et sit fugiat. Aliquip et voluptate ut cupidatat reprehenderit deserunt. Tempor exercitation occaecat commodo do Lorem fugiat mollit sunt ea eu."
+        ]
+      },
+      "description": {
+        "__TYPE__": "StructuredTextContent",
+        "value": [
+          {
+            "type": "paragraph",
+            "content": {
+              "text": "Enim qui reprehenderit culpa Lorem ex commodo ullamco proident fugiat consectetur. Laboris aliqua in magna culpa ipsum non ea laborum tempor sunt nostrud reprehenderit eiusmod cillum."
+            }
           }
+        ]
+      },
+      "cta1": {
+        "__TYPE__": "LinkContent",
+        "value": {
+          "__TYPE__": "DocumentLink",
+          "id": "mock_document_id"
         }
-      ]
-    },
-    "cta1": {
-      "__TYPE__": "LinkContent",
-      "value": {
-        "__TYPE__": "DocumentLink",
-        "id": "mock_document_id"
-      }
-    },
-    "ctaLabel1": {
-      "__TYPE__": "FieldContent",
-      "value": "never",
-      "type": "Text"
-    },
-    "cta2": {
-      "__TYPE__": "LinkContent",
-      "value": {
-        "__TYPE__": "DocumentLink",
-        "id": "mock_document_id"
-      }
-    },
-    "ctaLabel2": {
-      "__TYPE__": "FieldContent",
-      "value": "scientific",
-      "type": "Text"
-    },
-    "image": {
-      "__TYPE__": "ImageContent",
-      "origin": {
-        "id": "main",
+      },
+      "ctaLabel1": {
+        "__TYPE__": "FieldContent",
+        "value": "money",
+        "type": "Text"
+      },
+      "cta2": {
+        "__TYPE__": "LinkContent",
+        "value": {
+          "__TYPE__": "DocumentLink",
+          "id": "mock_document_id"
+        }
+      },
+      "ctaLabel2": {
+        "__TYPE__": "FieldContent",
+        "value": "corn",
+        "type": "Text"
+      },
+      "image": {
+        "__TYPE__": "ImageContent",
+        "origin": {
+          "id": "main",
+          "url": "https://images.unsplash.com/photo-1537498425277-c283d32ef9db",
+          "width": 4380,
+          "height": 2895
+        },
         "url": "https://images.unsplash.com/photo-1537498425277-c283d32ef9db",
         "width": 4380,
-        "height": 2895
-      },
-      "url": "https://images.unsplash.com/photo-1537498425277-c283d32ef9db",
-      "width": 4380,
-      "height": 2895,
-      "edit": {
-        "zoom": 1,
-        "crop": {
-          "x": 0,
-          "y": 0
+        "height": 2895,
+        "edit": {
+          "zoom": 1,
+          "crop": {
+            "x": 0,
+            "y": 0
+          },
+          "background": "transparent"
         },
-        "background": "transparent"
-      },
-      "thumbnails": {}
-    }
-  },
-  "items": [
-    {
-      "__TYPE__": "GroupItemContent",
-      "value": []
-    }
-  ]
-}
+        "thumbnails": {}
+      }
+    },
+    "items": [
+      {
+        "__TYPE__": "GroupItemContent",
+        "value": []
+      }
+    ]
+  }
+]

--- a/e2e-projects/next/slices/marketing/Separator/mocks.json
+++ b/e2e-projects/next/slices/marketing/Separator/mocks.json
@@ -1,11 +1,13 @@
-{
-  "__TYPE__": "SharedSliceContent",
-  "variation": "default-slice",
-  "primary": {},
-  "items": [
-    {
-      "__TYPE__": "GroupItemContent",
-      "value": []
-    }
-  ]
-}
+[
+  {
+    "__TYPE__": "SharedSliceContent",
+    "variation": "default-slice",
+    "primary": {},
+    "items": [
+      {
+        "__TYPE__": "GroupItemContent",
+        "value": []
+      }
+    ]
+  }
+]

--- a/e2e-projects/next/slices/marketing/StatsSectionSplitWithImage/mocks.json
+++ b/e2e-projects/next/slices/marketing/StatsSectionSplitWithImage/mocks.json
@@ -1,105 +1,107 @@
-{
-  "__TYPE__": "SharedSliceContent",
-  "variation": "default-slice",
-  "primary": {
-    "title": {
-      "__TYPE__": "StructuredTextContent",
-      "value": [
-        {
-          "type": "heading1",
-          "content": {
-            "text": "Finish"
-          }
-        }
-      ]
-    },
-    "description": {
-      "__TYPE__": "StructuredTextContent",
-      "value": [
-        {
-          "type": "paragraph",
-          "content": {
-            "text": "Exercitation enim amet officia aute ea amet culpa deserunt."
-          }
-        }
-      ]
-    },
-    "icon": {
-      "__TYPE__": "ImageContent",
-      "origin": {
-        "id": "main",
-        "url": "https://images.unsplash.com/photo-1589321578146-4c1ba445cc88",
-        "width": 3168,
-        "height": 4752
-      },
-      "url": "https://images.unsplash.com/photo-1589321578146-4c1ba445cc88?rect=0%2C792%2C3168%2C3168&w=96&h=96",
-      "width": 96,
-      "height": 96,
-      "edit": {
-        "zoom": 1,
-        "crop": {
-          "x": 0,
-          "y": 792
-        },
-        "background": "transparent"
-      },
-      "thumbnails": {}
-    },
-    "image": {
-      "__TYPE__": "ImageContent",
-      "origin": {
-        "id": "main",
-        "url": "https://images.unsplash.com/photo-1547082299-de196ea013d6",
-        "width": 4272,
-        "height": 2848
-      },
-      "url": "https://images.unsplash.com/photo-1547082299-de196ea013d6",
-      "width": 4272,
-      "height": 2848,
-      "edit": {
-        "zoom": 1,
-        "crop": {
-          "x": 0,
-          "y": 0
-        },
-        "background": "transparent"
-      },
-      "thumbnails": {}
-    }
-  },
-  "items": [
-    {
-      "__TYPE__": "GroupItemContent",
-      "value": [
-        [
-          "stats",
+[
+  {
+    "__TYPE__": "SharedSliceContent",
+    "variation": "default-slice",
+    "primary": {
+      "title": {
+        "__TYPE__": "StructuredTextContent",
+        "value": [
           {
-            "__TYPE__": "StructuredTextContent",
-            "value": [
-              {
-                "type": "paragraph",
-                "content": {
-                  "text": "Lorem adipisicing quis mollit cillum elit dolor excepteur duis eu eu nulla cillum id."
-                }
-              }
-            ]
-          }
-        ],
-        [
-          "unit",
-          {
-            "__TYPE__": "StructuredTextContent",
-            "value": [
-              {
-                "type": "paragraph",
-                "content": {
-                  "text": "Anim veniam exercitation laboris. Nostrud consectetur ad tempor adipisicing ad esse est enim qui."
-                }
-              }
-            ]
+            "type": "heading1",
+            "content": {
+              "text": "Though"
+            }
           }
         ]
-      ]
-    }
-  ]
-}
+      },
+      "description": {
+        "__TYPE__": "StructuredTextContent",
+        "value": [
+          {
+            "type": "paragraph",
+            "content": {
+              "text": "In mollit culpa aliquip sunt eu tempor occaecat cillum quis voluptate Lorem enim. Elit eiusmod dolor ut."
+            }
+          }
+        ]
+      },
+      "icon": {
+        "__TYPE__": "ImageContent",
+        "origin": {
+          "id": "main",
+          "url": "https://images.unsplash.com/photo-1606248897732-2c5ffe759c04",
+          "width": 4000,
+          "height": 4000
+        },
+        "url": "https://images.unsplash.com/photo-1606248897732-2c5ffe759c04?rect=0%2C0%2C4000%2C4000&w=96&h=96",
+        "width": 96,
+        "height": 96,
+        "edit": {
+          "zoom": 1,
+          "crop": {
+            "x": 0,
+            "y": 0
+          },
+          "background": "transparent"
+        },
+        "thumbnails": {}
+      },
+      "image": {
+        "__TYPE__": "ImageContent",
+        "origin": {
+          "id": "main",
+          "url": "https://images.unsplash.com/photo-1560457079-9a6532ccb118",
+          "width": 4160,
+          "height": 3120
+        },
+        "url": "https://images.unsplash.com/photo-1560457079-9a6532ccb118",
+        "width": 4160,
+        "height": 3120,
+        "edit": {
+          "zoom": 1,
+          "crop": {
+            "x": 0,
+            "y": 0
+          },
+          "background": "transparent"
+        },
+        "thumbnails": {}
+      }
+    },
+    "items": [
+      {
+        "__TYPE__": "GroupItemContent",
+        "value": [
+          [
+            "stats",
+            {
+              "__TYPE__": "StructuredTextContent",
+              "value": [
+                {
+                  "type": "paragraph",
+                  "content": {
+                    "text": "Dolore deserunt nisi deserunt nostrud Lorem est."
+                  }
+                }
+              ]
+            }
+          ],
+          [
+            "unit",
+            {
+              "__TYPE__": "StructuredTextContent",
+              "value": [
+                {
+                  "type": "paragraph",
+                  "content": {
+                    "text": "Adipisicing esse tempor ea veniam exercitation ipsum id officia ipsum commodo sit."
+                  }
+                }
+              ]
+            }
+          ]
+        ]
+      }
+    ]
+  }
+]

--- a/e2e-projects/next/slices/navigation/FooterColumn/mocks.json
+++ b/e2e-projects/next/slices/navigation/FooterColumn/mocks.json
@@ -1,36 +1,38 @@
-{
-  "__TYPE__": "SharedSliceContent",
-  "variation": "default-slice",
-  "primary": {
-    "section_title": {
-      "__TYPE__": "FieldContent",
-      "value": "palace",
-      "type": "Text"
-    }
-  },
-  "items": [
-    {
-      "__TYPE__": "GroupItemContent",
-      "value": [
-        [
-          "link",
-          {
-            "__TYPE__": "LinkContent",
-            "value": {
-              "__TYPE__": "DocumentLink",
-              "id": "mock_document_id"
+[
+  {
+    "__TYPE__": "SharedSliceContent",
+    "variation": "default-slice",
+    "primary": {
+      "section_title": {
+        "__TYPE__": "FieldContent",
+        "value": "dry",
+        "type": "Text"
+      }
+    },
+    "items": [
+      {
+        "__TYPE__": "GroupItemContent",
+        "value": [
+          [
+            "link",
+            {
+              "__TYPE__": "LinkContent",
+              "value": {
+                "__TYPE__": "DocumentLink",
+                "id": "mock_document_id"
+              }
             }
-          }
-        ],
-        [
-          "link_label",
-          {
-            "__TYPE__": "FieldContent",
-            "value": "pattern",
-            "type": "Text"
-          }
+          ],
+          [
+            "link_label",
+            {
+              "__TYPE__": "FieldContent",
+              "value": "automobile",
+              "type": "Text"
+            }
+          ]
         ]
-      ]
-    }
-  ]
-}
+      }
+    ]
+  }
+]

--- a/e2e-projects/next/slices/navigation/MenuSubTab/mocks.json
+++ b/e2e-projects/next/slices/navigation/MenuSubTab/mocks.json
@@ -1,36 +1,38 @@
-{
-  "__TYPE__": "SharedSliceContent",
-  "variation": "default-slice",
-  "primary": {
-    "sectionTitle": {
-      "__TYPE__": "FieldContent",
-      "value": "sugar",
-      "type": "Text"
-    }
-  },
-  "items": [
-    {
-      "__TYPE__": "GroupItemContent",
-      "value": [
-        [
-          "subSectionTitle",
-          {
-            "__TYPE__": "FieldContent",
-            "value": "kitchen",
-            "type": "Text"
-          }
-        ],
-        [
-          "subSectionLink",
-          {
-            "__TYPE__": "LinkContent",
-            "value": {
-              "__TYPE__": "DocumentLink",
-              "id": "mock_document_id"
+[
+  {
+    "__TYPE__": "SharedSliceContent",
+    "variation": "default-slice",
+    "primary": {
+      "sectionTitle": {
+        "__TYPE__": "FieldContent",
+        "value": "palace",
+        "type": "Text"
+      }
+    },
+    "items": [
+      {
+        "__TYPE__": "GroupItemContent",
+        "value": [
+          [
+            "subSectionTitle",
+            {
+              "__TYPE__": "FieldContent",
+              "value": "press",
+              "type": "Text"
             }
-          }
+          ],
+          [
+            "subSectionLink",
+            {
+              "__TYPE__": "LinkContent",
+              "value": {
+                "__TYPE__": "DocumentLink",
+                "id": "mock_document_id"
+              }
+            }
+          ]
         ]
-      ]
-    }
-  ]
-}
+      }
+    ]
+  }
+]

--- a/packages/slice-machine/lib/mock/Slice.ts
+++ b/packages/slice-machine/lib/mock/Slice.ts
@@ -15,7 +15,10 @@ export default function MockSlice(
     );
 
     if (!variationMock) {
-      return SharedSliceMock.generate(sliceModel);
+      return SharedSliceMock.generate(sliceModel, {
+        variation: variation.id,
+        type: "SharedSlice",
+      });
     }
     if (!sliceDiff) return variationMock;
     const patched = SharedSliceMock.patch(sliceDiff, sliceModel, variationMock);
@@ -23,7 +26,10 @@ export default function MockSlice(
       return variationMock;
     }
     if (!patched.result) {
-      return SharedSliceMock.generate(sliceModel);
+      return SharedSliceMock.generate(sliceModel, {
+        variation: variation.id,
+        type: "SharedSlice",
+      });
     }
     return patched.result;
   });


### PR DESCRIPTION
Fixes recent migration system which stored mocks as objects instead of array of ShareSliceContent.
It also regenerates mocks for `e2e/next` project.

Files updated:
- https://github.com/prismicio/slice-machine/pull/892/files#diff-0a9ff6b3591008dc4fb943f43395ce9e97461acf833d2680acf98d550eae31bb
- https://github.com/prismicio/slice-machine/pull/892/files#diff-09cf19c809d6149735f456c326576ee3717ea95068dce7363ad65d68743e1894