### PR TITLE
fix(init): init S3 ACL before pushing screenshots (SMX-131)

### DIFF
--- a/packages/init/src/SliceMachineInitProcess.ts
+++ b/packages/init/src/SliceMachineInitProcess.ts
@@ -847,6 +847,9 @@ ${chalk.cyan("?")} Your Prismic repository name`.replace("\n", ""),
 									return;
 								}
 
+								task.title = "Pushing slices... (initializing ACL)";
+								await this.manager.screenshots.initS3ACL();
+
 								let pushed = 0;
 								task.title = `Pushing slices... (0/${slices.length})`;
 								await Promise.all(


### PR DESCRIPTION
## Context

SMX-131

## The Solution

S3 ACL was not inited before pushing screenshots

## Impact / Dependencies

<!--
List all the impacts your development might have on internal and external features.
Ideally this should have been discussed prior to this development.

Link of any other PRs that are related to this development.
They should also be referenced in the ticket for reviews.
-->




## Checklist before requesting a review
- [ ] I hereby declare my code ready for review.
- [ ] If it is a critical feature, I have added tests.
- [ ] The CI is successful.
- [ ] If there could backward compatibility issues, it has been discussed and planned.




## [OPT] Preview

<!--
Visual aid of your work.
It can either be screenshots or a video.
This could help reviewers to get context quickly.
-->




<!--
A funny animal picture is welcome to close your PR!
You can find one here https://unsplash.com/s/photos/funny-animal-picture
-->