### PR TITLE
fix: track slice-simulator:setup once

### DIFF
--- a/packages/slice-machine/components/Simulator/components/SetupModal/index.tsx
+++ b/packages/slice-machine/components/Simulator/components/SetupModal/index.tsx
@@ -2,11 +2,13 @@ import Card from "@components/Card";
 import SliceMachineModal from "@components/SliceMachineModal";
 import { Box, Flex, Heading, Text } from "theme-ui";
 
+import { useEffect } from "react";
 import { Tab, Tabs, TabList, TabPanel } from "react-tabs";
 import { useSelector } from "react-redux";
 import { SliceMachineStoreType } from "@src/redux/type";
 import { selectIsSimulatorAvailableForFramework } from "@src/modules/environment";
 import { selectSetupSteps } from "@src/modules/simulator";
+import { telemetry } from "@src/apiClient";
 
 import HTMLRenderer from "@components/HTMLRenderer";
 
@@ -84,6 +86,10 @@ const SetupModal: React.FC<{ isOpen: boolean }> = ({ isOpen }) => {
   );
 
   const steps = setupSteps || [];
+
+  useEffect(() => {
+    if (isOpen) void telemetry.track({ event: "slice-simulator:setup" });
+  }, [isOpen]);
 
   return (
     <SliceMachineModal isOpen={isOpen}>

--- a/packages/slice-machine/src/modules/simulator/index.ts
+++ b/packages/slice-machine/src/modules/simulator/index.ts
@@ -19,7 +19,6 @@ import {
   getSimulatorSetupSteps,
   saveSliceMock,
   SaveSliceMockRequest,
-  telemetry,
 } from "@src/apiClient";
 import {
   selectIsSimulatorAvailableForFramework,
@@ -201,7 +200,6 @@ export function* checkSetupSaga(
       return;
     }
     yield call(failCheckSetupSaga, { setupSteps: setupSteps.steps });
-    yield call(trackOpenSetupModalSaga);
   } catch (error) {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
     yield put(checkSimulatorSetupCreator.failure({ error: error as Error }));
@@ -247,10 +245,6 @@ export function* failCheckSetupSaga({
     })
   );
   yield put(modalOpenCreator({ modalKey: ModalKeysEnum.SIMULATOR_SETUP }));
-}
-
-export function* trackOpenSetupModalSaga() {
-  void telemetry.track({ event: "slice-simulator:setup" });
 }
 
 export function* saveSliceMockSaga({

--- a/packages/slice-machine/test/src/modules/simulator.test.ts
+++ b/packages/slice-machine/test/src/modules/simulator.test.ts
@@ -13,10 +13,7 @@ import {
 } from "@src/modules/simulator";
 import { select } from "redux-saga/effects";
 import { testSaga, expectSaga } from "redux-saga-test-plan";
-import {
-  checkSetupSaga,
-  trackOpenSetupModalSaga,
-} from "@src/modules/simulator";
+import { checkSetupSaga } from "@src/modules/simulator";
 import { SimulatorStoreType } from "@src/modules/simulator/types";
 
 import {
@@ -170,7 +167,6 @@ describe("[Simulator module]", () => {
       saga
         .next(response2)
         .call(failCheckSetupSaga, { setupSteps: response2.steps });
-      saga.next().call(trackOpenSetupModalSaga);
       saga.next().isDone();
     });
     it("should open setup modal if checkSimulatorSetupCreator.failure action", () => {


### PR DESCRIPTION
## Context

Resolves SMX-133: AAUser, opening the Slice Simulator setup screen once should only be tracked once.

## The Solution

1. Move `telemetry.track` call from `packages/slice-machine/src/modules/simulator/index.ts` to `packages/slice-machine/components/Simulator/components/SetupModal/index.tsx`.

## Checklist before requesting a review
- [x] I hereby declare my code ready for review.
- [ ] If it is a critical feature, I have added tests.
- [ ] The CI is successful.
- [ ] If there could backward compatibility issues, it has been discussed and planned.