### PR TITLE
backport widget reorder index 0

### DIFF
--- a/packages/slice-machine/lib/builders/SliceBuilder/FieldZones/index.tsx
+++ b/packages/slice-machine/lib/builders/SliceBuilder/FieldZones/index.tsx
@@ -110,7 +110,7 @@ const FieldZones: React.FunctionComponent<FieldZonesProps> = ({
       variation.id,
       widgetArea,
       result.source.index,
-      (result.destination && result.destination.index) || undefined
+      result.destination?.index ?? undefined
     );
   };
 


### PR DESCRIPTION
https://linear.app/prismic/issue/SMX-138/[backport]-aauser-i-can-drag-and-drop-slice-item-to-first-place
backport slice order widget fix of bug preventing items to be moved to index 0 