### PR TITLE
improve slice validation error messages

### DIFF
--- a/packages/manager/src/managers/slices/SlicesManager.ts
+++ b/packages/manager/src/managers/slices/SlicesManager.ts
@@ -280,7 +280,11 @@ export class SlicesManager extends BaseManager {
 
 		return {
 			model: data[0]?.model,
-			errors,
+			errors: errors.map((error) => {
+				error.message = `Failed to decode slice model with id '${args.sliceID}': ${error.message}`;
+
+				return error;
+			}),
 		};
 	}
 

--- a/packages/start-slicemachine/src/StartSliceMachineProcess.ts
+++ b/packages/start-slicemachine/src/StartSliceMachineProcess.ts
@@ -219,8 +219,11 @@ export class StartSliceMachineProcess {
 		// Validate Slice models.
 		const allSlices = await this._sliceMachineManager.slices.readAllSlices();
 		if (allSlices.errors.length > 0) {
-			// TODO: Provide better error message.
-			throw new Error(allSlices.errors.join(", "));
+			throw new Error(
+				`Errors ocurred while validating your project's slices.\n\n${allSlices.errors.join(
+					"\n\n",
+				)}`,
+			);
 		}
 
 		// Validate Custom Type models.

--- a/packages/start-slicemachine/src/StartSliceMachineProcess.ts
+++ b/packages/start-slicemachine/src/StartSliceMachineProcess.ts
@@ -220,7 +220,7 @@ export class StartSliceMachineProcess {
 		const allSlices = await this._sliceMachineManager.slices.readAllSlices();
 		if (allSlices.errors.length > 0) {
 			throw new Error(
-				`Errors ocurred while validating your project's slices.\n\n${allSlices.errors.join(
+				`Errors occurred while validating your project's slices.\n\n${allSlices.errors.join(
 					"\n\n",
 				)}`,
 			);


### PR DESCRIPTION
## Context

Ticket: https://linear.app/prismic/issue/SMX-137/aauser-i-want-to-see-a-more-descriptive-error-message-when-a-slice

## The Solution

<!--
Highlight explanations where the complexity in your development is.
Keep in mind that the reviewer might not have as much context as you do.
This is very important to make sure the review is thorough and the reviewer understand your changes.
-->




## Impact / Dependencies

The read errors thrown by the next-adapter hook could still be improved:
At the moment reading any slice in a library that contains invalid JSON (even if it's not the invalid slice itself) will log an error. This is due to the hook reading every slice in a library to find the model for the requested one. 
This means that we will still see 1 error for each slice in a library that has invalid JSON.

This PR does not address this issue and will be improved on by @lihbr when updating the next adapter


## Checklist before requesting a review
- [ ] I hereby declare my code ready for review.
- [ ] If it is a critical feature, I have added tests.
- [ ] The CI is successful.
- [ ] If there could backward compatibility issues, it has been discussed and planned.




## [OPT] Preview

<!--
Visual aid of your work.
It can either be screenshots or a video.
This could help reviewers to get context quickly.
-->




<!--
A funny animal picture is welcome to close your PR!
You can find one here https://unsplash.com/s/photos/funny-animal-picture
-->