### PR TITLE
fix: throwing slice-simulator:setup:read hook

### DIFF
--- a/packages/adapter-next/src/hooks/sliceSimulator-setup-read.ts
+++ b/packages/adapter-next/src/hooks/sliceSimulator-setup-read.ts
@@ -209,9 +209,11 @@ const createStep3 = async ({
 			}
 
 			// Check if the URL is accessible.
-			const res = await fetch(project.config.localSliceSimulatorURL);
-
-			if (!res.ok) {
+			let res;
+			try {
+				res = await fetch(project.config.localSliceSimulatorURL);
+			} catch {}
+			if (!res || !res.ok) {
 				return {
 					title: "Unable to connect to simulator page",
 					message: source`


### PR DESCRIPTION
## Context

Resolves SMX-130: AAUser, I want to see SM Simulator instructions when I have not completed the configuration.

## The Solution

1. `catch` the `ECONNREFUSED` exception thrown by the `fetch` call.

## Checklist before requesting a review
- [x] I hereby declare my code ready for review.
- [ ] If it is a critical feature, I have added tests.
- [x] The CI is successful.
- [ ] If there could backward compatibility issues, it has been discussed and planned.