### PR TITLE
chore: add dev:adapter-next script

### DIFF
--- a/e2e-projects/next/package.json
+++ b/e2e-projects/next/package.json
@@ -26,7 +26,7 @@
     "recharts": "^2.1.11"
   },
   "devDependencies": {
-    "@slicemachine/adapter-next": "^0.0.9",
+    "@slicemachine/adapter-next": "0.0.13-dev-plugins-m2.2",
     "autoprefixer": "^10.4.4",
     "eslint": "^8.12.0",
     "eslint-config-next": "^12.1.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,7 +52,7 @@
         "recharts": "^2.1.11"
       },
       "devDependencies": {
-        "@slicemachine/adapter-next": "^0.0.9",
+        "@slicemachine/adapter-next": "0.0.13-dev-plugins-m2.2",
         "autoprefixer": "^10.4.4",
         "eslint": "^8.12.0",
         "eslint-config-next": "^12.1.4",
@@ -287,44 +287,6 @@
         "@prismicio/client": "^6",
         "next": "^11 || ^12",
         "react": "^17 || ^18"
-      }
-    },
-    "e2e-projects/next/node_modules/@slicemachine/adapter-next": {
-      "version": "0.0.9",
-      "resolved": "https://registry.npmjs.org/@slicemachine/adapter-next/-/adapter-next-0.0.9.tgz",
-      "integrity": "sha512-3asdyEPnHribuLdk86xWaOu6iag03VjRtomOyTyiH3cIJ5ecspE8XSb06xbHykxhZ9dxnTikdp1paA+JAVaa9A==",
-      "dev": true,
-      "dependencies": {
-        "@prismicio/slice-simulator-core": "^0.2.7",
-        "@prismicio/types": "^0.2.7",
-        "@slicemachine/plugin-kit": "^0.1.8",
-        "common-tags": "^1.8.2",
-        "fs-extra": "^11.1.0",
-        "node-fetch": "^3.3.0",
-        "pascal-case": "^3.1.2",
-        "prismic-ts-codegen": "^0.1.5"
-      },
-      "engines": {
-        "node": ">=14.15.0"
-      },
-      "peerDependencies": {
-        "next": "^11 || ^12 || ^13",
-        "react": "^17 || ^18"
-      }
-    },
-    "e2e-projects/next/node_modules/@slicemachine/plugin-kit": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/@slicemachine/plugin-kit/-/plugin-kit-0.1.8.tgz",
-      "integrity": "sha512-GSqpLXhPRdnZc9C/Ws0zST5h2K88WYXPw0VqOo6Um6Wa3oTc246VcnjOGJDyLKEj4u24ALYpj0ScI4Dnry6wyA==",
-      "dev": true,
-      "dependencies": {
-        "@prismicio/types": "^0.2.3",
-        "common-tags": "^1.8.2",
-        "defu": "^6.1.0",
-        "prettier": "^2.7.1"
-      },
-      "engines": {
-        "node": ">=14.15.0"
       }
     },
     "e2e-projects/next/node_modules/@swc/helpers": {
@@ -41431,7 +41393,7 @@
         "@prismicio/next": "^0.1.2",
         "@prismicio/react": "^2.2.0",
         "@prismicio/slice-simulator-react": "^0.2.3-alpha.0",
-        "@slicemachine/adapter-next": "^0.0.9",
+        "@slicemachine/adapter-next": "0.0.13-dev-plugins-m2.2",
         "@tailwindcss/aspect-ratio": "^0.4.0",
         "@tailwindcss/forms": "^0.5.0",
         "@tailwindcss/typography": "^0.5.2",
@@ -41548,34 +41510,6 @@
             "@prismicio/helpers": "^2.3.5",
             "@prismicio/types": "^0.2.3",
             "imgix-url-builder": "^0.0.3"
-          }
-        },
-        "@slicemachine/adapter-next": {
-          "version": "0.0.9",
-          "resolved": "https://registry.npmjs.org/@slicemachine/adapter-next/-/adapter-next-0.0.9.tgz",
-          "integrity": "sha512-3asdyEPnHribuLdk86xWaOu6iag03VjRtomOyTyiH3cIJ5ecspE8XSb06xbHykxhZ9dxnTikdp1paA+JAVaa9A==",
-          "dev": true,
-          "requires": {
-            "@prismicio/slice-simulator-core": "^0.2.7",
-            "@prismicio/types": "^0.2.7",
-            "@slicemachine/plugin-kit": "^0.1.8",
-            "common-tags": "^1.8.2",
-            "fs-extra": "^11.1.0",
-            "node-fetch": "^3.3.0",
-            "pascal-case": "^3.1.2",
-            "prismic-ts-codegen": "^0.1.5"
-          }
-        },
-        "@slicemachine/plugin-kit": {
-          "version": "0.1.8",
-          "resolved": "https://registry.npmjs.org/@slicemachine/plugin-kit/-/plugin-kit-0.1.8.tgz",
-          "integrity": "sha512-GSqpLXhPRdnZc9C/Ws0zST5h2K88WYXPw0VqOo6Um6Wa3oTc246VcnjOGJDyLKEj4u24ALYpj0ScI4Dnry6wyA==",
-          "dev": true,
-          "requires": {
-            "@prismicio/types": "^0.2.3",
-            "common-tags": "^1.8.2",
-            "defu": "^6.1.0",
-            "prettier": "^2.7.1"
           }
         },
         "@swc/helpers": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "dev:start-slicemachine": "npm --workspace start-slicemachine run dev",
     "dev:plugin-kit": "npm --workspace @slicemachine/plugin-kit run dev",
     "dev:slice-machine-ui": "npm --workspace slice-machine-ui run dev",
+    "dev:adapter-next": "npm --workspace @slicemachine/adapter-next run dev",
     "dev:e2e-next": "cd ./e2e-projects/next && npm run dev -- --port 8000",
     "cypress-setup": "./cypress-setup.sh",
     "clean-e2e-projects": "git checkout e2e-projects/ && git clean -f e2e-projects/",


### PR DESCRIPTION
## Context

The `dev` script of the `@slicemachine/adapter-next` workspace isn't executed by the root `dev` script.

## The Solution

1. Add the missing `dev:adapter-next` script to the root `package.json` file.
2. Update `cimsirp`'s `devDependencies` so that the `@slicemachine/adapter-next` workspace gets symlinked.

## Checklist before requesting a review
- [x] I hereby declare my code ready for review.
- [ ] If it is a critical feature, I have added tests.
- [x] The CI is successful.
- [ ] If there could backward compatibility issues, it has been discussed and planned.