### PR TITLE
unlink sm folder

### DIFF
--- a/packages/start-slicemachine/src/legacyMigrations/migrateAssets.ts
+++ b/packages/start-slicemachine/src/legacyMigrations/migrateAssets.ts
@@ -23,16 +23,6 @@ const createPathToDeprecatedLibrary = (cwd: string) =>
 const createPathToCustomTypesAssets = (cwd: string) =>
 	path.join(createPathToDeprecatedLibrary(cwd), "assets", "customtypes");
 
-const safeUnlink = (pathToUnlink: string, type: "file" | "folder") => {
-	try {
-		if (type === "file") {
-			fsSync.unlinkSync(pathToUnlink);
-		} else {
-			fsSync.rmSync(pathToUnlink, { recursive: true });
-		}
-	} catch (_) {}
-};
-
 const ensureOrGenerateSliceScreenshot = (
 	variationsIDs: string[],
 	targetPathToSliceFolder: string,
@@ -166,7 +156,6 @@ export const migrateAssets = async (
 				targetPathToSliceFolder,
 				deprecatedPathToSliceAssets,
 			);
-			safeUnlink(deprecatedPathToMocks, "file");
 		});
 
 		const allCustomTypes = await manager.customTypes.readAllCustomTypes();
@@ -195,16 +184,9 @@ export const migrateAssets = async (
 			sentryErrorHandlers.node("migrateAssets", error);
 		}
 	} finally {
-		safeUnlink(
-			path.join(
-				createPathToDeprecatedLibrary(manager.cwd),
-				MOCK_CONFIG_FILE_NAME,
-			),
-			"file",
-		);
-		safeUnlink(
-			path.join(createPathToDeprecatedLibrary(manager.cwd), "assets"),
-			"folder",
-		);
+		const dotSlicemachine = createPathToDeprecatedLibrary(manager.cwd);
+		if (fsSync.existsSync(dotSlicemachine)) {
+			fsSync.rmSync(dotSlicemachine, { recursive: true });
+		}
 	}
 };

--- a/packages/start-slicemachine/src/legacyMigrations/migrateAssets.ts
+++ b/packages/start-slicemachine/src/legacyMigrations/migrateAssets.ts
@@ -13,7 +13,6 @@ import { DocumentMock, SharedSliceMock } from "@prismicio/mocks";
 import * as sentryErrorHandlers from "../lib/sentryErrorHandlers";
 
 const MOCKS_FILE_NAME = "mocks.json";
-const MOCK_CONFIG_FILE_NAME = "mock-config.json";
 
 const SharedSliceContentArray = t.array(SharedSliceContent);
 const DocumentArray = t.array(Document);


### PR DESCRIPTION
Remove `.slicemachine` folder after legacy assets migration