### PR TITLE
Enable skipped e2e tests

### DIFF
--- a/cypress-setup.sh
+++ b/cypress-setup.sh
@@ -26,7 +26,7 @@ rm -rf e2e-projects/cypress-next-app \
 && npx --yes create-next-app e2e-projects/cypress-next-app \
 && npx --yes vite-node ./cypress/plugins/addAuth.ts -- ${EMAIL} ${PASSWORD} ${PRISMIC_URL} \
 && npx --yes vite-node ./cypress/plugins/createRepo.ts -- "${_PRISMIC_REPO}" "${PASSWORD}" "${PRISMIC_URL}" \
-&& npm --workspace=packages/plugin-kit --workspace=packages/manager --workspace=packages/adapter-next --workspace=packages/init --workspace=packages/start-slicemachine --workspace=packages/slice-machine pack --pack-destination ./e2e-projects/cypress-next-app \
+&& npm --workspace=packages/plugin-kit --workspace=packages/manager --workspace=packages/adapter-next --workspace=packages/init --workspace=packages/start-slicemachine --workspace=packages/slice-machine pack --silent --pack-destination ./e2e-projects/cypress-next-app \
 && cd e2e-projects/cypress-next-app \
 && npm i *.tgz \
 && npx @slicemachine/init --repository ${_PRISMIC_REPO} \

--- a/cypress/consts.js
+++ b/cypress/consts.js
@@ -19,4 +19,4 @@ export const SLICE_MOCK_FILE = (sliceName) =>
 export const SLICE_MODEL = (sliceName) =>
   `${SLICES_FOLDER}/${sliceName}/model.json`;
 
-export const SIMULATOR_PATH = path.join(ROOT, "pages", "slice-simulator.jsx");
+export const SIMULATOR_PATH = path.join(ROOT, "pages", "slice-simulator.js");

--- a/cypress/e2e/slices/00-create.cy.js
+++ b/cypress/e2e/slices/00-create.cy.js
@@ -115,8 +115,7 @@ describe("Create Slices", () => {
     cy.renameSlice(sliceName, editedSliceName);
   });
 
-  // TODO enable once fields sorting is fixed
-  it.skip("allows drag n drop to the top position", () => {
+  it("allows drag n drop to the top position", () => {
     // inspired by https://github.com/atlassian/react-beautiful-dnd/blob/master/cypress/integration/reorder.spec.js
     // could not get it to work with mouse events
 

--- a/cypress/e2e/user-flows/scenario_008_edit_mock_from_simulator.cy.js
+++ b/cypress/e2e/user-flows/scenario_008_edit_mock_from_simulator.cy.js
@@ -14,7 +14,7 @@ describe("Scenario 008", () => {
     cy.setSliceMachineUserContext({});
   });
 
-  it("edits the different mock fields available in the editor", function () {
+  it("edits the different mock fields available in the editor", () => {
     cy.createSlice(SLICE.library, SLICE.id, SLICE.name);
 
     sliceBuilder

--- a/cypress/e2e/user-flows/scenario_008_edit_mock_from_simulator.cy.js
+++ b/cypress/e2e/user-flows/scenario_008_edit_mock_from_simulator.cy.js
@@ -9,8 +9,7 @@ const SLICE = {
   library: ".--slices",
 };
 
-// TODO: Enable once mocks are working
-describe.skip("Scenario 008", () => {
+describe("Scenario 008", () => {
   beforeEach(() => {
     cy.clearProject();
     cy.setSliceMachineUserContext({});

--- a/cypress/e2e/user-flows/scenario_008_edit_mock_from_simulator.cy.js
+++ b/cypress/e2e/user-flows/scenario_008_edit_mock_from_simulator.cy.js
@@ -1,7 +1,6 @@
 import { simulatorPage } from "../../pages/simulator/simulatorPage";
 import { editorPage } from "../../pages/simulator/editorPage";
 import { sliceBuilder } from "../../pages/slices/sliceBuilder";
-import { SLICE_MOCK_FILE } from "../../consts";
 
 const SLICE = {
   id: "scenario008",
@@ -15,7 +14,7 @@ describe("Scenario 008", () => {
     cy.setSliceMachineUserContext({});
   });
 
-  it("edits the different mock fields available in the editor", () => {
+  it("edits the different mock fields available in the editor", function () {
     cy.createSlice(SLICE.library, SLICE.id, SLICE.name);
 
     sliceBuilder
@@ -27,28 +26,6 @@ describe("Scenario 008", () => {
       .addNewWidgetField("SelectField", "Select")
       .addNewWidgetField("ImageField", "Image")
       .save();
-
-    // force mock value for the boolean and select fields
-    cy.modifyFile(SLICE_MOCK_FILE(SLICE.name), (mock) =>
-      mock.map((variation) =>
-        variation.variation === "default"
-          ? variation
-          : {
-              ...variation,
-              primary: {
-                ...variation.primary,
-                booleanfield: {
-                  ...variation.primary.booleanfield,
-                  value: false,
-                },
-                selectfield: {
-                  ...variation.primary.selectfield,
-                  value: "1",
-                },
-              },
-            }
-      )
-    );
 
     simulatorPage.setup();
     sliceBuilder.openSimulator();
@@ -68,12 +45,28 @@ describe("Scenario 008", () => {
     simulatorPage.toggleEditor();
     cy.contains("Scenario008 • SecondVariation").should("be.visible");
 
+    // Need to know the initial of Boolean and Select fields to know if the update worked
+    cy.getInputByLabel("SelectField")
+      .invoke("text")
+      .then((currentValue) => {
+        cy.wrap(currentValue == "1" ? "2" : "1").as("newSelectValue");
+      });
+    cy.getInputByLabel("BooleanField")
+      .invoke("attr", "aria-checked")
+      .then((currentValue) => {
+        cy.wrap(currentValue == "true" ? "false" : "true").as(
+          "newBooleanValue"
+        );
+      });
+
     // editor # change field values
     editorPage.type("SimpleTextField", "SimpleTextContent");
     editorPage.type("RichTextField", "RichTextContent");
     editorPage.type("NumberField", "42", "have.value");
     editorPage.toggleBooleanField("BooleanField");
-    editorPage.select("SelectField", "2");
+    cy.get("@newSelectValue").then((value) => {
+      editorPage.select("SelectField", value);
+    });
 
     editorPage
       .changeImage("ImageField")
@@ -93,10 +86,14 @@ describe("Scenario 008", () => {
     );
     cy.getInputByLabel("RichTextField").should("contain", "RichTextContent");
     cy.getInputByLabel("NumberField").should("have.value", "42");
-    cy.getInputByLabel("BooleanField")
-      .invoke("attr", "aria-checked")
-      .should("equal", "true");
-    cy.getInputByLabel("SelectField").should("contain", "2");
+    cy.get("@newBooleanValue").then((value) => {
+      cy.getInputByLabel("BooleanField")
+        .invoke("attr", "aria-checked")
+        .should("equal", value);
+    });
+    cy.get("@newSelectValue").then((value) => {
+      cy.getInputByLabel("SelectField").should("contain", value);
+    });
 
     cy.getInputByLabel("Alt text").should("have.value", "An ananas maybe");
     cy.get("@newImageSrc").then((newImageSrc) => {

--- a/e2e-projects/next/package.json
+++ b/e2e-projects/next/package.json
@@ -26,13 +26,13 @@
     "recharts": "^2.1.11"
   },
   "devDependencies": {
-    "@slicemachine/adapter-next": "0.0.13-dev-plugins-m3.3",
+    "@slicemachine/adapter-next": "0.0.13-dev-plugins-m3.4",
     "autoprefixer": "^10.4.4",
     "eslint": "^8.37.0",
     "eslint-config-next": "^12.1.4",
     "postcss": "^8.4.12",
-    "slice-machine-ui": "0.6.1-dev-plugins-m3.3",
-    "start-slicemachine": "0.6.1-dev-plugins-m3.3",
+    "slice-machine-ui": "0.6.1-dev-plugins-m3.4",
+    "start-slicemachine": "0.6.1-dev-plugins-m3.4",
     "tailwindcss": "^3.0.23"
   }
 }

--- a/e2e-projects/next/package.json
+++ b/e2e-projects/next/package.json
@@ -26,13 +26,13 @@
     "recharts": "^2.1.11"
   },
   "devDependencies": {
-    "@slicemachine/adapter-next": "0.0.13-dev-plugins-m3.4",
+    "@slicemachine/adapter-next": "0.0.13-dev-plugins-m3.5",
     "autoprefixer": "^10.4.4",
     "eslint": "^8.37.0",
     "eslint-config-next": "^12.1.4",
     "postcss": "^8.4.12",
-    "slice-machine-ui": "0.6.1-dev-plugins-m3.4",
-    "start-slicemachine": "0.6.1-dev-plugins-m3.4",
+    "slice-machine-ui": "0.6.1-dev-plugins-m3.5",
+    "start-slicemachine": "0.6.1-dev-plugins-m3.5",
     "tailwindcss": "^3.0.23"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,13 +52,13 @@
         "recharts": "^2.1.11"
       },
       "devDependencies": {
-        "@slicemachine/adapter-next": "0.0.13-dev-plugins-m3.3",
+        "@slicemachine/adapter-next": "0.0.13-dev-plugins-m3.4",
         "autoprefixer": "^10.4.4",
         "eslint": "^8.37.0",
         "eslint-config-next": "^12.1.4",
         "postcss": "^8.4.12",
-        "slice-machine-ui": "0.6.1-dev-plugins-m3.3",
-        "start-slicemachine": "0.6.1-dev-plugins-m3.3",
+        "slice-machine-ui": "0.6.1-dev-plugins-m3.4",
+        "start-slicemachine": "0.6.1-dev-plugins-m3.4",
         "tailwindcss": "^3.0.23"
       }
     },
@@ -39165,12 +39165,12 @@
     },
     "packages/adapter-next": {
       "name": "@slicemachine/adapter-next",
-      "version": "0.0.13-dev-plugins-m3.3",
+      "version": "0.0.13-dev-plugins-m3.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@prismicio/slice-simulator-core": "^0.2.7",
         "@prismicio/types-internal": "2.0.0-alpha.9",
-        "@slicemachine/plugin-kit": "0.1.8-dev-plugins-m3.3",
+        "@slicemachine/plugin-kit": "0.1.8-dev-plugins-m3.4",
         "common-tags": "^1.8.2",
         "fs-extra": "^11.1.0",
         "node-fetch": "^3.3.1",
@@ -39302,12 +39302,12 @@
     },
     "packages/adapter-nuxt": {
       "name": "@slicemachine/adapter-nuxt",
-      "version": "0.0.2-dev-plugins-m3.3",
+      "version": "0.0.2-dev-plugins-m3.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@prismicio/slice-simulator-core": "^0.2.7",
         "@prismicio/types-internal": "2.0.0-alpha.9",
-        "@slicemachine/plugin-kit": "0.1.8-dev-plugins-m3.3",
+        "@slicemachine/plugin-kit": "0.1.8-dev-plugins-m3.4",
         "common-tags": "^1.8.2",
         "fs-extra": "^11.1.0",
         "magicast": "^0.2.1",
@@ -41229,12 +41229,12 @@
     },
     "packages/adapter-nuxt2": {
       "name": "@slicemachine/adapter-nuxt2",
-      "version": "0.0.2-dev-plugins-m3.3",
+      "version": "0.0.2-dev-plugins-m3.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@prismicio/slice-simulator-core": "^0.2.7",
         "@prismicio/types-internal": "2.0.0-alpha.9",
-        "@slicemachine/plugin-kit": "0.1.8-dev-plugins-m3.3",
+        "@slicemachine/plugin-kit": "0.1.8-dev-plugins-m3.4",
         "common-tags": "^1.8.2",
         "fs-extra": "^11.1.0",
         "magicast": "^0.2.1",
@@ -41470,12 +41470,12 @@
     },
     "packages/init": {
       "name": "@slicemachine/init",
-      "version": "0.1.1-dev-plugins-m3.3",
+      "version": "0.1.1-dev-plugins-m3.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@antfu/ni": "^0.20.0",
         "@lihbr/listr-update-renderer": "^0.5.3",
-        "@slicemachine/manager": "0.1.1-dev-plugins-m3.3",
+        "@slicemachine/manager": "0.1.1-dev-plugins-m3.4",
         "chalk": "^4.1.2",
         "globby": "^13.1.3",
         "listr": "^0.14.3",
@@ -41490,7 +41490,7 @@
       },
       "devDependencies": {
         "@size-limit/preset-small-lib": "^8.2.4",
-        "@slicemachine/plugin-kit": "0.1.8-dev-plugins-m3.3",
+        "@slicemachine/plugin-kit": "0.1.8-dev-plugins-m3.4",
         "@types/listr": "^0.14.4",
         "@types/prompts": "^2.4.3",
         "@types/semver": "^7.3.13",
@@ -41650,14 +41650,14 @@
     },
     "packages/manager": {
       "name": "@slicemachine/manager",
-      "version": "0.1.1-dev-plugins-m3.3",
+      "version": "0.1.1-dev-plugins-m3.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@antfu/ni": "^0.20.0",
         "@prismicio/custom-types-client": "^1.1.0",
         "@prismicio/mocks": "2.0.0-alpha.2",
         "@prismicio/types-internal": "2.0.0-alpha.9",
-        "@slicemachine/plugin-kit": "0.1.8-dev-plugins-m3.3",
+        "@slicemachine/plugin-kit": "0.1.8-dev-plugins-m3.4",
         "@wooorm/starry-night": "^1.6.0",
         "analytics-node": "^6.2.0",
         "cookie": "^0.5.0",
@@ -41962,7 +41962,7 @@
     },
     "packages/plugin-kit": {
       "name": "@slicemachine/plugin-kit",
-      "version": "0.1.8-dev-plugins-m3.3",
+      "version": "0.1.8-dev-plugins-m3.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@prismicio/types-internal": "2.0.0-alpha.9",
@@ -42144,7 +42144,7 @@
     },
     "packages/slice-machine": {
       "name": "slice-machine-ui",
-      "version": "0.6.1-dev-plugins-m3.3",
+      "version": "0.6.1-dev-plugins-m3.4",
       "license": "MIT",
       "dependencies": {
         "@extractus/oembed-extractor": "^3.1.8",
@@ -42152,7 +42152,7 @@
         "@prismicio/editor-ui": "^0.3.0",
         "@prismicio/mocks": "2.0.0-alpha.2",
         "@prismicio/types-internal": "2.0.0-alpha.9",
-        "@slicemachine/manager": "0.1.1-dev-plugins-m3.3",
+        "@slicemachine/manager": "0.1.1-dev-plugins-m3.4",
         "fast-deep-equal": "^3.1.3",
         "fp-ts": "^2.13.1",
         "html-react-parser": "^3.0.12",
@@ -42164,7 +42164,7 @@
         "puppeteer": "^19.7.5",
         "react": "^18.2.0",
         "semver": "^7.3.8",
-        "start-slicemachine": "0.6.1-dev-plugins-m3.3",
+        "start-slicemachine": "0.6.1-dev-plugins-m3.4",
         "yup": "^0.32.11"
       },
       "devDependencies": {
@@ -42373,10 +42373,10 @@
       }
     },
     "packages/start-slicemachine": {
-      "version": "0.6.1-dev-plugins-m3.3",
+      "version": "0.6.1-dev-plugins-m3.4",
       "license": "Apache-2.0",
       "dependencies": {
-        "@slicemachine/manager": "0.1.1-dev-plugins-m3.3",
+        "@slicemachine/manager": "0.1.1-dev-plugins-m3.4",
         "body-parser": "^1.20.2",
         "chalk": "^4.1.2",
         "cors": "^2.8.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,13 +52,13 @@
         "recharts": "^2.1.11"
       },
       "devDependencies": {
-        "@slicemachine/adapter-next": "0.0.13-dev-plugins-m3.4",
+        "@slicemachine/adapter-next": "0.0.13-dev-plugins-m3.5",
         "autoprefixer": "^10.4.4",
         "eslint": "^8.37.0",
         "eslint-config-next": "^12.1.4",
         "postcss": "^8.4.12",
-        "slice-machine-ui": "0.6.1-dev-plugins-m3.4",
-        "start-slicemachine": "0.6.1-dev-plugins-m3.4",
+        "slice-machine-ui": "0.6.1-dev-plugins-m3.5",
+        "start-slicemachine": "0.6.1-dev-plugins-m3.5",
         "tailwindcss": "^3.0.23"
       }
     },
@@ -39345,12 +39345,12 @@
     },
     "packages/adapter-next": {
       "name": "@slicemachine/adapter-next",
-      "version": "0.0.13-dev-plugins-m3.4",
+      "version": "0.0.13-dev-plugins-m3.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@prismicio/slice-simulator-core": "^0.2.7",
         "@prismicio/types-internal": "2.0.0-alpha.9",
-        "@slicemachine/plugin-kit": "0.1.8-dev-plugins-m3.4",
+        "@slicemachine/plugin-kit": "0.1.8-dev-plugins-m3.5",
         "common-tags": "^1.8.2",
         "fs-extra": "^11.1.0",
         "node-fetch": "^3.3.1",
@@ -39482,12 +39482,12 @@
     },
     "packages/adapter-nuxt": {
       "name": "@slicemachine/adapter-nuxt",
-      "version": "0.0.2-dev-plugins-m3.4",
+      "version": "0.0.2-dev-plugins-m3.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@prismicio/slice-simulator-core": "^0.2.7",
         "@prismicio/types-internal": "2.0.0-alpha.9",
-        "@slicemachine/plugin-kit": "0.1.8-dev-plugins-m3.4",
+        "@slicemachine/plugin-kit": "0.1.8-dev-plugins-m3.5",
         "common-tags": "^1.8.2",
         "fs-extra": "^11.1.0",
         "magicast": "^0.2.1",
@@ -41409,12 +41409,12 @@
     },
     "packages/adapter-nuxt2": {
       "name": "@slicemachine/adapter-nuxt2",
-      "version": "0.0.2-dev-plugins-m3.4",
+      "version": "0.0.2-dev-plugins-m3.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@prismicio/slice-simulator-core": "^0.2.7",
         "@prismicio/types-internal": "2.0.0-alpha.9",
-        "@slicemachine/plugin-kit": "0.1.8-dev-plugins-m3.4",
+        "@slicemachine/plugin-kit": "0.1.8-dev-plugins-m3.5",
         "common-tags": "^1.8.2",
         "fs-extra": "^11.1.0",
         "magicast": "^0.2.1",
@@ -41650,12 +41650,12 @@
     },
     "packages/init": {
       "name": "@slicemachine/init",
-      "version": "0.1.1-dev-plugins-m3.4",
+      "version": "0.1.1-dev-plugins-m3.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@antfu/ni": "^0.20.0",
         "@lihbr/listr-update-renderer": "^0.5.3",
-        "@slicemachine/manager": "0.1.1-dev-plugins-m3.4",
+        "@slicemachine/manager": "0.1.1-dev-plugins-m3.5",
         "chalk": "^4.1.2",
         "globby": "^13.1.3",
         "listr": "^0.14.3",
@@ -41670,7 +41670,7 @@
       },
       "devDependencies": {
         "@size-limit/preset-small-lib": "^8.2.4",
-        "@slicemachine/plugin-kit": "0.1.8-dev-plugins-m3.4",
+        "@slicemachine/plugin-kit": "0.1.8-dev-plugins-m3.5",
         "@types/listr": "^0.14.4",
         "@types/prompts": "^2.4.3",
         "@types/semver": "^7.3.13",
@@ -41830,14 +41830,14 @@
     },
     "packages/manager": {
       "name": "@slicemachine/manager",
-      "version": "0.1.1-dev-plugins-m3.4",
+      "version": "0.1.1-dev-plugins-m3.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@antfu/ni": "^0.20.0",
         "@prismicio/custom-types-client": "^1.1.0",
         "@prismicio/mocks": "2.0.0-alpha.2",
         "@prismicio/types-internal": "2.0.0-alpha.9",
-        "@slicemachine/plugin-kit": "0.1.8-dev-plugins-m3.4",
+        "@slicemachine/plugin-kit": "0.1.8-dev-plugins-m3.5",
         "@wooorm/starry-night": "^1.6.0",
         "analytics-node": "^6.2.0",
         "cookie": "^0.5.0",
@@ -42142,7 +42142,7 @@
     },
     "packages/plugin-kit": {
       "name": "@slicemachine/plugin-kit",
-      "version": "0.1.8-dev-plugins-m3.4",
+      "version": "0.1.8-dev-plugins-m3.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@prismicio/types-internal": "2.0.0-alpha.9",
@@ -42324,7 +42324,7 @@
     },
     "packages/slice-machine": {
       "name": "slice-machine-ui",
-      "version": "0.6.1-dev-plugins-m3.4",
+      "version": "0.6.1-dev-plugins-m3.5",
       "license": "MIT",
       "dependencies": {
         "@extractus/oembed-extractor": "^3.1.8",
@@ -42332,7 +42332,7 @@
         "@prismicio/editor-ui": "^0.3.0",
         "@prismicio/mocks": "2.0.0-alpha.2",
         "@prismicio/types-internal": "2.0.0-alpha.9",
-        "@slicemachine/manager": "0.1.1-dev-plugins-m3.4",
+        "@slicemachine/manager": "0.1.1-dev-plugins-m3.5",
         "fast-deep-equal": "^3.1.3",
         "fp-ts": "^2.13.1",
         "html-react-parser": "^3.0.12",
@@ -42344,7 +42344,7 @@
         "puppeteer": "^19.7.5",
         "react": "^18.2.0",
         "semver": "^7.3.8",
-        "start-slicemachine": "0.6.1-dev-plugins-m3.4",
+        "start-slicemachine": "0.6.1-dev-plugins-m3.5",
         "yup": "^0.32.11"
       },
       "devDependencies": {
@@ -42553,10 +42553,10 @@
       }
     },
     "packages/start-slicemachine": {
-      "version": "0.6.1-dev-plugins-m3.4",
+      "version": "0.6.1-dev-plugins-m3.5",
       "license": "Apache-2.0",
       "dependencies": {
-        "@slicemachine/manager": "0.1.1-dev-plugins-m3.4",
+        "@slicemachine/manager": "0.1.1-dev-plugins-m3.5",
         "body-parser": "^1.20.2",
         "chalk": "^4.1.2",
         "cors": "^2.8.5",


### PR DESCRIPTION
## Context

- https://linear.app/prismic/issue/SMX-154/e2e-tests-enable-skipped-tests

## The Solution

- Enable skip tests
- When we run the slicemachine init script, it already creates a `slice-simulator.js` file. It was conflicting with the `slice-simulator.jsx` file that tests are creating.
- Changed the way we edit boolean and select fields in Slice simulator to avoid relying on the `mocks.json` file.
- Removed logs in the output of the CI that were introducing lag when scrolling in the e2e job of the ci. These logs were listing all the files of the packages `dist/` folder.

## Checklist before requesting a review
- [x] I hereby declare my code ready for review.
- [x] If it is a critical feature, I have added tests.
- [x] The CI is successful.
- [x] If there could backward compatibility issues, it has been discussed and planned.
