### PR TITLE
Allow user to reset slice image field dimensions to auto

### DIFF
--- a/packages/slice-machine/lib/models/common/widgets/Image/Form.tsx
+++ b/packages/slice-machine/lib/models/common/widgets/Image/Form.tsx
@@ -17,14 +17,24 @@ import {
 } from "./components";
 import { TabFields } from "@lib/models/common/CustomType";
 
+const nullableNumberSchema = () => {
+  return yup
+    .number()
+    .nullable()
+    .transform((value: string | number, originalValue: string | number) =>
+      // When the user empties the field, it should convert it to null so that "auto" dimensions are set
+      originalValue === "" ? null : value
+    );
+};
+
 const FormFields = {
   label: DefaultFields.label,
   id: DefaultFields.id,
   constraint: {
     validate: () =>
       yup.object().defined().shape({
-        width: yup.number().nullable(),
-        height: yup.number().nullable(),
+        width: nullableNumberSchema(),
+        height: nullableNumberSchema(),
       }),
   },
   thumbnails: {

--- a/packages/slice-machine/test/lib/models/common/widgets/index.test.ts
+++ b/packages/slice-machine/test/lib/models/common/widgets/index.test.ts
@@ -60,4 +60,25 @@ describe("Widgets", () => {
       expect(field).toEqual(fieldExpected);
     }
   );
+
+  // Issue: https://github.com/prismicio/slice-machine/issues/672
+  test("allow resetting image constraints to auto when width and height values are empty strings", () => {
+    const field = Widgets.Image.create("Image");
+
+    expect(
+      Widgets.Image.schema.isValidSync(
+        {
+          type: field?.type,
+          config: {
+            ...field?.config,
+            constraint: {
+              width: "",
+              height: "",
+            },
+          },
+        },
+        { stripUnknown: true }
+      )
+    ).toBeTruthy();
+  });
 });


### PR DESCRIPTION
## Context

- [AAUser, I can reset Slice image field dimensions to "auto“](https://linear.app/prismic/issue/DT-815/aauser-i-can-reset-slice-image-field-dimensions-to-auto)
- Fixes #672 

## The Solution

- Adding a transform function with Yup let us transform the empty string to null to have "auto" dimensions

## Impact / Dependencies

- The model doesn't contain: `”constraint":{}` but `"constraint": { "width": null, "height": null }`
There should not be an impact from that and the result is still auto dimensions, but reviewer could help me confirm that.

## Checklist before requesting a review
- [x] I hereby declare my code ready for review.
- [x] If it is a critical feature, I have added tests.
- [x] The CI is successful.
- ~~If there could backward compatibility issues, it has been discussed and planned.~~

## Preview

https://user-images.githubusercontent.com/19946868/234526066-ca0b17bd-0f49-4596-87e3-9544b18cea83.mov
