### PR TITLE
make e2e tests app use local next-adapter build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,8 +158,8 @@ jobs:
       - name: Set up Node
         uses: ./.github/actions/setup-node
 
-      - name: Build Slice Machine UI, init and start scripts
-        run: npm run build --workspace packages/init --workspace packages/slice-machine --workspace packages/start-slicemachine
+      - name: Build Slice Machine UI, next-adapter, init and start scripts
+        run: npm run build --workspace packages/init --workspace packages/slice-machine --workspace packages/start-slicemachine --workspace packages/adapter-next
 
       - name: Running End to End tests
         run: npm run test:e2e

--- a/cypress-setup.sh
+++ b/cypress-setup.sh
@@ -30,7 +30,6 @@ rm -rf e2e-projects/cypress-next-app \
 && cd e2e-projects/cypress-next-app \
 && npm i *.tgz \
 && npx @slicemachine/init --repository ${_PRISMIC_REPO} \
-&& npm i --save-dev slice-machine-ui*.tgz \
-&& npm i \
+&& npm i --save-dev slice-machine-ui*.tgz slicemachine-adapter-next*.tgz \
 && npx --yes json -I -f package.json -e "this.scripts.slicemachine=\"start-slicemachine\"" \
 && npx --yes json -I -f slicemachine.config.json -e "this.localSliceSimulatorURL=\"http://localhost:3000/slice-simulator\""


### PR DESCRIPTION
## Context

- Allows the e2e tests app to load the next-adapter build from the branch instead of the production one.

## The Solution

- Build `next-adapter` and reference it locally
- The CI is green again

## Checklist before requesting a review
- [x] I hereby declare my code ready for review.
- [x] If it is a critical feature, I have added tests.
- [x] The CI is successful.
- [x] If there could backward compatibility issues, it has been discussed and planned.


