### PR TITLE
Fix code snippet for GeoPoint field type in Next

### DIFF
--- a/packages/adapter-next/src/hooks/snippet-read.ts
+++ b/packages/adapter-next/src/hooks/snippet-read.ts
@@ -118,6 +118,21 @@ export const snippetRead: SnippetReadHook<PluginOptions> = async (
 			};
 		}
 
+		case "GeoPoint": {
+			const code = await format(
+				stripIndent`
+					<>{JSON.stringify(${dotPath(fieldPath)})}</>
+				`,
+				helpers,
+			);
+
+			return {
+				label,
+				language: "tsx",
+				code,
+			};
+		}
+
 		default: {
 			return {
 				label,

--- a/packages/adapter-next/test/plugin-snippet-read.test.ts
+++ b/packages/adapter-next/test/plugin-snippet-read.test.ts
@@ -84,7 +84,7 @@ testSnippet("date", `<>{${model.id}.data.date}</>`);
 
 testSnippet("embed", `<>{${model.id}.data.embed}</>`);
 
-testSnippet("geoPoint", `<>{${model.id}.data.geoPoint}</>`);
+testSnippet("geoPoint", `<>{JSON.stringify(${model.id}.data.geoPoint)}</>`);
 
 testSnippet(
 	"group",


### PR DESCRIPTION
## Context

- [AAUser, I want to copy/paste a valid React GeoPoint code snippet](https://linear.app/prismic/issue/DT-960/aauser-i-want-to-copypaste-a-valid-react-geopoint-code-snippet)
- Fixes #790 

## The Solution

- Add a specific code snippet in Next adapter with a simple stringify
- Stringify solution let us have the object display and looks the same as with Nuxt adapter

## Impact / Dependencies

- None that I can think of

## Checklist before requesting a review
- [x] I hereby declare my code ready for review.
- [x] If it is a critical feature, I have added tests.~~
- [x] The CI is successful.
- ~~If there could backward compatibility issues, it has been discussed and planned.~~

## Preview

### Next before

<img width="1326" alt="Screenshot 2023-04-27 at 10 09 22" src="https://user-images.githubusercontent.com/19946868/234827859-e292d04c-ee4b-482e-ba3a-0fd77e92b17b.png">

### Next after

<img width="450" alt="Screenshot 2023-04-27 at 10 09 11" src="https://user-images.githubusercontent.com/19946868/234827898-bb82323b-4ff8-45b5-9c5f-cf14fa6ad90e.png">

### And for reference in Nuxt 

<img width="453" alt="Screenshot 2023-04-27 at 09 45 27" src="https://user-images.githubusercontent.com/19946868/234828045-e67166b0-7b6c-4ee4-b8f0-9f1906e4dccd.png">
