### PR TITLE
Prevent renaming a slice with a name starting with a number

### DIFF
--- a/cypress/e2e/slices/00-create.cy.js
+++ b/cypress/e2e/slices/00-create.cy.js
@@ -1,6 +1,9 @@
 import { SLICE_MOCK_FILE } from "../../consts";
+import { sliceRenameModal } from "../../pages/RenameModal";
 import { simulatorPage } from "../../pages/simulator/simulatorPage";
+import { createSliceModal } from "../../pages/slices/createSliceModal";
 import { sliceBuilder } from "../../pages/slices/sliceBuilder";
+import { slicesList } from "../../pages/slices/slicesList";
 
 const sliceName = "TestSlice";
 const editedSliceName = "EditedSliceName";
@@ -142,5 +145,28 @@ describe("Create Slices", () => {
     cy.get('ul[data-cy="slice-non-repeatable-zone"] > li')
       .eq(0)
       .contains("Description");
+  });
+
+  // See: #599
+  it("A user cannot create a slice with a name starting with a number", () => {
+    slicesList.goTo();
+    slicesList.emptyStateButton.click();
+
+    createSliceModal.nameInput.type("42Test");
+    createSliceModal.submitButton.should("be.disabled");
+  });
+
+  // See: #791
+  it("A user cannot rename a slice with a name starting with a number", () => {
+    const sliceName = "SliceName";
+
+    cy.createSlice(lib, sliceId, sliceName);
+    slicesList.goTo();
+
+    slicesList.getOptionDopDownButton(sliceName).click();
+    slicesList.renameButton.click();
+
+    sliceRenameModal.input.clear().type("42Test");
+    sliceRenameModal.submitButton.should("be.disabled");
   });
 });

--- a/cypress/pages/RenameModal.js
+++ b/cypress/pages/RenameModal.js
@@ -7,8 +7,13 @@ class RenameModal {
   get root() {
     return cy.get(this.rootSelector);
   }
+
   get input() {
     return cy.get(this.inputSelector);
+  }
+
+  get submitButton() {
+    return cy.get("button[type=submit]");
   }
 
   submit() {

--- a/cypress/pages/slices/createSliceModal.js
+++ b/cypress/pages/slices/createSliceModal.js
@@ -7,6 +7,10 @@ class CreateSliceModal {
     return cy.get("input[data-cy=slice-name-input]");
   }
 
+  get submitButton() {
+    return cy.get("button[type=submit]");
+  }
+
   submit() {
     this.root.submit();
     return this;

--- a/packages/slice-machine/components/Forms/CreateCustomTypeModal/CreateCustomTypeModal.tsx
+++ b/packages/slice-machine/components/Forms/CreateCustomTypeModal/CreateCustomTypeModal.tsx
@@ -2,8 +2,8 @@ import { SetStateAction, useState } from "react";
 import { Box } from "theme-ui";
 
 import ModalFormCard from "@components/ModalFormCard";
-import { InputBox } from "./components/InputBox";
-import { SelectRepeatable } from "./components/SelectRepeatable";
+import { InputBox } from "../components/InputBox";
+import { SelectRepeatable } from "../components/SelectRepeatable";
 import useSliceMachineActions from "@src/modules/useSliceMachineActions";
 import { useSelector } from "react-redux";
 import { SliceMachineStoreType } from "@src/redux/type";
@@ -27,7 +27,7 @@ interface FormValues {
   repeatable: boolean;
 }
 
-const CreateCustomTypeModal: React.FC = () => {
+export const CreateCustomTypeModal: React.FC = () => {
   const { createCustomType, closeModals } = useSliceMachineActions();
 
   const {
@@ -172,5 +172,3 @@ const CreateCustomTypeModal: React.FC = () => {
     </ModalFormCard>
   );
 };
-
-export default CreateCustomTypeModal;

--- a/packages/slice-machine/components/Forms/CreateCustomTypeModal/index.tsx
+++ b/packages/slice-machine/components/Forms/CreateCustomTypeModal/index.tsx
@@ -1,0 +1,1 @@
+export { CreateCustomTypeModal } from "./CreateCustomTypeModal";

--- a/packages/slice-machine/components/Forms/CreateSliceModal/CreateSliceModal.tsx
+++ b/packages/slice-machine/components/Forms/CreateSliceModal/CreateSliceModal.tsx
@@ -2,13 +2,10 @@ import { Box, Label } from "theme-ui";
 
 import Select from "react-select";
 import ModalFormCard from "@components/ModalFormCard";
-import camelCase from "lodash/camelCase";
-import startCase from "lodash/startCase";
-import { InputBox } from "./components/InputBox";
-import { RESERVED_SLICE_NAME } from "@lib/consts";
+import { InputBox } from "../components/InputBox";
 import { SliceSM } from "@lib/models/common/Slice";
 import { LibraryUI } from "@lib/models/common/LibraryUI";
-import { API_ID_REGEX } from "@lib/consts";
+import { validateSliceModalValues } from "../formsValidator";
 
 const formId = "create-new-slice";
 
@@ -23,14 +20,9 @@ type CreateSliceModalProps = {
 
 type FormValues = { sliceName: string; from: string };
 
-const CreateSliceModal: React.FunctionComponent<CreateSliceModalProps> = ({
-  isOpen,
-  isCreatingSlice,
-  onSubmit,
-  close,
-  libraries,
-  remoteSlices,
-}) => {
+export const CreateSliceModal: React.FunctionComponent<
+  CreateSliceModalProps
+> = ({ isOpen, isCreatingSlice, onSubmit, close, libraries, remoteSlices }) => {
   return (
     <ModalFormCard
       dataCy="create-slice-modal"
@@ -48,37 +40,9 @@ const CreateSliceModal: React.FunctionComponent<CreateSliceModalProps> = ({
         sliceName: "",
         from: libraries[0].name,
       }}
-      validate={({ sliceName }) => {
-        if (!sliceName) {
-          return { sliceName: "Cannot be empty" };
-        }
-        if (!API_ID_REGEX.exec(sliceName)) {
-          return { sliceName: "No special characters allowed" };
-        }
-        const cased = startCase(camelCase(sliceName)).replace(/\s/gm, "");
-        if (cased !== sliceName.trim()) {
-          return { sliceName: "Value has to be PascalCased" };
-        }
-        // See: #599
-        if (sliceName.match(/^\d/)) {
-          return { sliceName: "Value cannot start with a number" };
-        }
-        if (RESERVED_SLICE_NAME.includes(sliceName)) {
-          return {
-            sliceName: `${sliceName} is reserved for Slice Machine use`,
-          };
-        }
-
-        const localNames = libraries.flatMap((lib) =>
-          lib.components.map((slice) => slice.model.name)
-        );
-        const remoteNames = remoteSlices.map((slice) => slice.name);
-        const usedNames = [...localNames, ...remoteNames];
-
-        if (usedNames.includes(sliceName)) {
-          return { sliceName: "Slice name is already taken." };
-        }
-      }}
+      validate={(values) =>
+        validateSliceModalValues(values, libraries, remoteSlices)
+      }
       content={{
         title: "Create a new slice",
       }}
@@ -118,5 +82,3 @@ const CreateSliceModal: React.FunctionComponent<CreateSliceModalProps> = ({
     </ModalFormCard>
   );
 };
-
-export default CreateSliceModal;

--- a/packages/slice-machine/components/Forms/CreateSliceModal/index.tsx
+++ b/packages/slice-machine/components/Forms/CreateSliceModal/index.tsx
@@ -1,0 +1,1 @@
+export { CreateSliceModal } from "./CreateSliceModal";

--- a/packages/slice-machine/components/Forms/formsTypes.ts
+++ b/packages/slice-machine/components/Forms/formsTypes.ts
@@ -1,0 +1,3 @@
+export interface SliceModalValues {
+  sliceName: string;
+}

--- a/packages/slice-machine/components/Forms/formsValidator.ts
+++ b/packages/slice-machine/components/Forms/formsValidator.ts
@@ -1,0 +1,48 @@
+import { SliceModalValues } from "./formsTypes";
+import { RESERVED_SLICE_NAME, API_ID_REGEX } from "@lib/consts";
+import { LibraryUI } from "@lib/models/common/LibraryUI";
+import { SliceSM } from "@lib/models/common/Slice";
+import camelCase from "lodash/camelCase";
+import startCase from "lodash/startCase";
+
+type SliceModalValuesValidity =
+  | {
+      sliceName?: string;
+    }
+  | undefined;
+
+export function validateSliceModalValues(
+  { sliceName }: SliceModalValues,
+  localLibs: ReadonlyArray<LibraryUI>,
+  remoteLibs: ReadonlyArray<SliceSM>
+): SliceModalValuesValidity {
+  if (!sliceName) {
+    return { sliceName: "Cannot be empty" };
+  }
+  if (!API_ID_REGEX.exec(sliceName)) {
+    return { sliceName: "No special characters allowed" };
+  }
+  const cased = startCase(camelCase(sliceName)).replace(/\s/gm, "");
+  if (cased !== sliceName.trim()) {
+    return { sliceName: "Value has to be PascalCased" };
+  }
+  // See: #599
+  if (sliceName.match(/^\d/)) {
+    return { sliceName: "Value cannot start with a number" };
+  }
+  if (RESERVED_SLICE_NAME.includes(sliceName)) {
+    return {
+      sliceName: `${sliceName} is reserved for Slice Machine use`,
+    };
+  }
+
+  const localNames = localLibs.flatMap((lib) =>
+    lib.components.map((slice) => slice.model.name)
+  );
+  const remoteNames = remoteLibs.map((slice) => slice.name);
+  const usedNames = [...localNames, ...remoteNames];
+
+  if (usedNames.includes(sliceName)) {
+    return { sliceName: "Slice name is already taken." };
+  }
+}

--- a/packages/slice-machine/pages/index.tsx
+++ b/packages/slice-machine/pages/index.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { Flex, Link as ThemeLink, Text } from "theme-ui";
 
 import Container from "@components/Container";
-import CreateCustomTypeModal from "@components/Forms/CreateCustomTypeModal";
+import { CreateCustomTypeModal } from "@components/Forms/CreateCustomTypeModal";
 import Header from "@components/Header";
 import EmptyState from "@components/EmptyState";
 import { Button } from "@components/Button";

--- a/packages/slice-machine/pages/slices.tsx
+++ b/packages/slice-machine/pages/slices.tsx
@@ -3,7 +3,7 @@ import { MdHorizontalSplit } from "react-icons/md";
 import { Box, Flex, Text, Link } from "theme-ui";
 import Container from "components/Container";
 
-import CreateSliceModal from "components/Forms/CreateSliceModal";
+import { CreateSliceModal } from "components/Forms/CreateSliceModal";
 
 import Header from "components/Header";
 import Grid from "components/Grid";

--- a/packages/slice-machine/test/components/CreateCustomTypeModal.test.tsx
+++ b/packages/slice-machine/test/components/CreateCustomTypeModal.test.tsx
@@ -4,7 +4,7 @@ import { describe, test, afterEach, expect, vi } from "vitest";
 import SegmentClient from "analytics-node";
 
 import { render, fireEvent, act } from "../__testutils__";
-import CreateCustomTypeModal from "../../components/Forms/CreateCustomTypeModal";
+import { CreateCustomTypeModal } from "../../components/Forms/CreateCustomTypeModal";
 import { ModalKeysEnum } from "../../src/modules/modal/types";
 
 vi.mock("next/router", () => require("next-router-mock"));


### PR DESCRIPTION
## Context

- [AAUser, I cannot rename a slice name with a name starting with a number](https://linear.app/prismic/issue/DT-1109/aauser-i-cannot-rename-a-slice-name-with-a-name-starting-with-a-number)
- Fixes #791

## The Solution

- Mutualize code between the CreateSliceModal and RenameSliceModal, so they share the same validation function, and it's not possible to correctly validate in one ase and not the other
- Added some tests to understand your Cypress setup

## Impact / Dependencies

- Simple refactor since I didn't want to change too much change for this simple fix
- Don't know if you have some best practices for the code organization, example the file "types.ts" and "validator.ts"

## Checklist before requesting a review
- [x] I hereby declare my code ready for review.
- [x] If it is a critical feature, I have added tests. 
- [x] The CI is successful.
- ~~If there could backward compatibility issues, it has been discussed and planned.~~

## Preview

<img width="550" alt="Screenshot 2023-04-27 at 14 22 01" src="https://user-images.githubusercontent.com/19946868/234860520-7526e258-7d75-48ef-b1d0-5d5d9d2e78a5.png">
