### PR TITLE
Fix default value checkbox for Select Field

### DIFF
--- a/packages/slice-machine/components/FormFields/CheckboxControl.jsx
+++ b/packages/slice-machine/components/FormFields/CheckboxControl.jsx
@@ -3,14 +3,15 @@ import { useState, useEffect } from "react";
 import { FormFieldCheckbox } from "./";
 
 /**
- * This components allows to set/unset the value of an arbitrary field via checking/unchecking the box
+ * This components allows to set/unset the value of an arbitrary field via
+ * checking/unchecking the box
  *
- * field: the controlled Formik field that we want to manipulate
- * label: a function of text displayed next to the checkbox. Can be either a string or a function
- * controlledValue: the value of the field being controlled
- * setControlledValue: function to update the value of the controlled value in Formik
- * buildControlledValue: function to build the new value based on the current controlled value and the state of the checkbox
- *
+ * Field: the controlled Formik field that we want to manipulate label: a
+ * function of text displayed next to the checkbox. Can be either a string or a
+ * function controlledValue: the value of the field being controlled
+ * setControlledValue: function to update the value of the controlled value in
+ * Formik buildControlledValue: function to build the new value based on the
+ * current controlled value and the state of the checkbox
  */
 const CheckboxControl = ({
   field,
@@ -31,7 +32,7 @@ const CheckboxControl = ({
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
     buildControlledValue
       ? // eslint-disable-next-line @typescript-eslint/no-unsafe-call
-        setControlledValue(buildControlledValue(controlledValue))
+        setControlledValue(buildControlledValue(controlledValue, isChecked))
       : // eslint-disable-next-line @typescript-eslint/no-unsafe-call
         setControlledValue(buildControlledValue);
     // Adding the missing dependency to this hook triggers an infinite loop


### PR DESCRIPTION
## Context

- [AAUser, I want to set the default value of a Select field](https://linear.app/prismic/issue/DT-1059/aauser-i-want-to-set-the-default-value-of-a-select-field)

## The Solution

- Without TypeScript, hard to see this kind of problems, but basically there is a "buildControlledValue" that receive 2 params. The second param is if the first value should be considered the default one, and it was never given to the function.
The "buildControlledValue" function is located [here](https://github.com/prismicio/slice-machine/blob/master/packages/slice-machine/lib/models/common/widgets/Select/FormFields.jsx#L17) 

## Impact / Dependencies

- It was introduced in this [tag](https://github.com/prismicio/slice-machine/compare/slice-machine-ui%400.6.0...slice-machine-ui%400.6.1#diff-055a1d388300e2493dc0a9089422a4a349b835b2290b45ace19ace8f85a0e682R34) for the 0.6.1 of slice-machine-ui
Don't look like it could be an impact on my fix
Didn't want to change this code because it will be refactored anyway, so I just provided a fix, so user can use the default value feature again

## Checklist before requesting a review
- [x] I hereby declare my code ready for review.
- ~~If it is a critical feature, I have added tests.~~
- [x] The CI is successful.
- ~~If there could backward compatibility issues, it has been discussed and planned.~~

## Preview

![Screenshot 2023-04-27 at 18 09 02](https://user-images.githubusercontent.com/19946868/234925601-6ecda0d8-1918-400e-be81-368108d906c8.png)

<img width="953" alt="Screenshot 2023-04-27 at 18 09 20" src="https://user-images.githubusercontent.com/19946868/234925609-2be8f63e-a5d4-4258-99c6-58c0db3d6ee1.png">
