### PR TITLE
Add new script to contribute more easily to slice machine

### DIFF
--- a/e2e-projects/next/package.json
+++ b/e2e-projects/next/package.json
@@ -7,7 +7,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "slicemachine": "start-slicemachine"
+    "slicemachine": "start-slicemachine",
+    "slicemachine:dev": "NODE_ENV=development start-slicemachine"
   },
   "dependencies": {
     "@headlessui/react": "^1.5.0",


### PR DESCRIPTION
## Context

We have our own slice machine project in e2e and to dev with it, we need to run "NODE_ENV=development start-slicemachine".

## The Solution

I added a new script "slicemachine:dev" to launch it quicker when needed

## Impact / Dependencies

If I understood correctly, this is a test project for us, so no impact for me

## Checklist before requesting a review
- [x] I hereby declare my code ready for review.
- ~~If it is a critical feature, I have added tests.~~
- [x] The CI is successful.
- ~~If there could backward compatibility issues, it has been discussed and planned.~~
