### PR TITLE
Remove link to simulator from Custom Types page

### DIFF
--- a/packages/slice-machine/components/FormFields/CheckboxControl.jsx
+++ b/packages/slice-machine/components/FormFields/CheckboxControl.jsx
@@ -6,12 +6,14 @@ import { FormFieldCheckbox } from "./";
  * This components allows to set/unset the value of an arbitrary field via
  * checking/unchecking the box
  *
- * Field: the controlled Formik field that we want to manipulate label: a
- * function of text displayed next to the checkbox. Can be either a string or a
- * function controlledValue: the value of the field being controlled
- * setControlledValue: function to update the value of the controlled value in
- * Formik buildControlledValue: function to build the new value based on the
- * current controlled value and the state of the checkbox
+ * @param field - The controlled Formik field that we want to manipulate
+ * @param label - A function of text displayed next to the checkbox. Can be
+ *   either a string or a function
+ * @param controlledValue - The value of the field being controlled
+ * @param setControlledValue - Function to update the value of the controlled
+ *   value in
+ * @param buildControlledValue - Formik function to build the new value based on
+ *   the current controlled value and the state of the checkbox
  */
 const CheckboxControl = ({
   field,

--- a/packages/slice-machine/lib/builders/CustomTypeBuilder/TabZone/index.tsx
+++ b/packages/slice-machine/lib/builders/CustomTypeBuilder/TabZone/index.tsx
@@ -133,6 +133,7 @@ const TabZone: React.FC<TabZoneProps> = ({ tabId, fields, sliceZone }) => {
   return (
     <>
       <Zone
+        zoneType="customType"
         // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
         tabId={tabId}
         title="Static Zone"

--- a/packages/slice-machine/lib/builders/SliceBuilder/FieldZones/index.tsx
+++ b/packages/slice-machine/lib/builders/SliceBuilder/FieldZones/index.tsx
@@ -118,6 +118,7 @@ const FieldZones: React.FunctionComponent<FieldZonesProps> = ({
   return (
     <>
       <Zone
+        zoneType="slice"
         tabId={undefined}
         title="Non-Repeatable Zone"
         dataTip={dataTipText}
@@ -142,6 +143,7 @@ const FieldZones: React.FunctionComponent<FieldZonesProps> = ({
       />
       <Box mt={4} />
       <Zone
+        zoneType="slice"
         tabId={undefined}
         isRepeatable
         title="Repeatable Zone"

--- a/packages/slice-machine/lib/builders/common/EditModal/index.jsx
+++ b/packages/slice-machine/lib/builders/common/EditModal/index.jsx
@@ -26,7 +26,7 @@ if (process.env.NODE_ENV !== "test") {
 
 const FORM_ID = "edit-modal-form";
 
-const EditModal = ({ close, data, fields, onSave }) => {
+const EditModal = ({ close, data, fields, onSave, zoneType }) => {
   const { theme } = useThemeUI();
 
   // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
@@ -161,11 +161,52 @@ const EditModal = ({ close, data, fields, onSave }) => {
             initialValues,
           } = props;
 
+          const fieldModelTabContent = CustomForm ? (
+            <CustomForm
+              key="field-model-tab-content"
+              {...props}
+              // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+              fields={fields}
+            />
+          ) : (
+            <FlexGrid key="field-model-tab-content">
+              {/* eslint-disable-next-line @typescript-eslint/no-unsafe-argument */}
+              {Object.entries(FormFields).map(([key, field]) => (
+                <Col key={key}>
+                  <WidgetFormField
+                    fieldName={createFieldNameFromKey(key)}
+                    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+                    formField={field}
+                    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+                    fields={fields}
+                    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+                    initialValues={initialValues}
+                  />
+                </Col>
+              ))}
+            </FlexGrid>
+          );
+
+          const mockDataTabContent = zoneType === "slice" && (
+            <Box key="mock-data-tab-content">
+              <DeprecatedMockConfigMessage />
+            </Box>
+          );
+
+          const tabs = ["Field Model"];
+          const cardContent = [fieldModelTabContent];
+
+          // Only display "Mock Data" tab for slice with the simulator fallback display, see DT-991
+          if (zoneType === "slice") {
+            tabs.push("Mock Data");
+            cardContent.push(mockDataTabContent);
+          }
+
           return (
             <Card
               borderFooter
               footerSx={{ p: 0, mb: 5 }}
-              tabs={["Field Model", "Mock Data"]}
+              tabs={tabs}
               Header={({ radius }) => (
                 <Flex
                   sx={{
@@ -224,31 +265,7 @@ const EditModal = ({ close, data, fields, onSave }) => {
                 </Flex>
               }
             >
-              {CustomForm ? (
-                // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-                <CustomForm {...props} fields={fields} />
-              ) : (
-                <FlexGrid>
-                  {/* eslint-disable-next-line @typescript-eslint/no-unsafe-argument */}
-                  {Object.entries(FormFields).map(([key, field]) => (
-                    <Col key={key}>
-                      <WidgetFormField
-                        fieldName={createFieldNameFromKey(key)}
-                        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-                        formField={field}
-                        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-                        fields={fields}
-                        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-                        initialValues={initialValues}
-                      />
-                    </Col>
-                  ))}
-                </FlexGrid>
-              )}
-
-              <Box>
-                <DeprecatedMockConfigMessage />
-              </Box>
+              {cardContent}
             </Card>
           );
         }}

--- a/packages/slice-machine/lib/builders/common/EditModal/index.jsx
+++ b/packages/slice-machine/lib/builders/common/EditModal/index.jsx
@@ -187,17 +187,17 @@ const EditModal = ({ close, data, fields, onSave, zoneType }) => {
             </FlexGrid>
           );
 
-          const mockDataTabContent = zoneType === "slice" && (
-            <Box key="mock-data-tab-content">
-              <DeprecatedMockConfigMessage />
-            </Box>
-          );
-
           const tabs = ["Field Model"];
           const cardContent = [fieldModelTabContent];
 
           // Only display "Mock Data" tab for slice with the simulator fallback display, see DT-991
           if (zoneType === "slice") {
+            const mockDataTabContent = (
+              <Box key="mock-data-tab-content">
+                <DeprecatedMockConfigMessage />
+              </Box>
+            );
+
             tabs.push("Mock Data");
             cardContent.push(mockDataTabContent);
           }

--- a/packages/slice-machine/lib/builders/common/Zone/index.jsx
+++ b/packages/slice-machine/lib/builders/common/Zone/index.jsx
@@ -13,6 +13,7 @@ import ZoneHeader from "./components/ZoneHeader";
 import EmptyState from "./components/EmptyState";
 
 const Zone = ({
+  zoneType /* type of the zone: customType or slice */,
   tabId,
   title /* text info to display in Card Header */,
   fields /* widgets registered in the zone */,
@@ -165,6 +166,8 @@ const Zone = ({
         onSave={onSave}
         // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-assignment
         fields={poolOfFieldsToCheck}
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+        zoneType={zoneType}
       />
       <SelectFieldTypeModal
         data={selectModalData}

--- a/packages/slice-machine/test/lib/builders/EditModal.test.tsx
+++ b/packages/slice-machine/test/lib/builders/EditModal.test.tsx
@@ -36,7 +36,13 @@ describe("EditModal", () => {
     const fields = [field];
 
     render(
-      <EditModal onSave={saveFn} close={closeFn} data={data} fields={fields} />
+      <EditModal
+        onSave={saveFn}
+        close={closeFn}
+        data={data}
+        fields={fields}
+        zoneType="slice"
+      />
     );
 
     const removeButton = document.querySelector(
@@ -85,7 +91,13 @@ describe("EditModal", () => {
     const closeFn = vi.fn();
 
     render(
-      <EditModal onSave={saveFn} close={closeFn} data={data} fields={fields} />
+      <EditModal
+        onSave={saveFn}
+        close={closeFn}
+        data={data}
+        fields={fields}
+        zoneType="slice"
+      />
     );
 
     const labelInput = document.querySelector('input[name="config.label"]');


### PR DESCRIPTION
## Context

- [AAUser, I don't need a link to the Simulator on the Custom Types page](https://linear.app/prismic/issue/DT-991/aauser-i-dont-need-a-link-to-the-simulator-on-the-custom-types-page)

## The Solution

- I identified the different zones that we have in two: custom_type or slice, with that I was able to remove the tab on custom type context

## Impact / Dependencies

- Should not have any impact outside of the removal of the tab. 
- For me the best way was to use a new prop because all the other ones were not specific enough or too risky to use for the maintenance
- I also changed the way to pass down the card children because it requires an array if I don't want to refactor everything, and it should not pass down even null or false as JSX to prevent Tabs to have two children. With just a simple condition, I end up with this:
```
warning: Failed prop type: There should be an equal number of 'Tab' and 'TabPanel' in `Tabs`. Received 1 'Tab' and 2 'TabPanel'.
```

## Checklist before requesting a review
- [x] I hereby declare my code ready for review.
- ~~If it is a critical feature, I have added tests.~~
- [x] The CI is successful.
- ~~If there could backward compatibility issues, it has been discussed and planned.~~

## Preview

Before, on the custom type context, I have the Mock tab:

<img width="1010" alt="Screenshot 2023-04-27 at 19 41 14" src="https://user-images.githubusercontent.com/19946868/234946367-30b099c8-e3e3-4622-adf2-a319e67382eb.png">

On the custom type context, I now don't have the Mock tab:

<img width="1044" alt="Screenshot 2023-04-27 at 19 37 44" src="https://user-images.githubusercontent.com/19946868/234944349-773cd6e0-bb2a-4cf4-8e87-9fcf9b12d7dd.png">

