### PR TITLE
Feature/sticky-modal-headers-and-footer

### DIFF
--- a/packages/slice-machine/components/Card/WithTabs/components.jsx
+++ b/packages/slice-machine/components/Card/WithTabs/components.jsx
@@ -10,7 +10,9 @@ export const CustomTabList = ({ children, ...otherProps }) => (
       px: (theme) => `calc(${theme.space[3]}px + 8px)`,
       borderBottom: `1px solid #DFE1E5`,
       bg: "headSection",
-      position: "relative",
+      position: "sticky",
+      zIndex: 1,
+      top: 64,
     }}
     {...otherProps}
   >
@@ -31,7 +33,6 @@ export const CustomTab = ({ children, ...otherProps }) => {
         padding: "8px 0px",
         border: "none",
         bottom: "-1px",
-        border: "none",
         opacity: "0.8",
         transition: "all 150ms cubic-bezier(0.215,0.60,0.355,1)",
         borderRadius: "0",

--- a/packages/slice-machine/components/Card/index.tsx
+++ b/packages/slice-machine/components/Card/index.tsx
@@ -54,6 +54,7 @@ const Card: React.FC<CardProps> = ({
             : null),
           ...footerSx,
         }}
+        radius={radius}
         withRadius
       >
         {typeof Footer === "object" ? Footer : <Footer />}

--- a/packages/slice-machine/components/DeleteCTModal/index.tsx
+++ b/packages/slice-machine/components/DeleteCTModal/index.tsx
@@ -46,13 +46,11 @@ export const DeleteCustomTypeModal: React.FunctionComponent<
       style={{
         content: {
           maxWidth: 612,
-          borderRadius: "0px",
         },
       }}
       onRequestClose={closeModals}
     >
       <Card
-        radius={"0px"}
         bodySx={{
           p: 0,
           bg: "white",
@@ -61,13 +59,18 @@ export const DeleteCustomTypeModal: React.FunctionComponent<
           padding: 16,
         }}
         footerSx={{
+          position: "sticky",
+          bottom: 0,
           p: 0,
         }}
-        sx={{ border: "none", borderRadius: "0px" }}
+        sx={{ border: "none", overflow: "hidden" }}
         borderFooter
         Header={() => (
           <Flex
             sx={{
+              position: "sticky",
+              top: 0,
+              zIndex: 1,
               p: "16px",
               alignItems: "center",
               justifyContent: "space-between",
@@ -94,7 +97,7 @@ export const DeleteCustomTypeModal: React.FunctionComponent<
               alignItems: "center",
               paddingRight: 16,
               borderTop: (t) => `1px solid ${String(t.colors?.darkBorders)}`,
-              backgroundColor: "white",
+              backgroundColor: "gray",
             }}
           >
             <Button

--- a/packages/slice-machine/components/DeleteSliceModal/index.tsx
+++ b/packages/slice-machine/components/DeleteSliceModal/index.tsx
@@ -38,13 +38,11 @@ export const DeleteSliceModal: React.FunctionComponent<
       style={{
         content: {
           maxWidth: 612,
-          borderRadius: "0px",
         },
       }}
       onRequestClose={closeModals}
     >
       <Card
-        radius={"0px"}
         bodySx={{
           p: 0,
           bg: "white",
@@ -53,13 +51,19 @@ export const DeleteSliceModal: React.FunctionComponent<
           padding: 16,
         }}
         footerSx={{
+          position: "sticky",
+          bottom: 0,
           p: 0,
         }}
-        sx={{ border: "none", borderRadius: "0px" }}
+        sx={{ border: "none" }}
         borderFooter
         Header={() => (
           <Flex
             sx={{
+              position: "sticky",
+              background: "gray",
+              top: 0,
+              zIndex: 1,
               p: "16px",
               alignItems: "center",
               justifyContent: "space-between",
@@ -86,7 +90,7 @@ export const DeleteSliceModal: React.FunctionComponent<
               alignItems: "center",
               paddingRight: 16,
               borderTop: (t) => `1px solid ${String(t.colors?.darkBorders)}`,
-              backgroundColor: "white",
+              backgroundColor: "gray",
             }}
           >
             <Button

--- a/packages/slice-machine/components/Forms/CreateSliceModal.tsx
+++ b/packages/slice-machine/components/Forms/CreateSliceModal.tsx
@@ -112,6 +112,7 @@ const CreateSliceModal: React.FunctionComponent<CreateSliceModalProps> = ({
                 },
               };
             }}
+            menuPortalTarget={document.body}
           />
         </Box>
       )}

--- a/packages/slice-machine/components/ModalFormCard/index.tsx
+++ b/packages/slice-machine/components/ModalFormCard/index.tsx
@@ -71,7 +71,7 @@ function ModalCard<Values extends FormikValues>({
       contentLabel={title}
       style={{
         content: {
-          width: widthInPx || "900px",
+          width: widthInPx ?? "900px",
         },
       }}
     >
@@ -95,16 +95,27 @@ function ModalCard<Values extends FormikValues>({
           setFieldValue,
           setValues,
         }) => (
-          <Form id={formId} {...(dataCy ? { "data-cy": dataCy } : null)}>
+          <Form
+            id={formId}
+            {...(dataCy != null ? { "data-cy": dataCy } : null)}
+          >
             <Card
               borderFooter
-              footerSx={{ p: 3 }}
+              footerSx={{
+                p: 3,
+                position: "sticky",
+                bottom: 0,
+                background: "gray",
+              }}
               bodySx={{ px: 4, py: 4 }}
               sx={{ border: "none" }}
               {...cardProps}
               Header={({ radius }: { radius: string | number }) => (
                 <Flex
                   sx={{
+                    position: "sticky",
+                    top: 0,
+                    zIndex: 1,
                     p: "16px",
                     pl: 4,
                     bg: "headSection",
@@ -122,7 +133,11 @@ function ModalCard<Values extends FormikValues>({
               )}
               Footer={
                 !omitFooter ? (
-                  <Flex sx={{ alignItems: "space-between" }}>
+                  <Flex
+                    sx={{
+                      alignItems: "space-between",
+                    }}
+                  >
                     <Box sx={{ ml: "auto" }} />
                     <ThemeButton
                       mr={2}

--- a/packages/slice-machine/components/ScreenshotChangesModal/index.tsx
+++ b/packages/slice-machine/components/ScreenshotChangesModal/index.tsx
@@ -156,6 +156,10 @@ const ScreenshotChangesModal = ({
         Header={({ radius }: { radius: string | number }) => (
           <Flex
             sx={{
+              position: "sticky",
+              top: 0,
+              zIndex: 1,
+              background: "gray",
               p: "16px",
               alignItems: "center",
               justifyContent: "space-between",

--- a/packages/slice-machine/components/ScreenshotPreviewModal/index.tsx
+++ b/packages/slice-machine/components/ScreenshotPreviewModal/index.tsx
@@ -47,12 +47,17 @@ const ScreenshotPreviewModal: React.FunctionComponent<ScreenshotModalProps> = ({
           padding: 16,
         }}
         footerSx={{
+          position: "sticky",
+          bottom: 0,
           p: 0,
         }}
         sx={{ border: "none" }}
         Header={() => (
           <Flex
             sx={{
+              position: "sticky",
+              top: 0,
+              zIndex: 1,
               p: "16px",
               alignItems: "center",
               justifyContent: "space-between",

--- a/packages/slice-machine/components/Simulator/components/SetupModal/index.tsx
+++ b/packages/slice-machine/components/Simulator/components/SetupModal/index.tsx
@@ -102,6 +102,9 @@ const SetupModal: React.FC<{ isOpen: boolean }> = ({ isOpen }) => {
         Header={({ radius }: { radius: string | number }) => (
           <Flex
             sx={{
+              position: "sticky",
+              top: 0,
+              zIndex: 1,
               p: "16px",
               pl: 4,
               bg: "grey07",

--- a/packages/slice-machine/components/SliceMachineModal/index.tsx
+++ b/packages/slice-machine/components/SliceMachineModal/index.tsx
@@ -4,12 +4,13 @@ import * as React from "react";
 const SliceMachineModal: React.FunctionComponent<Modal.Props> = (props) => {
   const modalStyle = {
     content: {
-      padding: "0px 0px 40px 0px",
+      padding: "0px",
       top: "10%",
       maxWidth: "950px",
       margin: "auto",
       border: "0",
       background: "0",
+      borderRadius: "6px",
       ...props.style?.content,
     },
     overlay: {

--- a/packages/slice-machine/lib/builders/common/EditModal/index.jsx
+++ b/packages/slice-machine/lib/builders/common/EditModal/index.jsx
@@ -205,11 +205,14 @@ const EditModal = ({ close, data, fields, onSave, zoneType }) => {
           return (
             <Card
               borderFooter
-              footerSx={{ p: 0, mb: 5 }}
+              footerSx={{ position: "sticky", bottom: 0, p: 0 }}
               tabs={tabs}
               Header={({ radius }) => (
                 <Flex
                   sx={{
+                    position: "sticky",
+                    zIndex: 1,
+                    top: 0,
                     p: 3,
                     bg: "headSection",
                     alignItems: "center",
@@ -235,7 +238,13 @@ const EditModal = ({ close, data, fields, onSave, zoneType }) => {
               )}
               Footer={
                 <Flex
-                  sx={{ alignItems: "space-between", bg: "headSection", p: 3 }}
+                  sx={{
+                    position: "sticky",
+                    bottom: 0,
+                    alignItems: "space-between",
+                    bg: "headSection",
+                    p: 3,
+                  }}
                 >
                   <Box sx={{ ml: "auto" }} />
                   <Button

--- a/packages/slice-machine/lib/builders/common/SelectFieldTypeModal/index.jsx
+++ b/packages/slice-machine/lib/builders/common/SelectFieldTypeModal/index.jsx
@@ -33,6 +33,9 @@ const SelectFieldTypeModal = ({ data, close, onSelect, widgetsArray }) => {
         Header={({ radius }) => (
           <Flex
             sx={{
+              position: "sticky",
+              top: 0,
+              zIndex: 1,
               p: 3,
               pl: 4,
               bg: "headSection",


### PR DESCRIPTION
## Context
The save button, for example in the edit slices dialog, ends up out of view. I have clicked outside the dialog multiple times, which does not save it.

## The Solution
To fix this, I added position sticky to the headers and footers of the modal headers and footers. 

## Impact / Dependencies
This only impacts the UI of the slicemachine modals.


## Checklist before requesting a review
- [x] I hereby declare my code ready for review.
- [x] If it is a critical feature, I have added tests.
- [x] The CI is successful.
- [x] If there could backward compatibility issues, it has been discussed and planned.




## [OPT] Preview
<img width="1680" alt="image" src="https://user-images.githubusercontent.com/7714133/235515525-d0ebbe12-4740-487d-9c7b-bf13ff2f8724.png">




