### PR TITLE
Fix code snippet for Embed flied type in Next

### DIFF
--- a/packages/adapter-next/src/hooks/snippet-read.ts
+++ b/packages/adapter-next/src/hooks/snippet-read.ts
@@ -118,7 +118,8 @@ export const snippetRead: SnippetReadHook<PluginOptions> = async (
 			};
 		}
 
-		case "GeoPoint": {
+		case "GeoPoint":
+		case "Embed": {
 			const code = await format(
 				stripIndent`
 					<>{JSON.stringify(${dotPath(fieldPath)})}</>

--- a/packages/adapter-next/test/plugin-snippet-read.test.ts
+++ b/packages/adapter-next/test/plugin-snippet-read.test.ts
@@ -82,7 +82,7 @@ testSnippet(
 
 testSnippet("date", `<>{${model.id}.data.date}</>`);
 
-testSnippet("embed", `<>{${model.id}.data.embed}</>`);
+testSnippet("embed", `<>{JSON.stringify(${model.id}.data.embed)}</>`);
 
 testSnippet("geoPoint", `<>{JSON.stringify(${model.id}.data.geoPoint)}</>`);
 


### PR DESCRIPTION
## Context

- GeoPoint had a wrong code snippet in Next adapter, the goal is to do the same fix for Embed that have the same problem

## The Solution

- Add same fix as GeoPoint, add JSON.stringify in the code snippet

## Impact / Dependencies

- No impact

## Checklist before requesting a review
- [x] I hereby declare my code ready for review.
- [x] If it is a critical feature, I have added tests.
- [x] The CI is successful.
- ~~If there could backward compatibility issues, it has been discussed and planned.~~

## Preview

### Before

<img width="1309" alt="Screenshot 2023-05-02 at 09 48 56" src="https://user-images.githubusercontent.com/19946868/235610141-2dda221f-4397-4dbe-8eaf-557f77b45663.png">

### After

<img width="1312" alt="Screenshot 2023-05-02 at 09 46 13" src="https://user-images.githubusercontent.com/19946868/235610219-2d426f06-9da6-43ea-97fa-2bb31517a012.png">
