### PR TITLE
fix: update AWS ACL before uploading screenshots

### DIFF
--- a/packages/init/test/__testutils__/mockAWSACLAPI.ts
+++ b/packages/init/test/__testutils__/mockAWSACLAPI.ts
@@ -148,8 +148,10 @@ export const mockAWSACLAPI = (
 			rest.post(
 				new URL("delete-folder", endpoint).toString(),
 				async (req, res, ctx) => {
-					const { sliceId } = await req.json<{ sliceId: string }>();
-					if (config.deleteFolderEndpoint?.expectedSliceIDs.includes(sliceId)) {
+					const { sliceName: sliceID } = await req.json<{
+						sliceName: string;
+					}>();
+					if (config.deleteFolderEndpoint?.expectedSliceIDs.includes(sliceID)) {
 						return res(ctx.status(200));
 					} else {
 						return res(ctx.status(401));

--- a/packages/manager/src/managers/prismicRepository/PrismicRepositoryManager.ts
+++ b/packages/manager/src/managers/prismicRepository/PrismicRepositoryManager.ts
@@ -259,6 +259,9 @@ export class PrismicRepositoryManager extends BaseManager {
 		}
 
 		try {
+			// Update the AWS ACL before uploading screenshots as it might have expired
+			await this.screenshots.initS3ACL();
+
 			const allChanges: AllChangeTypes[] = await Promise.all(
 				args.changes.map(async (change) => {
 					if (change.type === "Slice") {

--- a/packages/manager/src/managers/screenshots/ScreenshotsManager.ts
+++ b/packages/manager/src/managers/screenshots/ScreenshotsManager.ts
@@ -118,9 +118,10 @@ export class ScreenshotsManager extends BaseManager {
 	}
 
 	async initS3ACL(): Promise<void> {
-		if (this._s3ACL) {
-			return;
-		}
+		// TODO: we need to find a way to create a new AWS ACL only when necessary (e.g., when it has expired).
+		// if (this._s3ACL) {
+		// 	return;
+		// }
 
 		const awsACLURL = new URL("create", API_ENDPOINTS.AwsAclProvider);
 		const awsACLRes = await this._fetch({ url: awsACLURL });

--- a/packages/manager/src/managers/slices/SlicesManager.ts
+++ b/packages/manager/src/managers/slices/SlicesManager.ts
@@ -641,8 +641,7 @@ export class SlicesManager extends BaseManager {
 	): Promise<SharedSlice> {
 		const sliceMachineConfig = await this.project.getSliceMachineConfig();
 
-		// Update the AWS ACL before uploading screenshots as it might have expired
-		await this.screenshots.initS3ACL();
+		let initS3ACL = false;
 
 		const variations = await Promise.all(
 			args.model.variations.map(async (variation) => {
@@ -667,6 +666,12 @@ export class SlicesManager extends BaseManager {
 				// If screenshot hasn't changed, do nothing
 				if (!hasScreenshotChanged) {
 					return variation;
+				}
+
+				// Update the AWS ACL before uploading the first screenshot as it might have expired
+				if (!initS3ACL) {
+					await this.screenshots.initS3ACL();
+					initS3ACL = true;
 				}
 
 				const keyPrefix = [

--- a/packages/manager/src/managers/slices/SlicesManager.ts
+++ b/packages/manager/src/managers/slices/SlicesManager.ts
@@ -641,6 +641,9 @@ export class SlicesManager extends BaseManager {
 	): Promise<SharedSlice> {
 		const sliceMachineConfig = await this.project.getSliceMachineConfig();
 
+		// Update the AWS ACL before uploading screenshots as it might have expired
+		await this.screenshots.initS3ACL();
+
 		const variations = await Promise.all(
 			args.model.variations.map(async (variation) => {
 				const screenshot = await this.readSliceScreenshot({

--- a/packages/manager/src/managers/slices/SlicesManager.ts
+++ b/packages/manager/src/managers/slices/SlicesManager.ts
@@ -641,8 +641,6 @@ export class SlicesManager extends BaseManager {
 	): Promise<SharedSlice> {
 		const sliceMachineConfig = await this.project.getSliceMachineConfig();
 
-		let initS3ACL = false;
-
 		const variations = await Promise.all(
 			args.model.variations.map(async (variation) => {
 				const screenshot = await this.readSliceScreenshot({
@@ -666,12 +664,6 @@ export class SlicesManager extends BaseManager {
 				// If screenshot hasn't changed, do nothing
 				if (!hasScreenshotChanged) {
 					return variation;
-				}
-
-				// Update the AWS ACL before uploading the first screenshot as it might have expired
-				if (!initS3ACL) {
-					await this.screenshots.initS3ACL();
-					initS3ACL = true;
 				}
 
 				const keyPrefix = [

--- a/packages/manager/test/SliceMachineManager-prismicRepository-pushChanges.test.ts
+++ b/packages/manager/test/SliceMachineManager-prismicRepository-pushChanges.test.ts
@@ -3,6 +3,7 @@ import { expect, it } from "vitest";
 import { createPrismicAuthLoginResponse } from "./__testutils__/createPrismicAuthLoginResponse";
 import { createTestPlugin } from "./__testutils__/createTestPlugin";
 import { createTestProject } from "./__testutils__/createTestProject";
+import { mockAWSACLAPI } from "./__testutils__/mockAWSACLAPI";
 import { mockCustomTypesAPI } from "./__testutils__/mockCustomTypesAPI";
 import { mockPrismicAuthAPI } from "./__testutils__/mockPrismicAuthAPI";
 import { mockPrismicUserAPI } from "./__testutils__/mockPrismicUserAPI";
@@ -64,6 +65,17 @@ it("pushes changes using the bulk delete API", async (ctx) => {
 	});
 
 	await manager.user.login(createPrismicAuthLoginResponse());
+
+	const authenticationToken = await manager.user.getAuthenticationToken();
+	const sliceMachineConfig = await manager.project.getSliceMachineConfig();
+
+	mockAWSACLAPI(ctx, {
+		createEndpoint: {
+			expectedPrismicRepository: sliceMachineConfig.repositoryName,
+			expectedAuthenticationToken: authenticationToken,
+		},
+	});
+
 	await manager.prismicRepository.pushChanges(
 		pushChangesPayload([sharedSliceModel.id], [customTypeModel.id]),
 	);

--- a/packages/slice-machine/test/__testutils__/mockAWSACLAPI.ts
+++ b/packages/slice-machine/test/__testutils__/mockAWSACLAPI.ts
@@ -148,8 +148,10 @@ export const mockAWSACLAPI = (
       rest.post(
         new URL("delete-folder", endpoint).toString(),
         async (req, res, ctx) => {
-          const { sliceId } = await req.json<{ sliceId: string }>();
-          if (config.deleteFolderEndpoint?.expectedSliceIDs.includes(sliceId)) {
+          const { sliceName: sliceID } = await req.json<{
+            sliceName: string;
+          }>();
+          if (config.deleteFolderEndpoint?.expectedSliceIDs.includes(sliceID)) {
             return res(ctx.status(200));
           } else {
             return res(ctx.status(401));


### PR DESCRIPTION
## Context

Resolves SM-1272/DT-1272 (#953 and #958): Cannot push changes because screenshot upload returns 403.

## The Solution

1. Always call `ScreenshotsManager.initS3ACL` in `SlicesManager.updateSliceModelScreenshotsInPlace`.

## Checklist before requesting a review
- [x] I hereby declare my code ready for review.
- [ ] If it is a critical feature, I have added tests.
- [x] The CI is successful.
- [ ] If there could backward compatibility issues, it has been discussed and planned.