### PR TITLE
fix(init): when the plugin fails, the init should continue

### DIFF
--- a/packages/init/src/SliceMachineInitProcess.ts
+++ b/packages/init/src/SliceMachineInitProcess.ts
@@ -1086,29 +1086,32 @@ ${chalk.cyan("?")} Your Prismic repository name`.replace("\n", ""),
 	}
 
 	protected initializePlugins(): Promise<void> {
-		return listrRun([
-			{
-				// TODO: Revert when plugin are introduced to users
-				// title: "Initializing plugins...",
-				title: "Initializing adapter...",
-				task: async (_, task) => {
-					const updateOutput = (data: Buffer | string | null) => {
-						if (data instanceof Buffer) {
-							task.output = data.toString();
-						} else if (typeof data === "string") {
-							task.output = data;
-						}
-					};
-
-					await this.manager.project.initProject({
-						log: updateOutput,
-					});
-
+		return listrRun(
+			[
+				{
 					// TODO: Revert when plugin are introduced to users
-					// task.title = "Initialized plugins";
-					task.title = "Initialized adapter";
+					// title: "Initializing plugins...",
+					title: "Initializing adapter...",
+					task: async (_, task) => {
+						const updateOutput = (data: Buffer | string | null) => {
+							if (data instanceof Buffer) {
+								task.output = data.toString();
+							} else if (typeof data === "string") {
+								task.output = data;
+							}
+						};
+
+						await this.manager.project.initProject({
+							log: updateOutput,
+						});
+
+						// TODO: Revert when plugin are introduced to users
+						// task.title = "Initialized plugins";
+						task.title = "Initialized adapter";
+					},
 				},
-			},
-		]);
+			],
+			{ exitOnError: false },
+		).catch(() => void 0);
 	}
 }

--- a/packages/init/test/SliceMachineInitProcess-initializePlugins.test.ts
+++ b/packages/init/test/SliceMachineInitProcess-initializePlugins.test.ts
@@ -90,7 +90,7 @@ it("if plugin init hook has errors it logs them and continues", async () => {
 	expect(stderr.length).toBe(0);
 });
 
-it.only("if plugin runner is not started it should inform the user about the issue and continue", async () => {
+it("if plugin runner is not started it should inform the user about the issue and continue", async () => {
 	const initProcess = createSliceMachineInitProcess();
 
 	const result = await watchStd(() => {

--- a/packages/init/test/SliceMachineInitProcess-initializePlugins.test.ts
+++ b/packages/init/test/SliceMachineInitProcess-initializePlugins.test.ts
@@ -93,22 +93,11 @@ it("if plugin init hook has errors it logs them and continues", async () => {
 it("if plugin runner is not started it should inform the user about the issue and continue", async () => {
 	const initProcess = createSliceMachineInitProcess();
 
-	const result = await watchStd(() => {
+	const { stdout, stderr } = await watchStd(() => {
 		// @ts-expect-error - Accessing protected method
 		return initProcess.initializePlugins();
 	});
 
-	expect(result).toMatchInlineSnapshot(`
-		{
-		  "stderr": [],
-		  "stdout": [
-		    "[15:41:12] Initializing adapter... [started]
-		",
-		    "[15:41:12] Initializing adapter... [failed]
-		",
-		    "[15:41:12] → Plugins have not been initialized. Run \`SliceMachineManager.plugins.prototype.initPlugins()\` before re-calling this method.
-		",
-		  ],
-		}
-	`);
+	expect(stderr.length).toBe(0);
+	expect(stdout).toMatch(/Plugins have not been initialized./);
 });


### PR DESCRIPTION
## Context
When running the init and the configuration step fails the init should continue.


<!--
Please include either
- a ticket
    - [Link text Here](https://link-url-here.org)

- a github issue / forum thread
    - Fixes #

- a detailed description of the issue and it's implications

This part should always include acceptance criteria weither they are accessible on a link or written here directly.
-->




## The Solution

<!--
Highlight explanations where the complexity in your development is.
Keep in mind that the reviewer might not have as much context as you do.
This is very important to make sure the review is thorough and the reviewer understand your changes.
-->




## Impact / Dependencies

<!--
List all the impacts your development might have on internal and external features.
Ideally this should have been discussed prior to this development.

Link of any other PRs that are related to this development.
They should also be referenced in the ticket for reviews.
-->




## Checklist before requesting a review
- [ ] I hereby declare my code ready for review.
- [ ] If it is a critical feature, I have added tests.
- [ ] The CI is successful.
- [ ] If there could backward compatibility issues, it has been discussed and planned.




## [OPT] Preview

<!--
Visual aid of your work.
It can either be screenshots or a video.
This could help reviewers to get context quickly.
-->




<!--
A funny animal picture is welcome to close your PR!
You can find one here https://unsplash.com/s/photos/funny-animal-picture
-->