### PR TITLE
fix: resolve tracking issues by add missing user agent header for custom types api calls

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8849,6 +8849,7 @@
     },
     "node_modules/@prismicio/custom-types-client": {
       "version": "1.1.0",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@prismicio/types": "^0.2.4"
@@ -41928,7 +41929,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@antfu/ni": "^0.20.0",
-        "@prismicio/custom-types-client": "^1.1.0",
+        "@prismicio/custom-types-client": "1.2.0-alpha.0",
         "@prismicio/mocks": "2.0.0-alpha.2",
         "@prismicio/types-internal": "2.0.0-alpha.9",
         "@slicemachine/plugin-kit": "0.2.0",
@@ -42022,6 +42023,17 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "packages/manager/node_modules/@prismicio/custom-types-client": {
+      "version": "1.2.0-alpha.0",
+      "resolved": "https://registry.npmjs.org/@prismicio/custom-types-client/-/custom-types-client-1.2.0-alpha.0.tgz",
+      "integrity": "sha512-iqLYoKmDKUvQoDnqGL2Fm7+mdvRPw2v3XXa0FpsNDNB55bT1oeGhNZdEt/PElCLIFxlxcKAgMR8herj6ULfNjA==",
+      "dependencies": {
+        "@prismicio/types": "^0.2.4"
+      },
+      "engines": {
+        "node": ">=14.15.0"
       }
     },
     "packages/manager/node_modules/@typescript-eslint/eslint-plugin": {

--- a/packages/manager/package.json
+++ b/packages/manager/package.json
@@ -62,7 +62,7 @@
 	},
 	"dependencies": {
 		"@antfu/ni": "^0.20.0",
-		"@prismicio/custom-types-client": "^1.1.0",
+		"@prismicio/custom-types-client": "1.2.0-alpha.0",
 		"@prismicio/mocks": "2.0.0-alpha.2",
 		"@prismicio/types-internal": "2.0.0-alpha.9",
 		"@slicemachine/plugin-kit": "0.2.0",

--- a/packages/manager/src/managers/customTypes/CustomTypesManager.ts
+++ b/packages/manager/src/managers/customTypes/CustomTypesManager.ts
@@ -1,5 +1,4 @@
 import * as t from "io-ts";
-import fetch from "../../lib/fetch";
 import * as prismicCustomTypesClient from "@prismicio/custom-types-client";
 import { CustomType } from "@prismicio/types-internal/lib/customtypes";
 import {
@@ -17,12 +16,14 @@ import {
 import { DecodeError } from "../../lib/DecodeError";
 import { assertPluginsInitialized } from "../../lib/assertPluginsInitialized";
 import { decodeHookResult } from "../../lib/decodeHookResult";
+import fetch from "../../lib/fetch";
 
-import { API_ENDPOINTS } from "../../constants/API_ENDPOINTS";
 import { OnlyHookErrors } from "../../types";
+import { API_ENDPOINTS } from "../../constants/API_ENDPOINTS";
+import { SLICE_MACHINE_USER_AGENT } from "../../constants/SLICE_MACHINE_USER_AGENT";
+import { UnauthorizedError } from "../../errors";
 
 import { BaseManager } from "../BaseManager";
-import { UnauthorizedError } from "../../errors";
 
 type SliceMachineManagerReadCustomTypeLibraryReturnType = {
 	ids: string[];
@@ -226,6 +227,7 @@ export class CustomTypesManager extends BaseManager {
 				endpoint: API_ENDPOINTS.PrismicModels,
 				repositoryName: sliceMachineConfig.repositoryName,
 				token: authenticationToken,
+				userAgent: SLICE_MACHINE_USER_AGENT,
 				fetch,
 			});
 
@@ -310,6 +312,7 @@ export class CustomTypesManager extends BaseManager {
 			endpoint: API_ENDPOINTS.PrismicModels,
 			repositoryName: sliceMachineConfig.repositoryName,
 			token: authenticationToken,
+			userAgent: SLICE_MACHINE_USER_AGENT,
 			fetch,
 		});
 

--- a/packages/manager/src/managers/slices/SlicesManager.ts
+++ b/packages/manager/src/managers/slices/SlicesManager.ts
@@ -1,7 +1,8 @@
 import * as t from "io-ts";
-import fetch from "../../lib/fetch";
 import * as prismicCustomTypesClient from "@prismicio/custom-types-client";
 import { SharedSliceContent } from "@prismicio/types-internal/lib/content";
+import { SliceComparator } from "@prismicio/types-internal/lib/customtypes/diff";
+import { SharedSlice } from "@prismicio/types-internal/lib/customtypes";
 import {
 	CallHookReturnType,
 	HookError,
@@ -19,17 +20,17 @@ import { DecodeError } from "../../lib/DecodeError";
 import { assertPluginsInitialized } from "../../lib/assertPluginsInitialized";
 import { bufferCodec } from "../../lib/bufferCodec";
 import { decodeHookResult } from "../../lib/decodeHookResult";
+import { createContentDigest } from "../../lib/createContentDigest";
+import { mockSlice } from "../../lib/mockSlice";
+import fetch from "../../lib/fetch";
 
 import { OnlyHookErrors } from "../../types";
 import { DEFAULT_SLICE_SCREENSHOT_URL } from "../../constants/DEFAULT_SLICE_SCREENSHOT_URL";
+import { SLICE_MACHINE_USER_AGENT } from "../../constants/SLICE_MACHINE_USER_AGENT";
 import { API_ENDPOINTS } from "../../constants/API_ENDPOINTS";
 import { UnauthenticatedError, UnauthorizedError } from "../../errors";
 
 import { BaseManager } from "../BaseManager";
-import { createContentDigest } from "../../lib/createContentDigest";
-import { mockSlice } from "../../lib/mockSlice";
-import { SliceComparator } from "@prismicio/types-internal/lib/customtypes/diff";
-import { SharedSlice } from "@prismicio/types-internal/lib/customtypes";
 
 type SlicesManagerReadSliceLibraryReturnType = {
 	sliceIDs: string[];
@@ -434,6 +435,7 @@ export class SlicesManager extends BaseManager {
 				endpoint: API_ENDPOINTS.PrismicModels,
 				repositoryName: sliceMachineConfig.repositoryName,
 				token: authenticationToken,
+				userAgent: SLICE_MACHINE_USER_AGENT,
 				fetch,
 			});
 
@@ -630,6 +632,7 @@ export class SlicesManager extends BaseManager {
 			endpoint: API_ENDPOINTS.PrismicModels,
 			repositoryName: sliceMachineConfig.repositoryName,
 			token: authenticationToken,
+			userAgent: SLICE_MACHINE_USER_AGENT,
 			fetch,
 		});
 


### PR DESCRIPTION
## Context

- [DT-1294 - (Regression) Tracking - AAPM I should see events of Custom Type Created and Shared Slice Created after the /init command automatically pushes models when ran with a starter](https://linear.app/prismic/issue/DT-1294/regression-tracking-aapm-i-should-see-events-of-custom-type-created)

Following PR: https://github.com/prismicio/prismic-custom-types-client/pull/8
New release 1.2.0-alpha.0 done (Thanks @lihbr)

## The Solution

- Add a new header user agent with "slice-machine" value as before the plugins refactoring
https://github.com/prismicio/slice-machine/blob/6fcf51a1fbc478357318f7109c7c0ad3a3374963/packages/client/src/index.ts#L88

## Impact / Dependencies

- All outgoing requests to the client should now have the header, no other impact
- Quick reorder of imports at the same time

## Checklist before requesting a review
- [x] I hereby declare my code ready for review.
- [ ] If it is a critical feature, I have added tests.
- [ ] The CI is successful.
- [ ] If there could backward compatibility issues, it has been discussed and planned.
