### PR TITLE
fix: add descriptive titles to all screens

### DIFF
--- a/packages/slice-machine/pages/[lib]/[sliceName]/[variation]/index.tsx
+++ b/packages/slice-machine/pages/[lib]/[sliceName]/[variation]/index.tsx
@@ -1,6 +1,19 @@
-import { createComponentWithSlice } from "@src/layouts/WithSlice";
+import Head from "next/head";
 import SliceBuilder from "lib/builders/SliceBuilder";
+import useCurrentSlice from "@src/hooks/useCurrentSlice";
+import { createComponentWithSlice } from "@src/layouts/WithSlice";
 
-const SliceBuilderPage = createComponentWithSlice(SliceBuilder);
+const SliceBuilderWithSlice = createComponentWithSlice(SliceBuilder);
 
-export default SliceBuilderPage;
+export default function SlicePage() {
+  const { slice } = useCurrentSlice();
+
+  return (
+    <>
+      <Head>
+        {slice ? <title>{slice.model.name} - Slice Machine</title> : null}
+      </Head>
+      <SliceBuilderWithSlice />
+    </>
+  );
+}

--- a/packages/slice-machine/pages/[lib]/[sliceName]/[variation]/simulator.tsx
+++ b/packages/slice-machine/pages/[lib]/[sliceName]/[variation]/simulator.tsx
@@ -11,7 +11,10 @@ export default function SimulatorPage() {
   return (
     <>
       <Head>
-        <title>Slice Simulator{slice ? ` - ${slice.model.name}` : ""}</title>
+        <title>
+          {slice ? `Simulator: ${slice.model.name}` : "Simulator"} - Slice
+          Machine
+        </title>
       </Head>
       <SimulatorWithSlice />
     </>

--- a/packages/slice-machine/pages/[lib]/[sliceName]/[variation]/simulator.tsx
+++ b/packages/slice-machine/pages/[lib]/[sliceName]/[variation]/simulator.tsx
@@ -1,6 +1,19 @@
+import Head from "next/head";
 import Simulator from "@components/Simulator";
+import useCurrentSlice from "@src/hooks/useCurrentSlice";
 import { createComponentWithSlice } from "@src/layouts/WithSlice";
 
-const WithSlice = createComponentWithSlice(Simulator);
+const SimulatorWithSlice = createComponentWithSlice(Simulator);
 
-export default WithSlice;
+export default function SimulatorPage() {
+  const { slice } = useCurrentSlice();
+
+  return (
+    <>
+      <Head>
+        <title>Slice Simulator{slice ? ` - ${slice.model.name}` : ""}</title>
+      </Head>
+      <SimulatorWithSlice />
+    </>
+  );
+}

--- a/packages/slice-machine/pages/_app.tsx
+++ b/packages/slice-machine/pages/_app.tsx
@@ -108,7 +108,7 @@ function MyApp({
   return (
     <>
       <Head>
-        <title>SliceMachine</title>
+        <title>Slice Machine</title>
       </Head>
       <ThemeProvider theme={theme}>
         <BaseStyles>

--- a/packages/slice-machine/pages/changelog.tsx
+++ b/packages/slice-machine/pages/changelog.tsx
@@ -1,3 +1,14 @@
+import Head from "next/head";
+
 import Changelog from "components/Changelog";
 
-export default Changelog;
+export default function ChangelogPage() {
+  return (
+    <>
+      <Head>
+        <title>Changelog - Slice Machine</title>
+      </Head>
+      <Changelog />
+    </>
+  );
+}

--- a/packages/slice-machine/pages/changes.tsx
+++ b/packages/slice-machine/pages/changes.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useMemo } from "react";
+import Head from "next/head";
 import { Box, Text } from "theme-ui";
 import Container from "../components/Container";
 import Header from "../components/Header";
@@ -110,41 +111,46 @@ const Changes: React.FunctionComponent = () => {
   ]);
 
   return (
-    <Container sx={{ display: "flex", flex: 1 }}>
-      <Box
-        as={"main"}
-        sx={{ flex: 1, display: "flex", flexDirection: "column" }}
-      >
-        <Header
-          link={{
-            Element: <Text>Changes</Text>,
-            href: "/changes",
-          }}
-          Actions={[
-            <Button
-              key="push-changes"
-              label="Push Changes"
-              onClick={() => onPush(false)} // not deleting documents by default
-              isLoading={isSyncing}
-              disabled={
-                numberOfChanges === 0 ||
-                !isOnline ||
-                authStatus === AuthStatus.UNAUTHORIZED ||
-                authStatus === AuthStatus.FORBIDDEN ||
-                isSyncing
-              }
-              Icon={MdLoop}
-              iconFill="#FFFFFF"
-              data-cy="push-changes"
-            />,
-          ]}
-        />
-        {PageContent}
-      </Box>
-      <SoftDeleteDocumentsDrawer pushChanges={onPush} />
-      <HardDeleteDocumentsDrawer pushChanges={onPush} />
-      <ReferencesErrorDrawer pushChanges={onPush} />
-    </Container>
+    <>
+      <Head>
+        <title>Changes - Slice Machine</title>
+      </Head>
+      <Container sx={{ display: "flex", flex: 1 }}>
+        <Box
+          as={"main"}
+          sx={{ flex: 1, display: "flex", flexDirection: "column" }}
+        >
+          <Header
+            link={{
+              Element: <Text>Changes</Text>,
+              href: "/changes",
+            }}
+            Actions={[
+              <Button
+                key="push-changes"
+                label="Push Changes"
+                onClick={() => onPush(false)} // not deleting documents by default
+                isLoading={isSyncing}
+                disabled={
+                  numberOfChanges === 0 ||
+                  !isOnline ||
+                  authStatus === AuthStatus.UNAUTHORIZED ||
+                  authStatus === AuthStatus.FORBIDDEN ||
+                  isSyncing
+                }
+                Icon={MdLoop}
+                iconFill="#FFFFFF"
+                data-cy="push-changes"
+              />,
+            ]}
+          />
+          {PageContent}
+        </Box>
+        <SoftDeleteDocumentsDrawer pushChanges={onPush} />
+        <HardDeleteDocumentsDrawer pushChanges={onPush} />
+        <ReferencesErrorDrawer pushChanges={onPush} />
+      </Container>
+    </>
   );
 };
 

--- a/packages/slice-machine/pages/cts/[ct].tsx
+++ b/packages/slice-machine/pages/cts/[ct].tsx
@@ -1,3 +1,4 @@
+import Head from "next/head";
 import { useRouter } from "next/router";
 
 import CustomTypeBuilder from "../../lib/builders/CustomTypeBuilder";
@@ -57,12 +58,17 @@ const CustomTypeBuilderWithRouter = () => {
   }
 
   return (
-    <CustomTypeBuilderWithProvider
-      customType={selectedCustomType.local}
-      remoteCustomType={
-        hasRemote(selectedCustomType) ? selectedCustomType.remote : undefined
-      }
-    />
+    <>
+      <Head>
+        <title>{selectedCustomType.local.label} - Slice Machine</title>
+      </Head>
+      <CustomTypeBuilderWithProvider
+        customType={selectedCustomType.local}
+        remoteCustomType={
+          hasRemote(selectedCustomType) ? selectedCustomType.remote : undefined
+        }
+      />
+    </>
   );
 };
 

--- a/packages/slice-machine/pages/index.tsx
+++ b/packages/slice-machine/pages/index.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import Head from "next/head";
 import { Flex, Link as ThemeLink, Text } from "theme-ui";
 
 import Container from "@components/Container";
@@ -35,70 +36,75 @@ const CustomTypes: React.FunctionComponent = () => {
   });
 
   return (
-    <Container sx={{ flex: 1, display: "flex", flexDirection: "column" }}>
-      <Header
-        link={{
-          Element: (
-            <>
-              <MdSpaceDashboard /> <Text ml={2}>Custom Types</Text>
-            </>
-          ),
-          href: "/",
-        }}
-        Actions={
-          sortedCustomTypes.length > 0
-            ? [
-                <Button
-                  key="create-custom-type"
-                  label="Create a Custom Type"
-                  onClick={openCreateCustomTypeModal}
-                  isLoading={isCreatingCustomType}
-                  disabled={isCreatingCustomType}
-                  Icon={GoPlus}
-                  iconFill="#FFFFFF"
-                  data-cy="create-ct"
-                />,
-              ]
-            : []
-        }
-      />
-      {sortedCustomTypes.length === 0 ? (
-        <Flex
-          sx={{
-            flex: 1,
-            justifyContent: "center",
-            alignItems: "center",
-          }}
-        >
-          <EmptyState
-            title={"What are Custom Types?"}
-            onCreateNew={openCreateCustomTypeModal}
-            isLoading={isCreatingCustomType}
-            buttonText={"Create one"}
-            videoPublicIdUrl={VIDEO_WHAT_ARE_CUSTOM_TYPES}
-            documentationComponent={
+    <>
+      <Head>
+        <title>Custom Types - Slice Machine</title>
+      </Head>
+      <Container sx={{ flex: 1, display: "flex", flexDirection: "column" }}>
+        <Header
+          link={{
+            Element: (
               <>
-                Custom Types are models for your documents. They are the place
-                where you define and configure Fields and Slices for your
-                content. They will be stored locally, and you will be able to
-                push them to your repository.{" "}
-                <ThemeLink
-                  target={"_blank"}
-                  href={"https://prismic.io/docs/core-concepts/custom-types "}
-                  sx={(theme) => ({ color: theme?.colors?.primary })}
-                >
-                  Learn more
-                </ThemeLink>
-                .
+                <MdSpaceDashboard /> <Text ml={2}>Custom Types</Text>
               </>
-            }
-          />
-        </Flex>
-      ) : (
-        <CustomTypeTable customTypes={sortedCustomTypes} />
-      )}
-      <CreateCustomTypeModal />
-    </Container>
+            ),
+            href: "/",
+          }}
+          Actions={
+            sortedCustomTypes.length > 0
+              ? [
+                  <Button
+                    key="create-custom-type"
+                    label="Create a Custom Type"
+                    onClick={openCreateCustomTypeModal}
+                    isLoading={isCreatingCustomType}
+                    disabled={isCreatingCustomType}
+                    Icon={GoPlus}
+                    iconFill="#FFFFFF"
+                    data-cy="create-ct"
+                  />,
+                ]
+              : []
+          }
+        />
+        {sortedCustomTypes.length === 0 ? (
+          <Flex
+            sx={{
+              flex: 1,
+              justifyContent: "center",
+              alignItems: "center",
+            }}
+          >
+            <EmptyState
+              title={"What are Custom Types?"}
+              onCreateNew={openCreateCustomTypeModal}
+              isLoading={isCreatingCustomType}
+              buttonText={"Create one"}
+              videoPublicIdUrl={VIDEO_WHAT_ARE_CUSTOM_TYPES}
+              documentationComponent={
+                <>
+                  Custom Types are models for your documents. They are the place
+                  where you define and configure Fields and Slices for your
+                  content. They will be stored locally, and you will be able to
+                  push them to your repository.{" "}
+                  <ThemeLink
+                    target={"_blank"}
+                    href={"https://prismic.io/docs/core-concepts/custom-types "}
+                    sx={(theme) => ({ color: theme?.colors?.primary })}
+                  >
+                    Learn more
+                  </ThemeLink>
+                  .
+                </>
+              }
+            />
+          </Flex>
+        ) : (
+          <CustomTypeTable customTypes={sortedCustomTypes} />
+        )}
+        <CreateCustomTypeModal />
+      </Container>
+    </>
   );
 };
 

--- a/packages/slice-machine/pages/onboarding.tsx
+++ b/packages/slice-machine/pages/onboarding.tsx
@@ -1,4 +1,5 @@
 import { type FC, type ReactNode, useEffect, useRef, useState } from "react";
+import Head from "next/head";
 import {
   Box,
   Button,
@@ -242,106 +243,114 @@ export default function Onboarding(): JSX.Element {
   }
 
   return (
-    <OnboardingGrid>
-      <Flex
-        sx={{
-          gridArea: "top-right",
-          alignItems: "center",
-          justifyContent: "end",
-          padding: "1em 4em",
-        }}
-      >
-        {!!state.step && (
-          <Button
-            variant="transparent"
-            onClick={finish}
-            title="skip onboarding"
-            tabIndex={0}
-            sx={{
-              color: "textClear",
-            }}
-          >
-            skip
-          </Button>
-        )}
-      </Flex>
-
-      {STEPS.map((Component, i) => (
+    <>
+      <Head>
+        <title>Welcome - Slice Machine</title>
+      </Head>
+      <OnboardingGrid>
         <Flex
-          key={`step-${i + 1}`}
           sx={{
-            display: i === state.step ? "flex" : "none",
-            gridArea: "content",
+            gridArea: "top-right",
             alignItems: "center",
-            justifyContent: "center",
-            alignContent: "center",
-            flexDirection: "column",
-            opacity: i === state.step ? "1" : "0",
-            pointerEvents: i === state.step ? "all" : "none",
-            transition: `opacity .2s ease-in`,
+            justifyContent: "end",
+            padding: "1em 4em",
           }}
         >
-          {Component}
+          {!!state.step && (
+            <Button
+              variant="transparent"
+              onClick={finish}
+              title="skip onboarding"
+              tabIndex={0}
+              sx={{
+                color: "textClear",
+              }}
+            >
+              skip
+            </Button>
+          )}
         </Flex>
-      ))}
 
-      <Flex
-        sx={{
-          gridArea: "footer",
-          alignItems: "start",
-          justifyContent: "center",
-          padingTop: "16px", // half height of a button
-        }}
-      >
-        {!!state.step && (
-          <StepIndicator current={state.step - 1} maxSteps={STEPS.length - 1} />
-        )}
-      </Flex>
-
-      <Flex
-        sx={{
-          gridArea: "footer-left",
-          alignItems: "start",
-          justifyContent: "space-around",
-        }}
-      >
-        {state.step >= 2 && (
-          <IconButton
-            tabIndex={0}
-            title="previous slide"
+        {STEPS.map((Component, i) => (
+          <Flex
+            key={`step-${i + 1}`}
             sx={{
-              width: "40px",
-              height: "40px",
-              borderRadius: "50%",
-              background: "#F1F1F4",
-              border: "1px solid rgba(62, 62, 72, 0.15)",
+              display: i === state.step ? "flex" : "none",
+              gridArea: "content",
+              alignItems: "center",
+              justifyContent: "center",
+              alignContent: "center",
+              flexDirection: "column",
+              opacity: i === state.step ? "1" : "0",
+              pointerEvents: i === state.step ? "all" : "none",
+              transition: `opacity .2s ease-in`,
             }}
-            onClick={prevSlide}
           >
-            <BiChevronLeft />
-          </IconButton>
-        )}
-      </Flex>
+            {Component}
+          </Flex>
+        ))}
 
-      <Flex
-        sx={{
-          gridArea: "footer-right",
-          alignItems: "start",
-          justifyContent: "end",
-          padding: "0em 4em",
-        }}
-      >
-        {!!state.step && (
-          <Button
-            data-cy="continue"
-            onClick={nextSlide}
-            title="continue"
-            tabIndex={0}
-          >
-            Continue
-          </Button>
-        )}
-      </Flex>
-    </OnboardingGrid>
+        <Flex
+          sx={{
+            gridArea: "footer",
+            alignItems: "start",
+            justifyContent: "center",
+            padingTop: "16px", // half height of a button
+          }}
+        >
+          {!!state.step && (
+            <StepIndicator
+              current={state.step - 1}
+              maxSteps={STEPS.length - 1}
+            />
+          )}
+        </Flex>
+
+        <Flex
+          sx={{
+            gridArea: "footer-left",
+            alignItems: "start",
+            justifyContent: "space-around",
+          }}
+        >
+          {state.step >= 2 && (
+            <IconButton
+              tabIndex={0}
+              title="previous slide"
+              sx={{
+                width: "40px",
+                height: "40px",
+                borderRadius: "50%",
+                background: "#F1F1F4",
+                border: "1px solid rgba(62, 62, 72, 0.15)",
+              }}
+              onClick={prevSlide}
+            >
+              <BiChevronLeft />
+            </IconButton>
+          )}
+        </Flex>
+
+        <Flex
+          sx={{
+            gridArea: "footer-right",
+            alignItems: "start",
+            justifyContent: "end",
+            padding: "0em 4em",
+          }}
+        >
+          {!!state.step && (
+            <Button
+              data-cy="continue"
+              onClick={nextSlide}
+              title="continue"
+              tabIndex={0}
+            >
+              Continue
+            </Button>
+          )}
+        </Flex>
+      </OnboardingGrid>
+    </>
   );
 }

--- a/packages/slice-machine/pages/slices.tsx
+++ b/packages/slice-machine/pages/slices.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import Head from "next/head";
 import { MdHorizontalSplit } from "react-icons/md";
 import { Box, Flex, Text, Link } from "theme-ui";
 import Container from "components/Container";
@@ -92,6 +93,9 @@ const SlicesIndex: React.FunctionComponent = () => {
 
   return (
     <>
+      <Head>
+        <title>Slices - Slice Machine</title>
+      </Head>
       <Container
         sx={{
           display: "flex",

--- a/packages/slice-machine/src/layouts/WithSlice.tsx
+++ b/packages/slice-machine/src/layouts/WithSlice.tsx
@@ -12,7 +12,7 @@ export type ComponentWithSliceProps = React.FC<{
 }>;
 
 export const createComponentWithSlice = (C: ComponentWithSliceProps) => {
-  const Wrapper: React.FC<{ pageProps: AppProps }> & {
+  const Wrapper: React.FC<{ pageProps?: AppProps }> & {
     CustomLayout?: React.FC<{ children: ReactNode }>;
   } = ({ pageProps }) => {
     const { slice, variation } = useCurrentSlice();

--- a/packages/slice-machine/test/pages/simulator.test.tsx
+++ b/packages/slice-machine/test/pages/simulator.test.tsx
@@ -279,7 +279,6 @@ describe.skip("simulator", () => {
     //   })
     // );
 
-    // @ts-expect-error TS(2741) FIXME: Property 'pageProps' is missing in type '{}' but r... Remove this comment to see the full error message
     const App = render(<Simulator />, {
       preloadedState: state as unknown as Partial<SliceMachineStoreType>,
     });


### PR DESCRIPTION
## Context

Slice Machine currently uses one title across all pages: "SliceMachine"

This is problematic because:

- It is difficult to distinguish browser history entries.
- It is difficult to distinguish browser tabs when multiple Slice Machine tabs are open.

The multiple tabs problem is most evident when Slice Simulator is opened; there is no way to know which tab is Slice Simulator or Slice Machine.

Requested by @a-trost

## The Solution

This PR adds a `<title>` to all pages using the following formats:

- Custom Types - Slice Machine (`/`)
- ${customTypeLabel} - Slice Machine (Custom Type page)
- Slices - Slice Machine (`/slices`)
- ${sliceName} - Slice Machine (Slice page)
- Simulator: ${sliceName} - Slice Machine (Slice Simulator page)
- Changes - Slice Machine (`/changes`)
- Changelog - Slice Machine (`/changelog`)
- Welcome - Slice Machine (`/onboarding`)

**Note**: This PR fixes the default title's "SliceMachine" styling to "Slice Machine" (with a space). [Slice Machine officially includes a space](https://prismic.io/slice-machine).

## Impact / Dependencies

The changes are minimal. I don't think there would be any negative impacts.

There is a positive impact in that users will be able to find their Slice Machine tabs more easily.

## Checklist before requesting a review

- [x] I hereby declare my code ready for review.
- [ ] If it is a critical feature, I have added tests.
- [x] The CI is successful.
- [ ] If there could backward compatibility issues, it has been discussed and planned.

## [OPT] Preview

**Tab bar:**
<img width="1239" alt="image" src="https://github.com/prismicio/slice-machine/assets/8601064/c0b353a5-b12d-42b3-baff-758df15cceb8">

**Browser history:**
<img width="504" alt="image" src="https://github.com/prismicio/slice-machine/assets/8601064/03a47797-f084-4bc3-a733-4718d7eae82e">

🐴