### PR TITLE
feat: link github repo to sm-ui package

### DIFF
--- a/packages/slice-machine/package.json
+++ b/packages/slice-machine/package.json
@@ -3,6 +3,11 @@
   "version": "1.0.3",
   "license": "MIT",
   "description": "A visual builder for your Slice Models with all the tools you need to generate data models and mock CMS content locally.",
+  "repository": {
+    "type": "git",
+    "url": "ssh://git@github.com/prismicio/slice-machine.git",
+    "directory": "packages/slice-machine"
+  },
   "_moduleAliases": {
     "@lib": "build/lib",
     "@models": "build/lib/models"


### PR DESCRIPTION
## Context

- See https://github.com/prismicio/slice-machine/issues/815 - DT-1083
- Dependency updaters such as [Renovate](https://github.com/renovatebot/renovate) fail to display the `slice-machine-ui` changelog when opening PRs. 

## The Solution

- I reproduced the issue and went through the Renovate [troubleshooting guide](https://docs.renovatebot.com/troubleshooting/) to understand the root cause. It could simply be because the we don't provide the changelog location when publishing `slice-machine-ui` to npm.
- Renovate is able to [parse Github releases](https://docs.renovatebot.com/configuration-options/#fetchreleasenotes), but it doesn't know where to look for.
- By the way this issue does not happen with other SM packages that declare a `repository` in the `package.json`, like `@slicemachine/init`.

## Checklist before requesting a review
- [x] I hereby declare my code ready for review.
- [ ] If it is a critical feature, I have added tests.
- [x] The CI is successful.
- [ ] If there could backward compatibility issues, it has been discussed and planned.

