### PR TITLE
feat(page types): update Custom Types creation and edition with default values and restrictions

### DIFF
--- a/cypress/e2e/customTypes/00-create.cy.js
+++ b/cypress/e2e/customTypes/00-create.cy.js
@@ -33,4 +33,33 @@ describe("Custom Types specs", () => {
       .should("have.a.property", "Foo Bar")
       .should("not.have.a.property", "Foo Bar ");
   });
+
+  it("A user can remove a Text field", () => {
+    cy.createCustomType(customTypeId, customTypeName);
+
+    cy.addFieldToCustomType("Key Text", "Key Text Field", "key_text_id");
+    cy.deleteWidgetField("Key Text");
+  });
+
+  it("A user cannot remove the default UID field", () => {
+    cy.createCustomType(customTypeId, customTypeName);
+
+    cy.getWidgetFieldMenu("UID").should("not.exist");
+  });
+
+  it("A user cannot add slices to a new Custom Type", () => {
+    cy.createCustomType(customTypeId, customTypeName);
+
+    cy.contains("Add a new slice").should("not.exist");
+  });
+
+  it("A user cannot add slices in a new Tab to a new Custom Type", () => {
+    cy.createCustomType(customTypeId, customTypeName);
+
+    cy.contains("Add Tab").click();
+    cy.getInputByLabel("New Tab ID").type("Foo");
+    cy.get("#create-tab").contains("Save").click();
+
+    cy.contains("Add a new slice").should("not.exist");
+  });
 });

--- a/cypress/e2e/user-flows/scenario_001.cy.js
+++ b/cypress/e2e/user-flows/scenario_001.cy.js
@@ -19,7 +19,6 @@ describe("I am a new SM user (with Next) who wants to create a Custom Type with 
     cy.createCustomType(customTypeId, customTypeName);
     customTypeBuilder.goTo(customTypeId);
 
-    cy.addFieldToCustomType("UID", "ID Field", "uid");
     cy.addFieldToCustomType("Key Text", "Key Text Field", "key_text_id");
     cy.addFieldToCustomType("Rich Text", "Rich Text Field", "rich_text_id");
     customTypeBuilder.save();

--- a/cypress/e2e/user-flows/scenario_slice_association.cy.js
+++ b/cypress/e2e/user-flows/scenario_slice_association.cy.js
@@ -11,7 +11,8 @@ const sliceName = `TestSlice${random}`;
 const sliceId = `test_slice${random}`; // generated automatically from the slice name
 const sliceLib = ".--slices";
 
-describe("I am an existing SM user (Next) and I want to associate a Slice to a CT and review my experience.", () => {
+// TODO: Use this test suite for Page Types since new Custom Type don't have Slice Zone anymore
+describe.skip("I am an existing SM user (Next) and I want to associate a Slice to a CT and review my experience.", () => {
   before(() => {
     cy.clearProject();
   });
@@ -23,13 +24,11 @@ describe("I am an existing SM user (Next) and I want to associate a Slice to a C
   it("Create a Custom type with multiple fields", () => {
     cy.createCustomType(customTypeId, customTypeName);
 
-    cy.addFieldToCustomType("UID", "ID Field", "uid");
     cy.addFieldToCustomType("Key Text", "Key Text Field", "key_text_id");
     cy.addFieldToCustomType("Rich Text", "Rich Text Field", "rich_text_id");
     customTypeBuilder.save();
 
     cy.reload();
-    cy.contains("ID Field");
     cy.contains("Key Text Field");
     cy.contains("Rich Text Field");
   });

--- a/cypress/e2e/user-flows/scenario_slice_association.cy.js
+++ b/cypress/e2e/user-flows/scenario_slice_association.cy.js
@@ -11,7 +11,7 @@ const sliceName = `TestSlice${random}`;
 const sliceId = `test_slice${random}`; // generated automatically from the slice name
 const sliceLib = ".--slices";
 
-// TODO: Use this test suite for Page Types since new Custom Type don't have Slice Zone anymore
+// TODO: DT-1316 - Use this test suite for Page Types since new Custom Type don't have Slice Zone anymore
 describe.skip("I am an existing SM user (Next) and I want to associate a Slice to a CT and review my experience.", () => {
   before(() => {
     cy.clearProject();

--- a/cypress/helpers/customTypes.js
+++ b/cypress/helpers/customTypes.js
@@ -26,6 +26,10 @@ export function createCustomType(id, name) {
   cy.location("pathname", { timeout: 15000 }).should("eq", `/cts/${id}`);
   cy.readFile(TYPES_FILE).should("contains", name);
   cy.readFile(CUSTOM_TYPE_MODEL(id));
+
+  // All new Custom Types have a default UID field
+  cy.contains("UID").should("be.visible");
+  cy.contains("data.uid").should("be.visible");
 }
 
 /**
@@ -116,4 +120,29 @@ export function addSlicesToCustomType(sliceIds) {
   customTypeBuilder.updateSliceZoneButton.click();
   sliceIds.forEach((sliceId) => updateSliceZoneModal.selectSlice(sliceId));
   updateSliceZoneModal.submit();
+}
+
+/**
+ * Get the Menu button of the relevant widget.
+ *
+ * @param {string} name Name of the widget field.
+ */
+export function getWidgetFieldMenu(name) {
+  return cy
+    .contains("div", name)
+    .parent()
+    .find("[data-cy='slice-menu-button']");
+}
+
+/**
+ * Delete the relevant widget.
+ *
+ * @param {string} name Name of the widget field.
+ */
+export function deleteWidgetField(name) {
+  cy.getWidgetFieldMenu(name).click();
+
+  cy.contains("div", "Delete field").click({ force: true });
+
+  cy.contains("div", name).should("not.exist");
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -43834,12 +43834,12 @@
     },
     "packages/adapter-next": {
       "name": "@slicemachine/adapter-next",
-      "version": "0.1.3-dev-page-types.2",
+      "version": "0.1.3-dev-page-types.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@prismicio/slice-simulator-core": "^0.2.7",
         "@prismicio/types-internal": "2.0.0-alpha.9",
-        "@slicemachine/plugin-kit": "0.2.1-dev-page-types.2",
+        "@slicemachine/plugin-kit": "0.2.1-dev-page-types.3",
         "common-tags": "^1.8.2",
         "fs-extra": "^11.1.0",
         "node-fetch": "^3.3.1",
@@ -43971,12 +43971,12 @@
     },
     "packages/adapter-nuxt": {
       "name": "@slicemachine/adapter-nuxt",
-      "version": "0.1.3-dev-page-types.2",
+      "version": "0.1.3-dev-page-types.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@prismicio/slice-simulator-core": "^0.2.7",
         "@prismicio/types-internal": "2.0.0-alpha.9",
-        "@slicemachine/plugin-kit": "0.2.1-dev-page-types.2",
+        "@slicemachine/plugin-kit": "0.2.1-dev-page-types.3",
         "common-tags": "^1.8.2",
         "fs-extra": "^11.1.0",
         "magicast": "^0.2.1",
@@ -45898,12 +45898,12 @@
     },
     "packages/adapter-nuxt2": {
       "name": "@slicemachine/adapter-nuxt2",
-      "version": "0.1.3-dev-page-types.2",
+      "version": "0.1.3-dev-page-types.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@prismicio/slice-simulator-core": "^0.2.7",
         "@prismicio/types-internal": "2.0.0-alpha.9",
-        "@slicemachine/plugin-kit": "0.2.1-dev-page-types.2",
+        "@slicemachine/plugin-kit": "0.2.1-dev-page-types.3",
         "common-tags": "^1.8.2",
         "fs-extra": "^11.1.0",
         "magicast": "^0.2.1",
@@ -46139,12 +46139,12 @@
     },
     "packages/init": {
       "name": "@slicemachine/init",
-      "version": "2.0.2-dev-page-types.2",
+      "version": "2.0.2-dev-page-types.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@antfu/ni": "^0.20.0",
         "@lihbr/listr-update-renderer": "^0.5.3",
-        "@slicemachine/manager": "0.2.2-dev-page-types.2",
+        "@slicemachine/manager": "0.2.2-dev-page-types.3",
         "chalk": "^4.1.2",
         "globby": "^13.1.3",
         "listr": "^0.14.3",
@@ -46159,7 +46159,7 @@
       },
       "devDependencies": {
         "@size-limit/preset-small-lib": "^8.2.4",
-        "@slicemachine/plugin-kit": "0.2.1-dev-page-types.2",
+        "@slicemachine/plugin-kit": "0.2.1-dev-page-types.3",
         "@types/listr": "^0.14.4",
         "@types/prompts": "^2.4.3",
         "@types/semver": "^7.3.13",
@@ -46319,14 +46319,14 @@
     },
     "packages/manager": {
       "name": "@slicemachine/manager",
-      "version": "0.2.2-dev-page-types.2",
+      "version": "0.2.2-dev-page-types.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@antfu/ni": "^0.20.0",
         "@prismicio/custom-types-client": "1.2.0-alpha.0",
         "@prismicio/mocks": "2.0.0-alpha.2",
         "@prismicio/types-internal": "2.0.0-alpha.9",
-        "@slicemachine/plugin-kit": "0.2.1-dev-page-types.2",
+        "@slicemachine/plugin-kit": "0.2.1-dev-page-types.3",
         "@wooorm/starry-night": "^1.6.0",
         "analytics-node": "^6.2.0",
         "cookie": "^0.5.0",
@@ -46642,7 +46642,7 @@
     },
     "packages/plugin-kit": {
       "name": "@slicemachine/plugin-kit",
-      "version": "0.2.1-dev-page-types.2",
+      "version": "0.2.1-dev-page-types.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@prismicio/types-internal": "2.0.0-alpha.9",
@@ -46824,7 +46824,7 @@
     },
     "packages/slice-machine": {
       "name": "slice-machine-ui",
-      "version": "1.0.3-dev-page-types.2",
+      "version": "1.0.3-dev-page-types.3",
       "license": "MIT",
       "dependencies": {
         "@extractus/oembed-extractor": "^3.1.8",
@@ -46832,7 +46832,7 @@
         "@prismicio/editor-ui": "0.4.0",
         "@prismicio/mocks": "2.0.0-alpha.2",
         "@prismicio/types-internal": "2.0.0-alpha.9",
-        "@slicemachine/manager": "0.2.2-dev-page-types.2",
+        "@slicemachine/manager": "0.2.2-dev-page-types.3",
         "@vanilla-extract/css": "1.11.0",
         "clsx": "1.2.1",
         "fast-deep-equal": "^3.1.3",
@@ -46846,7 +46846,7 @@
         "puppeteer": "^19.11.0",
         "react": "^18.2.0",
         "semver": "^7.3.8",
-        "start-slicemachine": "0.7.3-dev-page-types.2",
+        "start-slicemachine": "0.7.3-dev-page-types.3",
         "yup": "^0.32.11"
       },
       "devDependencies": {
@@ -47299,10 +47299,10 @@
       }
     },
     "packages/start-slicemachine": {
-      "version": "0.7.3-dev-page-types.2",
+      "version": "0.7.3-dev-page-types.3",
       "license": "Apache-2.0",
       "dependencies": {
-        "@slicemachine/manager": "0.2.2-dev-page-types.2",
+        "@slicemachine/manager": "0.2.2-dev-page-types.3",
         "body-parser": "^1.20.2",
         "chalk": "^4.1.2",
         "cors": "^2.8.5",

--- a/packages/slice-machine/components/ListItem/index.tsx
+++ b/packages/slice-machine/components/ListItem/index.tsx
@@ -21,6 +21,7 @@ type Item<F extends TabField> = { key: string; value: F };
 interface ListItemProps<F extends TabField, S extends AnyObjectSchema> {
   item: Item<F>;
   index: number;
+  customTypeFormat?: "page" | "custom";
   deleteItem: (key: string) => void;
   enterEditMode: (
     itemInfo: [string, F],
@@ -40,6 +41,7 @@ interface ListItemProps<F extends TabField, S extends AnyObjectSchema> {
 function ListItem<F extends TabField, S extends AnyObjectSchema>({
   item,
   index,
+  customTypeFormat,
   deleteItem,
   enterEditMode,
   modelFieldName,
@@ -59,7 +61,7 @@ function ListItem<F extends TabField, S extends AnyObjectSchema>({
   const {
     key,
     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-    value: { config },
+    value: { config, type },
   } = item;
 
   return (
@@ -130,43 +132,49 @@ function ListItem<F extends TabField, S extends AnyObjectSchema>({
                           }
                         />
                       )}
-                      <Menu>
-                        <MenuButton
-                          className="sliceMenuButton"
-                          data-cy="slice-menu-button"
-                          style={{
-                            padding: "0",
-                            cursor: "pointer",
-                            width: "32px",
-                            height: "32px",
-                            border: "none",
-                            background: "transparent",
-                            outline: "0",
-                          }}
-                        >
-                          <BsThreeDotsVertical
-                            size={20}
-                            color={theme.colors?.icons as string}
-                            style={{ pointerEvents: "none" }}
-                          />
-                        </MenuButton>
-                        <MenuList
-                          style={{
-                            background: theme.colors?.gray as string,
-                            border: "1px solid",
-                            borderRadius: "3px",
-                            borderColor: theme.colors?.borders as string,
-                            outline: "0",
-                          }}
-                        >
-                          <MenuItem
-                            style={{ padding: "6px", cursor: "pointer" }}
-                            onSelect={() => deleteItem(key)}
-                          >
-                            Delete field
-                          </MenuItem>
-                        </MenuList>
-                      </Menu>
+                      {
+                        // Prevent deletion of UID for any Custom Type expect the legacy one
+                        // that don't have a format property
+                        (!customTypeFormat || type !== "UID") && (
+                          <Menu>
+                            <MenuButton
+                              className="sliceMenuButton"
+                              data-cy="slice-menu-button"
+                              style={{
+                                padding: "0",
+                                cursor: "pointer",
+                                width: "32px",
+                                height: "32px",
+                                border: "none",
+                                background: "transparent",
+                                outline: "0",
+                              }}
+                            >
+                              <BsThreeDotsVertical
+                                size={20}
+                                color={theme.colors?.icons as string}
+                                style={{ pointerEvents: "none" }}
+                              />
+                            </MenuButton>
+                            <MenuList
+                              style={{
+                                background: theme.colors?.gray as string,
+                                border: "1px solid",
+                                borderRadius: "3px",
+                                borderColor: theme.colors?.borders as string,
+                                outline: "0",
+                              }}
+                            >
+                              <MenuItem
+                                style={{ padding: "6px", cursor: "pointer" }}
+                                onSelect={() => deleteItem(key)}
+                              >
+                                Delete field
+                              </MenuItem>
+                            </MenuList>
+                          </Menu>
+                        )
+                      }
                     </Flex>
                   </Flex>
                   {HintElement ? HintElement : null}

--- a/packages/slice-machine/lib/builders/CustomTypeBuilder/TabZone/index.tsx
+++ b/packages/slice-machine/lib/builders/CustomTypeBuilder/TabZone/index.tsx
@@ -49,7 +49,7 @@ const TabZone: React.FC<TabZoneProps> = ({ tabId, fields, sliceZone }) => {
       poolOfFields: selectCurrentPoolOfFields(store),
     })
   );
-  // TODO: Retrieve format from currentCustomType
+  // TODO: DT-1308 - Retrieve format from currentCustomType
   const customTypeFormat = "custom";
 
   if (!currentCustomType || !poolOfFields) {
@@ -160,7 +160,7 @@ const TabZone: React.FC<TabZoneProps> = ({ tabId, fields, sliceZone }) => {
         dataCy="ct-static-zone"
       />
       {
-        // TODO: Add condition to also display the slice zone for the Main tab of "page" format
+        // TODO: DT-1316 - Add condition to also display the slice zone for the Main tab of "page" format
 
         // Only display the slice zone for Page Types "Main" tab
         // or Custom Types that have a Slice Zone defined (for backward compatibility)

--- a/packages/slice-machine/lib/builders/CustomTypeBuilder/TabZone/index.tsx
+++ b/packages/slice-machine/lib/builders/CustomTypeBuilder/TabZone/index.tsx
@@ -49,6 +49,8 @@ const TabZone: React.FC<TabZoneProps> = ({ tabId, fields, sliceZone }) => {
       poolOfFields: selectCurrentPoolOfFields(store),
     })
   );
+  // TODO: Retrieve format from currentCustomType
+  const customTypeFormat = "custom";
 
   if (!currentCustomType || !poolOfFields) {
     return null;
@@ -134,6 +136,7 @@ const TabZone: React.FC<TabZoneProps> = ({ tabId, fields, sliceZone }) => {
     <>
       <Zone
         zoneType="customType"
+        customTypeFormat={customTypeFormat}
         // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
         tabId={tabId}
         title="Static Zone"
@@ -156,15 +159,23 @@ const TabZone: React.FC<TabZoneProps> = ({ tabId, fields, sliceZone }) => {
         renderFieldAccessor={(key) => `data${transformKeyAccessor(key)}`}
         dataCy="ct-static-zone"
       />
-      <SliceZone
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-        tabId={tabId}
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-        sliceZone={sliceZone}
-        onRemoveSharedSlice={onRemoveSharedSlice}
-        onCreateSliceZone={onCreateSliceZone}
-        onSelectSharedSlices={onSelectSharedSlices}
-      />
+      {
+        // TODO: Add condition to also display the slice zone for the Main tab of "page" format
+
+        // Only display the slice zone for Page Types "Main" tab
+        // or Custom Types that have a Slice Zone defined (for backward compatibility)
+        sliceZone && (
+          <SliceZone
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+            tabId={tabId}
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+            sliceZone={sliceZone}
+            onRemoveSharedSlice={onRemoveSharedSlice}
+            onCreateSliceZone={onCreateSliceZone}
+            onSelectSharedSlices={onSelectSharedSlices}
+          />
+        )
+      }
     </>
   );
 };

--- a/packages/slice-machine/lib/builders/SliceBuilder/FieldZones/index.tsx
+++ b/packages/slice-machine/lib/builders/SliceBuilder/FieldZones/index.tsx
@@ -119,6 +119,7 @@ const FieldZones: React.FunctionComponent<FieldZonesProps> = ({
     <>
       <Zone
         zoneType="slice"
+        customTypeFormat={undefined}
         tabId={undefined}
         title="Non-Repeatable Zone"
         dataTip={dataTipText}
@@ -144,6 +145,7 @@ const FieldZones: React.FunctionComponent<FieldZonesProps> = ({
       <Box mt={4} />
       <Zone
         zoneType="slice"
+        customTypeFormat={undefined}
         tabId={undefined}
         isRepeatable
         title="Repeatable Zone"

--- a/packages/slice-machine/lib/builders/common/Zone/Card/index.jsx
+++ b/packages/slice-machine/lib/builders/common/Zone/Card/index.jsx
@@ -14,6 +14,7 @@ import Li from "components/Li";
 
 const FieldZone = ({
   fields,
+  customTypeFormat,
   title,
   tabId,
   enterEditMode,
@@ -68,6 +69,8 @@ const FieldZone = ({
                   item,
                   // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
                   index,
+                  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+                  customTypeFormat,
                   // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-assignment
                   tabId,
                   // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment

--- a/packages/slice-machine/lib/builders/common/Zone/index.jsx
+++ b/packages/slice-machine/lib/builders/common/Zone/index.jsx
@@ -14,6 +14,7 @@ import EmptyState from "./components/EmptyState";
 
 const Zone = ({
   zoneType /* type of the zone: customType or slice */,
+  customTypeFormat /* custom type format: page, custom or undefined */,
   tabId,
   title /* text info to display in Card Header */,
   fields /* widgets registered in the zone */,
@@ -120,6 +121,8 @@ const Zone = ({
         )
       }
       <Card
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment
+        customTypeFormat={customTypeFormat}
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment
         tabId={tabId}
         // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment

--- a/packages/slice-machine/src/modules/availableCustomTypes/factory.ts
+++ b/packages/slice-machine/src/modules/availableCustomTypes/factory.ts
@@ -1,18 +1,35 @@
-import { CustomTypeSM } from "@lib/models/common/CustomType";
+import { CustomTypeSM, TabFields } from "@lib/models/common/CustomType";
 
 export const createCustomType = (
   id: string,
   label: string,
   repeatable: boolean
-): CustomTypeSM => ({
-  id,
-  label,
-  repeatable,
-  tabs: [
-    {
-      key: "Main",
-      value: [],
-    },
-  ],
-  status: true,
-});
+): CustomTypeSM => {
+  const defaultMainTabValue: TabFields = [];
+
+  // All new custom type should have a default UID field non-editable
+  if (repeatable) {
+    defaultMainTabValue.push({
+      key: "uid",
+      value: {
+        type: "UID",
+        config: {
+          label: "UID",
+        },
+      },
+    });
+  }
+
+  return {
+    id,
+    label,
+    repeatable,
+    tabs: [
+      {
+        key: "Main",
+        value: defaultMainTabValue,
+      },
+    ],
+    status: true,
+  };
+};

--- a/packages/slice-machine/test/pages/cts.test.tsx
+++ b/packages/slice-machine/test/pages/cts.test.tsx
@@ -221,7 +221,7 @@ describe("Custom Type Builder", () => {
     );
   });
 
-  // TODO: Use this test for Page Types since new Custom Type don't have Slice Zone anymore
+  // TODO: DT-1316 - Use this test for Page Types since new Custom Type don't have Slice Zone anymore
   test.skip("should send a tracking event when the user adds a slice", async () => {
     const customTypeId = "a-page";
 

--- a/packages/slice-machine/test/pages/cts.test.tsx
+++ b/packages/slice-machine/test/pages/cts.test.tsx
@@ -221,7 +221,8 @@ describe("Custom Type Builder", () => {
     );
   });
 
-  test("should send a tracking event when the user adds a slice", async () => {
+  // TODO: Use this test for Page Types since new Custom Type don't have Slice Zone anymore
+  test.skip("should send a tracking event when the user adds a slice", async () => {
     const customTypeId = "a-page";
 
     Router.push({

--- a/packages/slice-machine/test/src/modules/availableCustomTypes/factory.test.ts
+++ b/packages/slice-machine/test/src/modules/availableCustomTypes/factory.test.ts
@@ -13,7 +13,17 @@ describe("[Custom types factory]", () => {
         tabs: [
           {
             key: "Main",
-            value: [],
+            value: [
+              {
+                key: "uid",
+                value: {
+                  type: "UID",
+                  config: {
+                    label: "UID",
+                  },
+                },
+              },
+            ],
           },
         ],
       };


### PR DESCRIPTION
## Context

Completes DT-1323: [AAUser, I can create a Custom Type with default fields and restrictions](https://linear.app/prismic/issue/DT-1323/aauser-i-can-create-a-custom-type-with-default-fields-and-restrictions)

## The Solution

- Faking a customTypeFormat const that will come from custom type value later on
- Passing it to be sure we don't allow removing the UID default field (discussed with Côme about that, and we want to let the possibility to old Custom Type before format) 
- Update e2e tests with changes
- Add new e2e tests to protect changes
- Fix unit tests with changes

## Impact / Dependencies

- Don't add unit tests because it will be simpler with the new version of prismic-types-internal
- With these changes it's not possible to link slices to a Custom Types since Page Types is not available yet

## Checklist before requesting a review
- [x] I hereby declare my code ready for review.
- [x] If it is a critical feature, I have added tests.
- [x] The CI is successful.
- [x] If there could backward compatibility issues, it has been discussed and planned.

## Preview

https://github.com/prismicio/slice-machine/assets/19946868/9479e7ec-f0ec-49b5-9f58-6bc400a93168
