### PR TITLE
Track page format

### DIFF
--- a/packages/manager/src/managers/telemetry/types.ts
+++ b/packages/manager/src/managers/telemetry/types.ts
@@ -1,3 +1,4 @@
+import { CustomTypeFormat } from "../customTypes/types";
 import type { LimitType } from "../prismicRepository/types";
 
 export const SegmentEventType = {
@@ -115,7 +116,7 @@ type CustomTypeCreatedSegmentEvent = SegmentEvent<
 	{
 		id: string;
 		name: string;
-		format: "page" | "custom";
+		format: CustomTypeFormat;
 		type: "repeatable" | "single";
 	}
 >;
@@ -140,7 +141,7 @@ type CustomTypeSavedSegmentEvent = SegmentEvent<
 	{
 		id: string;
 		name: string;
-		format: "page" | "custom";
+		format: CustomTypeFormat;
 		type: "repeatable" | "single";
 	}
 >;

--- a/packages/manager/src/managers/telemetry/types.ts
+++ b/packages/manager/src/managers/telemetry/types.ts
@@ -112,7 +112,12 @@ type OpenVideoTutorialsSegmentEvent = SegmentEvent<
 
 type CustomTypeCreatedSegmentEvent = SegmentEvent<
 	typeof SegmentEventType.customType_created,
-	{ id: string; name: string; type: "repeatable" | "single" }
+	{
+		id: string;
+		name: string;
+		format: "page" | "custom";
+		type: "repeatable" | "single";
+	}
 >;
 
 type CustomTypeFieldAddedSegmentEvent = SegmentEvent<
@@ -132,7 +137,12 @@ type CustomTypeSliceZoneUpdatedSegmentEvent = SegmentEvent<
 
 type CustomTypeSavedSegmentEvent = SegmentEvent<
 	typeof SegmentEventType.customType_saved,
-	{ id: string; name: string; type: "repeatable" | "single" }
+	{
+		id: string;
+		name: string;
+		format: "page" | "custom";
+		type: "repeatable" | "single";
+	}
 >;
 
 type SliceCreatedSegmentEvent = SegmentEvent<

--- a/packages/manager/test/SliceMachineManager-telemetry-track.test.ts
+++ b/packages/manager/test/SliceMachineManager-telemetry-track.test.ts
@@ -99,6 +99,7 @@ it("maps event payloads correctly to expected Segment tracking payloads", async 
 		id: "test",
 		name: "testing",
 		type: "repeatable" as const,
+		format: "custom" as const,
 	};
 
 	await manager.telemetry.track({

--- a/packages/slice-machine/components/Forms/CreateCustomTypeModal/CreateCustomTypeModal.tsx
+++ b/packages/slice-machine/components/Forms/CreateCustomTypeModal/CreateCustomTypeModal.tsx
@@ -60,6 +60,7 @@ export const CreateCustomTypeModal: React.FC<CreateCustomTypeModalProps> = ({
       event: "custom-type:created",
       id,
       name,
+      format: "custom", // TODO: DT-1308 - Retrieve format from currentCustomType
       type: repeatable ? "repeatable" : "single",
     });
     createCustomType(id, name, repeatable);

--- a/packages/slice-machine/components/Forms/CreateCustomTypeModal/CreateCustomTypeModal.tsx
+++ b/packages/slice-machine/components/Forms/CreateCustomTypeModal/CreateCustomTypeModal.tsx
@@ -28,11 +28,11 @@ interface FormValues {
 }
 
 type CreateCustomTypeModalProps = {
-  format?: CustomTypeFormat;
+  format: CustomTypeFormat;
 };
 
 export const CreateCustomTypeModal: React.FC<CreateCustomTypeModalProps> = ({
-  format: _,
+  format,
 }) => {
   const { createCustomType, closeModals } = useSliceMachineActions();
 
@@ -60,7 +60,7 @@ export const CreateCustomTypeModal: React.FC<CreateCustomTypeModalProps> = ({
       event: "custom-type:created",
       id,
       name,
-      format: "custom", // TODO: DT-1308 - Retrieve format from currentCustomType
+      format,
       type: repeatable ? "repeatable" : "single",
     });
     createCustomType(id, name, repeatable);

--- a/packages/slice-machine/lib/models/common/CustomType/index.ts
+++ b/packages/slice-machine/lib/models/common/CustomType/index.ts
@@ -8,11 +8,17 @@ import { SlicesSM } from "../Slices";
 
 export * from "./tab";
 
+export const CustomTypeFormat = {
+  page: "page",
+  custom: "custom",
+};
+
 export const CustomTypeSM = t.exact(
   t.intersection([
     t.type({
       id: t.string,
       label: StringOrNull,
+      format: withFallback(t.keyof(CustomTypeFormat), "custom"),
       repeatable: withFallback(t.boolean, true),
       tabs: t.array(TabSM),
       status: withFallback(t.boolean, true),

--- a/packages/slice-machine/src/modules/availableCustomTypes/factory.ts
+++ b/packages/slice-machine/src/modules/availableCustomTypes/factory.ts
@@ -23,6 +23,7 @@ export const createCustomType = (
   return {
     id,
     label,
+    format: "custom",
     repeatable,
     tabs: [
       {

--- a/packages/slice-machine/src/modules/selectedCustomType/sagas.ts
+++ b/packages/slice-machine/src/modules/selectedCustomType/sagas.ts
@@ -28,7 +28,7 @@ export function* saveCustomTypeSaga() {
       event: "custom-type:saved",
       id: currentCustomType.id,
       name: currentCustomType.label ?? currentCustomType.id,
-      format: "custom", // TODO: DT-1308 - Retrieve format from currentCustomType
+      format: currentCustomType.format,
       type: currentCustomType.repeatable ? "repeatable" : "single",
     });
     yield put(saveCustomTypeCreator.success({ customType: currentCustomType }));

--- a/packages/slice-machine/src/modules/selectedCustomType/sagas.ts
+++ b/packages/slice-machine/src/modules/selectedCustomType/sagas.ts
@@ -27,7 +27,8 @@ export function* saveCustomTypeSaga() {
     void telemetry.track({
       event: "custom-type:saved",
       id: currentCustomType.id,
-      name: currentCustomType.label || currentCustomType.id,
+      name: currentCustomType.label ?? currentCustomType.id,
+      format: "custom", // TODO: DT-1308 - Retrieve format from currentCustomType
       type: currentCustomType.repeatable ? "repeatable" : "single",
     });
     yield put(saveCustomTypeCreator.success({ customType: currentCustomType }));

--- a/packages/slice-machine/test/components/CreateCustomTypeModal.test.tsx
+++ b/packages/slice-machine/test/components/CreateCustomTypeModal.test.tsx
@@ -24,7 +24,7 @@ describe("CreateCustomTypeModal", () => {
     const fakeName = "testing-name";
     const fakeRepo = "foo";
 
-    render(<CreateCustomTypeModal />, {
+    render(<CreateCustomTypeModal format="custom" />, {
       preloadedState: {
         // @ts-expect-error TS(2739) FIXME: Type '{ repo: string; }' is missing the following ... Remove this comment to see the full error message
         environment: {
@@ -65,6 +65,7 @@ describe("CreateCustomTypeModal", () => {
         properties: {
           id: fakeId,
           name: fakeName,
+          format: "custom",
           type: "repeatable",
           nodeVersion: process.versions.node,
         },

--- a/packages/slice-machine/test/src/modules/availableCustomTypes/factory.test.ts
+++ b/packages/slice-machine/test/src/modules/availableCustomTypes/factory.test.ts
@@ -8,6 +8,7 @@ describe("[Custom types factory]", () => {
       const expectedCustomType: CustomTypeSM = {
         id: "id",
         label: "lama",
+        format: "custom",
         repeatable: true,
         status: true,
         tabs: [
@@ -33,6 +34,7 @@ describe("[Custom types factory]", () => {
       const expectedCustomType: CustomTypeSM = {
         id: "id",
         label: "lama",
+        format: "custom",
         repeatable: false,
         status: true,
         tabs: [


### PR DESCRIPTION
Add CT format to tracking events "custom-type:created" and "custom-type:saved"

https://linear.app/prismic/issue/DT-1325/aapm-i-can-see-tracking-up-to-date-with-the-new-page-types-feature

Done is Dev Segment, needs to be done in prod once merged