### PR TITLE
fix(adapter-next,adapter-nuxt,adapter-nuxt2): use SemVer range

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34812,9 +34812,9 @@
       }
     },
     "node_modules/prismic-ts-codegen": {
-      "version": "0.1.9",
-      "resolved": "https://registry.npmjs.org/prismic-ts-codegen/-/prismic-ts-codegen-0.1.9.tgz",
-      "integrity": "sha512-15kA2MSgPp4B2m00yrH3hGmc0vbgSGNqnkJw2DNuyq97nMX1RVU3XXLoJTnn8t0FUOKLeIZGUaaWYiLCJlfwuQ==",
+      "version": "0.1.10",
+      "resolved": "https://registry.npmjs.org/prismic-ts-codegen/-/prismic-ts-codegen-0.1.10.tgz",
+      "integrity": "sha512-Ef2vprn2OAedN2TdP1QeolRLzG8jW3QjRhCq2e1JmxTGYYf7fHNSu40J1crY4ZIZXJC48tf+o2cH4/+ATKiEcg==",
       "dependencies": {
         "@prismicio/custom-types-client": "^1.1.0",
         "common-tags": "^1.8.2",
@@ -43997,7 +43997,7 @@
         "fs-extra": "^11.1.0",
         "node-fetch": "^3.3.1",
         "pascal-case": "^3.1.2",
-        "prismic-ts-codegen": "0.1.9"
+        "prismic-ts-codegen": "^0.1.10"
       },
       "devDependencies": {
         "@prismicio/mock": "^0.2.0",
@@ -44181,7 +44181,7 @@
         "magicast": "^0.2.1",
         "node-fetch": "^3.3.1",
         "pascal-case": "^3.1.2",
-        "prismic-ts-codegen": "0.1.9"
+        "prismic-ts-codegen": "^0.1.10"
       },
       "devDependencies": {
         "@prismicio/mock": "^0.2.0",
@@ -46108,7 +46108,7 @@
         "magicast": "^0.2.1",
         "node-fetch": "^3.3.1",
         "pascal-case": "^3.1.2",
-        "prismic-ts-codegen": "0.1.9"
+        "prismic-ts-codegen": "^0.1.10"
       },
       "devDependencies": {
         "@prismicio/mock": "^0.2.0",

--- a/packages/adapter-next/package.json
+++ b/packages/adapter-next/package.json
@@ -64,7 +64,7 @@
 		"fs-extra": "^11.1.0",
 		"node-fetch": "^3.3.1",
 		"pascal-case": "^3.1.2",
-		"prismic-ts-codegen": "0.1.9"
+		"prismic-ts-codegen": "^0.1.10"
 	},
 	"devDependencies": {
 		"@prismicio/mock": "^0.2.0",

--- a/packages/adapter-nuxt/package.json
+++ b/packages/adapter-nuxt/package.json
@@ -65,7 +65,7 @@
 		"magicast": "^0.2.1",
 		"node-fetch": "^3.3.1",
 		"pascal-case": "^3.1.2",
-		"prismic-ts-codegen": "0.1.9"
+		"prismic-ts-codegen": "^0.1.10"
 	},
 	"devDependencies": {
 		"@prismicio/mock": "^0.2.0",

--- a/packages/adapter-nuxt2/package.json
+++ b/packages/adapter-nuxt2/package.json
@@ -65,7 +65,7 @@
 		"magicast": "^0.2.1",
 		"node-fetch": "^3.3.1",
 		"pascal-case": "^3.1.2",
-		"prismic-ts-codegen": "0.1.9"
+		"prismic-ts-codegen": "^0.1.10"
 	},
 	"devDependencies": {
 		"@prismicio/mock": "^0.2.0",


### PR DESCRIPTION


## Context

Not using SemVer ranges for dependencies can have undesired side effects when not explicitely required. For example users would not get patch releases when pinning a stable version.

Currently, this prevent users from getting a fix we released on `prismic-ts-codegen`, making pre-client v7 app types not working.

## The Solution

<!--
Highlight explanations where the complexity in your development is.
Keep in mind that the reviewer might not have as much context as you do.
This is very important to make sure the review is thorough and the reviewer understand your changes.
-->




## Impact / Dependencies

<!--
List all the impacts your development might have on internal and external features.
Ideally this should have been discussed prior to this development.

Link of any other PRs that are related to this development.
They should also be referenced in the ticket for reviews.
-->




## Checklist before requesting a review
- [x] I hereby declare my code ready for review.
- [ ] If it is a critical feature, I have added tests.
- [x] The CI is successful.
- [ ] If there could backward compatibility issues, it has been discussed and planned.




## [OPT] Preview

<!--
Visual aid of your work.
It can either be screenshots or a video.
This could help reviewers to get context quickly.
-->




<!--
A funny animal picture is welcome to close your PR!
You can find one here https://unsplash.com/s/photos/funny-animal-picture
-->