### PR TITLE
fix(init): Fix tracking for framework and starter when create a repository

### DIFF
--- a/packages/init/src/lib/framework.ts
+++ b/packages/init/src/lib/framework.ts
@@ -1,7 +1,8 @@
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
-
 import semver from "semver";
+
+import { FrameworkWroomTelemetryID } from "@slicemachine/manager";
 
 import { version as pkgVersion } from "../../package.json";
 
@@ -12,9 +13,14 @@ export type Framework = {
 	name: string;
 
 	/**
-	 * Framework's name sent to Prismic
+	 * Framework 's id sent to Segment from Slice Machine
 	 */
-	prismicName: string;
+	sliceMachineTelemetryID: "next-11-13" | "nuxt-2" | "nuxt-3" | "universal";
+
+	/**
+	 * Framework's id sent to Segment from wroom.
+	 */
+	wroomTelemetryID: FrameworkWroomTelemetryID;
 
 	/**
 	 * A link to the Prismic documentation for the framework
@@ -60,7 +66,8 @@ const DEFAULT_DEV_DEPENDENCIES: Record<string, string> = {
 export const FRAMEWORKS: Record<string, Framework> = {
 	"nuxt-2": {
 		name: "Nuxt 2",
-		prismicName: "nuxt-2",
+		sliceMachineTelemetryID: "nuxt-2",
+		wroomTelemetryID: "nuxt",
 		prismicDocumentation: "https://prismic.dev/init/nuxt-2",
 		adapterName: "@slicemachine/adapter-nuxt2",
 		compatibility: {
@@ -73,7 +80,8 @@ export const FRAMEWORKS: Record<string, Framework> = {
 	},
 	"nuxt-3": {
 		name: "Nuxt 3",
-		prismicName: "nuxt-3",
+		sliceMachineTelemetryID: "nuxt-3",
+		wroomTelemetryID: "nuxt",
 		prismicDocumentation: "https://prismic.dev/init/nuxt-3",
 		adapterName: "@slicemachine/adapter-nuxt",
 		compatibility: {
@@ -86,7 +94,8 @@ export const FRAMEWORKS: Record<string, Framework> = {
 	},
 	"next-11-13": {
 		name: "Next.js 11-13",
-		prismicName: "next-11-13",
+		sliceMachineTelemetryID: "next-11-13",
+		wroomTelemetryID: "next",
 		prismicDocumentation: "https://prismic.dev/init/next-11-13",
 		adapterName: "@slicemachine/adapter-next",
 		compatibility: {
@@ -104,7 +113,8 @@ export const FRAMEWORKS: Record<string, Framework> = {
  */
 export const UNIVERSAL: Framework = {
 	name: "universal (no framework)",
-	prismicName: "universal",
+	sliceMachineTelemetryID: "universal",
+	wroomTelemetryID: "other",
 	prismicDocumentation: "https://prismic.dev/init/universal",
 	adapterName: "@slicemachine/adapter-universal",
 	compatibility: {},

--- a/packages/init/src/lib/starters.ts
+++ b/packages/init/src/lib/starters.ts
@@ -1,0 +1,30 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+
+import { StarterID } from "@slicemachine/manager";
+
+const STARTERS_REPOSITORY_NAME_TO_ID: Record<string, StarterID> = {
+	"nextjs-starter-prismic-multi-page": "next_multi_page",
+	"nextjs-starter-prismic-blog": "next_blog",
+	"nextjs-starter-prismic-multi-language": "next_multi_lang",
+	"nuxt-starter-prismic-multi-page": "nuxt_multi_page",
+	"nuxt-starter-prismic-blog": "nuxt_blog",
+	"nuxt-starter-prismic-multi-language": "nuxt_multi_lang",
+};
+
+export const detectStarterId = async (
+	cwd: string,
+): Promise<StarterID | undefined> => {
+	const path = join(cwd, "package.json");
+
+	try {
+		const pkg = JSON.parse(await readFile(path, "utf-8"));
+
+		return STARTERS_REPOSITORY_NAME_TO_ID[pkg.name];
+	} catch (error) {
+		throw new Error(
+			`Failed to read project's \`package.json\` at \`${path}\``,
+			{ cause: error },
+		);
+	}
+};

--- a/packages/init/test/SliceMachineInitProcess-createNewRepository.test.ts
+++ b/packages/init/test/SliceMachineInitProcess-createNewRepository.test.ts
@@ -57,7 +57,7 @@ it.skip("creates repository from context", async (ctx) => {
 	expect(spiedManager.prismicRepository.create).toHaveBeenCalledOnce();
 	expect(spiedManager.prismicRepository.create).toHaveBeenNthCalledWith(1, {
 		domain: "new-repo",
-		framework: UNIVERSAL.prismicName,
+		framework: UNIVERSAL.sliceMachineTelemetryID,
 	});
 	// @ts-expect-error - Accessing protected property
 	expect(initProcess.context.repository?.exists).toBe(true);

--- a/packages/init/test/SliceMachineInitProcess-detectEnvironment.test.ts
+++ b/packages/init/test/SliceMachineInitProcess-detectEnvironment.test.ts
@@ -5,12 +5,12 @@ import { createSliceMachineInitProcess } from "../src";
 
 import { watchStd } from "./__testutils__/watchStd";
 
-it("detects framework and package manager", async () => {
+it("detects framework, starter and package manager", async () => {
 	const initProcess = createSliceMachineInitProcess({ cwd: "/base" });
 	vol.fromJSON(
 		{
 			"./package.json": JSON.stringify({
-				name: "package-base",
+				name: "nuxt-starter-prismic-multi-page",
 				version: "0.0.0",
 				dependencies: {
 					next: "^13.0.0",
@@ -43,9 +43,11 @@ it("detects framework and package manager", async () => {
 		    },
 		    "name": "Next.js 11-13",
 		    "prismicDocumentation": "https://prismic.dev/init/next-11-13",
-		    "prismicName": "next-11-13",
+		    "sliceMachineTelemetryID": "next-11-13",
+		    "wroomTelemetryID": "next",
 		  },
 		  "packageManager": "npm",
+		  "starterID": "nuxt_multi_page",
 		}
 	`);
 });
@@ -88,9 +90,11 @@ it("assumes unconventional tags match semver range when detecting framework", as
 		    },
 		    "name": "Next.js 11-13",
 		    "prismicDocumentation": "https://prismic.dev/init/next-11-13",
-		    "prismicName": "next-11-13",
+		    "sliceMachineTelemetryID": "next-11-13",
+		    "wroomTelemetryID": "next",
 		  },
 		  "packageManager": "npm",
+		  "starterID": undefined,
 		}
 	`);
 });
@@ -127,9 +131,11 @@ it("falls back to npm if package manager is not detected", async () => {
 		    },
 		    "name": "universal (no framework)",
 		    "prismicDocumentation": "https://prismic.dev/init/universal",
-		    "prismicName": "universal",
+		    "sliceMachineTelemetryID": "universal",
+		    "wroomTelemetryID": "other",
 		  },
 		  "packageManager": "npm",
+		  "starterID": undefined,
 		}
 	`);
 });

--- a/packages/manager/src/index.ts
+++ b/packages/manager/src/index.ts
@@ -2,7 +2,11 @@
 // Non-Node.js-compatible exports should be defined in `./client.ts`.
 
 export type { CustomTypeFormat } from "./managers/customTypes/types";
-export type { PrismicRepository } from "./managers/prismicRepository/types";
+export type {
+	PrismicRepository,
+	FrameworkWroomTelemetryID,
+	StarterID,
+} from "./managers/prismicRepository/types";
 
 export type { SliceMachineManager } from "./managers/SliceMachineManager";
 export { createSliceMachineManager } from "./managers/createSliceMachineManager";

--- a/packages/manager/src/managers/prismicRepository/PrismicRepositoryManager.ts
+++ b/packages/manager/src/managers/prismicRepository/PrismicRepositoryManager.ts
@@ -22,8 +22,10 @@ import {
 	PrismicRepositoryUserAgent,
 	PrismicRepositoryUserAgents,
 	RawLimit,
+	StarterID,
 	TransactionalMergeArgs,
 	TransactionalMergeReturnType,
+	FrameworkWroomTelemetryID,
 } from "./types";
 import { assertPluginsInitialized } from "../../lib/assertPluginsInitialized";
 import { UnauthenticatedError } from "../../errors";
@@ -40,7 +42,8 @@ type PrismicRepositoryManagerCheckExistsArgs = {
 
 type PrismicRepositoryManagerCreateArgs = {
 	domain: string;
-	framework: string; // TODO: Type(?)
+	framework: FrameworkWroomTelemetryID;
+	starterID: StarterID | undefined;
 };
 
 type PrismicRepositoryManagerDeleteArgs = {
@@ -153,7 +156,9 @@ export class PrismicRepositoryManager extends BaseManager {
 		const body = {
 			...DEFAULT_REPOSITORY_SETTINGS,
 			domain: args.domain,
-			framework: args.framework, // This property appears to be optional for the API
+			// These properties are optional in the API but needed for tracking
+			framework: args.framework,
+			starterID: args.starterID,
 		};
 
 		const res = await this._fetch({

--- a/packages/manager/src/managers/prismicRepository/PrismicRepositoryManager.ts
+++ b/packages/manager/src/managers/prismicRepository/PrismicRepositoryManager.ts
@@ -43,7 +43,7 @@ type PrismicRepositoryManagerCheckExistsArgs = {
 type PrismicRepositoryManagerCreateArgs = {
 	domain: string;
 	framework: FrameworkWroomTelemetryID;
-	starterID: StarterID | undefined;
+	starterID?: StarterID;
 };
 
 type PrismicRepositoryManagerDeleteArgs = {

--- a/packages/manager/src/managers/prismicRepository/types.ts
+++ b/packages/manager/src/managers/prismicRepository/types.ts
@@ -131,3 +131,27 @@ export type TransactionalMergeArgs = {
 };
 
 export type TransactionalMergeReturnType = Limit | null;
+
+/**
+ * Framework id sent to Segment from wroom. Property used for the "framework"
+ * and "hasSlicemachine" properties.
+ *
+ * Values from:
+ * https://github.com/prismicio/wroom/blob/65d4f53fd46df7d366d80e7ba9c965339ac7369d/subprojects/common/app/models/Framework.scala#LL20C6-L20C6
+ */
+export type FrameworkWroomTelemetryID = "next" | "nuxt" | "other";
+
+/**
+ * Starter id sent to Segment from wroom.Property used for the "starter"
+ * properties.
+ *
+ * Values from:
+ * https://github.com/prismicio/wroom/blob/65d4f53fd46df7d366d80e7ba9c965339ac7369d/conf/application.conf#L938
+ */
+export type StarterID =
+	| "next_multi_page"
+	| "next_blog"
+	| "next_multi_lang"
+	| "nuxt_multi_page"
+	| "nuxt_blog"
+	| "nuxt_multi_lang";

--- a/packages/manager/test/SliceMachineManager-prismicRepository-create.test.ts
+++ b/packages/manager/test/SliceMachineManager-prismicRepository-create.test.ts
@@ -49,7 +49,8 @@ it.skip("creates a Prismic repository", async (ctx) => {
 
 	await manager.prismicRepository.create({
 		domain: "foo",
-		framework: "bar",
+		framework: "other",
+		starterID: undefined,
 	});
 
 	expect(count).toBe(1);
@@ -77,14 +78,15 @@ it("throws if the repository API call was unsuccessful", async (ctx) => {
 			expectedAuthenticationToken: authenticationToken,
 			expectedCookies: prismicAuthLoginResponse.cookies,
 			domain: "foo",
-			framework: "bar",
+			framework: "other",
 		},
 	});
 
 	await expect(async () => {
 		await manager.prismicRepository.create({
 			domain: "foo",
-			framework: "bar",
+			framework: "other",
+			starterID: undefined,
 		});
 	}).rejects.toThrow(/failed to create repository/i);
 });
@@ -102,7 +104,8 @@ it("throws if not logged in", async () => {
 	await expect(async () => {
 		await manager.prismicRepository.create({
 			domain: "foo",
-			framework: "bar",
+			framework: "other",
+			starterID: undefined,
 		});
 	}).rejects.toThrow(/not logged in/i);
 });

--- a/packages/manager/test/SliceMachineManager-prismicRepository-pushDocuments.test.ts
+++ b/packages/manager/test/SliceMachineManager-prismicRepository-pushDocuments.test.ts
@@ -151,7 +151,8 @@ it("throws if not logged in", async () => {
 	await expect(async () => {
 		await manager.prismicRepository.create({
 			domain: "foo",
-			framework: "bar",
+			framework: "other",
+			starterID: undefined,
 		});
 	}).rejects.toThrow(/not logged in/i);
 });


### PR DESCRIPTION
## Context

- Completes DT-1379

## The Solution

- In SM changing "next-11-13", "nuxt-2" or "nuxt-3" to "next" or "nuxt" that is sent to wroom but keep the specific framework for SM tracking.
- Sending a starter id from SM (thanks to package.json) AND Set the starterId parameter in the createDomain function in wroom  (PR soon in wroom)

## Impact / Dependencies

- new init procedure to detect the starter

## Checklist before requesting a review
- [x] I hereby declare my code ready for review.
- [x] If it is a critical feature, I have added tests.
- [ ] The CI is successful.
- [x] If there could backward compatibility issues, it has been discussed and planned.
