### PR TITLE
test(page types): Add integration tests for page types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13950,6 +13950,19 @@
         "react-dom": "^18.0.0"
       }
     },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.4.3",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.4.3.tgz",
+      "integrity": "sha512-kCUc5MEwaEMakkO5x7aoD+DLi02ehmEM2QCGWvNqAS1dV/fAvORWEjnjsEIvml59M7Y5kCkWN6fCCyPOe8OL6Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
+      }
+    },
     "node_modules/@theme-ui/color": {
       "version": "0.15.7",
       "dev": true,
@@ -47305,6 +47318,7 @@
         "@storybook/react-vite": "7.0.10",
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^14.0.0",
+        "@testing-library/user-event": "14.4.3",
         "@theme-ui/color": "^0.15.5",
         "@types/marked": "^4.0.8",
         "@types/react": "^18.0.28",

--- a/packages/slice-machine/components/DeleteCTModal/index.tsx
+++ b/packages/slice-machine/components/DeleteCTModal/index.tsx
@@ -4,7 +4,7 @@ import { SliceMachineStoreType } from "@src/redux/type";
 import { isModalOpen } from "@src/modules/modal";
 import { ModalKeysEnum } from "@src/modules/modal/types";
 import useSliceMachineActions from "@src/modules/useSliceMachineActions";
-import { Close, Flex, Heading, Paragraph, Text, useThemeUI } from "theme-ui";
+import { Close, Flex, Heading, Text, useThemeUI } from "theme-ui";
 import Card from "@components/Card";
 import { MdOutlineDelete } from "react-icons/md";
 import { Button } from "@components/Button";
@@ -130,7 +130,7 @@ export const DeleteCustomTypeModal: React.FunctionComponent<
           </Flex>
         )}
       >
-        <Paragraph>
+        <div>
           This action will immediately make the following change:
           <ul>
             <li>
@@ -150,7 +150,7 @@ export const DeleteCustomTypeModal: React.FunctionComponent<
               any associated Documents from your repository.
             </li>
           </ul>
-        </Paragraph>
+        </div>
       </Card>
     </SliceMachineModal>
   );

--- a/packages/slice-machine/package.json
+++ b/packages/slice-machine/package.json
@@ -65,6 +65,7 @@
     "@storybook/react-vite": "7.0.10",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^14.0.0",
+    "@testing-library/user-event": "14.4.3",
     "@theme-ui/color": "^0.15.5",
     "@types/marked": "^4.0.8",
     "@types/react": "^18.0.28",

--- a/packages/slice-machine/src/features/customTypes/__tests__/CustomTypesTablePage.test.tsx
+++ b/packages/slice-machine/src/features/customTypes/__tests__/CustomTypesTablePage.test.tsx
@@ -1,0 +1,336 @@
+// @vitest-environment jsdom
+import { describe, vi, test, TestContext } from "vitest";
+import mockRouter from "next-router-mock";
+import { CustomType } from "@prismicio/types-internal/lib/customtypes";
+
+import {
+  CustomTypeFormat,
+  createSliceMachineManager,
+} from "@slicemachine/manager";
+import { createSliceMachineManagerMSWHandler } from "@slicemachine/manager/test";
+import { CustomTypeReadHookData } from "@slicemachine/plugin-kit";
+import { CustomTypes } from "@lib/models/common/CustomType";
+import { render, screen, waitFor, within } from "test/__testutils__";
+import { createTestPlugin } from "test/__testutils__/createTestPlugin";
+import { createTestProject } from "test/__testutils__/createTestProject";
+import { CustomTypesTablePage } from "../customTypesTable/CustomTypesTablePage";
+import { CUSTOM_TYPES_MESSAGES } from "../customTypesMessages";
+import pkg from "../../../../package.json";
+
+const formats = [
+  {
+    format: "custom",
+  },
+  {
+    format: "page",
+  },
+];
+
+describe.each(formats)(
+  "CustomTypesTablePage > All formats > $format type",
+  (args) => {
+    const format = args.format as CustomTypeFormat;
+
+    test(`should display the ${format} types table`, async (ctx) => {
+      await renderCustomTypesTablePage({ format, ctx });
+
+      // Check each custom type for the current format
+      for (const customTypeMock of customTypesMockByFormat[format]) {
+        // Scope the check for each row
+        const row = screen
+          .getByText(customTypeMock.id)
+          .closest("tr") as HTMLElement;
+        expect(within(row).getByText(customTypeMock.id)).toBeVisible();
+        expect(
+          within(row).getByText(customTypeMock.label as string)
+        ).toBeVisible();
+        expect(
+          within(row).getByText(
+            customTypeMock.repeatable ? "Reusable" : "Single"
+          )
+        ).toBeVisible();
+      }
+
+      // Check that there is the correct number of custom types displayed
+      expect(screen.getAllByText(/MyID/)).toHaveLength(
+        customTypesMockByFormat[format].length
+      );
+    });
+
+    test(`should create a ${format} type from the table`, async (ctx) => {
+      const { user } = await renderCustomTypesTablePage({ format, ctx });
+
+      // Click on the create button
+      await user.click(screen.getByText("Create"));
+
+      // Ensure the modal is visible
+      expect(
+        await screen.findByText(`Create a new ${format} type`)
+      ).toBeVisible();
+
+      // Scope the test to the modal
+      const form = screen
+        .getByText(`Create a new ${format} type`)
+        .closest("form") as HTMLElement;
+
+      // Get form inputs
+      const idInput = within(form).getByPlaceholderText(
+        CUSTOM_TYPES_MESSAGES[format].inputPlaceholder
+      );
+      const nameInput = within(form).getByPlaceholderText(
+        `A display name for the ${format} type`
+      );
+
+      // Fill the form
+      const newCustomType = `MyNew${format}Type`;
+      await user.type(idInput, newCustomType);
+      await user.type(nameInput, `My new ${format} type`);
+
+      // Submit the form
+      await user.click(within(form).getByRole("button", { name: "Create" }));
+
+      // Check that the new custom type is visible in the table
+      expect(await screen.findByText(newCustomType)).toBeVisible();
+
+      // Check that the redirection has been done
+      expect(mockRouter.asPath).toEqual(`/${format}-types/${newCustomType}`);
+    });
+
+    test(`should delete a ${format} type from the table`, async (ctx) => {
+      const { user } = await renderCustomTypesTablePage({ format, ctx });
+
+      // Scope the test for the first row
+      const row = screen
+        .getByText(customTypesMockByFormat[format][0].id)
+        .closest("tr") as HTMLElement;
+
+      // Click on the table row settings button
+      await user.click(within(row).getByTestId("tableRowSettings"));
+
+      // Click on the remove button
+      await user.click(await screen.findByText("Remove"));
+
+      // Ensure the modal is visible
+      expect(await screen.findByText(`Delete ${format} type`)).toBeVisible();
+
+      // Confirm the deletion
+      await user.click(screen.getByRole("button", { name: "Delete" }));
+
+      // Check that the custom type is not visible
+      await waitFor(() => {
+        expect(
+          screen.queryByText(customTypesMockByFormat[format][0].id)
+        ).not.toBeInTheDocument();
+      });
+    });
+
+    test(`should rename a ${format} type from the table`, async (ctx) => {
+      const { user } = await renderCustomTypesTablePage({ format, ctx });
+
+      // Scope the test for the first row
+      const row = screen
+        .getByText(customTypesMockByFormat[format][0].id)
+        .closest("tr") as HTMLElement;
+
+      // Click on the table row settings button
+      await user.click(within(row).getByTestId("tableRowSettings"));
+
+      // Click on the rename button
+      await user.click(await screen.findByText("Rename"));
+
+      // Ensure the modal is visible
+      expect(await screen.findByText(`Rename a ${format} type`)).toBeVisible();
+
+      // Scope the test to the modal
+      const form = screen
+        .getByText(`Rename a ${format} type`)
+        .closest("form") as HTMLElement;
+
+      // Get form input
+      const renamedCustomType = `My renamed ${format} type`;
+      const nameInput = within(form).getByPlaceholderText(
+        `A display name for the ${format} type`
+      );
+
+      // Clear the name and type a new one
+      await user.clear(nameInput);
+      await user.type(nameInput, renamedCustomType);
+
+      // Submit the form
+      await user.click(screen.getByRole("button", { name: "Rename" }));
+
+      // Check that the old custom type label is not visible anymore
+      await waitFor(() => {
+        expect(
+          screen.queryByText(customTypesMockByFormat[format][0].label as string)
+        ).not.toBeInTheDocument();
+      });
+
+      // Check that the renamed custom type is visible
+      expect(screen.getByText(renamedCustomType)).toBeVisible();
+    });
+
+    test(`should access a ${format} type page builder from the table`, async (ctx) => {
+      const { user } = await renderCustomTypesTablePage({ format, ctx });
+
+      // Click on the table row
+      await user.click(screen.getByText(customTypesMockByFormat[format][0].id));
+
+      // Check that the redirection has been done
+      expect(mockRouter.asPath).toEqual(
+        `/${format}-types/${customTypesMockByFormat[format][0].id}`
+      );
+    });
+  }
+);
+
+describe("CustomTypesTablePage > Custom type", () => {
+  test("should convert a custom type to page type from the table", async (ctx) => {
+    const format = "custom";
+    const { user, rerender } = await renderCustomTypesTablePage({
+      format,
+      ctx,
+    });
+
+    // Scope the test for the first row
+    const row = screen
+      .getByText(customTypesMockByFormat[format][0].id)
+      .closest("tr") as HTMLElement;
+
+    // Click on the table row settings button
+    await user.click(within(row).getByTestId("tableRowSettings"));
+
+    // Click on the convert to page type button
+    await user.click(await screen.findByText("Convert to page type"));
+
+    // Check that the custom type is not visible anymore
+    await waitFor(() => {
+      expect(
+        screen.queryByText(customTypesMockByFormat[format][0].label as string)
+      ).not.toBeInTheDocument();
+    });
+
+    // Check that the converted custom type is visible on the page type table now
+    rerender(<CustomTypesTablePage format="page" />);
+    expect(
+      screen.getByText(customTypesMockByFormat[format][0].id)
+    ).toBeVisible();
+  });
+});
+
+function createCustomTypesMock(
+  format: CustomTypeFormat,
+  count: number
+): CustomType[] {
+  return Array.from(Array(count), (_, index) => ({
+    id: `MyID${format}${index}`,
+    label: `My ${format} ${index}`,
+    repeatable: !!(index % 2),
+    format,
+    status: true,
+    json: {},
+  }));
+}
+
+type CustomTypesMockByFormat = {
+  custom: CustomType[];
+  page: CustomType[];
+};
+
+const customTypesMockByFormat: CustomTypesMockByFormat = {
+  custom: createCustomTypesMock("custom", 10),
+  page: createCustomTypesMock("page", 10),
+};
+
+const customTypesMock = [
+  ...customTypesMockByFormat["custom"],
+  ...customTypesMockByFormat["page"],
+];
+
+type RenderCustomTypesTablePageArgs = {
+  format: CustomTypeFormat;
+  ctx: TestContext;
+};
+
+async function renderCustomTypesTablePage({
+  format,
+  ctx,
+}: RenderCustomTypesTablePageArgs) {
+  vi.mock("next/router", () => import("next-router-mock"));
+
+  const adapter = createTestPlugin({
+    setup: ({ hook }) => {
+      hook("custom-type:create", () => void 0);
+      hook("custom-type:update", () => void 0);
+      hook("custom-type:rename", () => void 0);
+      hook("custom-type:delete", () => void 0);
+      hook("custom-type-library:read", () => {
+        return { ids: customTypesMock.map((customType) => customType.id) };
+      });
+      hook("custom-type:read", (args: CustomTypeReadHookData) => {
+        const model = customTypesMock.find(
+          (customTypeMock) => customTypeMock.id === args.id
+        );
+
+        if (model) {
+          return { model: model };
+        }
+
+        throw new Error("not implemented");
+      });
+    },
+  });
+  const cwd = await createTestProject({
+    adapter,
+  });
+  const manager = createSliceMachineManager({
+    nativePlugins: { [adapter.meta.name]: adapter },
+    cwd,
+  });
+
+  await manager.telemetry.initTelemetry({
+    appName: pkg.name,
+    appVersion: pkg.version,
+  });
+  await manager.plugins.initPlugins();
+
+  ctx.msw.use(
+    createSliceMachineManagerMSWHandler({
+      url: "http://localhost:3000/_manager",
+      sliceMachineManager: manager,
+    })
+  );
+
+  const customTypeMockStore = {
+    preloadedState: {
+      availableCustomTypes: {
+        ...customTypesMockByFormat.custom.reduce(
+          (obj, item) => ({
+            ...obj,
+            [item.id]: { local: CustomTypes.toSM(item) },
+          }),
+          {}
+        ),
+        ...customTypesMockByFormat.page.reduce(
+          (obj, item) => ({
+            ...obj,
+            [item.id]: { local: CustomTypes.toSM(item) },
+          }),
+          {}
+        ),
+      },
+    },
+  };
+
+  const renderResults = render(
+    <CustomTypesTablePage format={format} />,
+    customTypeMockStore
+  );
+
+  // Ensure table finished loading
+  expect(
+    await screen.findByText(customTypesMockByFormat[format][0].id)
+  ).toBeVisible();
+
+  return renderResults;
+}

--- a/packages/slice-machine/src/features/customTypes/__tests__/createCustomType.test.ts
+++ b/packages/slice-machine/src/features/customTypes/__tests__/createCustomType.test.ts
@@ -1,11 +1,10 @@
 import { describe, expect } from "vitest";
 import { createCustomType } from "@src/features/customTypes/customTypesTable/createCustomType";
 
-describe("[Custom types factory]", () => {
-  describe("[createCustomType]", () => {
-    it("should create a custom type with repeatable true", () => {
-      expect(createCustomType("id", "lama", true, "custom"))
-        .toMatchInlineSnapshot(`
+describe("createCustomType test suite", () => {
+  it("should create a custom type with repeatable true", () => {
+    expect(createCustomType("id", "lama", true, "custom"))
+      .toMatchInlineSnapshot(`
           {
             "format": "custom",
             "id": "id",
@@ -24,15 +23,15 @@ describe("[Custom types factory]", () => {
             "status": true,
           }
         `);
-    });
+  });
 
-    it("should create a custom type with repeatable false", () => {
-      const result = createCustomType("id", "lama", false, "custom");
-      expect(result.id).toBe("id");
-      expect(result.label).toBe("lama");
-      expect(result.format).toBe("custom");
-      expect(result.json).toHaveProperty("Main");
-      expect(result).toMatchInlineSnapshot(`
+  it("should create a custom type with repeatable false", () => {
+    const result = createCustomType("id", "lama", false, "custom");
+    expect(result.id).toBe("id");
+    expect(result.label).toBe("lama");
+    expect(result.format).toBe("custom");
+    expect(result.json).toHaveProperty("Main");
+    expect(result).toMatchInlineSnapshot(`
         {
           "format": "custom",
           "id": "id",
@@ -44,15 +43,15 @@ describe("[Custom types factory]", () => {
           "status": true,
         }
       `);
-    });
+  });
 
-    it("should create a page type with a slice zone", () => {
-      const result = createCustomType("🥪", "label", true, "page");
-      expect(result.format).toBe("page");
-      expect(result.json).toHaveProperty("Main");
-      expect(result.json.Main).toHaveProperty("slices");
-      expect(result.json).toHaveProperty("SEO & Metadata");
-      expect(result).toMatchInlineSnapshot(`
+  it("should create a page type with a slice zone", () => {
+    const result = createCustomType("🥪", "label", true, "page");
+    expect(result.format).toBe("page");
+    expect(result.json).toHaveProperty("Main");
+    expect(result.json.Main).toHaveProperty("slices");
+    expect(result.json).toHaveProperty("SEO & Metadata");
+    expect(result).toMatchInlineSnapshot(`
         {
           "format": "page",
           "id": "🥪",
@@ -105,12 +104,12 @@ describe("[Custom types factory]", () => {
           "status": true,
         }
       `);
-    });
   });
+});
 
-  it("when non repeatable page type is should contain Main with a slice-zone, no uid, and a SEO tab", () => {
-    const result = createCustomType("foo", "bar", false, "page");
-    expect(result).toMatchInlineSnapshot(`
+it("when non repeatable page type is should contain Main with a slice-zone, no uid, and a SEO tab", () => {
+  const result = createCustomType("foo", "bar", false, "page");
+  expect(result).toMatchInlineSnapshot(`
       {
         "format": "page",
         "id": "foo",
@@ -157,5 +156,4 @@ describe("[Custom types factory]", () => {
         "status": true,
       }
     `);
-  });
 });

--- a/packages/slice-machine/src/features/customTypes/customTypesTable/CustomTypesTable.tsx
+++ b/packages/slice-machine/src/features/customTypes/customTypesTable/CustomTypesTable.tsx
@@ -148,6 +148,7 @@ export const CustomTypesTable: FC<CustomTypesTableProps> = ({
                       <IconButton
                         icon="moreVert"
                         loading={isCustomTypeBeingConverted}
+                        data-testid="tableRowSettings"
                       />
                     </DropdownMenuTrigger>
                     <DropdownMenuContent align="end">

--- a/packages/slice-machine/test/__testutils__/index.tsx
+++ b/packages/slice-machine/test/__testutils__/index.tsx
@@ -1,4 +1,5 @@
 import { render as rtlRender, RenderOptions } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { Store, AnyAction } from "redux";
 
 import { Provider } from "react-redux";
@@ -14,6 +15,10 @@ export type RenderArgs = Partial<
   } & RenderOptions
 >;
 
+type RenderReturnType = ReturnType<typeof rtlRender> & {
+  user: ReturnType<typeof userEvent.setup>;
+};
+
 function render(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   ui: any,
@@ -22,7 +27,13 @@ function render(
     store = configureStore(preloadedState).store,
     ...renderOptions
   }: RenderArgs = {}
-) {
+): RenderReturnType {
+  if (!document.getElementById("__next")) {
+    const div = document.createElement("div");
+    div.setAttribute("id", "__next");
+    document.body.appendChild(div);
+  }
+
   function Wrapper({
     children,
   }: {
@@ -37,7 +48,11 @@ function render(
       </ThemeUIThemeProvider>
     );
   }
-  return rtlRender(ui, { wrapper: Wrapper, ...renderOptions });
+  return {
+    user: userEvent.setup(),
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+    ...rtlRender(ui, { wrapper: Wrapper, ...renderOptions }),
+  };
 }
 
 // re-export everything

--- a/packages/slice-machine/test/components/CreateCustomTypeModal.test.tsx
+++ b/packages/slice-machine/test/components/CreateCustomTypeModal.test.tsx
@@ -15,10 +15,6 @@ describe("CreateCustomTypeModal", () => {
     vi.clearAllMocks();
   });
 
-  const div = document.createElement("div");
-  div.setAttribute("id", "__next");
-  document.body.appendChild(div);
-
   test("when a slice is created the tracker should be called", async () => {
     const fakeId = "testing_id";
     const fakeName = "testing-name";

--- a/packages/slice-machine/test/pages/custom-types.test.tsx
+++ b/packages/slice-machine/test/pages/custom-types.test.tsx
@@ -1,14 +1,6 @@
 // @vitest-environment jsdom
 
-import {
-  describe,
-  test,
-  afterEach,
-  beforeEach,
-  expect,
-  beforeAll,
-  vi,
-} from "vitest";
+import { describe, test, afterEach, beforeEach, expect, vi } from "vitest";
 import Router from "next/router";
 import mockRouter from "next-router-mock";
 import SegmentClient from "analytics-node";
@@ -25,12 +17,6 @@ import CreateCustomTypeBuilder from "../../pages/custom-types/[customTypeId]";
 vi.mock("next/router", () => import("next-router-mock"));
 
 describe("Custom Type Builder", () => {
-  beforeAll(async () => {
-    const div = document.createElement("div");
-    div.setAttribute("id", "__next");
-    document.body.appendChild(div);
-  });
-
   afterEach(() => {
     vi.clearAllMocks();
   });

--- a/packages/slice-machine/test/pages/simulator.test.tsx
+++ b/packages/slice-machine/test/pages/simulator.test.tsx
@@ -34,10 +34,6 @@ vi.mock("@prismicio/slice-simulator-com", () => {
 
 describe.skip("simulator", () => {
   beforeAll(async () => {
-    const div = document.createElement("div");
-    div.setAttribute("id", "__next");
-    document.body.appendChild(div);
-
     // USE THIS IF light mode is not enabled on ThemeProvider
     // Object.defineProperty(window, "matchMedia", {
     //   writable: true,

--- a/packages/slice-machine/test/pages/slices.test.tsx
+++ b/packages/slice-machine/test/pages/slices.test.tsx
@@ -1,14 +1,6 @@
 // @vitest-environment jsdom
 
-import {
-  describe,
-  test,
-  afterEach,
-  beforeEach,
-  expect,
-  beforeAll,
-  vi,
-} from "vitest";
+import { describe, test, afterEach, beforeEach, expect, vi } from "vitest";
 import mockRouter from "next-router-mock";
 import SegmentClient from "analytics-node";
 
@@ -24,12 +16,6 @@ import { createSliceMachineManagerMSWHandler } from "@slicemachine/manager/test"
 vi.mock("next/router", () => import("next-router-mock"));
 
 describe("slices", () => {
-  beforeAll(() => {
-    const div = document.createElement("div");
-    div.setAttribute("id", "__next");
-    document.body.appendChild(div);
-  });
-
   afterEach(() => {
     vi.clearAllMocks();
   });


### PR DESCRIPTION
## Context

- Completes DT-1375

## The Solution

- Create a first set of integration tests, with each "test()" not relying on implementation details.
- Create helpers to centralize implementation details.
- Fix an error in console when deleting a custom type, ul should not be children of p

## Checklist before requesting a review
- [x] I hereby declare my code ready for review.
- [ ] If it is a critical feature, I have added tests.
- [x] The CI is successful.
- [x] If there could backward compatibility issues, it has been discussed and planned.
