### PR TITLE
ci: fix end-to-end tests execution

### DIFF
--- a/cypress-setup.sh
+++ b/cypress-setup.sh
@@ -26,7 +26,7 @@ else
 fi
 
 rm -rf e2e-projects/cypress-next-app \
-&& yarn dlx --quiet create-next-app --app --eslint --import-alias '@/*' --src-dir --tailwind --typescript --use-npm e2e-projects/cypress-next-app \
+&& yarn dlx --quiet create-next-app --app --eslint --import-alias '@/*' --tailwind --typescript --use-npm e2e-projects/cypress-next-app \
 && yarn dlx --quiet vite-node ./cypress/plugins/addAuth.ts -- ${EMAIL} ${PASSWORD} ${PRISMIC_URL} \
 && yarn dlx --quiet vite-node ./cypress/plugins/createRepo.ts -- "${_PRISMIC_REPO}" "${PASSWORD}" "${PRISMIC_URL}" \
 && yarn workspaces foreach --include '{@slicemachine/adapter-next,@slicemachine/init,@slicemachine/manager,@slicemachine/plugin-kit,slice-machine-ui,start-slicemachine}' --topological --verbose pack --out "${THIS_DIR}"/e2e-projects/cypress-next-app/%s-%v.tgz \

--- a/cypress-setup.sh
+++ b/cypress-setup.sh
@@ -33,6 +33,6 @@ rm -rf e2e-projects/cypress-next-app \
 && cd e2e-projects/cypress-next-app \
 && npm i *.tgz \
 && npx @slicemachine/init --repository ${_PRISMIC_REPO} \
-&& npm i --save-dev slice-machine-ui*.tgz slicemachine-adapter-next*.tgz \
+&& npm i --save-dev slice-machine-ui*.tgz @slicemachine-adapter-next*.tgz \
 && npx json -I -f package.json -e "this.scripts.slicemachine=\"start-slicemachine\"" \
 && npx json -I -f slicemachine.config.json -e "this.localSliceSimulatorURL=\"http://localhost:3000/slice-simulator\""


### PR DESCRIPTION
## Context

- Fix end-to-end tests

<img width="330" alt="image" src="https://github.com/prismicio/slice-machine/assets/6433957/aa2ebfcb-7333-494a-9f5b-dc4c92ec5677">

## The Solution

- Fix a tgz file name that was not found. 
- Do not use create-next-app `src-dir` option. It was incompatible with the generated `slice-simulator.tsx` file

![image](https://github.com/prismicio/slice-machine/assets/6433957/add76620-7fd9-47cc-af57-da9f0023fbf0)


## Impact / Dependencies

None