### PR TITLE
fix(slice-machine-ui): Fix missing repository property in trackPageView

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
     },
     "e2e-projects/next": {
       "name": "cimsirp",
-      "version": "0.1.0",
+      "version": "0.1.1-dev-next-release.3",
       "dependencies": {
         "@headlessui/react": "^1.5.0",
         "@heroicons/react": "^1.0.6",
@@ -50,13 +50,13 @@
         "recharts": "^2.1.11"
       },
       "devDependencies": {
-        "@slicemachine/adapter-next": "0.3.1-dev-next-release.0",
+        "@slicemachine/adapter-next": "0.3.1-dev-next-release.4",
         "autoprefixer": "^10.4.4",
         "eslint": "^8.37.0",
         "eslint-config-next": "^12.1.4",
         "postcss": "^8.4.12",
-        "slice-machine-ui": "1.2.1-dev-next-release.0",
-        "start-slicemachine": "0.9.1-dev-next-release.0",
+        "slice-machine-ui": "1.2.1-dev-next-release.4",
+        "start-slicemachine": "0.9.1-dev-next-release.4",
         "tailwindcss": "^3.0.23"
       }
     },
@@ -43696,12 +43696,12 @@
     },
     "packages/adapter-next": {
       "name": "@slicemachine/adapter-next",
-      "version": "0.3.1-dev-next-release.0",
+      "version": "0.3.1-dev-next-release.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@prismicio/simulator": "^0.1.4",
         "@prismicio/types-internal": "2.0.0-beta.1",
-        "@slicemachine/plugin-kit": "0.4.1-dev-next-release.0",
+        "@slicemachine/plugin-kit": "0.4.1-dev-next-release.4",
         "common-tags": "^1.8.2",
         "fs-extra": "^11.1.0",
         "node-fetch": "^3.3.1",
@@ -43797,12 +43797,12 @@
     },
     "packages/adapter-nuxt": {
       "name": "@slicemachine/adapter-nuxt",
-      "version": "0.3.1-dev-next-release.0",
+      "version": "0.3.1-dev-next-release.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@prismicio/simulator": "^0.1.4",
         "@prismicio/types-internal": "2.0.0-beta.1",
-        "@slicemachine/plugin-kit": "0.4.1-dev-next-release.0",
+        "@slicemachine/plugin-kit": "0.4.1-dev-next-release.4",
         "common-tags": "^1.8.2",
         "fs-extra": "^11.1.0",
         "magicast": "^0.2.1",
@@ -45593,12 +45593,12 @@
     },
     "packages/adapter-nuxt2": {
       "name": "@slicemachine/adapter-nuxt2",
-      "version": "0.3.1-dev-next-release.0",
+      "version": "0.3.1-dev-next-release.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@prismicio/simulator": "^0.1.4",
         "@prismicio/types-internal": "2.0.0-beta.1",
-        "@slicemachine/plugin-kit": "0.4.1-dev-next-release.0",
+        "@slicemachine/plugin-kit": "0.4.1-dev-next-release.4",
         "common-tags": "^1.8.2",
         "fs-extra": "^11.1.0",
         "magicast": "^0.2.1",
@@ -45692,12 +45692,12 @@
     },
     "packages/init": {
       "name": "@slicemachine/init",
-      "version": "2.2.1-dev-next-release.0",
+      "version": "2.2.1-dev-next-release.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@antfu/ni": "^0.20.0",
         "@lihbr/listr-update-renderer": "^0.5.3",
-        "@slicemachine/manager": "0.4.1-dev-next-release.0",
+        "@slicemachine/manager": "0.4.1-dev-next-release.4",
         "chalk": "^4.1.2",
         "globby": "^13.1.3",
         "listr": "^0.14.3",
@@ -45712,7 +45712,7 @@
       },
       "devDependencies": {
         "@size-limit/preset-small-lib": "^8.2.4",
-        "@slicemachine/plugin-kit": "0.4.1-dev-next-release.0",
+        "@slicemachine/plugin-kit": "0.4.1-dev-next-release.4",
         "@types/listr": "^0.14.4",
         "@types/prompts": "^2.4.3",
         "@types/semver": "^7.3.13",
@@ -45768,14 +45768,14 @@
     },
     "packages/manager": {
       "name": "@slicemachine/manager",
-      "version": "0.4.1-dev-next-release.0",
+      "version": "0.4.1-dev-next-release.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@antfu/ni": "^0.20.0",
         "@prismicio/custom-types-client": "1.2.0-alpha.0",
         "@prismicio/mocks": "2.0.0-alpha.2",
         "@prismicio/types-internal": "2.0.0-beta.1",
-        "@slicemachine/plugin-kit": "0.4.1-dev-next-release.0",
+        "@slicemachine/plugin-kit": "0.4.1-dev-next-release.4",
         "@wooorm/starry-night": "^1.6.0",
         "analytics-node": "^6.2.0",
         "cookie": "^0.5.0",
@@ -46012,7 +46012,7 @@
     },
     "packages/plugin-kit": {
       "name": "@slicemachine/plugin-kit",
-      "version": "0.4.1-dev-next-release.0",
+      "version": "0.4.1-dev-next-release.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@prismicio/types-internal": "2.0.0-beta.1",
@@ -46052,7 +46052,7 @@
     },
     "packages/slice-machine": {
       "name": "slice-machine-ui",
-      "version": "1.2.1-dev-next-release.0",
+      "version": "1.2.1-dev-next-release.4",
       "license": "MIT",
       "dependencies": {
         "@extractus/oembed-extractor": "^3.1.8",
@@ -46061,7 +46061,7 @@
         "@prismicio/editor-ui": "0.4.2",
         "@prismicio/mocks": "2.0.0-alpha.2",
         "@prismicio/types-internal": "2.0.0-beta.1",
-        "@slicemachine/manager": "0.4.1-dev-next-release.0",
+        "@slicemachine/manager": "0.4.1-dev-next-release.4",
         "@vanilla-extract/css": "1.11.0",
         "clsx": "1.2.1",
         "fast-deep-equal": "^3.1.3",
@@ -46075,7 +46075,7 @@
         "puppeteer": "^19.11.0",
         "react": "^18.2.0",
         "semver": "^7.3.8",
-        "start-slicemachine": "0.9.1-dev-next-release.0",
+        "start-slicemachine": "0.9.1-dev-next-release.4",
         "yup": "^0.32.11"
       },
       "devDependencies": {
@@ -46173,10 +46173,10 @@
       "license": "MIT"
     },
     "packages/start-slicemachine": {
-      "version": "0.9.1-dev-next-release.0",
+      "version": "0.9.1-dev-next-release.4",
       "license": "Apache-2.0",
       "dependencies": {
-        "@slicemachine/manager": "0.4.1-dev-next-release.0",
+        "@slicemachine/manager": "0.4.1-dev-next-release.4",
         "body-parser": "^1.20.2",
         "chalk": "^4.1.2",
         "cors": "^2.8.5",

--- a/packages/slice-machine/src/hooks/useSMTracker.ts
+++ b/packages/slice-machine/src/hooks/useSMTracker.ts
@@ -75,6 +75,7 @@ async function trackPageView(): ReturnType<typeof telemetry.track> {
       : sliceMachineConfig.adapter.resolve;
   return telemetry.track({
     event: "page-view",
+    repository: sliceMachineConfig.repositoryName,
     url: window.location.href,
     path: window.location.pathname,
     search: window.location.search,


### PR DESCRIPTION
## Context

- Completes DT-1406: AAUser, in Slice Machine I can see the repository information in the events tracked

## The Solution

- Read the repositoryName from slice machine config (json file) and sent it to the manager, so it's send to Segment

## Impact / Dependencies

- It's required to have the repositoryName property in slice machine config (json file) but it's the case now so no impact 

## Checklist before requesting a review
- [x] I hereby declare my code ready for review.
- [ ] If it is a critical feature, I have added tests.
- [ ] The CI is successful.
- [ ] If there could backward compatibility issues, it has been discussed and planned.