### PR TITLE
chore(dev): Fix tracking sent to Prod instead of Dev when working as a contributor

### DIFF
--- a/e2e-projects/next/package.json
+++ b/e2e-projects/next/package.json
@@ -8,7 +8,7 @@
     "start": "next start",
     "lint": "next lint",
     "slicemachine": "start-slicemachine",
-    "slicemachine:dev": "NODE_ENV=development start-slicemachine"
+    "slicemachine:dev": "NODE_ENV=development SM_ENV=staging start-slicemachine"
   },
   "dependencies": {
     "@headlessui/react": "^1.5.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "prettier:check": "prettier --check .",
     "test": "lerna run test --stream",
     "test:e2e": "npm run cypress-setup && start-server-and-test 'npm run dev --prefix e2e-projects/cypress-next-app' http://localhost:3000 'SM_ENV=development ENABLE_SENTRY=false npm run slicemachine --prefix e2e-projects/cypress-next-app' http://localhost:9999 'cypress run'",
-    "test:e2e:dev": "npm run cypress-setup && start-server-and-test 'npm run dev --prefix e2e-projects/cypress-next-app' http://localhost:3000 'SM_ENV=development ENABLE_SENTRY=false npm run slicemachine --prefix e2e-projects/cypress-next-app' http://localhost:9999 'cypress open'",
+    "test:e2e:dev": "npm run cypress-setup && start-server-and-test 'npm run dev --prefix e2e-projects/cypress-next-app' http://localhost:3000 'SM_ENV=staging ENABLE_SENTRY=false npm run slicemachine --prefix e2e-projects/cypress-next-app' http://localhost:9999 'cypress open'",
     "::changeset": "npm run changeset add && git add .changeset && git commit -m '[release:changelog] update changeset'; echo 'We commited your changeset. You should defo push this master ✌️'",
     "::release": "manypkg check && npm run build && lerna publish && npm run run changeset",
     "bump:interactive": "lerna version prerelease --preid alpha --no-push --exact",


### PR DESCRIPTION
## Context

- Completes DT-1407 - Running "slicemachine:dev" to dev send tracker events to [Prod] SliceMachine

## The Solution

We need to always have SM_ENV to development to send the tracking to the correct location. I created a script, since with SM_ENV development you have env variables to declare

## Impact / Dependencies

- No impact

## Checklist before requesting a review
- [x] I hereby declare my code ready for review.
- [ ] If it is a critical feature, I have added tests.
- [x] The CI is successful.
- [ ] If there could backward compatibility issues, it has been discussed and planned.
