### PR TITLE
feat(adapter-next): mark generated Slice Simulator page as a Client Component

### DIFF
--- a/packages/adapter-next/src/hooks/project-init.ts
+++ b/packages/adapter-next/src/hooks/project-init.ts
@@ -264,6 +264,8 @@ const createSliceSimulatorPage = async ({
 	await fs.mkdir(path.dirname(filePath), { recursive: true });
 
 	let contents = source`
+		"use client"
+
 		import { SliceSimulator } from "@slicemachine/adapter-next/simulator";
 		import { SliceZone } from "@prismicio/react";
 

--- a/packages/adapter-next/test/plugin-project-init.test.ts
+++ b/packages/adapter-next/test/plugin-project-init.test.ts
@@ -815,7 +815,9 @@ describe("Slice Simulator route", () => {
 			);
 
 			expect(contents).toMatchInlineSnapshot(`
-				"import { SliceSimulator } from \\"@slicemachine/adapter-next/simulator\\";
+				"\\"use client\\";
+
+				import { SliceSimulator } from \\"@slicemachine/adapter-next/simulator\\";
 				import { SliceZone } from \\"@prismicio/react\\";
 
 				import { components } from \\"../../slices\\";
@@ -875,7 +877,9 @@ describe("Slice Simulator route", () => {
 			);
 
 			expect(contents).toMatchInlineSnapshot(`
-				"import { SliceSimulator } from \\"@slicemachine/adapter-next/simulator\\";
+				"\\"use client\\";
+
+				import { SliceSimulator } from \\"@slicemachine/adapter-next/simulator\\";
 				import { SliceZone } from \\"@prismicio/react\\";
 
 				import { components } from \\"../../slices\\";
@@ -966,7 +970,9 @@ describe("Slice Simulator route", () => {
 			);
 
 			expect(contents).toMatchInlineSnapshot(`
-				"import { SliceSimulator } from \\"@slicemachine/adapter-next/simulator\\";
+				"\\"use client\\";
+
+				import { SliceSimulator } from \\"@slicemachine/adapter-next/simulator\\";
 				import { SliceZone } from \\"@prismicio/react\\";
 
 				import { components } from \\"../../slices\\";
@@ -999,7 +1005,9 @@ describe("Slice Simulator route", () => {
 			);
 
 			expect(contents).toMatchInlineSnapshot(`
-				"import { SliceSimulator } from \\"@slicemachine/adapter-next/simulator\\";
+				"\\"use client\\";
+
+				import { SliceSimulator } from \\"@slicemachine/adapter-next/simulator\\";
 				import { SliceZone } from \\"@prismicio/react\\";
 
 				import { components } from \\"../slices\\";
@@ -1056,7 +1064,9 @@ describe("Slice Simulator route", () => {
 			);
 
 			expect(contents).toMatchInlineSnapshot(`
-				"import { SliceSimulator } from \\"@slicemachine/adapter-next/simulator\\";
+				"\\"use client\\";
+
+				import { SliceSimulator } from \\"@slicemachine/adapter-next/simulator\\";
 				import { SliceZone } from \\"@prismicio/react\\";
 
 				import { components } from \\"../slices\\";
@@ -1147,7 +1157,9 @@ describe("Slice Simulator route", () => {
 			);
 
 			expect(contents).toMatchInlineSnapshot(`
-				"import { SliceSimulator } from \\"@slicemachine/adapter-next/simulator\\";
+				"\\"use client\\";
+
+				import { SliceSimulator } from \\"@slicemachine/adapter-next/simulator\\";
 				import { SliceZone } from \\"@prismicio/react\\";
 
 				import { components } from \\"../slices\\";


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This PR fixes a bug in `@slicemachine/adapter-next` where the generated Slice Simulator page did not work by default when used in the App Router. The following error would appear:

```
- error Error: Functions cannot be passed directly to Client Components unless you explicitly expose it by marking it with "use server".
```

The error occurs because a function is passed to `<SliceSimulator>`'s `sliceZone` prop. `<SliceSimulator>` is a Client Component, which cannot accept function props from a Server Component [without specific handling](https://nextjs.org/docs/app/building-your-application/data-fetching/server-actions).

This PR fixes the issue by marking the Slice Simulator page as a Client Component, which should have no negative effect on the page. `<SliceSimulator>` was already correctly marked as a Client Component.

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->

🦧
