### PR TITLE
test(slice-machine-ui): remove slice simulator setup in e2e

### DIFF
--- a/cypress/e2e/customTypes/00-create.cy.js
+++ b/cypress/e2e/customTypes/00-create.cy.js
@@ -3,7 +3,7 @@ import { CUSTOM_TYPE_MODEL } from "../../consts";
 const customTypeName = "My Test";
 const customTypeId = "my_test";
 
-describe.skip("Custom Types specs", () => {
+describe("Custom Types specs", () => {
   beforeEach(() => {
     cy.setSliceMachineUserContext({});
     cy.clearProject();
@@ -61,13 +61,5 @@ describe.skip("Custom Types specs", () => {
     cy.get("#create-tab").contains("Save").click();
 
     cy.contains("Add a new slice").should("not.exist");
-  });
-
-  it("When creating a repeatable page-type it should add meta data tab", () => {
-    cy.createCustomType(customTypeId, customTypeName);
-    cy.contains("Metadata").click();
-    cy.contains("Meta Title");
-    cy.contains("Meta Description");
-    cy.contains("Meta Image");
   });
 });

--- a/cypress/e2e/slices/00-create.cy.js
+++ b/cypress/e2e/slices/00-create.cy.js
@@ -76,8 +76,6 @@ describe("Create Slices", () => {
 
     // simulator
 
-    simulatorPage.setup();
-
     sliceBuilder.openSimulator();
 
     cy.getInputByLabel("Description").first().clear();

--- a/cypress/e2e/slices/02-simulator-screenshots.cy.js
+++ b/cypress/e2e/slices/02-simulator-screenshots.cy.js
@@ -28,8 +28,6 @@ describe("I am an existing SM user and I want to take a screenshot from the slic
   });
 
   it("Open the simulator on the default variant", () => {
-    simulatorPage.setup();
-
     sliceBuilder.openSimulator();
 
     simulatorPage

--- a/cypress/e2e/user-flows/scenario_008_edit_mock_from_simulator.cy.js
+++ b/cypress/e2e/user-flows/scenario_008_edit_mock_from_simulator.cy.js
@@ -27,7 +27,6 @@ describe.skip("Scenario 008", () => {
       .addNewWidgetField("ImageField", "Image")
       .save();
 
-    simulatorPage.setup();
     sliceBuilder.openSimulator();
 
     // Wait for the editor to be fully loaded

--- a/cypress/fixtures/example.json
+++ b/cypress/fixtures/example.json
@@ -1,5 +1,0 @@
-{
-  "name": "Using fixtures to represent data",
-  "email": "hello@cypress.io",
-  "body": "Fixtures are a great way to mock data for responses to routes"
-}

--- a/cypress/helpers/customTypes.js
+++ b/cypress/helpers/customTypes.js
@@ -52,13 +52,13 @@ export function renameCustomType(id, actualName, newName) {
 
   customTypeRenameModal.root.should("be.visible");
   customTypeRenameModal.input.should("have.value", actualName);
-  customTypeRenameModal.input.clear().type(`${newName} - Edited`);
+  customTypeRenameModal.input.clear().type(newName);
   customTypeRenameModal.submit();
   customTypeRenameModal.root.should("not.exist");
 
-  customTypesList.getCustomTypeLabel(id).contains("Edited");
+  customTypesList.getCustomTypeRow(id).contains(newName);
 
-  cy.readFile(TYPES_FILE).should("contains", `${newName} - Edited`);
+  cy.readFile(TYPES_FILE).should("contains", newName);
   cy.readFile(CUSTOM_TYPE_MODEL(id)).then((model) => {
     expect(JSON.stringify(model)).to.contain(newName);
   });

--- a/cypress/pages/customTypes/customTypesList.js
+++ b/cypress/pages/customTypes/customTypesList.js
@@ -1,14 +1,14 @@
 class CustomTypesList {
   get emptyStateButton() {
-    return cy.get("[data-cy=empty-state-main-button]");
+    return cy.get("[data-cy=create-ct]");
   }
 
   getOptionDopDownButton(id) {
-    return this.getCustomTypeRow(id).get('[data-cy="edit-custom-type-menu"]');
+    return this.getCustomTypeRow(id).get('[data-testid="tableRowSettings"]');
   }
 
   get optionDopDownMenu() {
-    return cy.get('[data-cy="edit-custom-type-menu-dropdown"]');
+    return cy.get('[role="menu"][data-state="open"]');
   }
 
   get deleteButton() {
@@ -28,7 +28,7 @@ class CustomTypesList {
   }
 
   goTo() {
-    cy.visit("/");
+    cy.visit("/custom-types");
     return this;
   }
 }

--- a/cypress/pages/simulator/simulatorPage.js
+++ b/cypress/pages/simulator/simulatorPage.js
@@ -30,22 +30,6 @@ class SimulatorPage {
   }
 
   /**
-   * Setup the slice simulator in the example project, and stub the window open
-   * event to open in the same page.
-   */
-  setup() {
-    cy.readFile(MANIFEST_FILE, "utf-8").then((json) => {
-      const data = {
-        ...json,
-        localSliceSimulatorURL: "http://localhost:3000/slice-simulator",
-      };
-      return cy.writeFile(MANIFEST_FILE, JSON.stringify(data, null, 2));
-    });
-
-    return this;
-  }
-
-  /**
    * Use the screen size dropdown menu to change the simulator screen size.
    *
    * @param {string} startValue The expected start value of the dropdown button.

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "prettier:fix": "prettier --write .",
     "prettier:check": "prettier --check .",
     "test": "yarn workspaces foreach --parallel --topological-dev --verbose run test",
-    "test:e2e": "yarn cypress-setup && start-server-and-test 'npm run dev --prefix e2e-projects/cypress-next-app' http://localhost:3000 'SM_ENV=development ENABLE_SENTRY=false npm run slicemachine --prefix e2e-projects/cypress-next-app' http://localhost:9999 'cypress run'",
+    "test:e2e": "yarn cypress-setup && start-server-and-test 'npm run dev --prefix e2e-projects/cypress-next-app' http://localhost:3000 'SM_ENV=development ENABLE_SENTRY=false npm run slicemachine --prefix e2e-projects/cypress-next-app' http://localhost:9999 'cypress run --browser chromium'",
     "test:e2e:dev": "yarn cypress-setup && start-server-and-test 'npm run dev --prefix e2e-projects/cypress-next-app' http://localhost:3000 'SM_ENV=staging ENABLE_SENTRY=false npm run slicemachine --prefix e2e-projects/cypress-next-app' http://localhost:9999 'cypress open'",
     "cy:open": "cypress open",
     "bump:interactive": "lerna version prerelease --preid alpha --no-push --exact",


### PR DESCRIPTION
## Context

- https://linear.app/prismic/issue/DT-1471/[e2e]-remove-slice-simulator-setup-from-e2e-tests

When doing it I realised it was not a big effort to update selectors and enable the Custom Types test:
- https://linear.app/prismic/issue/DT-1470/[e2e]-restore-custom-types-rename-test


## The Solution


## Impact / Dependencies

- Tests only



## Checklist before requesting a review
- [x] I hereby declare my code ready for review.
- [ ] If it is a critical feature, I have added tests.
- [x] The CI is successful.
- [ ] If there could backward compatibility issues, it has been discussed and planned.

