### PR TITLE
feat(Changelog): Add information about the adapters update in the cha…

### DIFF
--- a/packages/manager/src/managers/SliceMachineManager.ts
+++ b/packages/manager/src/managers/SliceMachineManager.ts
@@ -14,7 +14,7 @@ import {
 
 import { createContentDigest } from "../lib/createContentDigest";
 
-import { PackageChangelog, PackageManager, SliceMachineConfig } from "../types";
+import { PackageManager, SliceMachineConfig } from "../types";
 import {
 	PrismicAuthManager,
 	PrismicUserProfile,
@@ -50,7 +50,6 @@ type SliceMachineManagerGetStateReturnType = {
 			localSliceSimulatorURL?: string;
 		};
 		repo: string;
-		changelog?: PackageChangelog;
 		packageManager: PackageManager;
 		supportsSliceSimulator: boolean;
 		endpoints: APIEndpoints;

--- a/packages/manager/src/managers/project/ProjectManager.ts
+++ b/packages/manager/src/managers/project/ProjectManager.ts
@@ -193,6 +193,27 @@ export class ProjectManager extends BaseManager {
 		return path.dirname(sliceMachinePackageJSONPath);
 	}
 
+	async getAdapterName(): Promise<string> {
+		const sliceMachineConfig = await this.getSliceMachineConfig();
+		const adapterName =
+			typeof sliceMachineConfig.adapter === "string"
+				? sliceMachineConfig.adapter
+				: sliceMachineConfig.adapter.resolve;
+
+		return adapterName;
+	}
+
+	async locateAdapterDir(): Promise<string> {
+		const projectRoot = await this.getRoot();
+		const adapterName = await this.getAdapterName();
+		const require = createRequire(path.join(projectRoot, "index.js"));
+		const adapterPackageJSONPath = require.resolve(
+			`${adapterName}/package.json`,
+		);
+
+		return path.dirname(adapterPackageJSONPath);
+	}
+
 	async initProject(args?: ProjectManagerInitProjectArgs): Promise<void> {
 		assertPluginsInitialized(this.sliceMachinePluginRunner);
 

--- a/packages/manager/src/managers/versions/VersionsManager.ts
+++ b/packages/manager/src/managers/versions/VersionsManager.ts
@@ -38,6 +38,41 @@ const detectVersionBumpKind = (
 	}
 };
 
+const filterStableVersions = (versions: string[]): string[] => {
+	return versions.filter((version) => {
+		// Exclude tagged versions (e.g. `1.0.0-alpha.0`).
+		// Exclude versions < 0.1.0 (e.g. `0.0.1`).
+		return (
+			/^[1-9]\d*\.\d+\.\d+$/.test(version) ||
+			/^\d+\.[1-9]\d*\.\d+$/.test(version)
+		);
+	});
+};
+
+const readPackageJSON = async (packageDir: string) => {
+	const packageJSONContents = await fs.readFile(
+		path.join(packageDir, "package.json"),
+		"utf8",
+	);
+
+	let packageJSON: unknown;
+	try {
+		packageJSON = JSON.parse(packageJSONContents);
+	} catch {
+		// noop
+	}
+
+	const { value, error } = decodePackageJSON(packageJSON);
+
+	if (error) {
+		throw new Error(
+			`Invalid ${packageDir} \`package.json\` file. ${error.errors.join(", ")}`,
+		);
+	}
+
+	return value;
+};
+
 type SliceMachineManagerGetReleaseNotesForVersionArgs = {
 	version: string;
 };
@@ -53,45 +88,16 @@ export class VersionsManager extends BaseManager {
 
 	async getRunningSliceMachineVersion(): Promise<string> {
 		const sliceMachineDir = await this.project.locateSliceMachineUIDir();
+		const packageJSON = await readPackageJSON(sliceMachineDir);
 
-		const sliceMachinePackageJSONContents = await fs.readFile(
-			path.join(sliceMachineDir, "package.json"),
-			"utf8",
-		);
-
-		let sliceMachinePackageJSON: unknown;
-		try {
-			sliceMachinePackageJSON = JSON.parse(sliceMachinePackageJSONContents);
-		} catch {
-			// noop
-		}
-
-		const { value, error } = decodePackageJSON(sliceMachinePackageJSON);
-
-		if (error) {
-			throw new Error(
-				`Invalid ${SLICE_MACHINE_NPM_PACKAGE_NAME} \`package.json\` file. ${error.errors.join(
-					", ",
-				)}`,
-			);
-		}
-
-		return value.version;
+		return packageJSON.version;
 	}
 
 	async getAllStableSliceMachineVersions(): Promise<string[]> {
 		const versions = await fetchNPMPackageVersions({
 			packageName: SLICE_MACHINE_NPM_PACKAGE_NAME,
 		});
-
-		const filteredVersions = versions.filter((version) => {
-			// Exclude tagged versions (e.g. `1.0.0-alpha.0`).
-			// Exclude versions < 0.1.0 (e.g. `0.0.1`).
-			return (
-				/^[1-9]\d*\.\d+\.\d+$/.test(version) ||
-				/^\d+\.[1-9]\d*\.\d+$/.test(version)
-			);
-		});
+		const filteredVersions = filterStableVersions(versions);
 
 		return semver.rsort(filteredVersions);
 	}
@@ -116,9 +122,33 @@ export class VersionsManager extends BaseManager {
 		return semver.maxSatisfying(versions, `^${currentVersion}`) ?? undefined;
 	}
 
-	async checkIsUpdateAvailable(): Promise<boolean> {
+	async checkIsSliceMachineUpdateAvailable(): Promise<boolean> {
 		const versions = await this.getAllStableSliceMachineVersions();
 		const currentVersion = await this.getRunningSliceMachineVersion();
+
+		return semver.gt(versions[0], currentVersion);
+	}
+
+	async getRunningAdapterVersion(): Promise<string> {
+		const adapterDir = await this.project.locateAdapterDir();
+		const value = await readPackageJSON(adapterDir);
+
+		return value.version;
+	}
+
+	async getAllStableAdapterVersions(): Promise<string[]> {
+		const adapterName = await this.project.getAdapterName();
+		const versions = await fetchNPMPackageVersions({
+			packageName: adapterName,
+		});
+		const filteredVersions = filterStableVersions(versions);
+
+		return semver.rsort(filteredVersions);
+	}
+
+	async checkIsAdapterUpdateAvailable(): Promise<boolean> {
+		const versions = await this.getAllStableAdapterVersions();
+		const currentVersion = await this.getRunningAdapterVersion();
 
 		return semver.gt(versions[0], currentVersion);
 	}

--- a/packages/manager/src/types.ts
+++ b/packages/manager/src/types.ts
@@ -1,23 +1,8 @@
 import { HookError, SliceMachinePluginOptions } from "@slicemachine/plugin-kit";
 import { detect as niDetect } from "@antfu/ni";
 
-import { VERSION_KIND } from "./constants/VERSION_KIND";
-
 export type PackageManager = NonNullable<Awaited<ReturnType<typeof niDetect>>>;
 export type { APIEndpoints } from "./constants/API_ENDPOINTS";
-
-export type PackageChangelog = {
-	currentVersion: string;
-	updateAvailable: boolean;
-	latestNonBreakingVersion: string | null;
-	versions: PackageVersion[];
-};
-
-export type PackageVersion = {
-	versionNumber: string;
-	releaseNote: string | null;
-	kind: (typeof VERSION_KIND)[keyof typeof VERSION_KIND] | undefined;
-};
 
 /**
  * A string, object, or instance representing a registered plugin.

--- a/packages/manager/test/SliceMachineManager-project-getAdapterName.test.ts
+++ b/packages/manager/test/SliceMachineManager-project-getAdapterName.test.ts
@@ -1,0 +1,27 @@
+import { expect, it } from "vitest";
+
+import { createTestPlugin } from "./__testutils__/createTestPlugin";
+import { createTestProject } from "./__testutils__/createTestProject";
+
+import { createSliceMachineManager } from "../src";
+
+it("returns the project's adapter namer", async () => {
+	const adapter = createTestPlugin();
+	const testSliceMachineConfig = {
+		repositoryName: "bar",
+		apiEndpoint: "baz",
+		adapter,
+		libraries: ["./qux"],
+		localSliceSimulatorURL: "quux",
+		plugins: ["corge"],
+	};
+	const cwd = await createTestProject(testSliceMachineConfig);
+	const manager = createSliceMachineManager({
+		nativePlugins: { [adapter.meta.name]: adapter },
+		cwd,
+	});
+
+	const adapterName = await manager.project.getAdapterName();
+
+	expect(adapterName).toEqual(adapter.meta.name);
+});

--- a/packages/manager/test/SliceMachineManager-project-locateAdapterDir.test.ts
+++ b/packages/manager/test/SliceMachineManager-project-locateAdapterDir.test.ts
@@ -1,0 +1,35 @@
+import { expect, it } from "vitest";
+import path from "node:path";
+
+import { createTestPlugin } from "./__testutils__/createTestPlugin";
+import { createTestProject } from "./__testutils__/createTestProject";
+import { mockAdapterDirectory } from "./__testutils__/mockAdapterDirectory";
+import { MOCK_BASE_DIRECTORY } from "./__setup__";
+
+import { createSliceMachineManager } from "../src";
+
+it("returns the path to the project's adapter directory", async (ctx) => {
+	const adapter = createTestPlugin();
+	const cwd = await createTestProject({ adapter });
+	const manager = createSliceMachineManager({
+		nativePlugins: { [adapter.meta.name]: adapter },
+		cwd,
+	});
+
+	const packageJSON = {
+		name: adapter.meta.name,
+		version: "1.0.0",
+	};
+
+	await mockAdapterDirectory({
+		ctx,
+		packageJSON,
+		adapterName: adapter.meta.name,
+	});
+
+	const adapterDir = await manager.project.locateAdapterDir();
+
+	expect(adapterDir).toBe(
+		path.dirname(`${MOCK_BASE_DIRECTORY}/${adapter.meta.name}/package.json`),
+	);
+});

--- a/packages/manager/test/SliceMachineManager-versions-checkIsAdapterUpdateAvailable.test.ts
+++ b/packages/manager/test/SliceMachineManager-versions-checkIsAdapterUpdateAvailable.test.ts
@@ -1,0 +1,64 @@
+import { expect, it } from "vitest";
+
+import { createTestPlugin } from "./__testutils__/createTestPlugin";
+import { createTestProject } from "./__testutils__/createTestProject";
+import { mockNPMRegistryAPI } from "./__testutils__/mockNPMRegistryAPI";
+import { mockAdapterDirectory } from "./__testutils__/mockAdapterDirectory";
+
+import { createSliceMachineManager } from "../src";
+
+it("returns true if an update is available", async (ctx) => {
+	const adapter = createTestPlugin();
+	const cwd = await createTestProject({ adapter });
+	const manager = createSliceMachineManager({
+		nativePlugins: { [adapter.meta.name]: adapter },
+		cwd,
+	});
+	const packageJSON = {
+		name: adapter.meta.name,
+		version: "1.0.0",
+	};
+
+	await mockAdapterDirectory({
+		ctx,
+		packageJSON,
+		adapterName: adapter.meta.name,
+	});
+
+	mockNPMRegistryAPI(ctx, {
+		packageName: adapter.meta.name,
+		versions: ["1.0.0", "2.0.0"],
+	});
+
+	const res = await manager.versions.checkIsAdapterUpdateAvailable();
+
+	expect(res).toStrictEqual(true);
+});
+
+it("returns false if an update is not available", async (ctx) => {
+	const adapter = createTestPlugin();
+	const cwd = await createTestProject({ adapter });
+	const manager = createSliceMachineManager({
+		nativePlugins: { [adapter.meta.name]: adapter },
+		cwd,
+	});
+	const packageJSON = {
+		name: adapter.meta.name,
+		version: "1.0.0",
+	};
+
+	await mockAdapterDirectory({
+		ctx,
+		packageJSON,
+		adapterName: adapter.meta.name,
+	});
+
+	mockNPMRegistryAPI(ctx, {
+		packageName: adapter.meta.name,
+		versions: ["1.0.0"],
+	});
+
+	const res = await manager.versions.checkIsAdapterUpdateAvailable();
+
+	expect(res).toStrictEqual(false);
+});

--- a/packages/manager/test/SliceMachineManager-versions-checkIsSliceMachineUpdateAvailable.test.ts
+++ b/packages/manager/test/SliceMachineManager-versions-checkIsSliceMachineUpdateAvailable.test.ts
@@ -24,7 +24,7 @@ it("returns true if an update is available", async (ctx) => {
 		versions: ["1.0.0", "2.0.0"],
 	});
 
-	const res = await manager.versions.checkIsUpdateAvailable();
+	const res = await manager.versions.checkIsSliceMachineUpdateAvailable();
 
 	expect(res).toStrictEqual(true);
 });
@@ -46,7 +46,7 @@ it("returns false if an update is not available", async (ctx) => {
 		versions: ["1.0.0"],
 	});
 
-	const res = await manager.versions.checkIsUpdateAvailable();
+	const res = await manager.versions.checkIsSliceMachineUpdateAvailable();
 
 	expect(res).toStrictEqual(false);
 });

--- a/packages/manager/test/SliceMachineManager-versions-getAllStableAdapterVersions.test.ts
+++ b/packages/manager/test/SliceMachineManager-versions-getAllStableAdapterVersions.test.ts
@@ -1,0 +1,43 @@
+import { expect, it } from "vitest";
+
+import { createTestPlugin } from "./__testutils__/createTestPlugin";
+import { createTestProject } from "./__testutils__/createTestProject";
+import { mockNPMRegistryAPI } from "./__testutils__/mockNPMRegistryAPI";
+
+import { createSliceMachineManager } from "../src";
+
+it("returns stable adapter versions", async (ctx) => {
+	const adapter = createTestPlugin();
+	const cwd = await createTestProject({ adapter });
+	const manager = createSliceMachineManager({
+		nativePlugins: { [adapter.meta.name]: adapter },
+		cwd,
+	});
+
+	mockNPMRegistryAPI(ctx, {
+		packageName: adapter.meta.name,
+		versions: [
+			"0.0.1",
+			"0.1.0",
+			"0.1.1",
+			"0.2.0",
+			"1.0.0",
+			"1.0.0-test.0",
+			"1.0.1",
+			"1.1.0",
+			"2.0.0",
+		],
+	});
+
+	const res = await manager.versions.getAllStableAdapterVersions();
+
+	expect(res).toStrictEqual([
+		"2.0.0",
+		"1.1.0",
+		"1.0.1",
+		"1.0.0",
+		"0.2.0",
+		"0.1.1",
+		"0.1.0",
+	]);
+});

--- a/packages/manager/test/SliceMachineManager-versions-getRunningAdapterVersion.test.ts
+++ b/packages/manager/test/SliceMachineManager-versions-getRunningAdapterVersion.test.ts
@@ -1,0 +1,31 @@
+import { expect, it } from "vitest";
+
+import { createTestPlugin } from "./__testutils__/createTestPlugin";
+import { createTestProject } from "./__testutils__/createTestProject";
+import { mockAdapterDirectory } from "./__testutils__/mockAdapterDirectory";
+
+import { createSliceMachineManager } from "../src";
+
+it("returns the version of the project's adapter", async (ctx) => {
+	const adapter = createTestPlugin();
+	const cwd = await createTestProject({ adapter });
+	const manager = createSliceMachineManager({
+		nativePlugins: { [adapter.meta.name]: adapter },
+		cwd,
+	});
+
+	const packageJSON = {
+		name: adapter.meta.name,
+		version: "1.0.0",
+	};
+
+	await mockAdapterDirectory({
+		ctx,
+		packageJSON,
+		adapterName: adapter.meta.name,
+	});
+
+	const version = await manager.versions.getRunningAdapterVersion();
+
+	expect(version).toBe(packageJSON.version);
+});

--- a/packages/manager/test/__setup__.ts
+++ b/packages/manager/test/__setup__.ts
@@ -97,8 +97,9 @@ vi.mock("fs/promises", async () => {
 	};
 });
 
-const MOCK_SLICE_MACHINE_PACKAGE_JSON_PATH =
-	"/foo/bar/baz/slice-machine-ui/package.json";
+export const MOCK_BASE_DIRECTORY = "/foo/bar/baz";
+
+const MOCK_SLICE_MACHINE_PACKAGE_JSON_PATH = `${MOCK_BASE_DIRECTORY}/baz/slice-machine-ui/package.json`;
 
 vi.mock("module", async () => {
 	const actual = (await vi.importActual(
@@ -115,6 +116,8 @@ vi.mock("module", async () => {
 				resolve: (id: string) => {
 					if (id === "slice-machine-ui/package.json") {
 						return MOCK_SLICE_MACHINE_PACKAGE_JSON_PATH;
+					} else if (id.startsWith("test-plugin-")) {
+						return `${MOCK_BASE_DIRECTORY}/${id}`;
 					}
 
 					return actualCreateRequire(id);

--- a/packages/manager/test/__testutils__/mockAdapterDirectory.ts
+++ b/packages/manager/test/__testutils__/mockAdapterDirectory.ts
@@ -1,0 +1,20 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { TestContext } from "vitest";
+import { MOCK_BASE_DIRECTORY } from "../__setup__";
+
+export const mockAdapterDirectory = async (args: {
+	ctx: TestContext;
+	packageJSON?: Record<string, unknown>;
+	adapterName: string;
+}): Promise<void> => {
+	const mockAdapterDirectory = path.dirname(
+		`${MOCK_BASE_DIRECTORY}/${args.adapterName}/package.json`,
+	);
+
+	await fs.mkdir(mockAdapterDirectory, { recursive: true });
+	await fs.writeFile(
+		path.posix.join(mockAdapterDirectory, "package.json"),
+		JSON.stringify(args.packageJSON ?? {}),
+	);
+};

--- a/packages/slice-machine/components/AppLayout/Navigation/index.test.tsx
+++ b/packages/slice-machine/components/AppLayout/Navigation/index.test.tsx
@@ -60,10 +60,17 @@ function renderApp({ canUpdate }: { canUpdate: boolean }): RenderReturnType {
           apiEndpoint: "https://foo.cdn.prismic.io/api/v2",
         },
         changelog: {
-          currentVersion: "",
-          updateAvailable: canUpdate,
-          latestNonBreakingVersion: null,
-          versions: [],
+          sliceMachine: {
+            currentVersion: "",
+            updateAvailable: canUpdate,
+            latestNonBreakingVersion: null,
+            versions: [],
+          },
+          adapter: {
+            name: "",
+            updateAvailable: canUpdate,
+            versions: [],
+          },
         },
       } as unknown as FrontEndEnvironment,
       userContext: {

--- a/packages/slice-machine/components/AppLayout/Navigation/index.tsx
+++ b/packages/slice-machine/components/AppLayout/Navigation/index.tsx
@@ -45,7 +45,9 @@ const Navigation: FC = () => {
   const repoDomain = new URL(apiEndpoint).hostname.replace(".cdn", "");
   const repoAddress = apiEndpoint.replace(".cdn.", ".").replace("/api/v2", "");
   const latestVersion =
-    changelog.versions.length > 0 ? changelog.versions[0] : null;
+    changelog.sliceMachine.versions.length > 0
+      ? changelog.sliceMachine.versions[0]
+      : null;
   const numberOfChanges = unSyncedSlices.length + unSyncedCustomTypes.length;
   const formattedNumberOfChanges = numberOfChanges > 9 ? "+9" : numberOfChanges;
   const displayNumberOfChanges = numberOfChanges !== 0 && isOnline;
@@ -64,7 +66,7 @@ const Navigation: FC = () => {
   ) => {
     setUpdatesViewed({
       latest: latestVersion && latestVersion.versionNumber,
-      latestNonBreaking: changelog.latestNonBreakingVersion,
+      latestNonBreaking: changelog.sliceMachine.latestNonBreakingVersion,
     });
     handleNavigation(event);
   };
@@ -134,7 +136,8 @@ const Navigation: FC = () => {
         </SideNavListItem>
       </SideNavList>
 
-      {changelog.updateAvailable && (
+      {(changelog.sliceMachine.updateAvailable ||
+        changelog.adapter.updateAvailable) && (
         <UpdateInfo
           href="/changelog"
           onClick={handleChangeLogNavigationFromUpdateBox}
@@ -160,7 +163,8 @@ const Navigation: FC = () => {
             onClick={handleNavigation}
             RightElement={
               <RightElement>
-                {changelog.currentVersion && `v${changelog.currentVersion}`}
+                {changelog.sliceMachine.currentVersion &&
+                  `v${changelog.sliceMachine.currentVersion}`}
               </RightElement>
             }
           />

--- a/packages/slice-machine/components/Changelog/index.tsx
+++ b/packages/slice-machine/components/Changelog/index.tsx
@@ -19,7 +19,7 @@ export default function Changelog() {
     })
   );
 
-  const latestVersion = changelog.versions[0];
+  const latestVersion = changelog.sliceMachine.versions[0];
 
   const [selectedVersion, setSelectedVersion] = useState<
     PackageVersion | undefined
@@ -41,11 +41,11 @@ export default function Changelog() {
         selectVersion={(version) => setSelectedVersion(version)}
       />
 
-      {changelog.versions.length === 0 || !selectedVersion ? (
+      {changelog.sliceMachine.versions.length === 0 || !selectedVersion ? (
         <Flex
           sx={{
-            width: "650px",
-            minWidth: "650px",
+            width: "754px",
+            minWidth: "754px",
             height: "100%",
             borderRight: "1px solid",
             borderColor: "grey01",

--- a/packages/slice-machine/components/Changelog/navigation/VersionBadge.tsx
+++ b/packages/slice-machine/components/Changelog/navigation/VersionBadge.tsx
@@ -7,14 +7,16 @@ interface VersionBadgeProps {
   isSelected: boolean;
   onClick: () => void;
   versionNumber: string;
-  tag: VersionTags | null;
+  tags: VersionTags[];
+  hasUpToDateVersions: boolean;
 }
 
 export const VersionBadge: React.FC<VersionBadgeProps> = ({
   isSelected,
   onClick,
   versionNumber,
-  tag,
+  tags,
+  hasUpToDateVersions,
 }) => {
   return (
     <Flex
@@ -39,7 +41,15 @@ export const VersionBadge: React.FC<VersionBadgeProps> = ({
       onClick={onClick}
     >
       <Text>{versionNumber}</Text>
-      {tag && <VersionTag type={tag} />}
+      <Flex
+        sx={{
+          gap: "8px",
+        }}
+      >
+        {tags.map((tag) => (
+          <VersionTag type={tag} hasUpToDateVersions={hasUpToDateVersions} />
+        ))}
+      </Flex>
     </Flex>
   );
 };

--- a/packages/slice-machine/components/Changelog/navigation/VersionTag.tsx
+++ b/packages/slice-machine/components/Changelog/navigation/VersionTag.tsx
@@ -3,9 +3,13 @@ import { VersionTags } from ".";
 
 interface VersionTagProps {
   type: VersionTags;
+  hasUpToDateVersions: boolean;
 }
 
-export const VersionTag: React.FC<VersionTagProps> = ({ type }) => (
+export const VersionTag: React.FC<VersionTagProps> = ({
+  type,
+  hasUpToDateVersions,
+}) => (
   <Text
     sx={{
       padding: "0px 4px",
@@ -19,10 +23,16 @@ export const VersionTag: React.FC<VersionTagProps> = ({ type }) => (
         bg: "grey02",
         color: "code.gray",
       }),
-      ...(type === VersionTags.Current && {
-        bg: "lightGreen",
-        color: "code.green",
-      }),
+      ...(type === VersionTags.Current &&
+        hasUpToDateVersions && {
+          bg: "lightGreen",
+          color: "code.green",
+        }),
+      ...(type === VersionTags.Current &&
+        !hasUpToDateVersions && {
+          bg: "lightOrange",
+          color: "code.orange",
+        }),
     }}
   >
     {type}

--- a/packages/slice-machine/components/Changelog/navigation/index.tsx
+++ b/packages/slice-machine/components/Changelog/navigation/index.tsx
@@ -21,19 +21,29 @@ export const Navigation: React.FC<NavigationProps> = ({
   selectVersion,
 }) => {
   const latestVersion: string | undefined =
-    changelog.versions[0]?.versionNumber;
+    changelog.sliceMachine.versions[0]?.versionNumber;
+  const hasUpToDateVersions =
+    !changelog.adapter.updateAvailable &&
+    !changelog.sliceMachine.updateAvailable;
 
-  function findVersionTag(versionNumber: string): VersionTags | null {
-    switch (versionNumber) {
-      case latestVersion:
-        return VersionTags.Latest;
-      case changelog.latestNonBreakingVersion:
-        return VersionTags.LatestNonBreaking;
-      case changelog.currentVersion:
-        return VersionTags.Current;
-      default:
-        return null;
+  function findVersionTags(versionNumber: string): VersionTags[] {
+    const tags = [];
+
+    // Display Latest or LatestNonBreaking tag
+    if (versionNumber === latestVersion) {
+      tags.push(VersionTags.Latest);
+    } else if (
+      versionNumber === changelog.sliceMachine.latestNonBreakingVersion
+    ) {
+      tags.push(VersionTags.LatestNonBreaking);
     }
+
+    // Display Current tag
+    if (versionNumber === changelog.sliceMachine.currentVersion) {
+      tags.push(VersionTags.Current);
+    }
+
+    return tags;
   }
 
   return (
@@ -84,7 +94,7 @@ export const Navigation: React.FC<NavigationProps> = ({
           overflow: "auto",
         }}
       >
-        {changelog.versions.map((version, index) => (
+        {changelog.sliceMachine.versions.map((version, index) => (
           <VersionBadge
             key={`versionBadge-${version.versionNumber}-${index}`}
             isSelected={
@@ -92,7 +102,8 @@ export const Navigation: React.FC<NavigationProps> = ({
             }
             onClick={() => selectVersion(version)}
             versionNumber={version.versionNumber}
-            tag={findVersionTag(version.versionNumber)}
+            tags={findVersionTags(version.versionNumber)}
+            hasUpToDateVersions={hasUpToDateVersions}
           />
         ))}
       </Flex>

--- a/packages/slice-machine/components/Changelog/versionDetails/UpdateCommandBox.tsx
+++ b/packages/slice-machine/components/Changelog/versionDetails/UpdateCommandBox.tsx
@@ -15,11 +15,21 @@ export const UpdateCommandBox: React.FC<UpdateCommandBoxProps> = ({
   selectedVersion,
   packageManager,
 }) => {
-  const isLatest =
-    selectedVersion.versionNumber === changelog.versions[0].versionNumber;
-  const version = isLatest ? "latest" : selectedVersion.versionNumber;
-  const packageSpec = `slice-machine-ui@${version}`;
-  const installCommand = getInstallCommand(packageManager, packageSpec);
+  const isLatestSliceMachineVersion =
+    selectedVersion.versionNumber ===
+    changelog.sliceMachine.versions[0].versionNumber;
+  const sliceMachineVersionToInstall = isLatestSliceMachineVersion
+    ? "latest"
+    : selectedVersion.versionNumber;
+  const packagesSpecs = getPackagesSpecs({
+    sliceMachineVersionToInstall,
+    isLatestSliceMachineVersion,
+    adapterName: changelog.adapter.name,
+  });
+  const installCommand = getInstallCommand(packageManager, packagesSpecs);
+  const isOnlyAdapterUpdate =
+    changelog.adapter.updateAvailable &&
+    !changelog.sliceMachine.updateAvailable;
 
   return (
     <Flex
@@ -39,6 +49,18 @@ export const UpdateCommandBox: React.FC<UpdateCommandBoxProps> = ({
       >
         How to install
       </Text>
+      {isOnlyAdapterUpdate && isLatestSliceMachineVersion && (
+        <Text
+          sx={{
+            fontSize: "12px",
+            fontWeight: 500,
+            lineHeight: "16px",
+          }}
+        >
+          It looks like you are using an outdated version of the adapter. Run
+          this command to update your adapter:
+        </Text>
+      )}
       <Flex
         sx={{
           gap: "8px",
@@ -63,18 +85,40 @@ export const UpdateCommandBox: React.FC<UpdateCommandBoxProps> = ({
 
 function getInstallCommand(
   packageManager: PackageManager,
-  packageSpec: string
+  packagesSpecs: string[]
 ): string {
+  const packagesSpecsStr = packagesSpecs.join(" ");
+
   switch (packageManager) {
     case "bun":
-      return `bun add --development ${packageSpec}`;
+      return `bun add --development ${packagesSpecsStr}`;
     case "npm":
-      return `npm install --save-dev ${packageSpec}`;
+      return `npm install --save-dev ${packagesSpecsStr}`;
     case "pnpm":
     case "pnpm@6":
-      return `pnpm add --save-dev ${packageSpec}`;
+      return `pnpm add --save-dev ${packagesSpecsStr}`;
     case "yarn":
     case "yarn@berry":
-      return `yarn add --dev ${packageSpec}`;
+      return `yarn add --dev ${packagesSpecsStr}`;
   }
+}
+
+type GetPackagesSpecsArgs = {
+  sliceMachineVersionToInstall: string;
+  isLatestSliceMachineVersion: boolean;
+  adapterName: string;
+};
+
+function getPackagesSpecs({
+  sliceMachineVersionToInstall,
+  isLatestSliceMachineVersion,
+  adapterName,
+}: GetPackagesSpecsArgs) {
+  const packagesSpecs = [`slice-machine-ui@${sliceMachineVersionToInstall}`];
+
+  if (isLatestSliceMachineVersion) {
+    packagesSpecs.push(`${adapterName}@latest`);
+  }
+
+  return packagesSpecs;
 }

--- a/packages/slice-machine/components/Changelog/versionDetails/index.tsx
+++ b/packages/slice-machine/components/Changelog/versionDetails/index.tsx
@@ -34,8 +34,8 @@ export const VersionDetails: React.FC<VersionDetailsProps> = ({
   return (
     <Flex
       sx={{
-        width: "650px",
-        minWidth: "650px",
+        width: "754px",
+        minWidth: "754px",
         height: "100%",
         borderRight: "1px solid",
         borderColor: "grey01",

--- a/packages/slice-machine/lib/models/common/versions.ts
+++ b/packages/slice-machine/lib/models/common/versions.ts
@@ -20,9 +20,20 @@ export interface ReleaseNote {
   draft: boolean;
 }
 
-export interface PackageChangelog {
+type SliceMachinePackageChangelog = {
   currentVersion: string;
-  updateAvailable: boolean;
   latestNonBreakingVersion: string | null;
+  updateAvailable: boolean;
   versions: PackageVersion[];
+};
+
+type AdapterPackageChangelog = {
+  name: string;
+  updateAvailable: boolean;
+  versions: string[];
+};
+
+export interface PackageChangelog {
+  sliceMachine: SliceMachinePackageChangelog;
+  adapter: AdapterPackageChangelog;
 }

--- a/packages/slice-machine/src/apiClient.ts
+++ b/packages/slice-machine/src/apiClient.ts
@@ -280,17 +280,23 @@ export const getChangelogApiClient = async (): Promise<PackageChangelog> => {
   const [
     currentVersion,
     latestNonBreakingVersion,
-    updateAvailable,
-    versionsWithKind,
+    sliceMachineUpdateAvailable,
+    sliceMachineVersionWithKind,
+    adapterUpdateAvailable,
+    adapterVersions,
+    adapterName,
   ] = await Promise.all([
     managerClient.versions.getRunningSliceMachineVersion(),
     managerClient.versions.getLatestNonBreakingSliceMachineVersion(),
-    managerClient.versions.checkIsUpdateAvailable(),
+    managerClient.versions.checkIsSliceMachineUpdateAvailable(),
     managerClient.versions.getAllStableSliceMachineVersionsWithKind(),
+    managerClient.versions.checkIsAdapterUpdateAvailable(),
+    managerClient.versions.getAllStableAdapterVersions(),
+    managerClient.project.getAdapterName(),
   ]);
 
-  const versionsWithMetadata = await Promise.all(
-    versionsWithKind.map(async (versionWithKind) => {
+  const sliceMachineVersionsWithMetadata = await Promise.all(
+    sliceMachineVersionWithKind.map(async (versionWithKind) => {
       const releaseNotes =
         await managerClient.versions.getSliceMachineReleaseNotesForVersion({
           version: versionWithKind.version,
@@ -305,10 +311,17 @@ export const getChangelogApiClient = async (): Promise<PackageChangelog> => {
   );
 
   return {
-    currentVersion,
-    updateAvailable,
-    latestNonBreakingVersion: latestNonBreakingVersion ?? null,
-    versions: versionsWithMetadata,
+    sliceMachine: {
+      currentVersion,
+      latestNonBreakingVersion: latestNonBreakingVersion ?? null,
+      updateAvailable: sliceMachineUpdateAvailable,
+      versions: sliceMachineVersionsWithMetadata,
+    },
+    adapter: {
+      name: adapterName,
+      updateAvailable: adapterUpdateAvailable,
+      versions: adapterVersions,
+    },
   };
 };
 

--- a/packages/slice-machine/src/modules/environment/index.ts
+++ b/packages/slice-machine/src/modules/environment/index.ts
@@ -82,10 +82,17 @@ export const selectIsSimulatorAvailableForFramework = (
 export const getChangelog = (store: SliceMachineStoreType) => {
   return (
     store.environment.changelog ?? {
-      currentVersion: "",
-      updateAvailable: false,
-      latestNonBreakingVersion: null,
-      versions: [],
+      sliceMachine: {
+        currentVersion: "",
+        updateAvailable: false,
+        latestNonBreakingVersion: null,
+        versions: [],
+      },
+      adapter: {
+        updateAvailable: false,
+        versions: [],
+        name: "",
+      },
     }
   );
 };

--- a/packages/slice-machine/test/pages/simulator.test.tsx
+++ b/packages/slice-machine/test/pages/simulator.test.tsx
@@ -114,7 +114,9 @@ describe.skip("simulator", () => {
       },
       environment: {
         changelog: {
-          currentVersion: "0.0.0",
+          sliceMachine: {
+            currentVersion: "0.0.0",
+          },
         },
         manifest: {
           localSliceSimulatorURL: "http://localhost:3000/slice-simulator",
@@ -287,7 +289,9 @@ describe.skip("simulator", () => {
     expect(SegmentClient.prototype.track).toHaveBeenCalledWith(
       expect.objectContaining({
         event: "SliceMachine Slice Simulator Open",
-        properties: { version: state.environment.changelog.currentVersion },
+        properties: {
+          version: state.environment.changelog.sliceMachine.currentVersion,
+        },
       }),
       expect.any(Function)
     );

--- a/packages/slice-machine/test/pages/slices.test.tsx
+++ b/packages/slice-machine/test/pages/slices.test.tsx
@@ -55,7 +55,9 @@ describe("slices", () => {
 
     const environment = {
       changelog: {
-        currentVersion: "0.0.1",
+        sliceMachine: {
+          currentVersion: "0.0.1",
+        },
       },
     };
 

--- a/packages/slice-machine/test/src/modules/__fixtures__/serverState.ts
+++ b/packages/slice-machine/test/src/modules/__fixtures__/serverState.ts
@@ -15,10 +15,17 @@ export const dummyServerState: Pick<
     },
     packageManager: "npm",
     changelog: {
-      currentVersion: "0.2.0",
-      latestNonBreakingVersion: "0.1.2",
-      updateAvailable: false,
-      versions: [],
+      sliceMachine: {
+        currentVersion: "0.2.0",
+        latestNonBreakingVersion: "0.1.2",
+        updateAvailable: false,
+        versions: [],
+      },
+      adapter: {
+        name: "test-adapter",
+        updateAvailable: false,
+        versions: [],
+      },
     },
     endpoints: {
       PrismicWroom: "https://prismic.io/",

--- a/packages/slice-machine/test/src/modules/environment.test.ts
+++ b/packages/slice-machine/test/src/modules/environment.test.ts
@@ -47,10 +47,17 @@ describe("[Environment module]", () => {
 
     it("should update the environment state given CHANGELOG.RESPONSE action", () => {
       const newChangeLog = {
-        currentVersion: "1.0.0",
-        updateAvailable: true,
-        latestNonBreakingVersion: "0.1.2",
-        versions: [],
+        sliceMachine: {
+          currentVersion: "1.0.0",
+          updateAvailable: true,
+          latestNonBreakingVersion: "0.1.2",
+          versions: [],
+        },
+        adapter: {
+          name: "test-adapter",
+          updateAvailable: true,
+          versions: [],
+        },
       };
       const action = getChangelogCreator.success({
         changelog: newChangeLog,
@@ -78,10 +85,17 @@ describe("[Environment module]", () => {
       } as SliceMachineStoreType;
       const result = getChangelog(sliceMachineStore);
       expect(result).toEqual({
-        currentVersion: "",
-        latestNonBreakingVersion: null,
-        updateAvailable: false,
-        versions: [],
+        sliceMachine: {
+          currentVersion: "",
+          latestNonBreakingVersion: null,
+          updateAvailable: false,
+          versions: [],
+        },
+        adapter: {
+          name: "",
+          updateAvailable: false,
+          versions: [],
+        },
       });
     });
   });


### PR DESCRIPTION
## Context

- Completes DT-1465

## The Solution

- Create new function in the managers to be able to get the required information
- Update the condition to display the warning in the Side Nav to take into account the Adapter
- Update the color of the CURRENT tag when necessary
- Add a warning when only the adapter need an update
- The command for latest SM version now always display the way to update adapter at the same time

## Left To Do

- Clean code
- Check for improvements
- Check more the testing part
- Wait for Benjamin design confirmation

## Impact / Dependencies

- User should now be able to easily update both Slice Machine and the adapter
- It's not perfect and confusing because here it creates an artificial link between an adapter and SM that could not exist in the future

## Checklist before requesting a review

- [x] I hereby declare my code ready for review.
- [ ] If it is a critical feature, I have added tests.
- [ ] The CI is successful.
- [ ] If there could backward compatibility issues, it has been discussed and planned.

## Preview

<img width="1054" alt="Screenshot 2023-07-13 at 00 29 09" src="https://github.com/prismicio/slice-machine/assets/19946868/8a2fa063-794b-45d2-a53a-def24cac2a92">

<img width="1093" alt="Screenshot 2023-07-13 at 00 28 57" src="https://github.com/prismicio/slice-machine/assets/19946868/0d83024f-2fec-4d9e-980c-10ea471f72ef">

<img width="1088" alt="Screenshot 2023-07-13 at 00 30 41" src="https://github.com/prismicio/slice-machine/assets/19946868/e91a766a-037a-4a27-994e-01e093486697">
