### PR TITLE
feat(SideNav): Add info in Changes menu item when user is disconnected

### DIFF
--- a/packages/slice-machine/components/AppLayout/Navigation/ChangesRightElement.tsx
+++ b/packages/slice-machine/components/AppLayout/Navigation/ChangesRightElement.tsx
@@ -1,0 +1,33 @@
+import { FC } from "react";
+
+import { useUnSyncChanges } from "@src/hooks/useUnSyncChanges";
+import { RightElement } from "@src/components/SideNav/SideNav";
+import { AuthStatus } from "@src/modules/userContext/types";
+import { useNetwork } from "@src/hooks/useNetwork";
+
+export const ChangesRightElement: FC = () => {
+  const isOnline = useNetwork();
+  const { unSyncedSlices, unSyncedCustomTypes, authStatus } =
+    useUnSyncChanges();
+  const numberOfChanges = unSyncedSlices.length + unSyncedCustomTypes.length;
+
+  if (
+    !isOnline ||
+    authStatus === AuthStatus.UNAUTHORIZED ||
+    authStatus === AuthStatus.FORBIDDEN
+  ) {
+    return <RightElement>Login required</RightElement>;
+  }
+
+  if (numberOfChanges === 0) {
+    return null;
+  }
+
+  const formattedNumberOfChanges = numberOfChanges > 9 ? "+9" : numberOfChanges;
+
+  return (
+    <RightElement type="pill" data-cy="changes-number">
+      {formattedNumberOfChanges}
+    </RightElement>
+  );
+};

--- a/packages/slice-machine/components/AppLayout/Navigation/index.test.tsx
+++ b/packages/slice-machine/components/AppLayout/Navigation/index.test.tsx
@@ -1,29 +1,40 @@
 // @vitest-environment jsdom
 import { describe, test, expect, vi } from "vitest";
+import Router from "next/router";
+import { act } from "react-dom/test-utils";
+import { createSliceMachineManagerMSWHandler } from "@slicemachine/manager/test";
+import { createSliceMachineManager } from "@slicemachine/manager";
+
+import { FrontEndEnvironment } from "@lib/models/common/Environment";
+import { UserContextStoreType } from "@src/modules/userContext/types";
+import { AuthStatus } from "@src/modules/userContext/types";
+import { createTestPlugin } from "test/__testutils__/createTestPlugin";
+import { createTestProject } from "test/__testutils__/createTestProject";
 import {
   render,
   within,
   screen,
   type RenderReturnType,
   waitFor,
-} from "../../../test/__testutils__";
+} from "test/__testutils__";
 import SideNavigation from "./index";
-import { FrontEndEnvironment } from "@lib/models/common/Environment";
-import { UserContextStoreType } from "@src/modules/userContext/types";
-import { act } from "react-dom/test-utils";
-import { createSliceMachineManagerMSWHandler } from "@slicemachine/manager/test";
-
-import Router from "next/router";
-import { createTestPlugin } from "test/__testutils__/createTestPlugin";
-import { createTestProject } from "test/__testutils__/createTestProject";
-import { createSliceMachineManager } from "@slicemachine/manager";
 import { cache } from "@prismicio/editor-support/Suspense";
 
 const mockRouter = vi.mocked(Router);
 
 vi.mock("next/router", () => import("next-router-mock"));
 
-function renderApp({ canUpdate }: { canUpdate: boolean }): RenderReturnType {
+type renderSideNavigationArgs = {
+  canUpdate: boolean;
+  hasChanges?: boolean;
+  authStatus?: AuthStatus;
+};
+
+function renderSideNavigation({
+  canUpdate,
+  hasChanges = false,
+  authStatus = AuthStatus.AUTHORIZED,
+}: renderSideNavigationArgs): RenderReturnType {
   return render(<SideNavigation />, {
     preloadedState: {
       availableCustomTypes: {},
@@ -52,7 +63,17 @@ function renderApp({ canUpdate }: { canUpdate: boolean }): RenderReturnType {
             },
           },
         ],
-        remoteSlices: [],
+        remoteSlices: hasChanges
+          ? [
+              {
+                name: "slices/a",
+                id: "a",
+                type: "SharedSlice",
+                variations: [],
+                description: "",
+              },
+            ]
+          : [],
       },
       environment: {
         repo: "foo",
@@ -75,6 +96,7 @@ function renderApp({ canUpdate }: { canUpdate: boolean }): RenderReturnType {
       } as unknown as FrontEndEnvironment,
       userContext: {
         hasSeenTutorialsToolTip: false,
+        authStatus: authStatus,
       } as unknown as UserContextStoreType,
     },
   });
@@ -83,10 +105,11 @@ function renderApp({ canUpdate }: { canUpdate: boolean }): RenderReturnType {
 describe("Side Navigation", () => {
   beforeEach(() => {
     cache.clear();
+    localStorage.clear();
   });
 
   test("Logo and repo area", async () => {
-    renderApp({ canUpdate: true });
+    renderSideNavigation({ canUpdate: true });
     expect(await screen.findByText("foo")).toBeVisible();
     expect(await screen.findByText("foo.prismic.io")).toBeVisible();
     const link = await screen.findByTitle("Open prismic repository");
@@ -95,12 +118,12 @@ describe("Side Navigation", () => {
   });
 
   test("Update box when update is available", async () => {
-    renderApp({ canUpdate: true });
+    renderSideNavigation({ canUpdate: true });
     expect(await screen.findByText("Updates Available")).toBeVisible();
   });
 
   test("Update box when there are no updates", async () => {
-    renderApp({ canUpdate: false });
+    renderSideNavigation({ canUpdate: false });
     const element = await act(() => screen.queryByText("Updates Available"));
     expect(element).toBeNull();
   });
@@ -118,7 +141,7 @@ describe("Side Navigation", () => {
   ])(
     "internal navigation links: when clicking title %s it should navigate to %s",
     async (title, path) => {
-      const { user } = renderApp({ canUpdate: true });
+      const { user } = renderSideNavigation({ canUpdate: true });
 
       await act(() => mockRouter.push("/"));
 
@@ -132,6 +155,95 @@ describe("Side Navigation", () => {
       expect(mockRouter.asPath).toBe(path);
     }
   );
+
+  test("should display the number of changes on the 'Changes' item", async () => {
+    renderSideNavigation({ canUpdate: true, hasChanges: true });
+
+    expect(await screen.findByText("Changes")).toBeVisible();
+    const changesItem = screen
+      .getByText("Changes")
+      .closest("a") as HTMLAnchorElement;
+
+    expect(within(changesItem).getByText("1")).toBeVisible();
+  });
+
+  test("should not display the number of changes or 'Disconnect' on the 'Changes' item", async () => {
+    renderSideNavigation({ canUpdate: true, hasChanges: false });
+
+    expect(await screen.findByText("Changes")).toBeVisible();
+    const changesItem = screen
+      .getByText("Changes")
+      .closest("a") as HTMLAnchorElement;
+
+    expect(within(changesItem).queryByText("1")).not.toBeInTheDocument();
+    expect(
+      within(changesItem).queryByText("Login required")
+    ).not.toBeInTheDocument();
+  });
+
+  test("should display the information that user is disconnected on the 'Changes' item when unauthorized", async () => {
+    renderSideNavigation({
+      canUpdate: true,
+      hasChanges: true,
+      authStatus: AuthStatus.UNAUTHORIZED,
+    });
+
+    expect(await screen.findByText("Changes")).toBeVisible();
+    const changesItem = screen
+      .getByText("Changes")
+      .closest("a") as HTMLAnchorElement;
+
+    expect(within(changesItem).getByText("Login required")).toBeVisible();
+  });
+
+  test("should display the information that user is disconnected on the 'Changes' item when forbidden", async () => {
+    renderSideNavigation({
+      canUpdate: true,
+      hasChanges: true,
+      authStatus: AuthStatus.FORBIDDEN,
+    });
+
+    expect(await screen.findByText("Changes")).toBeVisible();
+    const changesItem = screen
+      .getByText("Changes")
+      .closest("a") as HTMLAnchorElement;
+
+    expect(within(changesItem).getByText("Login required")).toBeVisible();
+  });
+
+  test("should display the information that user is disconnected on the 'Changes' item when offline", async () => {
+    vi.spyOn(navigator, "onLine", "get").mockReturnValueOnce(false);
+
+    renderSideNavigation({
+      canUpdate: true,
+      hasChanges: true,
+    });
+
+    expect(await screen.findByText("Changes")).toBeVisible();
+    const changesItem = screen
+      .getByText("Changes")
+      .closest("a") as HTMLAnchorElement;
+
+    expect(within(changesItem).getByText("Login required")).toBeVisible();
+  });
+
+  test("should not display the information that user is disconnected when user is online", async () => {
+    vi.spyOn(navigator, "onLine", "get").mockReturnValueOnce(true);
+
+    renderSideNavigation({
+      canUpdate: true,
+      hasChanges: true,
+    });
+
+    expect(await screen.findByText("Changes")).toBeVisible();
+    const changesItem = screen
+      .getByText("Changes")
+      .closest("a") as HTMLAnchorElement;
+
+    expect(
+      within(changesItem).queryByText("Login required")
+    ).not.toBeInTheDocument();
+  });
 
   test("Video Item with next", async (ctx) => {
     const adapter = createTestPlugin({
@@ -156,7 +268,7 @@ describe("Side Navigation", () => {
       })
     );
 
-    renderApp({ canUpdate: true });
+    renderSideNavigation({ canUpdate: true });
 
     const link = (await screen.findByText("Tutorial")).parentElement
       ?.parentElement as HTMLElement;
@@ -172,7 +284,7 @@ describe("Side Navigation", () => {
   });
 
   test("Video Item not next", async () => {
-    const { user } = renderApp({ canUpdate: true });
+    const { user } = renderSideNavigation({ canUpdate: true });
 
     const link = (await screen.findByText("Tutorial")).parentElement
       ?.parentElement as HTMLElement;

--- a/packages/slice-machine/components/AppLayout/Navigation/index.tsx
+++ b/packages/slice-machine/components/AppLayout/Navigation/index.tsx
@@ -3,8 +3,6 @@ import { useRouter } from "next/router";
 import { useSelector } from "react-redux";
 
 import VideoItem from "@components/AppLayout/Navigation/VideoItem";
-import { useNetwork } from "@src/hooks/useNetwork";
-import { useUnSyncChanges } from "@src/hooks/useUnSyncChanges";
 import { LightningIcon } from "@src/icons/Lightning";
 import { RadarIcon } from "@src/icons/RadarIcon";
 import { CUSTOM_TYPES_CONFIG } from "@src/features/customTypes/customTypesConfig";
@@ -28,6 +26,7 @@ import {
   getChangelog,
   getRepoName,
 } from "@src/modules/environment";
+import { ChangesRightElement } from "./ChangesRightElement";
 
 const Navigation: FC = () => {
   const { changelog, repoName, apiEndpoint, hasSeenTutorialsToolTip } =
@@ -37,8 +36,6 @@ const Navigation: FC = () => {
       apiEndpoint: getApiEndpoint(store),
       hasSeenTutorialsToolTip: userHasSeenTutorialsToolTip(store),
     }));
-  const isOnline = useNetwork();
-  const { unSyncedSlices, unSyncedCustomTypes } = useUnSyncChanges();
   const router = useRouter();
   const currentPath = router.asPath;
   const repoDomain = new URL(apiEndpoint).hostname.replace(".cdn", "");
@@ -47,9 +44,6 @@ const Navigation: FC = () => {
     changelog.sliceMachine.versions.length > 0
       ? changelog.sliceMachine.versions[0]
       : null;
-  const numberOfChanges = unSyncedSlices.length + unSyncedCustomTypes.length;
-  const formattedNumberOfChanges = numberOfChanges > 9 ? "+9" : numberOfChanges;
-  const displayNumberOfChanges = numberOfChanges !== 0 && isOnline;
   const { setUpdatesViewed, setSeenTutorialsToolTip } =
     useSliceMachineActions();
 
@@ -112,13 +106,7 @@ const Navigation: FC = () => {
             active={currentPath.startsWith("/changes")}
             onClick={handleNavigation}
             Icon={RadarIcon}
-            RightElement={
-              displayNumberOfChanges && (
-                <RightElement type="pill" data-cy="changes-number">
-                  {formattedNumberOfChanges}
-                </RightElement>
-              )
-            }
+            RightElement={<ChangesRightElement />}
           />
         </SideNavListItem>
 

--- a/packages/slice-machine/src/components/SideNav/SideNav.css.ts
+++ b/packages/slice-machine/src/components/SideNav/SideNav.css.ts
@@ -316,7 +316,7 @@ export const rightElementText = style([
     alignSelf: "baseline",
     fontSize: "12px",
     lineHeight: "16px",
-    maxWidth: "68px",
+    maxWidth: "82px",
   },
 ]);
 


### PR DESCRIPTION
## Context

- Completes DT-1503

## The Solution

- Create a new component, "ChangesRightElement" to better manage that information and the conditions
- Added tests for that
- Increase a bit the max-width so it fit 
  - The max-width is strictly for the ellipsis as you can see, so no problem to increase it
  - max-width depend on the text that still need to be validated

## Impact / Dependencies

- No impact

## Checklist before requesting a review
- [x] I hereby declare my code ready for review.
- [ ] If it is a critical feature, I have added tests.
- [ ] The CI is successful.
- [ ] If there could backward compatibility issues, it has been discussed and planned.

## Preview

![Screenshot 2023-07-20 at 17 25 50](https://github.com/prismicio/slice-machine/assets/19946868/26788eff-1802-46e9-8340-c08b673dc17f)

