### PR TITLE
refactor(eslint): disable existing eslint warnings & make CI fail on new warnings

### DIFF
--- a/packages/adapter-next/package.json
+++ b/packages/adapter-next/package.json
@@ -46,7 +46,7 @@
 		"build": "vite build",
 		"dev": "vite build --watch",
 		"format": "prettier --write .",
-		"lint": "eslint --ext .js,.ts .",
+		"lint": "eslint --max-warnings 0 --ext .js,.ts .",
 		"prepack": "$npm_execpath run build",
 		"size": "size-limit",
 		"test": "yarn lint && yarn types && yarn unit && yarn build && yarn size",

--- a/packages/adapter-nuxt/package.json
+++ b/packages/adapter-nuxt/package.json
@@ -46,7 +46,7 @@
 		"build": "vite build",
 		"dev": "vite build --watch",
 		"format": "prettier --write .",
-		"lint": "eslint --ext .js,.ts .",
+		"lint": "eslint --max-warnings 0 --ext .js,.ts .",
 		"prepack": "$npm_execpath run build",
 		"size": "size-limit",
 		"test": "yarn lint && yarn types && yarn unit && yarn build && yarn size",

--- a/packages/adapter-nuxt2/package.json
+++ b/packages/adapter-nuxt2/package.json
@@ -46,7 +46,7 @@
 		"build": "vite build",
 		"dev": "vite build --watch",
 		"format": "prettier --write .",
-		"lint": "eslint --ext .js,.ts .",
+		"lint": "eslint --max-warnings 0 --ext .js,.ts .",
 		"prepack": "$npm_execpath run build",
 		"size": "size-limit",
 		"test": "yarn lint && yarn types && yarn unit && yarn build && yarn size",

--- a/packages/init/package.json
+++ b/packages/init/package.json
@@ -40,7 +40,7 @@
 		"build": "vite build",
 		"dev": "vite build --watch",
 		"format": "prettier --write .",
-		"lint": "eslint --ext .js,.ts .",
+		"lint": "eslint --max-warnings 0 --ext .js,.ts .",
 		"prepack": "$npm_execpath run build",
 		"size": "size-limit",
 		"test": "yarn lint && yarn types && yarn unit && yarn build && yarn size",

--- a/packages/manager/package.json
+++ b/packages/manager/package.json
@@ -50,7 +50,7 @@
 		"build": "vite build",
 		"dev": "vite build --watch --mode development",
 		"format": "prettier --write .",
-		"lint": "eslint --ext .js,.ts .",
+		"lint": "eslint --max-warnings 0 --ext .js,.ts .",
 		"prepack": "$npm_execpath run build",
 		"size": "size-limit",
 		"test": "yarn lint && yarn types && yarn unit && yarn build && yarn size",

--- a/packages/plugin-kit/package.json
+++ b/packages/plugin-kit/package.json
@@ -35,7 +35,7 @@
 		"build": "vite build",
 		"dev": "vite build --watch",
 		"format": "prettier --write .",
-		"lint": "eslint --ext .js,.ts .",
+		"lint": "eslint --max-warnings 0 --ext .js,.ts .",
 		"prepack": "$npm_execpath run build",
 		"size": "size-limit",
 		"test": "yarn lint && yarn types && yarn unit && yarn build && yarn size",

--- a/packages/slice-machine/components/Button/index.tsx
+++ b/packages/slice-machine/components/Button/index.tsx
@@ -14,6 +14,7 @@ export interface SmButtonProps extends ButtonProps {
 
 // Small helper to allow us to target spinner and icon in the CY
 const cyIdBuilder = (dataCy: string | undefined, id: string) => {
+  // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
   if (dataCy) return `${dataCy}-${id}`;
   return "";
 };

--- a/packages/slice-machine/components/Card/CardBox.tsx
+++ b/packages/slice-machine/components/Card/CardBox.tsx
@@ -21,6 +21,7 @@ export const CardBox: FC<CardBoxProps> = ({
   <Box
     sx={{
       p: 4,
+      // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions, @typescript-eslint/prefer-nullish-coalescing
       bg: bg || background,
       ...(withRadius
         ? {

--- a/packages/slice-machine/components/Card/Default.jsx
+++ b/packages/slice-machine/components/Card/Default.jsx
@@ -31,12 +31,13 @@ const DefaultCard = ({
       >
         {HeaderContent}
         {
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+          // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions, @typescript-eslint/no-unsafe-assignment
           close ? <Close onClick={close} type="button" /> : null
         }
       </Flex>
     )}
     Footer={
+      // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
       FooterContent ? (
         <Flex sx={{ alignItems: "space-between", bg: "headSection", p: 3 }}>
           <Box sx={{ ml: "auto" }} />

--- a/packages/slice-machine/components/Card/Preview.jsx
+++ b/packages/slice-machine/components/Card/Preview.jsx
@@ -22,6 +22,7 @@ const PreviewCard = ({
         border: ({ colors }) => `2px solid ${colors.primary}`,
         boxShadow: "0 0 0 3px rgba(81, 99, 186, 0.2)",
       },
+      // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
       border: selected
         ? "2px solid rgba(81, 99, 186, 1)"
         : "2px solid rgba(81, 99, 186, 0.2)",

--- a/packages/slice-machine/components/Card/WithTabs/components.jsx
+++ b/packages/slice-machine/components/Card/WithTabs/components.jsx
@@ -34,6 +34,7 @@ export const CustomTab = ({ children, ...otherProps }) => {
         opacity: "0.8",
         transition: "all 150ms cubic-bezier(0.215,0.60,0.355,1)",
         borderRadius: "0",
+        // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
         ...(otherProps.selected
           ? {
               // eslint-disable-next-line @typescript-eslint/restrict-template-expressions

--- a/packages/slice-machine/components/Card/WithTabs/index.jsx
+++ b/packages/slice-machine/components/Card/WithTabs/index.jsx
@@ -31,7 +31,7 @@ const WithTabs = ({
       <Tabs defaultIndex={defaultIndex} onSelect={(i) => setCurrentIndex(i)}>
         <TabList>
           {
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, @typescript-eslint/strict-boolean-expressions
             (tabs || []).map((tab) => (
               <Tab
                 // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment

--- a/packages/slice-machine/components/Card/index.tsx
+++ b/packages/slice-machine/components/Card/index.tsx
@@ -39,6 +39,7 @@ const Card: React.FC<CardProps> = ({
     {SubHeader ? <SubHeader radius={radius} /> : null}
     <CardBox bg={bg} background={background} sx={bodySx} withRadius={!Footer}>
       {Body ? <Body /> : null}
+      {/* eslint-disable-next-line @typescript-eslint/strict-boolean-expressions */}
       {children ? children : null}
     </CardBox>
     {Footer ? (

--- a/packages/slice-machine/components/Changelog/index.tsx
+++ b/packages/slice-machine/components/Changelog/index.tsx
@@ -23,6 +23,7 @@ export default function Changelog() {
 
   const [selectedVersion, setSelectedVersion] = useState<
     PackageVersion | undefined
+    // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
   >(latestVersion || undefined);
 
   useEffect(() => {

--- a/packages/slice-machine/components/Changelog/versionDetails/index.tsx
+++ b/packages/slice-machine/components/Changelog/versionDetails/index.tsx
@@ -72,6 +72,7 @@ export const VersionDetails: React.FC<VersionDetailsProps> = ({
           gap: "24px",
         }}
       >
+        {/* eslint-disable-next-line @typescript-eslint/strict-boolean-expressions */}
         {selectedVersion.releaseNote?.includes("# Breaking Change") && (
           <Flex
             sx={{
@@ -96,6 +97,7 @@ export const VersionDetails: React.FC<VersionDetailsProps> = ({
           selectedVersion={selectedVersion}
           packageManager={packageManager}
         />
+        {/* eslint-disable-next-line @typescript-eslint/strict-boolean-expressions */}
         {selectedVersion?.releaseNote ? (
           <ReleaseNoteDetails releaseNote={selectedVersion.releaseNote} />
         ) : (

--- a/packages/slice-machine/components/CodeBlock/index.tsx
+++ b/packages/slice-machine/components/CodeBlock/index.tsx
@@ -13,6 +13,7 @@ const CodeBlock: React.FC<{
   Header?: React.FC;
 }> = ({ children, lang, sx, codeStyle, codeClass, Header }) => {
   const { theme } = useThemeUI();
+  // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
   const text = lang
     ? hljs.highlight(children, { language: lang === "vue" ? "html" : lang })
         .value
@@ -22,6 +23,7 @@ const CodeBlock: React.FC<{
     <Flex as="pre" sx={sx}>
       {Header ? <Header /> : null}
       <code
+        // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
         className={`hljs${codeClass ? ` ${codeClass}` : ""}`}
         style={{
           overflowX: "auto",

--- a/packages/slice-machine/components/ConfigErrors/index.jsx
+++ b/packages/slice-machine/components/ConfigErrors/index.jsx
@@ -38,7 +38,7 @@ const ConfigErrors = ({ errors }) => (
           </Text>
           <br />
           {
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/strict-boolean-expressions
             value.run ? (
               <Text mt={1}>
                 Try running:{" "}
@@ -53,7 +53,7 @@ const ConfigErrors = ({ errors }) => (
           }
 
           {
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-member-access
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/strict-boolean-expressions
             value.do ? <Text mt={1}>Todo: {value.do}</Text> : null
           }
         </Li>

--- a/packages/slice-machine/components/FormFields/Array.jsx
+++ b/packages/slice-machine/components/FormFields/Array.jsx
@@ -42,7 +42,7 @@ const FormFieldArray = ({
       >
         {label}
         {
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-member-access
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/strict-boolean-expressions
           meta.touched && meta.error ? (
             <Text as="span" variant="text.labelError">
               {
@@ -62,7 +62,7 @@ const FormFieldArray = ({
         render={(arrayHelpers) => (
           <div>
             {
-              // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-member-access
+              // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/strict-boolean-expressions
               field.value && field.value.length > 0
                 ? // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
                   field.value.map((opt, i) => (

--- a/packages/slice-machine/components/FormFields/Checkbox.jsx
+++ b/packages/slice-machine/components/FormFields/Checkbox.jsx
@@ -17,7 +17,7 @@ const FormFieldCheckbox = ({
         type="checkbox"
         // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
         name={fieldName}
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/strict-boolean-expressions
         onChange={() => onChange(!meta.value)}
         // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
         checked={meta.value}

--- a/packages/slice-machine/components/FormFields/CheckboxControl.jsx
+++ b/packages/slice-machine/components/FormFields/CheckboxControl.jsx
@@ -26,12 +26,12 @@ const CheckboxControl = ({
 }) => {
   // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-assignment
   const [isChecked, setCheck] = useState(
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/strict-boolean-expressions
     defaultValue || field.defaultValue || false
   );
 
   useEffect(() => {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, @typescript-eslint/strict-boolean-expressions
     buildControlledValue
       ? // eslint-disable-next-line @typescript-eslint/no-unsafe-call
         setControlledValue(buildControlledValue(controlledValue, isChecked))
@@ -50,7 +50,7 @@ const CheckboxControl = ({
       }}
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
       fieldName={field.name}
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/strict-boolean-expressions
       onChange={(value) => setCheck(value) && onChange && onChange(value)}
       label={
         // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call

--- a/packages/slice-machine/components/FormFields/Input.tsx
+++ b/packages/slice-machine/components/FormFields/Input.tsx
@@ -73,16 +73,20 @@ export const FormFieldInput = ({
   initialValues,
   isDisabled,
 }: FormFieldInputProps) => {
+  // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
   const style = meta.error
     ? InputFieldStyles.ERROR
-    : isDisabled || formField.disabled
+    : // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
+    isDisabled || formField.disabled
     ? InputFieldStyles.DISABLED
     : undefined;
 
   return (
     <Box sx={sx}>
       <Label variant="label.primary" htmlFor={fieldName}>
+        {/* eslint-disable-next-line @typescript-eslint/strict-boolean-expressions, @typescript-eslint/prefer-nullish-coalescing */}
         {formField.label || fieldName}
+        {/* eslint-disable-next-line @typescript-eslint/strict-boolean-expressions */}
         {meta.touched && meta.error ? (
           <Text as="span" variant="text.labelError">
             {meta.error}
@@ -93,6 +97,7 @@ export const FormFieldInput = ({
         id={fieldName}
         name={fieldName}
         type="text"
+        // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions, @typescript-eslint/prefer-nullish-coalescing
         placeholder={formField.placeholder || formField.label || fieldName}
         {...(formField.fieldLevelValidation && initialValues
           ? {
@@ -108,6 +113,7 @@ export const FormFieldInput = ({
         {...field}
         as={Input}
         sx={getInputFieldStyles(style)}
+        // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions, @typescript-eslint/prefer-nullish-coalescing
         disabled={isDisabled || formField.disabled}
       />
     </Box>

--- a/packages/slice-machine/components/FormFields/SelectDefaultValue.jsx
+++ b/packages/slice-machine/components/FormFields/SelectDefaultValue.jsx
@@ -4,7 +4,7 @@ import { useFormikContext } from "formik";
 import { FormFieldCheckbox } from "./";
 
 const SelectDefaultValue = ({ field, meta, helpers }) => {
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/strict-boolean-expressions
   const [isChecked, setCheck] = useState(field.defaultValue || false);
   const {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
@@ -12,7 +12,7 @@ const SelectDefaultValue = ({ field, meta, helpers }) => {
   } = useFormikContext();
 
   useEffect(() => {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/strict-boolean-expressions
     if (isChecked && options.length) {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
       helpers.setValue(options[0]);
@@ -20,13 +20,16 @@ const SelectDefaultValue = ({ field, meta, helpers }) => {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
       helpers.setValue("");
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isChecked]);
 
   useEffect(() => {
+    // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
     if (isChecked) {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
       helpers.setValue(options[0]);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [options]);
 
   return (
@@ -35,7 +38,7 @@ const SelectDefaultValue = ({ field, meta, helpers }) => {
       meta={meta}
       onChange={setCheck}
       label={`use first value as default ${
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/restrict-template-expressions, @typescript-eslint/no-unsafe-member-access
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/restrict-template-expressions, @typescript-eslint/strict-boolean-expressions
         options.length ? `("${options[0]}")` : ""
       }`}
     />

--- a/packages/slice-machine/components/Forms/CreateCustomTypeModal/CreateCustomTypeModal.tsx
+++ b/packages/slice-machine/components/Forms/CreateCustomTypeModal/CreateCustomTypeModal.tsx
@@ -129,6 +129,7 @@ export const CreateCustomTypeModal: React.FC<CreateCustomTypeModalProps> = ({
           errors.label = "Cannot be empty.";
         }
 
+        // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
         if (!errors.label && customTypeLabels.includes(label)) {
           errors.label = `${customTypesMessages.name({
             start: true,
@@ -140,10 +141,12 @@ export const CreateCustomTypeModal: React.FC<CreateCustomTypeModalProps> = ({
           errors.id = "ID cannot be empty.";
         }
 
+        // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
         if (!errors.id && id && !API_ID_REGEX.exec(id)) {
           errors.id = "Invalid id: No special characters allowed.";
         }
         if (
+          // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
           !errors.id &&
           id &&
           customTypeIds
@@ -176,6 +179,7 @@ export const CreateCustomTypeModal: React.FC<CreateCustomTypeModalProps> = ({
               start: false,
               plural: false,
             })}`}
+            // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
             error={touched.label ? errors.label : undefined}
             onChange={(e) => handleLabelChange(e, values, setValues)}
           />
@@ -187,6 +191,7 @@ export const CreateCustomTypeModal: React.FC<CreateCustomTypeModalProps> = ({
               plural: false,
             })} ID`}
             placeholder={customTypesMessages.inputPlaceholder}
+            // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
             error={touched.id ? errors.id : undefined}
             onChange={(e) => handleIdChange(e, setFieldValue)}
           />

--- a/packages/slice-machine/components/Forms/CreateSliceModal/CreateSliceModal.tsx
+++ b/packages/slice-machine/components/Forms/CreateSliceModal/CreateSliceModal.tsx
@@ -128,6 +128,7 @@ export const CreateSliceModal: FC<CreateSliceModalProps> = ({
             name="sliceName"
             label="Slice Name"
             placeholder="Pascalised Slice API ID (e.g. TextBlock)"
+            // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
             error={touched.sliceName ? errors.sliceName : undefined}
             dataCy="slice-name-input"
           />

--- a/packages/slice-machine/components/Forms/RenameSliceModal/RenameSliceModal.tsx
+++ b/packages/slice-machine/components/Forms/RenameSliceModal/RenameSliceModal.tsx
@@ -60,6 +60,7 @@ export const RenameSliceModal: React.FC<RenameSliceModalProps> = ({
             label="Slice Name"
             data-cy="slice-name-input"
             placeholder="Pascalised Slice API ID (e.g. TextBlock)"
+            // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
             error={touched.sliceName ? errors.sliceName : undefined}
             dataCy="slice-name-input"
           />

--- a/packages/slice-machine/components/Forms/components/InputBox.tsx
+++ b/packages/slice-machine/components/Forms/components/InputBox.tsx
@@ -30,10 +30,13 @@ export const InputBox: React.FunctionComponent<InputBoxProps> = ({
       as={Input}
       autoComplete="off"
       {...(onChange ? { onChange } : null)}
+      // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
       {...(dataCy ? { "data-cy": dataCy } : null)}
     />
+    {/* eslint-disable-next-line @typescript-eslint/strict-boolean-expressions */}
     {error ? (
       <Text
+        // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
         data-cy={dataCy ? `${dataCy}-error` : "input-error"}
         sx={{ color: "error", mt: 1 }}
       >

--- a/packages/slice-machine/components/Grid/index.tsx
+++ b/packages/slice-machine/components/Grid/index.tsx
@@ -28,6 +28,7 @@ function Grid<T>({
       }}
     >
       {elems.map((elem: T | undefined, i: number) =>
+        // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
         elem ? (
           <span key={`${defineElementKey(elem)}-${i + 1}`}>
             {renderElem(elem, i)}

--- a/packages/slice-machine/components/HTMLRenderer/index.tsx
+++ b/packages/slice-machine/components/HTMLRenderer/index.tsx
@@ -112,12 +112,14 @@ const HTMLRenderer = ({
 }: HTMLRendererProps): JSX.Element => {
   const parserOptions: HTMLReactParserOptions = {
     replace: (domNode) => {
+      // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
       if (domNode instanceof Element && domNode.attribs) {
         const children = domToReact(domNode.children, parserOptions);
 
         const resolvedComponents = { ...components, ...defaultComponents };
         const Comp = resolvedComponents[domNode.name];
 
+        // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
         if (Comp) {
           return (
             <Comp name={domNode.name} {...domNode.attribs}>

--- a/packages/slice-machine/components/KebabMenuDropdown/index.tsx
+++ b/packages/slice-machine/components/KebabMenuDropdown/index.tsx
@@ -35,6 +35,7 @@ export const KebabMenuDropdown: React.FC<KebabMenuDropdownProps> = ({
           <KebabMenuList
             menuOptions={menuOptions}
             closeMenu={() => setIsOpen(false)}
+            // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
             dataCy={dataCy && `${dataCy}-dropdown`}
           />
         )}

--- a/packages/slice-machine/components/ListItem/index.tsx
+++ b/packages/slice-machine/components/ListItem/index.tsx
@@ -102,7 +102,7 @@ function ListItem<F extends TabField, S extends AnyObjectSchema>({
                   >
                     <ItemHeader
                       theme={theme}
-                      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
+                      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/strict-boolean-expressions, @typescript-eslint/prefer-nullish-coalescing
                       text={config?.label || key}
                       sliceFieldName={
                         renderFieldAccessor && renderFieldAccessor(key)

--- a/packages/slice-machine/components/ListItem/utils.js
+++ b/packages/slice-machine/components/ListItem/utils.js
@@ -23,7 +23,7 @@ export const getDraggedDomPosition = (event) => {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
       .slice(0, sourceIndex)
       .reduce((total, curr) => {
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/strict-boolean-expressions
         const style = curr.currentStyle || window.getComputedStyle(curr);
         // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-member-access
         const marginBottom = parseFloat(style.marginBottom);

--- a/packages/slice-machine/components/ReviewModal/index.tsx
+++ b/packages/slice-machine/components/ReviewModal/index.tsx
@@ -80,8 +80,10 @@ const ReviewModal: React.FunctionComponent = () => {
     useSliceMachineActions();
 
   const sliceCount =
+    // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
     libraries && libraries.length
       ? libraries.reduce((count, lib) => {
+          // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
           if (!lib) return count;
           return count + lib.components.length;
         }, 0)
@@ -96,6 +98,7 @@ const ReviewModal: React.FunctionComponent = () => {
   );
 
   const hasPushedAnHourAgo = Boolean(
+    // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
     lastSyncChange && Date.now() - lastSyncChange >= 3600000
   );
 

--- a/packages/slice-machine/components/ScreenshotChangesModal/DropZone.tsx
+++ b/packages/slice-machine/components/ScreenshotChangesModal/DropZone.tsx
@@ -47,7 +47,9 @@ const DropZone: React.FC<DropZoneProps> = ({
     event.preventDefault();
     setIsDragActive(false);
     const maybeFile = event.dataTransfer.files?.[0];
+    // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
     if (maybeFile) {
+      // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
       if (imageTypes.find((t) => `image/${t}` === maybeFile.type)) {
         if (maybeFile.size > 128000000) {
           return openToaster(

--- a/packages/slice-machine/components/ScreenshotChangesModal/Views/index.tsx
+++ b/packages/slice-machine/components/ScreenshotChangesModal/Views/index.tsx
@@ -52,6 +52,7 @@ const VariationScreenshot: React.FC<{
   const { generateSliceCustomScreenshot } = useSliceMachineActions();
   const maybeScreenshot = slice.screenshots[variationID];
 
+  // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
   const ViewRenderer = maybeScreenshot
     ? viewRenderer[ScreenshotView.Default]
     : viewRenderer[ScreenshotView.EmptyState];
@@ -84,6 +85,7 @@ const VariationScreenshot: React.FC<{
             label={"Capture screenshot from Slice Simulator"}
           />
         ) : null}
+        {/* eslint-disable-next-line @typescript-eslint/strict-boolean-expressions */}
         {maybeScreenshot ? (
           <FileInputRenderer {...fileInputProps} isDragActive={false}>
             <>

--- a/packages/slice-machine/components/ScreenshotChangesModal/index.tsx
+++ b/packages/slice-machine/components/ScreenshotChangesModal/index.tsx
@@ -27,6 +27,7 @@ const VariationIcon: React.FC<{ isValid?: boolean }> = ({ isValid }) => (
       bg: "#FFF",
     }}
   >
+    {/* eslint-disable-next-line @typescript-eslint/strict-boolean-expressions */}
     {isValid ? (
       <AiOutlinePicture style={{ fontSize: "16px" }} />
     ) : (
@@ -97,6 +98,7 @@ const VariationsList = ({
                   alignItems: "center",
                 }}
               >
+                {/* eslint-disable-next-line @typescript-eslint/strict-boolean-expressions */}
                 <VariationIcon isValid={!!slice.screenshots[variation.id]} />
                 <Text sx={{ ml: 2 }}>{variation.name}</Text>
               </Flex>
@@ -112,6 +114,7 @@ const variationSetter = (
   defaultVariationSelector: SliceVariationSelector | undefined,
   slices: ComponentUI[]
 ) =>
+  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
   defaultVariationSelector ||
   (slices.length
     ? {
@@ -139,6 +142,7 @@ const ScreenshotChangesModal = ({
 
   useEffect(() => {
     setVariationSelector(variationSetter(defaultVariationSelector, slices));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [defaultVariationSelector, isOpen]);
 
   if (slices.length === 0 || !variationSelector) return null;

--- a/packages/slice-machine/components/ScreenshotChangesModal/useCustomScreenshot.tsx
+++ b/packages/slice-machine/components/ScreenshotChangesModal/useCustomScreenshot.tsx
@@ -33,6 +33,7 @@ const FileInputRenderer: React.FC<HandleFileProp> = ({
         flex: 1,
       }}
     >
+      {/* eslint-disable-next-line @typescript-eslint/strict-boolean-expressions, @typescript-eslint/prefer-nullish-coalescing */}
       {children || "Select file"}
     </Label>
     <input

--- a/packages/slice-machine/components/ScreenshotPreview/index.tsx
+++ b/packages/slice-machine/components/ScreenshotPreview/index.tsx
@@ -32,6 +32,7 @@ export const ScreenshotPreview: React.FC<ScreenshotPreviewProps> = ({
         ...sx,
       }}
     >
+      {/* eslint-disable-next-line @typescript-eslint/strict-boolean-expressions */}
       {hideMissingWarning ? null : src ? (
         <MemoedImage src={src} />
       ) : (

--- a/packages/slice-machine/components/Simulator/components/IframeRenderer/index.tsx
+++ b/packages/slice-machine/components/Simulator/components/IframeRenderer/index.tsx
@@ -67,6 +67,7 @@ const IframeRenderer: React.FunctionComponent<IframeRendererProps> = ({
     useSliceMachineActions();
 
   useEffect((): void => {
+    // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
     if (!simulatorUrl) {
       connectToSimulatorFailure();
       return;
@@ -93,6 +94,7 @@ const IframeRenderer: React.FunctionComponent<IframeRendererProps> = ({
       .catch(() => {
         connectToSimulatorFailure();
       });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [client, apiContent, simulatorUrl]);
 
   const [viewportSize, setViewportSize] = useState<ScreenDimensions>();
@@ -120,6 +122,7 @@ const IframeRenderer: React.FunctionComponent<IframeRendererProps> = ({
         ...(dryRun ? { display: "none" } : {}),
       }}
     >
+      {/* eslint-disable-next-line @typescript-eslint/strict-boolean-expressions */}
       {simulatorUrl ? (
         <iframe
           id="__iframe-renderer"
@@ -138,6 +141,7 @@ const IframeRenderer: React.FunctionComponent<IframeRendererProps> = ({
           }}
         />
       ) : null}
+      {/* eslint-disable-next-line @typescript-eslint/strict-boolean-expressions */}
       {client?.connected ? <div id="__iframe-ready" /> : null}
     </Flex>
   );

--- a/packages/slice-machine/components/Simulator/components/SetupModal/index.tsx
+++ b/packages/slice-machine/components/Simulator/components/SetupModal/index.tsx
@@ -37,6 +37,7 @@ const TitleCard: React.FC<{
         >
           <TextWithInlineCode>{title}</TextWithInlineCode>
         </Heading>
+        {/* eslint-disable-next-line @typescript-eslint/strict-boolean-expressions */}
         {excerpt && (
           <Text
             as="p"
@@ -85,6 +86,7 @@ const SetupModal: React.FC<{ isOpen: boolean }> = ({ isOpen }) => {
     })
   );
 
+  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
   const steps = setupSteps || [];
 
   useEffect(() => {

--- a/packages/slice-machine/components/Simulator/index.tsx
+++ b/packages/slice-machine/components/Simulator/index.tsx
@@ -75,11 +75,13 @@ const Simulator: ComponentWithSliceProps = ({ slice, variation }) => {
   }, [endpoints.PrismicOembed, endpoints.PrismicUnsplash]);
 
   const setupIntervalId = useRef<NodeJS.Timeout | null>(null);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   const checkSimulatorSetupCb = useCallback(() => checkSimulatorSetup(), []);
 
   useEffect(() => {
     checkSimulatorSetup();
     void telemetry.track({ event: "slice-simulator:open" });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const startedNewEditorSessionRef = useRef(false);
@@ -99,6 +101,7 @@ const Simulator: ComponentWithSliceProps = ({ slice, variation }) => {
       return UiState.FAILED_SETUP;
     }
     if (manifestStatus === "ok") {
+      // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
       if (isWaitingForIFrameCheck || !iframeStatus) {
         return UiState.LOADING_IFRAME;
       }
@@ -117,6 +120,7 @@ const Simulator: ComponentWithSliceProps = ({ slice, variation }) => {
       }, 3000);
       setupIntervalId.current = id;
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [currentState]);
 
   useEffect(() => {
@@ -126,6 +130,7 @@ const Simulator: ComponentWithSliceProps = ({ slice, variation }) => {
       }
       connectToSimulatorIframe();
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [manifestStatus]);
 
   useEffect(() => {
@@ -161,9 +166,11 @@ const Simulator: ComponentWithSliceProps = ({ slice, variation }) => {
     if (editorState?.variation === variation.id) return editorState;
 
     return (
+      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
       slice.mocks?.find((m) => m.variation === variation.id) ||
       defaultSharedSliceContent(variation.id)
     );
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [editorState, variation.id]);
 
   // this is temporary, it allows to retain the slice ID generated
@@ -176,6 +183,7 @@ const Simulator: ComponentWithSliceProps = ({ slice, variation }) => {
           [k: string]: unknown;
         }
       ).id,
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     []
   );
 
@@ -187,6 +195,7 @@ const Simulator: ComponentWithSliceProps = ({ slice, variation }) => {
       ...(renderSliceMock(sharedSlice, editorContent) as object),
       id: renderedSliceId,
     }),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [sharedSlice, editorContent]
   );
 
@@ -211,6 +220,7 @@ const Simulator: ComponentWithSliceProps = ({ slice, variation }) => {
           saveSliceMock({
             libraryID: slice.from,
             sliceID: slice.model.id,
+            // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
             mocks: (slice.mocks || [])
               .filter((mock) => mock.variation !== editorState.variation)
               .concat(editorState),
@@ -307,6 +317,7 @@ const Simulator: ComponentWithSliceProps = ({ slice, variation }) => {
           ) : null}
         </Flex>
       </Box>
+      {/* eslint-disable-next-line @typescript-eslint/strict-boolean-expressions */}
       {!!slice.screenshots[variation.id]?.url && (
         <ScreenshotPreviewModal
           sliceName={slice.model.name}

--- a/packages/slice-machine/components/SliceMachineIconButton/index.tsx
+++ b/packages/slice-machine/components/SliceMachineIconButton/index.tsx
@@ -3,6 +3,7 @@ import { IconButtonProps } from "@theme-ui/components";
 import { IconType } from "react-icons/lib";
 
 const defaultActiveSx = (active: boolean, hasError: boolean | null): object => {
+  // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
   if (hasError) {
     return {
       border: ({ colors }: { colors: Record<string, string> }) =>

--- a/packages/slice-machine/components/Tooltip/TextWithTooltip.tsx
+++ b/packages/slice-machine/components/Tooltip/TextWithTooltip.tsx
@@ -48,6 +48,7 @@ export const TextWithTooltip: React.FC<TextWithTooltipProps> = ({
       >
         {text}
       </Text>
+      {/* eslint-disable-next-line @typescript-eslint/strict-boolean-expressions */}
       {showTooltip && (
         <ReactTooltip
           id={text}

--- a/packages/slice-machine/components/WindowPortal/index.js
+++ b/packages/slice-machine/components/WindowPortal/index.js
@@ -5,7 +5,7 @@ import { createPortal } from "react-dom";
 function copyStyles(sourceDoc, targetDoc) {
   // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-member-access
   Array.from(sourceDoc.styleSheets).forEach((styleSheet) => {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-member-access
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/strict-boolean-expressions
     if (styleSheet.cssRules) {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment
       const newStyleEl = sourceDoc.createElement("style");
@@ -29,6 +29,7 @@ const WindowPortal = ({ children, onClose }) => {
   });
 
   const _onClose = () => {
+    // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
     if (win) {
       setTimeout(() => {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-call
@@ -44,6 +45,7 @@ const WindowPortal = ({ children, onClose }) => {
   }, []);
 
   useEffect(() => {
+    // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
     if (win) {
       copyStyles(document, win.document);
       // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
@@ -52,10 +54,11 @@ const WindowPortal = ({ children, onClose }) => {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-call
       win.addEventListener("beforeunload", _onClose);
       return () =>
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/strict-boolean-expressions
         (win && win.removeEventListener("beforeunload", _onClose)) ||
         _onClose();
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [win]);
   // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-argument
   return state.isAppended ? createPortal(children, state.container) : null;

--- a/packages/slice-machine/lib/builders/CustomTypeBuilder/SliceZone/List.tsx
+++ b/packages/slice-machine/lib/builders/CustomTypeBuilder/SliceZone/List.tsx
@@ -40,6 +40,7 @@ export const SlicesList: React.FC<SlicesListProps> = ({
         })} contains Slices that are incompatible.`,
         ToasterType.WARNING
       );
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [hasLegacySlices]);
 
   return (

--- a/packages/slice-machine/lib/builders/CustomTypeBuilder/SliceZone/index.tsx
+++ b/packages/slice-machine/lib/builders/CustomTypeBuilder/SliceZone/index.tsx
@@ -29,6 +29,7 @@ const mapAvailableAndSharedSlices = (
   sliceZone: SlicesSM,
   libraries: ReadonlyArray<LibraryUI> | null
 ) => {
+  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
   const availableSlices = (libraries || []).reduce<ReadonlyArray<ComponentUI>>(
     (acc, curr: LibraryUI) => {
       return [...acc, ...curr.components];
@@ -127,6 +128,7 @@ const SliceZone: React.FC<SliceZoneProps> = ({
         onRemoveSharedSlice(key);
       });
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [notFound]);
 
   const sharedSlicesInSliceZone = slicesInSliceZone

--- a/packages/slice-machine/lib/builders/CustomTypeBuilder/TabModal/create.tsx
+++ b/packages/slice-machine/lib/builders/CustomTypeBuilder/TabModal/create.tsx
@@ -25,6 +25,7 @@ const InputBox = ({
       as={Input}
       autoComplete="off"
     />
+    {/* eslint-disable-next-line @typescript-eslint/strict-boolean-expressions */}
     {error ? <Text sx={{ color: "error", mt: 1 }}>{error}</Text> : null}
   </Box>
 );

--- a/packages/slice-machine/lib/builders/CustomTypeBuilder/TabModal/update.tsx
+++ b/packages/slice-machine/lib/builders/CustomTypeBuilder/TabModal/update.tsx
@@ -34,6 +34,7 @@ const InputBox = ({
       autoComplete="off"
       {...rest}
     />
+    {/* eslint-disable-next-line @typescript-eslint/strict-boolean-expressions */}
     {error ? <Text sx={{ color: "error", mt: 1 }}>{error}</Text> : null}
   </Box>
 );

--- a/packages/slice-machine/lib/builders/CustomTypeBuilder/TabZone/index.tsx
+++ b/packages/slice-machine/lib/builders/CustomTypeBuilder/TabZone/index.tsx
@@ -55,6 +55,7 @@ const TabZone: React.FC<TabZoneProps> = ({
     poolOfFields: selectCurrentPoolOfFields(store),
   }));
 
+  // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
   if (!poolOfFields) {
     return null;
   }

--- a/packages/slice-machine/lib/builders/SliceBuilder/FieldZones/index.tsx
+++ b/packages/slice-machine/lib/builders/SliceBuilder/FieldZones/index.tsx
@@ -58,6 +58,7 @@ const FieldZones: React.FunctionComponent<FieldZonesProps> = ({
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       mockValue: any;
     }) => {
+      // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
       if (mockValue) {
         updateSliceWidgetMock(
           variation.id,
@@ -89,6 +90,7 @@ const FieldZones: React.FunctionComponent<FieldZonesProps> = ({
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       const widget = Widgets[widgetTypeName];
+      // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
       if (!widget) {
         console.log(
           `Could not find widget with type name "${widgetTypeName}". Please contact us!`
@@ -130,6 +132,7 @@ const FieldZones: React.FunctionComponent<FieldZonesProps> = ({
         onSave={_onSave(WidgetsArea.Primary)}
         onSaveNewField={_onSaveNewField(WidgetsArea.Primary)}
         onDragEnd={_onDragEnd(WidgetsArea.Primary)}
+        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
         poolOfFieldsToCheck={variation.primary || []}
         renderHintBase={({ item }) =>
           // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-member-access
@@ -157,6 +160,7 @@ const FieldZones: React.FunctionComponent<FieldZonesProps> = ({
         onSave={_onSave(WidgetsArea.Items)}
         onSaveNewField={_onSaveNewField(WidgetsArea.Items)}
         onDragEnd={_onDragEnd(WidgetsArea.Items)}
+        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
         poolOfFieldsToCheck={variation.items || []}
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment, @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-member-access
         renderHintBase={({ item }) => `item${transformKeyAccessor(item.key)}`}

--- a/packages/slice-machine/lib/builders/SliceBuilder/Header/VariationModal.tsx
+++ b/packages/slice-machine/lib/builders/SliceBuilder/Header/VariationModal.tsx
@@ -11,6 +11,7 @@ import { Text, Box, Button, Label, Input, Flex } from "theme-ui";
 
 const Error = ({ msg }: { msg?: string }) => (
   <Text as="span" sx={{ fontSize: 12, color: "error", mt: "5px", ml: 2 }}>
+    {/* eslint-disable-next-line @typescript-eslint/strict-boolean-expressions, @typescript-eslint/prefer-nullish-coalescing */}
     {msg || "Error!"}
   </Text>
 );
@@ -40,16 +41,19 @@ const VariationModal: React.FunctionComponent<{
     name?: string;
     origin: { value: string };
   }) {
+    // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
     const idError = !(id && id.length) ? { id: "Required!" } : null;
     const existingIdError = variations.find((v) => v.id === id)
       ? { id: "This id already exists!" }
       : null;
+    // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
     const nameError = !(name && name.length) ? { name: "Required!" } : null;
     const originError = !(
       origin.value.length && variations.find((v) => v.id === origin.value)
     )
       ? { id: "Yuu must select an existing variation!" }
       : null;
+    // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
     const invalidIdError = id &&
       id.length &&
       !/^[A-Za-z0-9]+([A-Za-z0-9]+)*$/.exec(id) && {
@@ -95,6 +99,7 @@ const VariationModal: React.FunctionComponent<{
 
   useEffect(() => {
     reset();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [initialVariation, isOpen]);
 
   // eslint-disable-next-line @typescript-eslint/require-await

--- a/packages/slice-machine/lib/builders/SliceBuilder/Header/VariationsPopover/index.tsx
+++ b/packages/slice-machine/lib/builders/SliceBuilder/Header/VariationsPopover/index.tsx
@@ -27,6 +27,7 @@ const VarationsPopover: React.FunctionComponent<{
 }) => {
   const [isOpen, setIsOpen] = useState(false);
   const [current, setCurrent] = useState<VariationSM>(
+    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     defaultValue || variations[0]
   );
 

--- a/packages/slice-machine/lib/builders/SliceBuilder/Header/index.tsx
+++ b/packages/slice-machine/lib/builders/SliceBuilder/Header/index.tsx
@@ -81,12 +81,14 @@ const Header: React.FC<{
               isSimulatorAvailableForFramework={
                 isSimulatorAvailableForFramework
               }
+              // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
               isTouched={!!isTouched}
             />,
             <Button
               key="header-save-button"
               label="Save to File System"
               isLoading={isLoading}
+              // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
               disabled={!isTouched || isLoading}
               onClick={onSave}
               Icon={AiFillSave}

--- a/packages/slice-machine/lib/builders/SliceBuilder/index.tsx
+++ b/packages/slice-machine/lib/builders/SliceBuilder/index.tsx
@@ -67,8 +67,10 @@ const SliceBuilder: ComponentWithSliceProps = ({ slice, variation }) => {
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       handleRemoteResponse(openToaster)(data);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [data]);
 
+  // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
   if (!variation) return null;
   else
     return (

--- a/packages/slice-machine/lib/builders/SliceBuilder/links.ts
+++ b/packages/slice-machine/lib/builders/SliceBuilder/links.ts
@@ -17,9 +17,11 @@ export function variation({
   all: [string, string, object];
 } {
   const href = `/[lib]/[sliceName]/[variation]${
+    // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
     isSimulator ? "/simulator" : ""
   }`;
   const as = `/${lib}/${sliceName}/${variationId}${
+    // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
     isSimulator ? "/simulator" : ""
   }`;
 

--- a/packages/slice-machine/lib/builders/common/EditModal/Field.jsx
+++ b/packages/slice-machine/lib/builders/common/EditModal/Field.jsx
@@ -31,6 +31,7 @@ const WidgetFormField = ({ fieldName, formField, fields, initialValues }) => {
           : null),
       }}
     >
+      {/* eslint-disable-next-line @typescript-eslint/strict-boolean-expressions */}
       {MaybeCustomComponent ? (
         <MaybeCustomComponent
           meta={meta}

--- a/packages/slice-machine/lib/builders/common/EditModal/Form.jsx
+++ b/packages/slice-machine/lib/builders/common/EditModal/Form.jsx
@@ -25,6 +25,7 @@ const WidgetForm = ({
           // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
           const withDefaultValues = Object.entries(rest).reduce(
             (acc, [key, value]) => {
+              // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
               if (typeof value !== Boolean && !value) {
                 // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
                 const maybeDefaultValue = FormFields[key]?.defaultValue;

--- a/packages/slice-machine/lib/builders/common/EditModal/index.jsx
+++ b/packages/slice-machine/lib/builders/common/EditModal/index.jsx
@@ -29,7 +29,7 @@ const FORM_ID = "edit-modal-form";
 const EditModal = ({ close, data, fields, onSave, zoneType }) => {
   const { theme } = useThemeUI();
 
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/strict-boolean-expressions
   if (!data.isOpen) {
     return null;
   }
@@ -47,6 +47,7 @@ const EditModal = ({ close, data, fields, onSave, zoneType }) => {
     initialModelValues.type
   );
 
+  // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
   if (!maybeWidget) {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-member-access
     return <div>{initialModelValues.type} not found</div>;
@@ -62,7 +63,7 @@ const EditModal = ({ close, data, fields, onSave, zoneType }) => {
   const initialConfig = {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
     ...createInitialValues(removeProp(FormFields, "id")),
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/strict-boolean-expressions
     ...(maybeWidget.prepareInitialValues
       ? // eslint-disable-next-line
         maybeWidget.prepareInitialValues(initialModelValues.config)
@@ -91,6 +92,7 @@ const EditModal = ({ close, data, fields, onSave, zoneType }) => {
     }
   })();
 
+  // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
   if (err) {
     console.error(
       // eslint-disable-next-line @typescript-eslint/restrict-template-expressions, @typescript-eslint/no-unsafe-member-access
@@ -102,7 +104,7 @@ const EditModal = ({ close, data, fields, onSave, zoneType }) => {
   const initialValues = {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
     id: apiId,
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/strict-boolean-expressions
     config: validatedSchema ? validatedSchema.config : initialConfig,
   };
 
@@ -161,6 +163,7 @@ const EditModal = ({ close, data, fields, onSave, zoneType }) => {
             initialValues,
           } = props;
 
+          // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
           const fieldModelTabContent = CustomForm ? (
             <CustomForm
               key="field-model-tab-content"
@@ -225,7 +228,7 @@ const EditModal = ({ close, data, fields, onSave, zoneType }) => {
                 >
                   <ItemHeader
                     theme={theme}
-                    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+                    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/strict-boolean-expressions
                     text={label || id}
                     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
                     WidgetIcon={WidgetIcon}
@@ -259,7 +262,7 @@ const EditModal = ({ close, data, fields, onSave, zoneType }) => {
                   <Button
                     form={formId}
                     type="submit"
-                    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+                    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/strict-boolean-expressions
                     disabled={!isValid && isSubmitting}
                     sx={{
                       fontWeight: "400",

--- a/packages/slice-machine/lib/builders/common/SelectFieldTypeModal/index.jsx
+++ b/packages/slice-machine/lib/builders/common/SelectFieldTypeModal/index.jsx
@@ -13,7 +13,7 @@ if (process.env.NODE_ENV !== "test") {
 }
 
 const SelectFieldTypeModal = ({ data, close, onSelect, widgetsArray }) => {
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/strict-boolean-expressions
   if (!data.isOpen) {
     return null;
   }
@@ -65,11 +65,11 @@ const SelectFieldTypeModal = ({ data, close, onSelect, widgetsArray }) => {
                 // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
                 const { Meta, TYPE_NAME, CUSTOM_NAME } = widget;
                 return (
-                  // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-assignment
+                  // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/strict-boolean-expressions
                   <Col key={CUSTOM_NAME || TYPE_NAME}>
                     <FieldTypeCard
                       {...Meta}
-                      // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-call
+                      // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-call, @typescript-eslint/strict-boolean-expressions
                       onSelect={() => onSelect(CUSTOM_NAME || TYPE_NAME)}
                     />
                   </Col>

--- a/packages/slice-machine/lib/builders/common/Zone/Card/components/ErrorTooltip.tsx
+++ b/packages/slice-machine/lib/builders/common/Zone/Card/components/ErrorTooltip.tsx
@@ -6,6 +6,7 @@ interface ErrorTooltip {
 }
 
 export const ErrorTooltip: React.FC<ErrorTooltip> = ({ error }) => {
+  // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
   if (error) {
     return (
       <>

--- a/packages/slice-machine/lib/builders/common/Zone/Card/components/Hints/CodeBlock.tsx
+++ b/packages/slice-machine/lib/builders/common/Zone/Card/components/Hints/CodeBlock.tsx
@@ -30,6 +30,7 @@ const CodeBlock: React.FC<CodeBlockProps> = ({ code, lang }) => {
   const [isCopied, setIsCopied] = useState(false);
 
   const copy = (): void => {
+    // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
     code &&
       void navigator.clipboard.writeText(code).then(() => {
         setIsCopied(true);
@@ -39,6 +40,7 @@ const CodeBlock: React.FC<CodeBlockProps> = ({ code, lang }) => {
       });
   };
 
+  // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
   return code ? (
     <Flex
       sx={{

--- a/packages/slice-machine/lib/builders/common/Zone/Card/components/Hints/index.tsx
+++ b/packages/slice-machine/lib/builders/common/Zone/Card/components/Hints/index.tsx
@@ -22,16 +22,20 @@ const Hint: React.FC<HintProps> = ({ show, renderHintBase, item }) => {
     });
   });
 
+  // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
   if (error) {
     console.error(error);
   }
 
+  // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
   if (!data || error) {
     return null;
   }
 
+  // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
   const snippets = data.snippets || [];
 
+  // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
   if (!snippets[0]) {
     return null;
   }

--- a/packages/slice-machine/lib/builders/common/Zone/Card/components/NewField.tsx
+++ b/packages/slice-machine/lib/builders/common/Zone/Card/components/NewField.tsx
@@ -55,6 +55,7 @@ const NewField: React.FC<NewField> = ({
   // @ts-expect-error We have to create a widget map or a service instead of using export name
   // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
   const widget: AnyWidget = Widgets[widgetTypeName];
+  // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
   if (!widget) {
     console.error(
       `Widget of type "${widgetTypeName}" not found. This is a problem on our side!`
@@ -86,6 +87,7 @@ const NewField: React.FC<NewField> = ({
       shouldValidate?: boolean
     ) => void
   ) => {
+    // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
     if (isIdFieldPristine && !FormFields.id.disabled) {
       setValues({
         ...values,
@@ -127,6 +129,7 @@ const NewField: React.FC<NewField> = ({
               ml: "34px",
               alignItems: "center",
               variant: "styles.listItem",
+              // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions, @typescript-eslint/prefer-nullish-coalescing
               border: (t) => `1px solid ${t.colors?.borders?.toString() || ""}`,
             }}
           >
@@ -170,9 +173,11 @@ const NewField: React.FC<NewField> = ({
                   as={RefInput}
                   innerRef={fieldRef}
                   sx={getInputFieldStyles(
+                    // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
                     FormFields.label.disabled
                       ? InputFieldStyles.DISABLED
-                      : errors.label
+                      : // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
+                      errors.label
                       ? InputFieldStyles.ERROR
                       : undefined
                   )}
@@ -203,9 +208,11 @@ const NewField: React.FC<NewField> = ({
                   }
                   as={RefInput}
                   sx={getInputFieldStyles(
+                    // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
                     FormFields.id.disabled
                       ? InputFieldStyles.DISABLED
-                      : errors.id
+                      : // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
+                      errors.id
                       ? InputFieldStyles.ERROR
                       : undefined
                   )}

--- a/packages/slice-machine/lib/builders/common/Zone/Card/index.jsx
+++ b/packages/slice-machine/lib/builders/common/Zone/Card/index.jsx
@@ -56,6 +56,7 @@ const FieldZone = ({
                 } = item;
                 // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-argument
                 const widget = findWidgetByConfigOrType(Widgets, config, type);
+                // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
                 if (!widget) {
                   return (
                     <Li>
@@ -92,6 +93,7 @@ const FieldZone = ({
                   isRepeatableCustomType,
                 };
 
+                // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
                 if (widget.CustomListItem) {
                   const { CustomListItem } = widget;
                   return <CustomListItem {...props} />;
@@ -108,7 +110,7 @@ const FieldZone = ({
                     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
                     renderHintBase={renderHintBase}
                     Widgets={Widgets}
-                    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+                    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/strict-boolean-expressions
                     typeName={widget.CUSTOM_NAME || widget.TYPE_NAME}
                   />
                 );

--- a/packages/slice-machine/lib/builders/common/Zone/index.jsx
+++ b/packages/slice-machine/lib/builders/common/Zone/index.jsx
@@ -76,7 +76,7 @@ const Zone = ({
       <ZoneHeader
         Heading={<Heading as="h6">{title}</Heading>}
         Actions={
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/strict-boolean-expressions
           fields.length ? (
             <Fragment>
               <Button
@@ -96,6 +96,7 @@ const Zone = ({
                 ml={2}
                 variant="buttons.darkSmall"
                 onClick={() => enterSelectMode()}
+                // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
                 data-cy={`add-${isRepeatable ? "Repeatable" : "Static"}-field`}
               >
                 <FaPlus
@@ -112,10 +113,11 @@ const Zone = ({
         }
       />
       {
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/strict-boolean-expressions
         !fields.length && !newFieldData && (
           <EmptyState
             onEnterSelectMode={() => enterSelectMode()}
+            // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
             zoneName={isRepeatable ? "Repeatable" : "Static"}
           />
         )
@@ -147,10 +149,11 @@ const Zone = ({
         // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
         isRepeatableCustomType={isRepeatableCustomType}
         newField={
+          // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
           newFieldData && (
             <NewField
               {...newFieldData}
-              // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-assignment
+              // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/strict-boolean-expressions
               fields={poolOfFieldsToCheck || fields}
               onSave={(...args) => {
                 // eslint-disable-next-line @typescript-eslint/no-unsafe-call

--- a/packages/slice-machine/lib/forms/fields.ts
+++ b/packages/slice-machine/lib/forms/fields.ts
@@ -75,6 +75,7 @@ export const Input = (
   defaultValue: string | undefined,
   placeholder: string
 ): InputType => {
+  // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
   const { min, max, required, matches } = conditions || {};
   return {
     type: FormTypes.INPUT,

--- a/packages/slice-machine/lib/forms/index.ts
+++ b/packages/slice-machine/lib/forms/index.ts
@@ -70,6 +70,7 @@ export const createValidationSchema = (FormFields: {
         .reduce((acc, [key, formField]) => {
           // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
           const { validate, yupType } = formField;
+          // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
           if (!validate) {
             return acc;
           }
@@ -84,9 +85,10 @@ export const createValidationSchema = (FormFields: {
           let validator = (Yup as any)[yupType]();
           // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
           Object.entries(validate)
+            // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
             .filter((e) => e && e[1])
             .forEach(([func, args]) => {
-              // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+              // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/strict-boolean-expressions
               if (args && validator[func]) {
                 // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
                 validator = validator[func](

--- a/packages/slice-machine/lib/models/common/ComponentUI.ts
+++ b/packages/slice-machine/lib/models/common/ComponentUI.ts
@@ -17,6 +17,7 @@ export const buildScreenshotUrls = (
   }
   return Object.entries(screenshots).reduce(
     (acc, [variationId, screenshot]) => {
+      // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
       return screenshot.hash
         ? {
             ...acc,
@@ -51,6 +52,7 @@ export const ComponentUI = {
     variationId?: string
   ): VariationSM | undefined {
     if (component.model.variations.length) {
+      // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
       if (variationId)
         return component.model.variations.find((v) => v.id === variationId);
       return component.model.variations[0];

--- a/packages/slice-machine/lib/models/common/CustomType/group.ts
+++ b/packages/slice-machine/lib/models/common/CustomType/group.ts
@@ -10,6 +10,7 @@ export const Group = {
       ...group,
       config: {
         ...group.config,
+        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
         fields: [...(group.config?.fields || []), newField],
       },
     };
@@ -19,6 +20,7 @@ export const Group = {
       ...group,
       config: {
         ...group.config,
+        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
         fields: (group.config?.fields || []).filter(({ key }) => key !== wkey),
       },
     };
@@ -29,6 +31,7 @@ export const Group = {
     if (!reorderedWidget)
       throw new Error(`Unable to reorder the widget at index ${start}.`);
 
+    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     const reorderedArea = (group.config?.fields || []).reduce<
       Array<{ key: string; value: NestableWidget }>
     >((acc, field, index) => {
@@ -61,6 +64,7 @@ export const Group = {
       ...group,
       config: {
         ...group.config,
+        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
         fields: (group.config?.fields || []).map((t) => {
           if (t.key === previousKey) {
             return {

--- a/packages/slice-machine/lib/models/common/CustomType/index.ts
+++ b/packages/slice-machine/lib/models/common/CustomType/index.ts
@@ -80,6 +80,7 @@ export type DeleteCustomTypeResponse =
 
 export const CustomType = {
   getSliceZones(ct: CustomTypeSM): ReadonlyArray<SlicesSM | null> {
+    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     return ct.tabs.map((t) => t.sliceZone || null);
   },
 };

--- a/packages/slice-machine/lib/models/common/CustomType/tab.ts
+++ b/packages/slice-machine/lib/models/common/CustomType/tab.ts
@@ -155,6 +155,7 @@ export const Tab = {
   reorderWidget(tab: TabSM, start: number, end: number): TabSM {
     const reorderedWidget: { key: string; value: TabField } | undefined =
       tab.value[start];
+    // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
     if (!reorderedWidget)
       throw new Error(`Unable to reorder the widget at index ${start}.`);
 

--- a/packages/slice-machine/lib/models/common/Group.ts
+++ b/packages/slice-machine/lib/models/common/Group.ts
@@ -56,6 +56,7 @@ export const Groups = {
     const fields = (() => {
       if (!group.config?.fields) return;
 
+      // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
       return Object.entries(group.config?.fields || {}).map(([key, value]) => ({
         key,
         value,

--- a/packages/slice-machine/lib/models/common/Library.ts
+++ b/packages/slice-machine/lib/models/common/Library.ts
@@ -26,10 +26,14 @@ export interface ComponentInfo {
 export const ComponentInfo = {
   hasPreviewsMissing(info: ComponentInfo): boolean {
     const { screenshots, model } = info;
+    // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
     if (!screenshots) return true;
-    return model.variations
-      .map((v) => v.id)
-      .some((variationId) => !screenshots[variationId]);
+    return (
+      model.variations
+        .map((v) => v.id)
+        // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
+        .some((variationId) => !screenshots[variationId])
+    );
   },
 };
 

--- a/packages/slice-machine/lib/models/common/Slice.ts
+++ b/packages/slice-machine/lib/models/common/Slice.ts
@@ -76,12 +76,14 @@ export const Variations = {
           variation.imageUrl === IMAGE_PLACEHOLDER_URL
             ? undefined
             : variation.imageUrl,
+        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
         primary: Object.entries(variation.primary || {}).map(
           ([key, value]) => ({
             key,
             value,
           })
         ),
+        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
         items: Object.entries(variation.items || {}).map(([key, value]) => ({
           key,
           value,

--- a/packages/slice-machine/lib/models/common/Slices.ts
+++ b/packages/slice-machine/lib/models/common/Slices.ts
@@ -42,6 +42,7 @@ export const SliceZone = {
     })(
       SlicesSM.decode({
         key,
+        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
         value: Object.entries(slices.config?.choices || []).map(
           ([key, value]) => ({ key, value })
         ),

--- a/packages/slice-machine/lib/models/common/Variation.ts
+++ b/packages/slice-machine/lib/models/common/Variation.ts
@@ -15,9 +15,12 @@ export const Variation = {
     start: number,
     end: number
   ): VariationSM {
+    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     const widgets = variation[widgetsArea] || [];
     const reorderedWidget: { key: string; value: NestableWidget } | undefined =
+      // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
       widgets && widgets[start];
+    // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
     if (!reorderedWidget)
       throw new Error(
         `Unable to reorder the widget at index ${start}. the list of widgets contains only ${widgets.length} elements.`
@@ -47,6 +50,7 @@ export const Variation = {
     newKey: string,
     newValue: NestableWidget
   ): VariationSM {
+    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     const widgets = variation[widgetsArea] || [];
 
     return {

--- a/packages/slice-machine/lib/models/common/widgets/ContentRelationship/Form.tsx
+++ b/packages/slice-machine/lib/models/common/widgets/ContentRelationship/Form.tsx
@@ -78,6 +78,7 @@ const WidgetForm = ({
             name="origin"
             options={options}
             onChange={(v) => {
+              // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
               if (v) {
                 void setFieldValue(
                   "config.customtypes",

--- a/packages/slice-machine/lib/models/common/widgets/Image/Form.tsx
+++ b/packages/slice-machine/lib/models/common/widgets/Image/Form.tsx
@@ -82,10 +82,13 @@ const thumbText = (
   } = {},
   allowAuto = false
 ) => {
+  // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
   if (allowAuto && !width && !height) {
     return "auto";
   }
+  // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
   if (width || height) {
+    // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
     return `${width ? width : "auto"}x${height ? height : "auto"}`;
   }
   return "...";
@@ -169,8 +172,11 @@ const Form: React.FC<FormProps> = (props) => {
                       error={
                         errors.thumbnails &&
                         touched.thumbnails &&
+                        // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
                         touched.thumbnails[i] &&
+                        // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
                         errors.thumbnails &&
+                        // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
                         errors.thumbnails[i]
                           ? true
                           : false

--- a/packages/slice-machine/lib/models/common/widgets/Select/FormFields.jsx
+++ b/packages/slice-machine/lib/models/common/widgets/Select/FormFields.jsx
@@ -10,12 +10,12 @@ import { FormFieldArray } from "@components/FormFields";
 
 const label = (controlledValue) =>
   `use first value as default ${
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/restrict-template-expressions, @typescript-eslint/no-unsafe-member-access
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/restrict-template-expressions, @typescript-eslint/strict-boolean-expressions
     controlledValue ? `("${controlledValue}")` : ""
   }`;
 
 const buildControlledValue = (controlledValue, isChecked) =>
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-member-access
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/strict-boolean-expressions
   isChecked ? controlledValue : undefined;
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
@@ -33,8 +33,9 @@ const FormFields = {
           // eslint-disable-next-line @typescript-eslint/no-unsafe-return
           return (
             value === undefined ||
+            // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
             (this.parent &&
-              // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+              // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/strict-boolean-expressions
               this.parent.options &&
               // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
               this.parent.options.find((e) => e === value))
@@ -72,7 +73,7 @@ const FormFields = {
         name: "non-empty values",
         message: "Values cannot be empty",
         test(value) {
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, @typescript-eslint/strict-boolean-expressions
           return !value.some((e) => !e || !e.length);
         },
       },

--- a/packages/slice-machine/lib/models/common/widgets/StructuredText/Form.tsx
+++ b/packages/slice-machine/lib/models/common/widgets/StructuredText/Form.tsx
@@ -14,6 +14,7 @@ import { AnyObject } from "yup/lib/types";
 import { isObject, isString } from "lodash";
 
 const isAllSet = (curr: Array<string>): boolean =>
+  // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
   !optionValues.find((e) => !curr.includes(e));
 
 const _createInitialOptions = (str: string) => {
@@ -50,16 +51,19 @@ function createValidator(key: "single" | "multi") {
         const val = getValueFromYupContext(ctx, key);
         const otherVal = getValueFromYupContext(ctx, other);
 
+        // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
         if (otherVal && typeof otherVal === "string") {
           return true;
         }
         if (typeof val !== "string") {
           return false;
         }
+        // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
         if ((!val || !val.length) && (!otherVal || !otherVal.length)) {
           return false;
         }
         const arr = val.split(",");
+        // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
         if (arr.find((e) => !optionValues.includes(e))) {
           return false;
         }
@@ -113,10 +117,13 @@ const WidgetForm: React.FC<{
     config: { single, multi },
   } = formValues;
 
+  // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
   const initialOptions = single
     ? _createInitialOptions(single)
-    : (multi && _createInitialOptions(multi)) || optionValues;
+    : // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
+      (multi && _createInitialOptions(multi)) || optionValues;
 
+  // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
   const [isMulti, setIsMulti] = useState(single ? false : true);
 
   const [acceptOptions, setAcceptOptions] = useState(initialOptions);
@@ -128,6 +135,7 @@ const WidgetForm: React.FC<{
       // prevent tests from failing for both values
       setFieldValue(accessors[1 - fieldNameIndex], undefined);
     }, 100);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isMulti, acceptOptions]);
 
   return (
@@ -182,6 +190,7 @@ const WidgetForm: React.FC<{
             }}
             active={acceptOptions.includes(opt.value)}
             onClick={() => {
+              // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
               if (acceptOptions.find((e) => e === opt.value)) {
                 return setAcceptOptions(
                   acceptOptions.filter((e) => e !== opt.value)
@@ -191,6 +200,7 @@ const WidgetForm: React.FC<{
             }}
           />
         ))}
+        {/* eslint-disable-next-line @typescript-eslint/strict-boolean-expressions */}
         {errors.config?.[isMulti ? "multi" : "single"] ? (
           <Box sx={{ position: "absolute" }}>
             <Text as="span" variant="text.labelError" pl={0}>

--- a/packages/slice-machine/lib/models/ui/Slice/index.tsx
+++ b/packages/slice-machine/lib/models/ui/Slice/index.tsx
@@ -242,6 +242,7 @@ export const SharedSlice = {
     const variationId = defaultVariation.id;
     const link = LinkUtil.variation(slice.href, slice.model.name, variationId);
 
+    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     const CardWrapper = Wrapper || WrapperByType[wrapperType];
 
     const screenshotUrl = slice.screenshots?.[variationId]?.url;
@@ -285,6 +286,7 @@ export const SharedSlice = {
                 borderRadius: "4px 4px 0 0",
               }}
             />
+            {/* eslint-disable-next-line @typescript-eslint/strict-boolean-expressions */}
             {showActions && !isDeleted(StatusOrCustom) ? (
               <ScreenshotMissingBanner slice={slice} />
             ) : null}
@@ -392,7 +394,7 @@ export const NonSharedSlice = {
             }}
           >
             <TextWithTooltip
-              // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
+              // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/strict-boolean-expressions
               text={slice?.value?.fieldset || slice.key}
               as="h6"
               sx={{

--- a/packages/slice-machine/lib/models/ui/Slice/wrappers.tsx
+++ b/packages/slice-machine/lib/models/ui/Slice/wrappers.tsx
@@ -12,6 +12,7 @@ export const LinkCardWrapper = ({
 }) => {
   //TODO: make the redirection through "connected-next-router" so that the router location is synched with redux
   return (
+    // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions, @typescript-eslint/prefer-nullish-coalescing
     <Link passHref href={link?.as || ""}>
       <ThemeLink
         sx={{

--- a/packages/slice-machine/lib/utils/index.ts
+++ b/packages/slice-machine/lib/utils/index.ts
@@ -30,6 +30,7 @@ export const ensureWidgetTypeExistence = (
 ) => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-explicit-any
   const widget: Widget<any, any> = Widgets[type];
+  // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
   if (!widget) {
     console.log(`Could not find widget with type name "${type}".`);
     return true;

--- a/packages/slice-machine/package.json
+++ b/packages/slice-machine/package.json
@@ -15,7 +15,7 @@
     "build": "cross-env NODE_OPTIONS=--max_old_space_size=8192 next build && next export",
     "dev": "next dev",
     "dev-cypress": "concurrently \"next dev\" \"npm run dev --prefix ../../e2e-projects/cypress-next-app\"",
-    "lint": "eslint --ext .ts,.tsx,.js,.jsx .",
+    "lint": "eslint --max-warnings 0 --ext .ts,.tsx,.js,.jsx .",
     "prepack": "$npm_execpath run build",
     "storybook": "storybook dev --no-open --port 6006",
     "storybook-build": "storybook build",
@@ -23,7 +23,7 @@
     "types": "tsc --noEmit",
     "unit": "vitest run --coverage",
     "unit:watch": "vitest watch",
-    "lint:precommit": "eslint",
+    "lint:precommit": "eslint --max-warnings 0",
     "depcheck": "depcheck --config=.depcheckrc",
     "audit": "yarn npm audit --environment production --severity high"
   },

--- a/packages/slice-machine/pages/_app.tsx
+++ b/packages/slice-machine/pages/_app.tsx
@@ -58,6 +58,7 @@ const RemoveDarkMode: FC<RemoveDarkModeProps> = ({ children }) => {
     if (setColorMode) {
       setColorMode("light");
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   return <>{children}</>;
@@ -105,6 +106,7 @@ function MyApp({
     setSMStore({ store, persistor });
   }, [serverState, smStore]);
 
+  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
   const ComponentLayout = Component.CustomLayout || SliceMachineApp;
 
   return (

--- a/packages/slice-machine/pages/slices.tsx
+++ b/packages/slice-machine/pages/slices.tsx
@@ -60,6 +60,7 @@ const SlicesIndex: React.FunctionComponent = () => {
     slices: frontendSlices,
   });
 
+  // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
   const slices = (libraries || []).map((l) => l.components).flat();
   const sliceCount = slices.length;
 
@@ -110,6 +111,7 @@ const SlicesIndex: React.FunctionComponent = () => {
                 : []
             }
           />
+          {/* eslint-disable-next-line @typescript-eslint/strict-boolean-expressions */}
           {sortedLibraries && (
             <Flex
               sx={{

--- a/packages/slice-machine/sentry.server.config.js
+++ b/packages/slice-machine/sentry.server.config.js
@@ -2,9 +2,11 @@
 
 import * as Sentry from "@sentry/nextjs";
 
+// eslint-disable-next-line @typescript-eslint/strict-boolean-expressions, @typescript-eslint/prefer-nullish-coalescing
 const SENTRY_DSN = process.env.SENTRY_DSN || process.env.NEXT_PUBLIC_SENTRY_DSN;
 
 Sentry.init({
+  // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions, @typescript-eslint/prefer-nullish-coalescing
   dsn: SENTRY_DSN || "",
   tracesSampleRate: 1.0,
 });

--- a/packages/slice-machine/src/features/customTypes/customTypesBuilder/CustomTypesBuilderPage.tsx
+++ b/packages/slice-machine/src/features/customTypes/customTypesBuilder/CustomTypesBuilderPage.tsx
@@ -92,6 +92,7 @@ const CustomTypesBuilderPageWithProvider: React.FC<
     () => {
       initCustomTypeStore(customType, remoteCustomType);
     },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [
       /* leave this empty to prevent local updates to disappear */
     ]

--- a/packages/slice-machine/src/hooks/useChangelog.ts
+++ b/packages/slice-machine/src/hooks/useChangelog.ts
@@ -7,5 +7,6 @@ export const useChangelog = () => {
 
   useEffect(() => {
     getChangelog();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 };

--- a/packages/slice-machine/src/hooks/useEditorContent.ts
+++ b/packages/slice-machine/src/hooks/useEditorContent.ts
@@ -14,6 +14,7 @@ function useEditorContentOnce({
 }) {
   return useMemo(() => {
     const editorContent: SharedSliceContent =
+      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
       slice.mocks?.find((m) => m.variation === variationID) ||
       defaultSharedSliceContent(variationID);
 

--- a/packages/slice-machine/src/hooks/useElementSize.ts
+++ b/packages/slice-machine/src/hooks/useElementSize.ts
@@ -18,5 +18,6 @@ export function useElementSize<E extends Element>(
       callback({ blockSize: height, inlineSize: width }, element);
     });
     resizeObserverRef.current.observe(element);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, deps);
 }

--- a/packages/slice-machine/src/hooks/useSMTracker.ts
+++ b/packages/slice-machine/src/hooks/useSMTracker.ts
@@ -25,6 +25,7 @@ const useSMTracker = () => {
 
     // For initial loading
     void trackPageView();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   // For handling page change

--- a/packages/slice-machine/src/hooks/useServerState.ts
+++ b/packages/slice-machine/src/hooks/useServerState.ts
@@ -8,6 +8,7 @@ import * as Sentry from "@sentry/nextjs";
 
 const useServerState = () => {
   const { refreshState } = useSliceMachineActions();
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   const handleRefreshState = useCallback(refreshState, []);
   const { data: serverState } = useSwr<ServerState>("getState", async () => {
     return await getState();

--- a/packages/slice-machine/src/hooks/useThrottle.ts
+++ b/packages/slice-machine/src/hooks/useThrottle.ts
@@ -19,6 +19,7 @@ function useThrottle<T>(
     return () => {
       clearTimeout(handler);
     };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [limit, ...args]);
 
   return throttledValue;

--- a/packages/slice-machine/src/hooks/useUnSyncChanges.ts
+++ b/packages/slice-machine/src/hooks/useUnSyncChanges.ts
@@ -65,11 +65,13 @@ export const useUnSyncChanges = (): UnSyncChanges => {
 
   const unSyncedSlices = components.filter(
     (component) =>
+      // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
       modelsStatuses.slices[component.model.id] &&
       unSyncStatuses.includes(modelsStatuses.slices[component.model.id])
   );
   const unSyncedCustomTypes = customTypes.filter(
     (customType) =>
+      // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
       modelsStatuses.customTypes[getModelId(customType)] &&
       unSyncStatuses.includes(
         modelsStatuses.customTypes[getModelId(customType)]

--- a/packages/slice-machine/src/models/slice/context.tsx
+++ b/packages/slice-machine/src/models/slice/context.tsx
@@ -40,6 +40,7 @@ export const SliceHandler: FC<Props> = ({ children }) => {
   const variation = (() => {
     if (!slice) {
       return undefined;
+      // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
     } else if (variationParam) {
       const maybeVariation = ComponentUI.variation(slice, variationParam);
       if (!maybeVariation) return ComponentUI.variation(slice);
@@ -59,6 +60,7 @@ export const SliceHandler: FC<Props> = ({ children }) => {
   //     void router.replace(`/${lib.name}/${slice.model.name}/${variation.id}`);
   // }, [lib, slice, variation, variationParam]);
 
+  // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
   if (!urlLib || !urlSliceName) {
     return <>{children}</>;
   }

--- a/packages/slice-machine/src/modules/selectedSlice/reducer.ts
+++ b/packages/slice-machine/src/modules/selectedSlice/reducer.ts
@@ -34,6 +34,7 @@ export const selectedSliceReducer: Reducer<
       return action.payload;
     }
     case getType(refreshStateCreator):
+      // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
       if (prevState === null || !action.payload.libraries) return prevState;
 
       const updatedSlice = action.payload.libraries

--- a/packages/slice-machine/src/modules/selectedSlice/selectors.ts
+++ b/packages/slice-machine/src/modules/selectedSlice/selectors.ts
@@ -7,6 +7,7 @@ export const selectSliceById = (
   libraryName: string,
   sliceId: string
 ) => {
+  // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
   const libraries = getLibraries(store) || [];
 
   const library = libraries.find((library) => library.name === libraryName);
@@ -30,6 +31,7 @@ export const selectCurrentSlice = (
   );
   const slice = library?.components.find((c) => c.model.name === sliceName);
 
+  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
   return slice || null;
 };
 

--- a/packages/slice-machine/src/modules/simulator/index.ts
+++ b/packages/slice-machine/src/modules/simulator/index.ts
@@ -133,6 +133,7 @@ export const simulatorReducer: Reducer<SimulatorStoreType, SimulatorActions> = (
     case getType(checkSimulatorSetupCreator.failure):
       return {
         ...state,
+        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
         setupSteps: action.payload.setupSteps || null,
         setupStatus: {
           ...state.setupStatus,
@@ -218,6 +219,7 @@ function* connectToSimulatorIframe() {
     timeout: delay(20000),
   });
 
+  // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
   if (iframeCheckOk) {
     yield put(connectToSimulatorIframeCreator.success());
     return;

--- a/packages/slice-machine/src/redux/store.ts
+++ b/packages/slice-machine/src/redux/store.ts
@@ -32,6 +32,7 @@ export default function configureStore(
   const composeEnhancers =
     process.env.NODE_ENV !== "production" &&
     typeof window === "object" &&
+    // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
     window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__
       ? // eslint-disable-next-line @typescript-eslint/no-unsafe-call
         window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__({

--- a/packages/slice-machine/src/utils/fieldNameCreator.ts
+++ b/packages/slice-machine/src/utils/fieldNameCreator.ts
@@ -10,7 +10,9 @@ export const createFriendlyFieldNameWithId = (fieldId: string): string => {
     .replace(
       /^([a-z])|([a-z][A-Z]+)/g,
       function (match: string, p1: string | undefined, p2: string | undefined) {
+        // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
         if (p2) return `${p2.slice(0, 1)} ${p2.slice(1, p2.length)}`;
+        // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
         if (p1) return p1.toUpperCase();
         return match;
       }

--- a/packages/start-slicemachine/package.json
+++ b/packages/start-slicemachine/package.json
@@ -43,7 +43,7 @@
 		"build": "vite build",
 		"dev": "vite build --watch --mode development",
 		"format": "prettier --write .",
-		"lint": "eslint --ext .js,.ts .",
+		"lint": "eslint --max-warnings 0 --ext .js,.ts .",
 		"prepack": "$npm_execpath run build",
 		"size": "size-limit",
 		"test": "yarn lint && yarn types && yarn unit && yarn build && yarn size",


### PR DESCRIPTION
## Context

- Completes DT-1521

## The Solution

- Used [eslint-interactive](https://github.com/mizdra/eslint-interactive)
- Added --max-warnings 0 to all eslint command

## Impact / Dependencies

- No warning 😌

## Checklist before requesting a review
- [x] I hereby declare my code ready for review.
- [ ] If it is a critical feature, I have added tests.
- [ ] The CI is successful.
- [ ] If there could backward compatibility issues, it has been discussed and planned.

## Preview

<img width="522" alt="Screenshot 2023-07-20 at 19 00 26" src="https://github.com/prismicio/slice-machine/assets/19946868/20d60fc0-22a5-4d34-ae07-4ab4d62d5ddd">

![Screenshot 2023-07-20 at 19 03 12](https://github.com/prismicio/slice-machine/assets/19946868/b560aecc-cff6-45b6-8a47-007d927e80ba)

