### PR TITLE
fix: toaster vanishing to quickly when saving a slice

### DIFF
--- a/packages/slice-machine/components/App/index.tsx
+++ b/packages/slice-machine/components/App/index.tsx
@@ -7,7 +7,6 @@ import { useRouter } from "next/router";
 import LoginModal from "@components/LoginModal";
 import ReviewModal from "@components/ReviewModal";
 import { MissingLibraries } from "@components/MissingLibraries";
-import ToastContainer from "@components/ToasterContainer";
 import { SliceHandler } from "@src/models/slice/context";
 import useServerState from "@src/hooks/useServerState";
 import { SliceMachineStoreType } from "@src/redux/type";
@@ -52,7 +51,6 @@ const SliceMachineApp: FC<Props> = ({ children }) => {
         </AppLayout>
         <LoginModal />
         <ReviewModal />
-        <ToastContainer />
       </BaseStyles>
     </div>
   );

--- a/packages/slice-machine/components/ToasterContainer/index.tsx
+++ b/packages/slice-machine/components/ToasterContainer/index.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect } from "react";
 
 import {
   ToastContainer as ReactToastifyContainer,
@@ -29,6 +29,10 @@ const getIconAccordingToasterType = ({
 };
 
 const ToastContainer: React.FunctionComponent = () => {
+  useEffect(() => {
+    console.log("TOAST MOUNTED");
+    return () => console.log("TOAST CONTAINER UNMOUNTED");
+  });
   return (
     <ReactToastifyContainer
       autoClose={2500}

--- a/packages/slice-machine/components/ToasterContainer/index.tsx
+++ b/packages/slice-machine/components/ToasterContainer/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React from "react";
 
 import {
   ToastContainer as ReactToastifyContainer,
@@ -29,10 +29,6 @@ const getIconAccordingToasterType = ({
 };
 
 const ToastContainer: React.FunctionComponent = () => {
-  useEffect(() => {
-    console.log("TOAST MOUNTED");
-    return () => console.log("TOAST CONTAINER UNMOUNTED");
-  });
   return (
     <ReactToastifyContainer
       autoClose={2500}

--- a/packages/slice-machine/pages/_app.tsx
+++ b/packages/slice-machine/pages/_app.tsx
@@ -39,6 +39,7 @@ import { normalizeFrontendCustomTypes } from "../lib/models/common/normalizers/c
 import Router from "next/router";
 
 import { NextPage } from "next";
+import ToastContainer from "@components/ToasterContainer";
 
 type NextPageWithLayout = NextPage & {
   CustomLayout?: React.FC<{ children: ReactNode }>;
@@ -120,17 +121,20 @@ function MyApp({
             {!smStore || !serverState ? (
               <LoadingPage />
             ) : (
-              <Provider store={smStore.store}>
-                <ConnectedRouter Router={Router}>
-                  <PersistGate loading={null} persistor={smStore.persistor}>
-                    <RouteChangeProvider>
-                      <ComponentLayout>
-                        <Component {...pageProps} />
-                      </ComponentLayout>
-                    </RouteChangeProvider>
-                  </PersistGate>
-                </ConnectedRouter>
-              </Provider>
+              <>
+                <Provider store={smStore.store}>
+                  <ConnectedRouter Router={Router}>
+                    <PersistGate loading={null} persistor={smStore.persistor}>
+                      <RouteChangeProvider>
+                        <ComponentLayout>
+                          <Component {...pageProps} />
+                        </ComponentLayout>
+                      </RouteChangeProvider>
+                    </PersistGate>
+                  </ConnectedRouter>
+                </Provider>
+                <ToastContainer />
+              </>
             )}
           </ThemeProvider>
         </RemoveDarkMode>


### PR DESCRIPTION
## Context
Toast was disappearing when saving a slice because it was being unmounted. move the ToastConainer further up in the component tree seems to have solved the issue.|

https://linear.app/prismic/issue/DT-1531/[spike-1-day]-slice-creation-notification-disappears-too-fast
<!--
Please include either
- a ticket
    - [Link text Here](https://link-url-here.org)

- a github issue / forum thread
    - Fixes #

- a detailed description of the issue and it's implications

This part should always include acceptance criteria weither they are accessible on a link or written here directly.
-->




## The Solution

<!--
Highlight explanations where the complexity in your development is.
Keep in mind that the reviewer might not have as much context as you do.
This is very important to make sure the review is thorough and the reviewer understand your changes.
-->




## Impact / Dependencies

<!--
List all the impacts your development might have on internal and external features.
Ideally this should have been discussed prior to this development.

Link of any other PRs that are related to this development.
They should also be referenced in the ticket for reviews.
-->




## Checklist before requesting a review
- [x] I hereby declare my code ready for review.
- [ ] If it is a critical feature, I have added tests.
- [ ] The CI is successful.
- [ ] If there could backward compatibility issues, it has been discussed and planned.




## [OPT] Preview

<!--
Visual aid of your work.
It can either be screenshots or a video.
This could help reviewers to get context quickly.
-->




<!--
A funny animal picture is welcome to close your PR!
You can find one here https://unsplash.com/s/photos/funny-animal-picture
-->