### PR TITLE
fix: export types using `exports`

### DIFF
--- a/packages/adapter-next/package.json
+++ b/packages/adapter-next/package.json
@@ -16,10 +16,12 @@
 	"type": "module",
 	"exports": {
 		".": {
+			"types": "./dist/index.d.ts",
 			"require": "./dist/index.cjs",
 			"import": "./dist/index.js"
 		},
 		"./simulator": {
+			"types": "./dist/simulator/index.d.ts",
 			"require": "./dist/simulator.cjs",
 			"import": "./dist/simulator.js"
 		},

--- a/packages/adapter-nuxt/package.json
+++ b/packages/adapter-nuxt/package.json
@@ -16,10 +16,12 @@
 	"type": "module",
 	"exports": {
 		".": {
+			"types": "./dist/index.d.ts",
 			"require": "./dist/index.cjs",
 			"import": "./dist/index.js"
 		},
 		"./simulator": {
+			"types": "./dist/simulator/index.d.ts",
 			"require": "./dist/simulator.cjs",
 			"import": "./dist/simulator.js"
 		},

--- a/packages/adapter-nuxt2/package.json
+++ b/packages/adapter-nuxt2/package.json
@@ -16,10 +16,12 @@
 	"type": "module",
 	"exports": {
 		".": {
+			"types": "./dist/index.d.ts",
 			"require": "./dist/index.cjs",
 			"import": "./dist/index.js"
 		},
 		"./simulator": {
+			"types": "./dist/simulator/index.d.ts",
 			"require": "./dist/simulator.cjs",
 			"import": "./dist/simulator.js"
 		},


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This PR exports types from `adapter-next`, `adapter-nuxt`, and `adapter-nuxt2`.

Without this PR, Next.js projects using Slice Simulator from `@slicemachine/adapter-next` would fail to build; Next.js now reads the `exports` property in `package.json` to determine types.

**Note**: A pre-release version of `@slicemachine/adapter-next` (`0.3.9-types-fix.0`) with the tag `types-fix` was published to unblock a video recording. Please delete the tag after merging and publishing the final version.

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->
