### PR TITLE
fix(adapter-nuxt2): Nuxt 2 doesn't support subpath exports correctly

### DIFF
--- a/packages/adapter-nuxt2/src/simulator/SliceSimulator.ts
+++ b/packages/adapter-nuxt2/src/simulator/SliceSimulator.ts
@@ -2,6 +2,12 @@ import Vue, { PropType, VNodeChildren } from "vue";
 import { CreateElement, ExtendedVue } from "vue/types/vue";
 
 import {
+	SliceSimulatorState,
+	SliceSimulatorOptions,
+	SliceSimulatorProps as BaseSliceSimulatorProps,
+} from "@prismicio/simulator/kit";
+import * as simulatorKit from "@prismicio/simulator/dist/kit.cjs";
+const {
 	getDefaultProps,
 	getDefaultSlices,
 	getDefaultMessage,
@@ -9,12 +15,9 @@ import {
 	disableEventHandler,
 	simulatorClass,
 	simulatorRootClass,
-	SliceSimulatorState,
-	SliceSimulatorOptions,
-	SliceSimulatorProps as BaseSliceSimulatorProps,
 	StateEventType,
 	SimulatorManager,
-} from "@prismicio/simulator/kit";
+} = simulatorKit as unknown as typeof import("@prismicio/simulator/kit");
 
 export type SliceSimulatorProps = Omit<BaseSliceSimulatorProps, "state">;
 

--- a/packages/adapter-nuxt2/test/simulator-SliceSimulator.test.ts
+++ b/packages/adapter-nuxt2/test/simulator-SliceSimulator.test.ts
@@ -1,7 +1,8 @@
 import { test, expect } from "vitest";
 
-import { SliceSimulator } from "../src/simulator";
+// Nuxt 2 is still under Webpack 4, not understanding subpath exports.
+// import { SliceSimulator } from "../src/simulator";
 
 test.todo("renders a Slice Simulator instance", async () => {
-	expect(SliceSimulator).toBeTruthy();
+	expect(true /* SliceSimulator */).toBeTruthy();
 });


### PR DESCRIPTION
This PR fixes subpath exports for Nuxt 2 which doesn't handle them (legacy framework).

See:
- Slack thread: https://prismic-team.slack.com/archives/C014VAACCQL/p1690800041933869
- Forum thread: https://community.prismic.io/t/missing-dependencies-nuxt-2-slicemachine-adapter-nuxt2/13536

## The Solution

We change the import of `@prismicio/slice-simulator/kit` to its CommonJS equivalent. This is not pretty but I think it's good enough since it only impacts Nuxt 2.

An alternative would be to inline `@prismicio/slice-simulator` inside `@slicemachine/adapter-nuxt2`. But I think this makes less sense.

## Impact / Dependencies

<!--
List all the impacts your development might have on internal and external features.
Ideally this should have been discussed prior to this development.

Link of any other PRs that are related to this development.
They should also be referenced in the ticket for reviews.
-->




## Checklist before requesting a review
- [x] I hereby declare my code ready for review.
- [ ] If it is a critical feature, I have added tests.
- [x] The CI is successful.
- [ ] If there could backward compatibility issues, it has been discussed and planned.




## [OPT] Preview

<!--
Visual aid of your work.
It can either be screenshots or a video.
This could help reviewers to get context quickly.
-->




<!--
A funny animal picture is welcome to close your PR!
You can find one here https://unsplash.com/s/photos/funny-animal-picture
-->