### PR TITLE
feat(plugin-kit): `updateSliceMachineConfig()` helper

### DIFF
--- a/packages/adapter-next/src/hooks/project-init.ts
+++ b/packages/adapter-next/src/hooks/project-init.ts
@@ -492,18 +492,7 @@ const modifySliceMachineConfig = async ({
 		}
 	}
 
-	const filePath = helpers.joinPathFromRoot("slicemachine.config.json");
-
-	let contents = JSON.stringify(project.config);
-
-	if (options.format) {
-		contents = await helpers.format(contents, filePath);
-	}
-
-	await fs.writeFile(
-		helpers.joinPathFromRoot("slicemachine.config.json"),
-		contents,
-	);
+	await helpers.updateProjectConfig(project.config, options.format);
 };
 
 const createRevalidateRoute = async ({

--- a/packages/adapter-next/src/hooks/project-init.ts
+++ b/packages/adapter-next/src/hooks/project-init.ts
@@ -492,7 +492,9 @@ const modifySliceMachineConfig = async ({
 		}
 	}
 
-	await helpers.updateProjectConfig(project.config, options.format);
+	await helpers.updateSliceMachineConfig(project.config, {
+		format: options.format,
+	});
 };
 
 const createRevalidateRoute = async ({

--- a/packages/adapter-nuxt/src/hooks/project-init.ts
+++ b/packages/adapter-nuxt/src/hooks/project-init.ts
@@ -186,7 +186,9 @@ const modifySliceMachineConfig = async ({
 		}
 	}
 
-	await helpers.updateProjectConfig(project.config, options.format);
+	await helpers.updateSliceMachineConfig(project.config, {
+		format: options.format,
+	});
 };
 
 export const projectInit: ProjectInitHook<PluginOptions> = async (

--- a/packages/adapter-nuxt/src/hooks/project-init.ts
+++ b/packages/adapter-nuxt/src/hooks/project-init.ts
@@ -11,6 +11,7 @@ import { loadFile, writeFile, type ASTNode } from "magicast";
 import { checkPathExists } from "../lib/checkPathExists";
 import { rejectIfNecessary } from "../lib/rejectIfNecessary";
 import { checkIsTypeScriptProject } from "../lib/checkIsTypeScriptProject";
+import { checkHasSrcDirectory } from "../lib/checkHasSrcDirectory";
 
 import type { PluginOptions } from "../types";
 
@@ -149,15 +150,55 @@ const createSliceSimulatorPage = async ({
 	await fs.writeFile(filePath, contents);
 };
 
+const modifySliceMachineConfig = async ({
+	helpers,
+	options,
+}: SliceMachineContext<PluginOptions>) => {
+	const hasSrcDirectory = await checkHasSrcDirectory({ helpers });
+	const project = await helpers.getProject();
+
+	// Add Slice Simulator URL.
+	project.config.localSliceSimulatorURL ||=
+		"http://localhost:3000/slice-simulator";
+
+	// Nest the default Slice Library in the src directory if it exists and
+	// is empty.
+	if (
+		hasSrcDirectory &&
+		JSON.stringify(project.config.libraries) === JSON.stringify(["./slices"])
+	) {
+		try {
+			const entries = await fs.readdir(helpers.joinPathFromRoot("slices"));
+
+			if (!entries.map((entry) => path.parse(entry).name).includes("index")) {
+				project.config.libraries = ["./src/slices"];
+			}
+		} catch (error) {
+			if (
+				error instanceof Error &&
+				"code" in error &&
+				error.code === "ENOENT"
+			) {
+				// The directory does not exist, which means we
+				// can safely nest the library.
+				project.config.libraries = ["./src/slices"];
+			}
+		}
+	}
+
+	await helpers.updateProjectConfig(project.config, options.format);
+};
+
 export const projectInit: ProjectInitHook<PluginOptions> = async (
 	{ installDependencies: _installDependencies },
 	context,
 ) => {
 	rejectIfNecessary(
 		await Promise.allSettled([
-			await installDependencies({ installDependencies: _installDependencies }),
-			await configurePrismicModule(context),
-			await createSliceSimulatorPage(context),
+			installDependencies({ installDependencies: _installDependencies }),
+			configurePrismicModule(context),
+			createSliceSimulatorPage(context),
+			modifySliceMachineConfig(context),
 		]),
 	);
 };

--- a/packages/adapter-nuxt/src/lib/checkHasSrcDirectory.ts
+++ b/packages/adapter-nuxt/src/lib/checkHasSrcDirectory.ts
@@ -1,0 +1,15 @@
+import { SliceMachineContext } from "@slicemachine/plugin-kit";
+
+import { PluginOptions } from "../types";
+import { checkPathExists } from "./checkPathExists";
+
+type CheckHasSrcDirectoryArgs = Pick<
+	SliceMachineContext<PluginOptions>,
+	"helpers"
+>;
+
+export async function checkHasSrcDirectory(
+	args: CheckHasSrcDirectoryArgs,
+): Promise<boolean> {
+	return await checkPathExists(args.helpers.joinPathFromRoot("src"));
+}

--- a/packages/adapter-nuxt/test/__testutils__/testGlobalContentTypes.ts
+++ b/packages/adapter-nuxt/test/__testutils__/testGlobalContentTypes.ts
@@ -12,6 +12,8 @@ import {
 import { generateTypes, GenerateTypesConfig } from "prismic-ts-codegen";
 import prettier from "prettier";
 
+import adapter from "../../src";
+
 const resolveModel = <TModel extends CustomType | SharedSlice>(
 	ctx: TestContext,
 	model: TModel | ((ctx: TestContext) => TModel),
@@ -124,6 +126,9 @@ export const testGlobalContentTypes = <TModel extends CustomType | SharedSlice>(
 			ctx.project.config.adapter.options.format = false;
 			const pluginRunner = createSliceMachinePluginRunner({
 				project: ctx.project,
+				nativePlugins: {
+					[ctx.project.config.adapter.resolve]: adapter,
+				},
 			});
 			await pluginRunner.init();
 

--- a/packages/adapter-nuxt/test/plugin-customType-create.test.ts
+++ b/packages/adapter-nuxt/test/plugin-customType-create.test.ts
@@ -7,6 +7,8 @@ import * as path from "node:path";
 
 import { testGlobalContentTypes } from "./__testutils__/testGlobalContentTypes";
 
+import adapter from "../src";
+
 /**
  * !!! DO NOT use this mock factory in tests !!!
  *
@@ -53,7 +55,12 @@ test("model.json is formatted by default", async (ctx) => {
 
 test("model.json is not formatted if formatting is disabled", async (ctx) => {
 	ctx.project.config.adapter.options.format = false;
-	const pluginRunner = createSliceMachinePluginRunner({ project: ctx.project });
+	const pluginRunner = createSliceMachinePluginRunner({
+		project: ctx.project,
+		nativePlugins: {
+			[ctx.project.config.adapter.resolve]: adapter,
+		},
+	});
 	await pluginRunner.init();
 
 	// Force unusual formatting to detect that formatting did not happen.

--- a/packages/adapter-nuxt/test/plugin-project-init.test.ts
+++ b/packages/adapter-nuxt/test/plugin-project-init.test.ts
@@ -1,8 +1,10 @@
-import { test, expect, vi } from "vitest";
+import { test, expect, vi, describe } from "vitest";
 import { createSliceMachinePluginRunner } from "@slicemachine/plugin-kit";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import prettier from "prettier";
+
+import adapter from "../src";
 
 test("installs dependencies", async (ctx) => {
 	const log = vi.fn();
@@ -18,178 +20,344 @@ test("installs dependencies", async (ctx) => {
 	});
 });
 
-test("configures Prismic module", async (ctx) => {
-	const log = vi.fn();
-	const installDependencies = vi.fn();
+describe("Prismic module", () => {
+	test("configures Prismic module", async (ctx) => {
+		const log = vi.fn();
+		const installDependencies = vi.fn();
 
-	const nuxtConfigPath = path.join(ctx.project.root, "nuxt.config.js");
-	await fs.writeFile(nuxtConfigPath, "export default defineNuxtConfig({})");
+		const nuxtConfigPath = path.join(ctx.project.root, "nuxt.config.js");
+		await fs.writeFile(nuxtConfigPath, "export default defineNuxtConfig({})");
 
-	await ctx.pluginRunner.callHook("project:init", { log, installDependencies });
+		await ctx.pluginRunner.callHook("project:init", {
+			log,
+			installDependencies,
+		});
 
-	await expect(fs.readFile(nuxtConfigPath, "utf-8")).resolves
-		.toMatchInlineSnapshot(`
-		"export default defineNuxtConfig({
-		  modules: [\\"@nuxtjs/prismic\\"],
+		await expect(fs.readFile(nuxtConfigPath, "utf-8")).resolves
+			.toMatchInlineSnapshot(`
+			"export default defineNuxtConfig({
+			  modules: [\\"@nuxtjs/prismic\\"],
 
-		  prismic: {
-		    endpoint: \\"qwerty\\"
-		  }
-		})"
-	`);
-});
-
-test("configures Prismic module with TypeScript project", async (ctx) => {
-	const log = vi.fn();
-	const installDependencies = vi.fn();
-
-	const nuxtConfigPath = path.join(ctx.project.root, "nuxt.config.ts");
-	await fs.writeFile(nuxtConfigPath, "export default defineNuxtConfig({})");
-
-	await ctx.pluginRunner.callHook("project:init", { log, installDependencies });
-
-	await expect(fs.readFile(nuxtConfigPath, "utf-8")).resolves
-		.toMatchInlineSnapshot(`
-		"export default defineNuxtConfig({
-		  modules: [\\"@nuxtjs/prismic\\"],
-
-		  prismic: {
-		    endpoint: \\"qwerty\\"
-		  }
-		})"
-	`);
-});
-
-test("creates a Slice Simulator page file", async (ctx) => {
-	const log = vi.fn();
-	const installDependencies = vi.fn();
-
-	await ctx.pluginRunner.callHook("project:init", { log, installDependencies });
-
-	const contents = await fs.readFile(
-		path.join(ctx.project.root, "pages", "slice-simulator.vue"),
-		"utf8",
-	);
-
-	expect(contents).toMatchInlineSnapshot(`
-		"<template>
-		  <SliceSimulator #default=\\"{ slices }\\">
-		    <SliceZone :slices=\\"slices\\" :components=\\"components\\" />
-		  </SliceSimulator>
-		</template>
-
-		<script setup>
-		import { SliceSimulator } from \\"@slicemachine/adapter-nuxt/simulator\\";
-		import { components } from \\"~/slices\\";
-		</script>
-		"
-	`);
-});
-
-test("creates a TypeScript Slice Simulator page file when TypeScript is enabled", async (ctx) => {
-	ctx.project.config.adapter.options.typescript = true;
-	const pluginRunner = createSliceMachinePluginRunner({
-		project: ctx.project,
+			  prismic: {
+			    endpoint: \\"qwerty\\"
+			  }
+			})"
+		`);
 	});
-	await pluginRunner.init();
 
-	const log = vi.fn();
-	const installDependencies = vi.fn();
+	test("configures Prismic module with TypeScript project", async (ctx) => {
+		const log = vi.fn();
+		const installDependencies = vi.fn();
 
-	await pluginRunner.callHook("project:init", { log, installDependencies });
+		const nuxtConfigPath = path.join(ctx.project.root, "nuxt.config.ts");
+		await fs.writeFile(nuxtConfigPath, "export default defineNuxtConfig({})");
 
-	const contents = await fs.readFile(
-		path.join(ctx.project.root, "pages", "slice-simulator.vue"),
-		"utf8",
-	);
+		await ctx.pluginRunner.callHook("project:init", {
+			log,
+			installDependencies,
+		});
 
-	expect(contents).toMatchInlineSnapshot(`
-		"<template>
-		  <SliceSimulator #default=\\"{ slices }\\">
-		    <SliceZone :slices=\\"slices\\" :components=\\"components\\" />
-		  </SliceSimulator>
-		</template>
+		await expect(fs.readFile(nuxtConfigPath, "utf-8")).resolves
+			.toMatchInlineSnapshot(`
+			"export default defineNuxtConfig({
+			  modules: [\\"@nuxtjs/prismic\\"],
 
-		<script setup lang=\\"ts\\">
-		import { SliceSimulator } from \\"@slicemachine/adapter-nuxt/simulator\\";
-		import { components } from \\"~/slices\\";
-		</script>
-		"
-	`);
+			  prismic: {
+			    endpoint: \\"qwerty\\"
+			  }
+			})"
+		`);
+	});
 });
 
-test("does not overwrite Slice Simulator page file if it already exists", async (ctx) => {
-	const log = vi.fn();
-	const installDependencies = vi.fn();
+describe("Slice Simulator page", () => {
+	test("creates a Slice Simulator page file", async (ctx) => {
+		const log = vi.fn();
+		const installDependencies = vi.fn();
 
-	const filePath = path.join(ctx.project.root, "pages", "slice-simulator.vue");
-	const contents = "foo";
+		await ctx.pluginRunner.callHook("project:init", {
+			log,
+			installDependencies,
+		});
 
-	await fs.mkdir(path.dirname(filePath), { recursive: true });
-	await fs.writeFile(filePath, contents);
+		const contents = await fs.readFile(
+			path.join(ctx.project.root, "pages", "slice-simulator.vue"),
+			"utf8",
+		);
 
-	await ctx.pluginRunner.callHook("project:init", { log, installDependencies });
+		expect(contents).toMatchInlineSnapshot(`
+			"<template>
+			  <SliceSimulator #default=\\"{ slices }\\">
+			    <SliceZone :slices=\\"slices\\" :components=\\"components\\" />
+			  </SliceSimulator>
+			</template>
 
-	const postHookContents = await fs.readFile(filePath, "utf8");
+			<script setup>
+			import { SliceSimulator } from \\"@slicemachine/adapter-nuxt/simulator\\";
+			import { components } from \\"~/slices\\";
+			</script>
+			"
+		`);
+	});
 
-	expect(postHookContents).toBe(contents);
+	test("creates a TypeScript Slice Simulator page file when TypeScript is enabled", async (ctx) => {
+		ctx.project.config.adapter.options.typescript = true;
+		const pluginRunner = createSliceMachinePluginRunner({
+			project: ctx.project,
+			nativePlugins: {
+				[ctx.project.config.adapter.resolve]: adapter,
+			},
+		});
+		await pluginRunner.init();
+
+		const log = vi.fn();
+		const installDependencies = vi.fn();
+
+		await pluginRunner.callHook("project:init", { log, installDependencies });
+
+		const contents = await fs.readFile(
+			path.join(ctx.project.root, "pages", "slice-simulator.vue"),
+			"utf8",
+		);
+
+		expect(contents).toMatchInlineSnapshot(`
+			"<template>
+			  <SliceSimulator #default=\\"{ slices }\\">
+			    <SliceZone :slices=\\"slices\\" :components=\\"components\\" />
+			  </SliceSimulator>
+			</template>
+
+			<script setup lang=\\"ts\\">
+			import { SliceSimulator } from \\"@slicemachine/adapter-nuxt/simulator\\";
+			import { components } from \\"~/slices\\";
+			</script>
+			"
+		`);
+	});
+
+	test("does not overwrite Slice Simulator page file if it already exists", async (ctx) => {
+		const log = vi.fn();
+		const installDependencies = vi.fn();
+
+		const filePath = path.join(
+			ctx.project.root,
+			"pages",
+			"slice-simulator.vue",
+		);
+		const contents = "foo";
+
+		await fs.mkdir(path.dirname(filePath), { recursive: true });
+		await fs.writeFile(filePath, contents);
+
+		await ctx.pluginRunner.callHook("project:init", {
+			log,
+			installDependencies,
+		});
+
+		const postHookContents = await fs.readFile(filePath, "utf8");
+
+		expect(postHookContents).toBe(contents);
+	});
+
+	test("creates Slice Simulator page file in the src directory if it exists", async (ctx) => {
+		const log = vi.fn();
+		const installDependencies = vi.fn();
+
+		await fs.mkdir(path.join(ctx.project.root, "src/pages"), {
+			recursive: true,
+		});
+
+		await ctx.pluginRunner.callHook("project:init", {
+			log,
+			installDependencies,
+		});
+
+		const pagesDir = await fs.readdir(
+			path.join(ctx.project.root, "src", "pages"),
+		);
+
+		expect(pagesDir).toContain("slice-simulator.vue");
+	});
+
+	test("Slice Simulator page file is formatted by default", async (ctx) => {
+		const log = vi.fn();
+		const installDependencies = vi.fn();
+
+		await ctx.pluginRunner.callHook("project:init", {
+			log,
+			installDependencies,
+		});
+
+		const contents = await fs.readFile(
+			path.join(ctx.project.root, "pages", "slice-simulator.vue"),
+			"utf8",
+		);
+
+		expect(contents).toBe(prettier.format(contents, { parser: "vue" }));
+	});
+
+	test("Slice Simulator page file is not formatted if formatting is disabled", async (ctx) => {
+		ctx.project.config.adapter.options.format = false;
+		const pluginRunner = createSliceMachinePluginRunner({
+			project: ctx.project,
+			nativePlugins: {
+				[ctx.project.config.adapter.resolve]: adapter,
+			},
+		});
+		await pluginRunner.init();
+
+		// Force unusual formatting to detect that formatting did not happen.
+		const prettierOptions = { printWidth: 10 };
+		await fs.writeFile(
+			path.join(ctx.project.root, ".prettierrc"),
+			JSON.stringify(prettierOptions),
+		);
+
+		const log = vi.fn();
+		const installDependencies = vi.fn();
+
+		await pluginRunner.callHook("project:init", { log, installDependencies });
+
+		const contents = await fs.readFile(
+			path.join(ctx.project.root, "pages", "slice-simulator.vue"),
+			"utf8",
+		);
+
+		expect(contents).not.toBe(
+			prettier.format(contents, {
+				...prettierOptions,
+				parser: "vue",
+			}),
+		);
+	});
 });
 
-test("creates Slice Simulator page file in the src directory if it exists", async (ctx) => {
-	const log = vi.fn();
-	const installDependencies = vi.fn();
+describe("modify slicemachine.config.json", () => {
+	test("adds default localSliceSimulatorURL", async (ctx) => {
+		const log = vi.fn();
+		const installDependencies = vi.fn();
 
-	await fs.mkdir(path.join(ctx.project.root, "src/pages"), { recursive: true });
+		await ctx.pluginRunner.callHook("project:init", {
+			log,
+			installDependencies,
+		});
 
-	await ctx.pluginRunner.callHook("project:init", { log, installDependencies });
+		const contents = JSON.parse(
+			await fs.readFile(
+				path.join(ctx.project.root, "slicemachine.config.json"),
+				"utf8",
+			),
+		);
 
-	const pagesDir = await fs.readdir(
-		path.join(ctx.project.root, "src", "pages"),
-	);
+		expect(contents.localSliceSimulatorURL).toBe(
+			"http://localhost:3000/slice-simulator",
+		);
+	});
 
-	expect(pagesDir).toContain("slice-simulator.vue");
-});
+	test("does not modify localSliceSimulatorURL if it already exists", async (ctx) => {
+		const log = vi.fn();
+		const installDependencies = vi.fn();
 
-test("Slice Simulator page file is formatted by default", async (ctx) => {
-	const log = vi.fn();
-	const installDependencies = vi.fn();
+		const preHookConfig = {
+			...ctx.project.config,
+			localSliceSimulatorURL: "foo",
+		};
 
-	await ctx.pluginRunner.callHook("project:init", { log, installDependencies });
+		await fs.writeFile(
+			path.join(ctx.project.root, "slicemachine.config.json"),
+			JSON.stringify(preHookConfig),
+		);
 
-	const contents = await fs.readFile(
-		path.join(ctx.project.root, "pages", "slice-simulator.vue"),
-		"utf8",
-	);
+		await ctx.pluginRunner.callHook("project:init", {
+			log,
+			installDependencies,
+		});
 
-	expect(contents).toBe(prettier.format(contents, { parser: "vue" }));
-});
+		const contents = JSON.parse(
+			await fs.readFile(
+				path.join(ctx.project.root, "slicemachine.config.json"),
+				"utf8",
+			),
+		);
 
-test("Slice Simulator page file is not formatted if formatting is disabled", async (ctx) => {
-	ctx.project.config.adapter.options.format = false;
-	const pluginRunner = createSliceMachinePluginRunner({ project: ctx.project });
-	await pluginRunner.init();
+		expect(contents.localSliceSimulatorURL).toBe(
+			preHookConfig.localSliceSimulatorURL,
+		);
+	});
 
-	// Force unusual formatting to detect that formatting did not happen.
-	const prettierOptions = { printWidth: 10 };
-	await fs.writeFile(
-		path.join(ctx.project.root, ".prettierrc"),
-		JSON.stringify(prettierOptions),
-	);
+	test("nests default Slice Library under src directory if it exists", async (ctx) => {
+		const log = vi.fn();
+		const installDependencies = vi.fn();
 
-	const log = vi.fn();
-	const installDependencies = vi.fn();
+		await fs.mkdir(path.join(ctx.project.root, "src"), { recursive: true });
 
-	await pluginRunner.callHook("project:init", { log, installDependencies });
+		await ctx.pluginRunner.callHook("project:init", {
+			log,
+			installDependencies,
+		});
 
-	const contents = await fs.readFile(
-		path.join(ctx.project.root, "pages", "slice-simulator.vue"),
-		"utf8",
-	);
+		const contents = JSON.parse(
+			await fs.readFile(
+				path.join(ctx.project.root, "slicemachine.config.json"),
+				"utf8",
+			),
+		);
 
-	expect(contents).not.toBe(
-		prettier.format(contents, {
-			...prettierOptions,
-			parser: "vue",
-		}),
-	);
+		expect(contents.libraries).toStrictEqual(["./src/slices"]);
+	});
+
+	test("does not nest the default Slice Library under src directory if it is not empty", async (ctx) => {
+		const log = vi.fn();
+		const installDependencies = vi.fn();
+
+		await fs.mkdir(path.join(ctx.project.root, "src"), { recursive: true });
+
+		await fs.mkdir(path.join(ctx.project.root, "slices"), { recursive: true });
+		await fs.writeFile(path.join(ctx.project.root, "slices", "index.js"), "");
+
+		await ctx.pluginRunner.callHook("project:init", {
+			log,
+			installDependencies,
+		});
+
+		const contents = JSON.parse(
+			await fs.readFile(
+				path.join(ctx.project.root, "slicemachine.config.json"),
+				"utf8",
+			),
+		);
+
+		expect(contents.libraries).toStrictEqual(["./slices"]);
+	});
+
+	test("does not modify Slice Library if it is not the default", async (ctx) => {
+		const log = vi.fn();
+		const installDependencies = vi.fn();
+
+		const preHookConfig = {
+			...ctx.project.config,
+			libraries: ["./foo"],
+		};
+
+		await fs.writeFile(
+			path.join(ctx.project.root, "slicemachine.config.json"),
+			JSON.stringify(preHookConfig),
+		);
+
+		await fs.mkdir(path.join(ctx.project.root, "src"), { recursive: true });
+
+		await ctx.pluginRunner.callHook("project:init", {
+			log,
+			installDependencies,
+		});
+
+		const contents = JSON.parse(
+			await fs.readFile(
+				path.join(ctx.project.root, "slicemachine.config.json"),
+				"utf8",
+			),
+		);
+
+		expect(contents.libraries).toStrictEqual(preHookConfig.libraries);
+	});
 });

--- a/packages/adapter-nuxt/test/plugin-slice-create.test.ts
+++ b/packages/adapter-nuxt/test/plugin-slice-create.test.ts
@@ -9,6 +9,8 @@ import * as tsm from "ts-morph";
 import { parseSourceFile } from "./__testutils__/parseSourceFile";
 import { testGlobalContentTypes } from "./__testutils__/testGlobalContentTypes";
 
+import adapter from "../src";
+
 /**
  * !!! DO NOT use this mock factory in tests !!!
  *
@@ -49,7 +51,12 @@ test("upserts a library index.js file", async (ctx) => {
 
 test("upserts a library index.ts file when TypeScript is enabled", async (ctx) => {
 	ctx.project.config.adapter.options.typescript = true;
-	const pluginRunner = createSliceMachinePluginRunner({ project: ctx.project });
+	const pluginRunner = createSliceMachinePluginRunner({
+		project: ctx.project,
+		nativePlugins: {
+			[ctx.project.config.adapter.resolve]: adapter,
+		},
+	});
 	await pluginRunner.init();
 
 	await pluginRunner.callHook("slice:create", { libraryID: "slices", model });
@@ -85,7 +92,12 @@ test("library index file includes created Slice", async (ctx) => {
 
 test("library index file includes created Slice without lazy-loading when disabled", async (ctx) => {
 	ctx.project.config.adapter.options.lazyLoadSlices = false;
-	const pluginRunner = createSliceMachinePluginRunner({ project: ctx.project });
+	const pluginRunner = createSliceMachinePluginRunner({
+		project: ctx.project,
+		nativePlugins: {
+			[ctx.project.config.adapter.resolve]: adapter,
+		},
+	});
 	await pluginRunner.init();
 
 	await pluginRunner.callHook("slice:create", {
@@ -149,7 +161,12 @@ test("model.json is formatted by default", async (ctx) => {
 
 test("model.json is not formatted if formatting is disabled", async (ctx) => {
 	ctx.project.config.adapter.options.format = false;
-	const pluginRunner = createSliceMachinePluginRunner({ project: ctx.project });
+	const pluginRunner = createSliceMachinePluginRunner({
+		project: ctx.project,
+		nativePlugins: {
+			[ctx.project.config.adapter.resolve]: adapter,
+		},
+	});
 	await pluginRunner.init();
 
 	// Force unusual formatting to detect that formatting did not happen.
@@ -190,7 +207,12 @@ test("component file is formatted by default", async (ctx) => {
 
 test("component file is not formatted if formatting is disabled", async (ctx) => {
 	ctx.project.config.adapter.options.format = false;
-	const pluginRunner = createSliceMachinePluginRunner({ project: ctx.project });
+	const pluginRunner = createSliceMachinePluginRunner({
+		project: ctx.project,
+		nativePlugins: {
+			[ctx.project.config.adapter.resolve]: adapter,
+		},
+	});
 	await pluginRunner.init();
 
 	// Force unusual formatting to detect that formatting did not happen.

--- a/packages/adapter-nuxt2/src/hooks/project-init.ts
+++ b/packages/adapter-nuxt2/src/hooks/project-init.ts
@@ -213,7 +213,9 @@ const modifySliceMachineConfig = async ({
 		}
 	}
 
-	await helpers.updateProjectConfig(project.config, options.format);
+	await helpers.updateSliceMachineConfig(project.config, {
+		format: options.format,
+	});
 };
 
 export const projectInit: ProjectInitHook<PluginOptions> = async (

--- a/packages/adapter-nuxt2/src/lib/checkHasSrcDirectory.ts
+++ b/packages/adapter-nuxt2/src/lib/checkHasSrcDirectory.ts
@@ -1,0 +1,15 @@
+import { SliceMachineContext } from "@slicemachine/plugin-kit";
+
+import { PluginOptions } from "../types";
+import { checkPathExists } from "./checkPathExists";
+
+type CheckHasSrcDirectoryArgs = Pick<
+	SliceMachineContext<PluginOptions>,
+	"helpers"
+>;
+
+export async function checkHasSrcDirectory(
+	args: CheckHasSrcDirectoryArgs,
+): Promise<boolean> {
+	return await checkPathExists(args.helpers.joinPathFromRoot("src"));
+}

--- a/packages/adapter-nuxt2/test/__setup__.ts
+++ b/packages/adapter-nuxt2/test/__setup__.ts
@@ -1,7 +1,7 @@
 import { beforeEach } from "vitest";
 import {
 	createSliceMachinePluginRunner,
-	SliceMachinePlugin,
+	SliceMachineConfig,
 	SliceMachinePluginRunner,
 	SliceMachineProject,
 } from "@slicemachine/plugin-kit";
@@ -11,13 +11,14 @@ import * as path from "node:path";
 import * as os from "node:os";
 
 import adapter, { PluginOptions } from "../src";
+import * as pkg from "../package.json";
 
 declare module "vitest" {
 	export interface TestContext {
 		project: SliceMachineProject & {
 			config: {
 				adapter: {
-					resolve: SliceMachinePlugin;
+					resolve: string;
 					options: PluginOptions;
 				};
 			};
@@ -32,20 +33,32 @@ beforeEach(async (ctx) => {
 		path.join(os.tmpdir(), "@slicemachine__adapter-nuxt2___"),
 	);
 
+	const config = {
+		adapter: {
+			resolve: pkg.name,
+			options: {},
+		},
+		libraries: ["./slices"],
+		repositoryName: "qwerty",
+		apiEndpoint: "https://qwerty.cdn.prismic.io/api/v2",
+	} satisfies SliceMachineConfig;
+
+	await fs.writeFile(
+		path.join(tmpRoot, "slicemachine.config.json"),
+		JSON.stringify(config),
+	);
+
 	ctx.project = {
 		root: tmpRoot,
-		config: {
-			adapter: {
-				resolve: adapter,
-				options: {},
-			},
-			libraries: ["./slices"],
-			repositoryName: "qwerty",
-			apiEndpoint: "https://qwerty.cdn.prismic.io/api/v2",
-		},
+		config,
 	};
 
-	ctx.pluginRunner = createSliceMachinePluginRunner({ project: ctx.project });
+	ctx.pluginRunner = createSliceMachinePluginRunner({
+		project: ctx.project,
+		nativePlugins: {
+			[pkg.name]: adapter,
+		},
+	});
 
 	ctx.mock = createMockFactory({ seed: ctx.meta.name });
 

--- a/packages/adapter-nuxt2/test/__testutils__/testGlobalContentTypes.ts
+++ b/packages/adapter-nuxt2/test/__testutils__/testGlobalContentTypes.ts
@@ -12,6 +12,8 @@ import {
 import { generateTypes, GenerateTypesConfig } from "prismic-ts-codegen";
 import prettier from "prettier";
 
+import adapter from "../../src";
+
 const resolveModel = <TModel extends CustomType | SharedSlice>(
 	ctx: TestContext,
 	model: TModel | ((ctx: TestContext) => TModel),
@@ -125,6 +127,9 @@ export const testGlobalContentTypes = <TModel extends CustomType | SharedSlice>(
 			ctx.project.config.adapter.options.format = false;
 			const pluginRunner = createSliceMachinePluginRunner({
 				project: ctx.project,
+				nativePlugins: {
+					[ctx.project.config.adapter.resolve]: adapter,
+				},
 			});
 			await pluginRunner.init();
 

--- a/packages/adapter-nuxt2/test/plugin-customType-create.test.ts
+++ b/packages/adapter-nuxt2/test/plugin-customType-create.test.ts
@@ -7,6 +7,8 @@ import * as path from "node:path";
 
 import { testGlobalContentTypes } from "./__testutils__/testGlobalContentTypes";
 
+import adapter from "../src";
+
 /**
  * !!! DO NOT use this mock factory in tests !!!
  *
@@ -53,7 +55,12 @@ test("model.json is formatted by default", async (ctx) => {
 
 test("model.json is not formatted if formatting is disabled", async (ctx) => {
 	ctx.project.config.adapter.options.format = false;
-	const pluginRunner = createSliceMachinePluginRunner({ project: ctx.project });
+	const pluginRunner = createSliceMachinePluginRunner({
+		project: ctx.project,
+		nativePlugins: {
+			[ctx.project.config.adapter.resolve]: adapter,
+		},
+	});
 	await pluginRunner.init();
 
 	// Force unusual formatting to detect that formatting did not happen.

--- a/packages/adapter-nuxt2/test/plugin-project-init.test.ts
+++ b/packages/adapter-nuxt2/test/plugin-project-init.test.ts
@@ -1,8 +1,10 @@
-import { test, expect, vi } from "vitest";
+import { test, expect, vi, describe } from "vitest";
 import { createSliceMachinePluginRunner } from "@slicemachine/plugin-kit";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import prettier from "prettier";
+
+import adapter from "../src";
 
 test("installs dependencies", async (ctx) => {
 	const log = vi.fn();
@@ -18,201 +20,369 @@ test("installs dependencies", async (ctx) => {
 	});
 });
 
-test("configures Prismic module", async (ctx) => {
-	const log = vi.fn();
-	const installDependencies = vi.fn();
+describe("Prismic module", () => {
+	test("configures Prismic module", async (ctx) => {
+		const log = vi.fn();
+		const installDependencies = vi.fn();
 
-	const nuxtConfigPath = path.join(ctx.project.root, "nuxt.config.js");
-	await fs.writeFile(nuxtConfigPath, "export default {}");
+		const nuxtConfigPath = path.join(ctx.project.root, "nuxt.config.js");
+		await fs.writeFile(nuxtConfigPath, "export default {}");
 
-	await ctx.pluginRunner.callHook("project:init", { log, installDependencies });
+		await ctx.pluginRunner.callHook("project:init", {
+			log,
+			installDependencies,
+		});
 
-	await expect(fs.readFile(nuxtConfigPath, "utf-8")).resolves
-		.toMatchInlineSnapshot(`
-		"export default {
-		  buildModules: [\\"@nuxtjs/prismic\\"],
+		await expect(fs.readFile(nuxtConfigPath, "utf-8")).resolves
+			.toMatchInlineSnapshot(`
+			"export default {
+			  buildModules: [\\"@nuxtjs/prismic\\"],
 
-		  prismic: {
-		    endpoint: \\"https://qwerty.cdn.prismic.io/api/v2\\",
-		    modern: true
-		  },
+			  prismic: {
+			    endpoint: \\"https://qwerty.cdn.prismic.io/api/v2\\",
+			    modern: true
+			  },
 
-		  build: {
-		    transpile: [\\"@prismicio/vue\\"]
-		  }
-		};"
-	`);
+			  build: {
+			    transpile: [\\"@prismicio/vue\\"]
+			  }
+			};"
+		`);
+	});
+
+	test("configures Prismic module with TypeScript project", async (ctx) => {
+		const log = vi.fn();
+		const installDependencies = vi.fn();
+
+		const nuxtConfigPath = path.join(ctx.project.root, "nuxt.config.ts");
+		await fs.writeFile(nuxtConfigPath, "export default {}");
+
+		await ctx.pluginRunner.callHook("project:init", {
+			log,
+			installDependencies,
+		});
+
+		await expect(fs.readFile(nuxtConfigPath, "utf-8")).resolves
+			.toMatchInlineSnapshot(`
+			"export default {
+			  buildModules: [\\"@nuxtjs/prismic\\"],
+
+			  prismic: {
+			    endpoint: \\"https://qwerty.cdn.prismic.io/api/v2\\",
+			    modern: true
+			  },
+
+			  build: {
+			    transpile: [\\"@prismicio/vue\\"]
+			  }
+			};"
+		`);
+	});
+
+	test("warns user that Nuxt config could not be updated", async (ctx) => {
+		const log = vi.fn();
+		const installDependencies = vi.fn();
+
+		const errorSpy = vi
+			.spyOn(console, "error")
+			.mockImplementationOnce(() => undefined);
+		const warnSpy = vi
+			.spyOn(console, "warn")
+			.mockImplementation(() => undefined);
+
+		const nuxtConfigPath = path.join(ctx.project.root, "nuxt.config.ts");
+		await fs.writeFile(nuxtConfigPath, "export default () => ({})");
+
+		await ctx.pluginRunner.callHook("project:init", {
+			log,
+			installDependencies,
+		});
+
+		expect(errorSpy).toHaveBeenCalledWith("Failed to update nuxt.config.ts");
+		expect(warnSpy.mock.calls).toMatchInlineSnapshot(`
+			[
+			  [
+			    "Ensure that the following has been added to nuxt.config.ts.",
+			  ],
+			  [
+			    "{
+				buildModules: [\\"@nuxtjs/prismic\\"],
+				prismic: {
+					endpoint: \\"https://qwerty.cdn.prismic.io/api/v2\\",
+					modern: true
+				},
+				build: {
+					transpile: [\\"@prismicio/vue\\"]
+				}
+			}",
+			  ],
+			]
+		`);
+	});
 });
 
-test("configures Prismic module with TypeScript project", async (ctx) => {
-	const log = vi.fn();
-	const installDependencies = vi.fn();
+describe("Slice Simulator page", () => {
+	test("creates a Slice Simulator page file", async (ctx) => {
+		const log = vi.fn();
+		const installDependencies = vi.fn();
 
-	const nuxtConfigPath = path.join(ctx.project.root, "nuxt.config.ts");
-	await fs.writeFile(nuxtConfigPath, "export default {}");
+		await ctx.pluginRunner.callHook("project:init", {
+			log,
+			installDependencies,
+		});
 
-	await ctx.pluginRunner.callHook("project:init", { log, installDependencies });
+		const contents = await fs.readFile(
+			path.join(ctx.project.root, "pages", "slice-simulator.vue"),
+			"utf8",
+		);
 
-	await expect(fs.readFile(nuxtConfigPath, "utf-8")).resolves
-		.toMatchInlineSnapshot(`
-		"export default {
-		  buildModules: [\\"@nuxtjs/prismic\\"],
+		expect(contents).toMatchInlineSnapshot(`
+			"<template>
+			  <SliceSimulator v-slot=\\"{ slices }\\">
+			    <SliceZone :slices=\\"slices\\" :components=\\"components\\" />
+			  </SliceSimulator>
+			</template>
 
-		  prismic: {
-		    endpoint: \\"https://qwerty.cdn.prismic.io/api/v2\\",
-		    modern: true
-		  },
+			<script>
+			import { SliceSimulator } from \\"@slicemachine/adapter-nuxt2/dist/simulator.cjs\\";
+			import { components } from \\"~/slices\\";
 
-		  build: {
-		    transpile: [\\"@prismicio/vue\\"]
-		  }
-		};"
-	`);
-});
+			export default {
+			  components: {
+			    SliceSimulator,
+			  },
+			  data() {
+			    return { components };
+			  },
+			};
+			</script>
+			"
+		`);
+	});
 
-test("creates a Slice Simulator page file", async (ctx) => {
-	const log = vi.fn();
-	const installDependencies = vi.fn();
+	test("does not overwrite Slice Simulator page file if it already exists", async (ctx) => {
+		const log = vi.fn();
+		const installDependencies = vi.fn();
 
-	await ctx.pluginRunner.callHook("project:init", { log, installDependencies });
+		const filePath = path.join(
+			ctx.project.root,
+			"pages",
+			"slice-simulator.vue",
+		);
+		const contents = "foo";
 
-	const contents = await fs.readFile(
-		path.join(ctx.project.root, "pages", "slice-simulator.vue"),
-		"utf8",
-	);
+		await fs.mkdir(path.dirname(filePath), { recursive: true });
+		await fs.writeFile(filePath, contents);
 
-	expect(contents).toMatchInlineSnapshot(`
-		"<template>
-		  <SliceSimulator v-slot=\\"{ slices }\\">
-		    <SliceZone :slices=\\"slices\\" :components=\\"components\\" />
-		  </SliceSimulator>
-		</template>
+		await ctx.pluginRunner.callHook("project:init", {
+			log,
+			installDependencies,
+		});
 
-		<script>
-		import { SliceSimulator } from \\"@slicemachine/adapter-nuxt2/dist/simulator.cjs\\";
-		import { components } from \\"~/slices\\";
+		const postHookContents = await fs.readFile(filePath, "utf8");
 
-		export default {
-		  components: {
-		    SliceSimulator,
-		  },
-		  data() {
-		    return { components };
-		  },
-		};
-		</script>
-		"
-	`);
-});
+		expect(postHookContents).toBe(contents);
+	});
 
-test("does not overwrite Slice Simulator page file if it already exists", async (ctx) => {
-	const log = vi.fn();
-	const installDependencies = vi.fn();
+	test("creates Slice Simulator page file in the src directory if it exists", async (ctx) => {
+		const log = vi.fn();
+		const installDependencies = vi.fn();
 
-	const filePath = path.join(ctx.project.root, "pages", "slice-simulator.vue");
-	const contents = "foo";
+		await fs.mkdir(path.join(ctx.project.root, "src/pages"), {
+			recursive: true,
+		});
 
-	await fs.mkdir(path.dirname(filePath), { recursive: true });
-	await fs.writeFile(filePath, contents);
+		await ctx.pluginRunner.callHook("project:init", {
+			log,
+			installDependencies,
+		});
 
-	await ctx.pluginRunner.callHook("project:init", { log, installDependencies });
+		const pagesDir = await fs.readdir(
+			path.join(ctx.project.root, "src", "pages"),
+		);
 
-	const postHookContents = await fs.readFile(filePath, "utf8");
+		expect(pagesDir).toContain("slice-simulator.vue");
+	});
 
-	expect(postHookContents).toBe(contents);
-});
+	test("Slice Simulator page file is formatted by default", async (ctx) => {
+		const log = vi.fn();
+		const installDependencies = vi.fn();
 
-test("creates Slice Simulator page file in the src directory if it exists", async (ctx) => {
-	const log = vi.fn();
-	const installDependencies = vi.fn();
+		await ctx.pluginRunner.callHook("project:init", {
+			log,
+			installDependencies,
+		});
 
-	await fs.mkdir(path.join(ctx.project.root, "src/pages"), { recursive: true });
+		const contents = await fs.readFile(
+			path.join(ctx.project.root, "pages", "slice-simulator.vue"),
+			"utf8",
+		);
 
-	await ctx.pluginRunner.callHook("project:init", { log, installDependencies });
+		expect(contents).toBe(prettier.format(contents, { parser: "vue" }));
+	});
 
-	const pagesDir = await fs.readdir(
-		path.join(ctx.project.root, "src", "pages"),
-	);
-
-	expect(pagesDir).toContain("slice-simulator.vue");
-});
-
-test("Slice Simulator page file is formatted by default", async (ctx) => {
-	const log = vi.fn();
-	const installDependencies = vi.fn();
-
-	await ctx.pluginRunner.callHook("project:init", { log, installDependencies });
-
-	const contents = await fs.readFile(
-		path.join(ctx.project.root, "pages", "slice-simulator.vue"),
-		"utf8",
-	);
-
-	expect(contents).toBe(prettier.format(contents, { parser: "vue" }));
-});
-
-test("Slice Simulator page file is not formatted if formatting is disabled", async (ctx) => {
-	ctx.project.config.adapter.options.format = false;
-	const pluginRunner = createSliceMachinePluginRunner({ project: ctx.project });
-	await pluginRunner.init();
-
-	// Force unusual formatting to detect that formatting did not happen.
-	const prettierOptions = { printWidth: 10 };
-	await fs.writeFile(
-		path.join(ctx.project.root, ".prettierrc"),
-		JSON.stringify(prettierOptions),
-	);
-
-	const log = vi.fn();
-	const installDependencies = vi.fn();
-
-	await pluginRunner.callHook("project:init", { log, installDependencies });
-
-	const contents = await fs.readFile(
-		path.join(ctx.project.root, "pages", "slice-simulator.vue"),
-		"utf8",
-	);
-
-	expect(contents).not.toBe(
-		prettier.format(contents, {
-			...prettierOptions,
-			parser: "vue",
-		}),
-	);
-});
-
-test("warns user that Nuxt config could not be updated", async (ctx) => {
-	const log = vi.fn();
-	const installDependencies = vi.fn();
-
-	const errorSpy = vi
-		.spyOn(console, "error")
-		.mockImplementationOnce(() => undefined);
-	const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
-
-	const nuxtConfigPath = path.join(ctx.project.root, "nuxt.config.ts");
-	await fs.writeFile(nuxtConfigPath, "export default () => ({})");
-
-	await ctx.pluginRunner.callHook("project:init", { log, installDependencies });
-
-	expect(errorSpy).toHaveBeenCalledWith("Failed to update nuxt.config.ts");
-	expect(warnSpy.mock.calls).toMatchInlineSnapshot(`
-		[
-		  [
-		    "Ensure that the following has been added to nuxt.config.ts.",
-		  ],
-		  [
-		    "{
-			buildModules: [\\"@nuxtjs/prismic\\"],
-			prismic: {
-				endpoint: \\"https://qwerty.cdn.prismic.io/api/v2\\",
-				modern: true
+	test("Slice Simulator page file is not formatted if formatting is disabled", async (ctx) => {
+		ctx.project.config.adapter.options.format = false;
+		const pluginRunner = createSliceMachinePluginRunner({
+			project: ctx.project,
+			nativePlugins: {
+				[ctx.project.config.adapter.resolve]: adapter,
 			},
-			build: {
-				transpile: [\\"@prismicio/vue\\"]
-			}
-		}",
-		  ],
-		]
-	`);
+		});
+		await pluginRunner.init();
+
+		// Force unusual formatting to detect that formatting did not happen.
+		const prettierOptions = { printWidth: 10 };
+		await fs.writeFile(
+			path.join(ctx.project.root, ".prettierrc"),
+			JSON.stringify(prettierOptions),
+		);
+
+		const log = vi.fn();
+		const installDependencies = vi.fn();
+
+		await pluginRunner.callHook("project:init", { log, installDependencies });
+
+		const contents = await fs.readFile(
+			path.join(ctx.project.root, "pages", "slice-simulator.vue"),
+			"utf8",
+		);
+
+		expect(contents).not.toBe(
+			prettier.format(contents, {
+				...prettierOptions,
+				parser: "vue",
+			}),
+		);
+	});
+});
+
+describe("modify slicemachine.config.json", () => {
+	test("adds default localSliceSimulatorURL", async (ctx) => {
+		const log = vi.fn();
+		const installDependencies = vi.fn();
+
+		await ctx.pluginRunner.callHook("project:init", {
+			log,
+			installDependencies,
+		});
+
+		const contents = JSON.parse(
+			await fs.readFile(
+				path.join(ctx.project.root, "slicemachine.config.json"),
+				"utf8",
+			),
+		);
+
+		expect(contents.localSliceSimulatorURL).toBe(
+			"http://localhost:3000/slice-simulator",
+		);
+	});
+
+	test("does not modify localSliceSimulatorURL if it already exists", async (ctx) => {
+		const log = vi.fn();
+		const installDependencies = vi.fn();
+
+		const preHookConfig = {
+			...ctx.project.config,
+			localSliceSimulatorURL: "foo",
+		};
+
+		await fs.writeFile(
+			path.join(ctx.project.root, "slicemachine.config.json"),
+			JSON.stringify(preHookConfig),
+		);
+
+		await ctx.pluginRunner.callHook("project:init", {
+			log,
+			installDependencies,
+		});
+
+		const contents = JSON.parse(
+			await fs.readFile(
+				path.join(ctx.project.root, "slicemachine.config.json"),
+				"utf8",
+			),
+		);
+
+		expect(contents.localSliceSimulatorURL).toBe(
+			preHookConfig.localSliceSimulatorURL,
+		);
+	});
+
+	test("nests default Slice Library under src directory if it exists", async (ctx) => {
+		const log = vi.fn();
+		const installDependencies = vi.fn();
+
+		await fs.mkdir(path.join(ctx.project.root, "src"), { recursive: true });
+
+		await ctx.pluginRunner.callHook("project:init", {
+			log,
+			installDependencies,
+		});
+
+		const contents = JSON.parse(
+			await fs.readFile(
+				path.join(ctx.project.root, "slicemachine.config.json"),
+				"utf8",
+			),
+		);
+
+		expect(contents.libraries).toStrictEqual(["./src/slices"]);
+	});
+
+	test("does not nest the default Slice Library under src directory if it is not empty", async (ctx) => {
+		const log = vi.fn();
+		const installDependencies = vi.fn();
+
+		await fs.mkdir(path.join(ctx.project.root, "src"), { recursive: true });
+
+		await fs.mkdir(path.join(ctx.project.root, "slices"), { recursive: true });
+		await fs.writeFile(path.join(ctx.project.root, "slices", "index.js"), "");
+
+		await ctx.pluginRunner.callHook("project:init", {
+			log,
+			installDependencies,
+		});
+
+		const contents = JSON.parse(
+			await fs.readFile(
+				path.join(ctx.project.root, "slicemachine.config.json"),
+				"utf8",
+			),
+		);
+
+		expect(contents.libraries).toStrictEqual(["./slices"]);
+	});
+
+	test("does not modify Slice Library if it is not the default", async (ctx) => {
+		const log = vi.fn();
+		const installDependencies = vi.fn();
+
+		const preHookConfig = {
+			...ctx.project.config,
+			libraries: ["./foo"],
+		};
+
+		await fs.writeFile(
+			path.join(ctx.project.root, "slicemachine.config.json"),
+			JSON.stringify(preHookConfig),
+		);
+
+		await fs.mkdir(path.join(ctx.project.root, "src"), { recursive: true });
+
+		await ctx.pluginRunner.callHook("project:init", {
+			log,
+			installDependencies,
+		});
+
+		const contents = JSON.parse(
+			await fs.readFile(
+				path.join(ctx.project.root, "slicemachine.config.json"),
+				"utf8",
+			),
+		);
+
+		expect(contents.libraries).toStrictEqual(preHookConfig.libraries);
+	});
 });

--- a/packages/adapter-nuxt2/test/plugin-slice-create.test.ts
+++ b/packages/adapter-nuxt2/test/plugin-slice-create.test.ts
@@ -9,6 +9,8 @@ import * as tsm from "ts-morph";
 import { parseSourceFile } from "./__testutils__/parseSourceFile";
 import { testGlobalContentTypes } from "./__testutils__/testGlobalContentTypes";
 
+import adapter from "../src";
+
 /**
  * !!! DO NOT use this mock factory in tests !!!
  *
@@ -49,7 +51,12 @@ test("upserts a library index.js file", async (ctx) => {
 
 test("upserts a library index.ts file when TypeScript is enabled", async (ctx) => {
 	ctx.project.config.adapter.options.typescript = true;
-	const pluginRunner = createSliceMachinePluginRunner({ project: ctx.project });
+	const pluginRunner = createSliceMachinePluginRunner({
+		project: ctx.project,
+		nativePlugins: {
+			[ctx.project.config.adapter.resolve]: adapter,
+		},
+	});
 	await pluginRunner.init();
 
 	await pluginRunner.callHook("slice:create", { libraryID: "slices", model });
@@ -85,7 +92,12 @@ test("library index file includes created Slice", async (ctx) => {
 
 test("library index file includes created Slice without lazy-loading when disabled", async (ctx) => {
 	ctx.project.config.adapter.options.lazyLoadSlices = false;
-	const pluginRunner = createSliceMachinePluginRunner({ project: ctx.project });
+	const pluginRunner = createSliceMachinePluginRunner({
+		project: ctx.project,
+		nativePlugins: {
+			[ctx.project.config.adapter.resolve]: adapter,
+		},
+	});
 	await pluginRunner.init();
 
 	await pluginRunner.callHook("slice:create", {
@@ -146,7 +158,12 @@ test("model.json is formatted by default", async (ctx) => {
 
 test("model.json is not formatted if formatting is disabled", async (ctx) => {
 	ctx.project.config.adapter.options.format = false;
-	const pluginRunner = createSliceMachinePluginRunner({ project: ctx.project });
+	const pluginRunner = createSliceMachinePluginRunner({
+		project: ctx.project,
+		nativePlugins: {
+			[ctx.project.config.adapter.resolve]: adapter,
+		},
+	});
 	await pluginRunner.init();
 
 	// Force unusual formatting to detect that formatting did not happen.
@@ -187,7 +204,12 @@ test("component file is formatted by default", async (ctx) => {
 
 test("component file is not formatted if formatting is disabled", async (ctx) => {
 	ctx.project.config.adapter.options.format = false;
-	const pluginRunner = createSliceMachinePluginRunner({ project: ctx.project });
+	const pluginRunner = createSliceMachinePluginRunner({
+		project: ctx.project,
+		nativePlugins: {
+			[ctx.project.config.adapter.resolve]: adapter,
+		},
+	});
 	await pluginRunner.init();
 
 	// Force unusual formatting to detect that formatting did not happen.

--- a/packages/plugin-kit/src/createSliceMachineHelpers.ts
+++ b/packages/plugin-kit/src/createSliceMachineHelpers.ts
@@ -6,7 +6,7 @@ import { stripIndent } from "common-tags";
 
 import { decodeSliceMachineConfig } from "./lib/decodeSliceMachineConfig";
 
-import { SliceMachineProject } from "./types";
+import { SliceMachineConfig, SliceMachineProject } from "./types";
 
 type FormatOptions = {
 	prettier?: prettier.Options;
@@ -72,6 +72,28 @@ export class SliceMachineHelpers {
 			...this._project,
 			config: sliceMachineConfig,
 		};
+	};
+
+	updateProjectConfig = async (
+		config: SliceMachineConfig,
+		format?: boolean,
+	): Promise<void> => {
+		const { value: sliceMachineConfig, error } =
+			decodeSliceMachineConfig(config);
+
+		if (error) {
+			// TODO: Write a more friendly and useful message.
+			throw new Error(`Invalid config provided. ${error.errors.join(", ")}`);
+		}
+
+		const configFilePath = this.joinPathFromRoot("slicemachine.config.json");
+		let content = JSON.stringify(sliceMachineConfig);
+
+		if (format) {
+			content = await this.format(content, configFilePath);
+		}
+
+		await fs.writeFile(configFilePath, content);
 	};
 
 	format = async (

--- a/packages/plugin-kit/src/createSliceMachineHelpers.ts
+++ b/packages/plugin-kit/src/createSliceMachineHelpers.ts
@@ -8,6 +8,10 @@ import { decodeSliceMachineConfig } from "./lib/decodeSliceMachineConfig";
 
 import { SliceMachineConfig, SliceMachineProject } from "./types";
 
+type UpdateSliceMachineConfigOptions = {
+	format?: boolean;
+};
+
 type FormatOptions = {
 	prettier?: prettier.Options;
 	/**
@@ -74,12 +78,12 @@ export class SliceMachineHelpers {
 		};
 	};
 
-	updateProjectConfig = async (
-		config: SliceMachineConfig,
-		format?: boolean,
+	updateSliceMachineConfig = async (
+		sliceMachineConfig: SliceMachineConfig,
+		options?: UpdateSliceMachineConfigOptions,
 	): Promise<void> => {
-		const { value: sliceMachineConfig, error } =
-			decodeSliceMachineConfig(config);
+		const { value: decodedSliceMachineConfig, error } =
+			decodeSliceMachineConfig(sliceMachineConfig);
 
 		if (error) {
 			// TODO: Write a more friendly and useful message.
@@ -87,9 +91,9 @@ export class SliceMachineHelpers {
 		}
 
 		const configFilePath = this.joinPathFromRoot("slicemachine.config.json");
-		let content = JSON.stringify(sliceMachineConfig);
+		let content = JSON.stringify(decodedSliceMachineConfig, null, 2);
 
-		if (format) {
+		if (options?.format) {
 			content = await this.format(content, configFilePath);
 		}
 

--- a/packages/plugin-kit/test/SliceMachineHelpers-getProject.test.ts
+++ b/packages/plugin-kit/test/SliceMachineHelpers-getProject.test.ts
@@ -36,7 +36,7 @@ it("returns Slice Machine project metadata", async () => {
 	await fs.rm(project.root, { recursive: true });
 });
 
-it("throws on not found config", async () => {
+it("throws when a config cannot be found", async () => {
 	const adapter = createTestAdapter();
 	const project = createSliceMachineProject(adapter);
 	project.root = await fs.mkdtemp(
@@ -55,7 +55,7 @@ it("throws on not found config", async () => {
 	await fs.rm(project.root, { recursive: true });
 });
 
-it("throws on invalid config", async () => {
+it("throws when a config is invalid", async () => {
 	const adapter = createTestAdapter();
 	const project = createSliceMachineProject(adapter);
 	project.root = await fs.mkdtemp(

--- a/packages/plugin-kit/test/SliceMachineHelpers-updateProjectConfig.test.ts
+++ b/packages/plugin-kit/test/SliceMachineHelpers-updateProjectConfig.test.ts
@@ -8,7 +8,7 @@ import { createTestAdapter } from "./__testutils__/createTestAdapter";
 
 import { createSliceMachinePluginRunner, SliceMachineConfig } from "../src";
 
-it("returns Slice Machine project metadata", async () => {
+it("updates Slice Machine project config", async () => {
 	const adapter = createTestAdapter();
 	const project = createSliceMachineProject(adapter);
 	project.root = await fs.mkdtemp(
@@ -28,50 +28,51 @@ it("returns Slice Machine project metadata", async () => {
 	await pluginRunner.init();
 
 	const res = await pluginRunner.rawHelpers.getProject();
+
 	expect(res).toStrictEqual({
 		...project,
 		config: smJSON,
 	});
 
+	const updatedSMJSON: SliceMachineConfig = {
+		repositoryName: "updatedRepositoryName",
+		adapter: "updatedAdapter",
+	};
+	await pluginRunner.rawHelpers.updateProjectConfig(updatedSMJSON, true);
+
+	const updatedRes = await pluginRunner.rawHelpers.getProject();
+
+	expect(updatedRes).toStrictEqual({
+		...project,
+		config: updatedSMJSON,
+	});
+
 	await fs.rm(project.root, { recursive: true });
 });
 
-it("throws on not found config", async () => {
+it("throws on invalid config provided", async () => {
 	const adapter = createTestAdapter();
 	const project = createSliceMachineProject(adapter);
 	project.root = await fs.mkdtemp(
 		path.join(os.tmpdir(), "@slicemachine__plugin-kit___"),
 	);
 
-	await fs.writeFile(path.join(project.root, "slicemachine.config.json"), "");
-
-	const pluginRunner = createSliceMachinePluginRunner({ project });
-	await pluginRunner.init();
-
-	expect(() => pluginRunner.rawHelpers.getProject()).rejects.toThrowError(
-		/No config found/,
-	);
-
-	await fs.rm(project.root, { recursive: true });
-});
-
-it("throws on invalid config", async () => {
-	const adapter = createTestAdapter();
-	const project = createSliceMachineProject(adapter);
-	project.root = await fs.mkdtemp(
-		path.join(os.tmpdir(), "@slicemachine__plugin-kit___"),
-	);
-
+	const smJSON: SliceMachineConfig = {
+		repositoryName: "repositoryName",
+		adapter: "adapter",
+	};
 	await fs.writeFile(
 		path.join(project.root, "slicemachine.config.json"),
-		JSON.stringify({}),
+		JSON.stringify(smJSON),
 	);
 
 	const pluginRunner = createSliceMachinePluginRunner({ project });
 	await pluginRunner.init();
 
-	expect(() => pluginRunner.rawHelpers.getProject()).rejects.toThrowError(
-		/Invalid config/,
-	);
+	expect(() =>
+		// @ts-expect-error - testing runtime type checking
+		pluginRunner.rawHelpers.updateProjectConfig({}),
+	).rejects.toThrowError(/Invalid config/);
+
 	await fs.rm(project.root, { recursive: true });
 });

--- a/packages/plugin-kit/test/SliceMachineHelpers-updateSliceMachineConfig.test.ts
+++ b/packages/plugin-kit/test/SliceMachineHelpers-updateSliceMachineConfig.test.ts
@@ -38,7 +38,9 @@ it("updates Slice Machine project config", async () => {
 		repositoryName: "updatedRepositoryName",
 		adapter: "updatedAdapter",
 	};
-	await pluginRunner.rawHelpers.updateProjectConfig(updatedSMJSON, true);
+	await pluginRunner.rawHelpers.updateSliceMachineConfig(updatedSMJSON, {
+		format: true,
+	});
 
 	const updatedRes = await pluginRunner.rawHelpers.getProject();
 
@@ -71,7 +73,7 @@ it("throws on invalid config provided", async () => {
 
 	expect(() =>
 		// @ts-expect-error - testing runtime type checking
-		pluginRunner.rawHelpers.updateProjectConfig({}),
+		pluginRunner.rawHelpers.updateSliceMachineConfig({ repositoryName: null }),
 	).rejects.toThrowError(/Invalid config/);
 
 	await fs.rm(project.root, { recursive: true });


### PR DESCRIPTION


## The Solution

<!--
Highlight explanations where the complexity in your development is.
Keep in mind that the reviewer might not have as much context as you do.
This is very important to make sure the review is thorough and the reviewer understand your changes.
-->

This PR introduces a standard `updateProjectConfig` helper on the Plugin Kit, allowing adapters to update Slice Machine configuration upon init.

This enables adapters to insert their Slice Simulator URL path, not requiring users to do it manually anymore, therefore reducing the Time To First Slice (cf. OKRs).

Additional context: https://www.notion.so/prismic/Adapter-Slice-Simulator-Config-e594f57a83274afd800684bdaf4df4a0?pvs=4

## Impact / Dependencies

<!--
List all the impacts your development might have on internal and external features.
Ideally this should have been discussed prior to this development.

Link of any other PRs that are related to this development.
They should also be referenced in the ticket for reviews.
-->

Adapters have been refactored to use the standardized helper.


## Checklist before requesting a review
- [x] I hereby declare my code ready for review.
- [x] If it is a critical feature, I have added tests.
- [x] The CI is successful.
- [x] If there could backward compatibility issues, it has been discussed and planned.



<!--
A funny animal picture is welcome to close your PR!
You can find one here https://unsplash.com/s/photos/funny-animal-picture
-->
![HennahaneThurstableGIF](https://github.com/prismicio/slice-machine/assets/25330882/8b6f927b-bcd5-4084-9623-abe014bdedaa)
