### PR TITLE
refactor(black-slate): add spacious variation

### DIFF
--- a/packages/slice-machine/src/components/BlankSlate/BlankSlate.css.ts
+++ b/packages/slice-machine/src/components/BlankSlate/BlankSlate.css.ts
@@ -23,14 +23,33 @@ export const root = style([
   { maxWidth: 498, minHeight: 400 },
 ]);
 
-export const withBackground = style([
+export const large = style([
   sprinkles({
     textAlign: "center",
     width: "100%",
   }),
   {
-    backgroundSize: "cover",
     height: "50vh",
+    maxWidth: "100%",
+  },
+]);
+
+export const withBackground = style([
+  sprinkles({
+    textAlign: "center",
+  }),
+  {
+    backgroundSize: "cover",
+  },
+]);
+
+export const spacious = style([
+  sprinkles({
+    textAlign: "center",
+    width: "100%",
+  }),
+  {
+    height: "100%",
     maxWidth: "100%",
   },
 ]);

--- a/packages/slice-machine/src/components/BlankSlate/BlankSlate.stories.tsx
+++ b/packages/slice-machine/src/components/BlankSlate/BlankSlate.stories.tsx
@@ -58,3 +58,21 @@ export const Background = {
     ),
   },
 } satisfies Story;
+
+export const Spacious: Story = {
+  args: {
+    backgroundImage: "/blank-slate-slice-zone.png",
+    variation: "spacious",
+    children: (
+      <BlankSlateContent>
+        <BlankSlateTitle>My blank slate title</BlankSlateTitle>
+        <BlankSlateDescription>
+          My blank slate description
+        </BlankSlateDescription>
+        <BlankSlateActions>
+          <Button>Create</Button>
+        </BlankSlateActions>
+      </BlankSlateContent>
+    ),
+  },
+};

--- a/packages/slice-machine/src/components/BlankSlate/BlankSlate.tsx
+++ b/packages/slice-machine/src/components/BlankSlate/BlankSlate.tsx
@@ -7,19 +7,25 @@ import * as styles from "./BlankSlate.css";
 interface BlankSlateProps extends PropsWithChildren {
   style?: CSSProperties;
   backgroundImage?: string;
+  variation?: "spacious";
 }
 
 export const BlankSlate: FC<BlankSlateProps> = ({
   backgroundImage,
   style,
+  variation,
   ...props
 }) => {
   const hasBackground = backgroundImage !== undefined;
+  const large = hasBackground && variation !== "spacious";
+  const spacious = variation === "spacious";
   return (
     <article
       {...props}
       className={clsx(styles.root, {
         [styles.withBackground]: hasBackground,
+        [styles.large]: large,
+        [styles.spacious]: spacious,
       })}
       style={{
         backgroundImage: hasBackground ? `url(${backgroundImage})` : undefined,


### PR DESCRIPTION
## Context
[Ticket](https://linear.app/prismic/issue/DT-1524/aadev-i-need-to-add-a-spacious-option-to-the-blankslate-component)

Adds a spacious variation to the blank slate component, this sets the width and height to 100%
completes DT-1524
<!--
Please include either
- a ticket
    - [Link text Here](https://link-url-here.org)

- a github issue / forum thread
    - Fixes #

- a detailed description of the issue and it's implications

This part should always include acceptance criteria weither they are accessible on a link or written here directly.
-->


<img width="1044" alt="Screenshot 2023-08-04 at 13 29 50" src="https://github.com/prismicio/slice-machine/assets/7499570/e99afe41-3118-42b7-bcb6-30e43007eb45">


## The Solution

<!--
Highlight explanations where the complexity in your development is.
Keep in mind that the reviewer might not have as much context as you do.
This is very important to make sure the review is thorough and the reviewer understand your changes.
-->




## Impact / Dependencies

<!--
List all the impacts your development might have on internal and external features.
Ideally this should have been discussed prior to this development.

Link of any other PRs that are related to this development.
They should also be referenced in the ticket for reviews.
-->




## Checklist before requesting a review
- [ ] I hereby declare my code ready for review.
- [ ] If it is a critical feature, I have added tests.
- [ ] The CI is successful.
- [ ] If there could backward compatibility issues, it has been discussed and planned.




## [OPT] Preview

<!--
Visual aid of your work.
It can either be screenshots or a video.
This could help reviewers to get context quickly.
-->




<!--
A funny animal picture is welcome to close your PR!
You can find one here https://unsplash.com/s/photos/funny-animal-picture
-->