### PR TITLE
fix(adapter-next): update page snippets to support unpublished previews

### DIFF
--- a/packages/adapter-next/src/hooks/documentation-read.ts
+++ b/packages/adapter-next/src/hooks/documentation-read.ts
@@ -40,8 +40,6 @@ export const documentationRead: DocumentationReadHook<PluginOptions> = async (
 
 					type Params = { uid: string };
 
-					export const dynamicParams = false;
-
 					export default async function Page({ params }: { params: Params }) {
 						const client = createClient();
 						const page = await client
@@ -57,7 +55,9 @@ export const documentationRead: DocumentationReadHook<PluginOptions> = async (
 						params: Params;
 					}): Promise<Metadata> {
 						const client = createClient();
-						const page = await client.getByUID("${model.id}", params.uid);
+						const page = await client
+							.getByUID("${model.id}", params.uid)
+							.catch(() => notFound());
 
 						return {
 							title: page.data.meta_title,
@@ -202,7 +202,6 @@ export const documentationRead: DocumentationReadHook<PluginOptions> = async (
 					import { createClient } from "@/prismicio";
 					import { components } from "@/slices";
 
-					export const dynamicParams = false;
 
 					export default async function Page({ params }) {
 						const client = createClient();
@@ -215,7 +214,9 @@ export const documentationRead: DocumentationReadHook<PluginOptions> = async (
 
 					export async function generateMetadata({ params }) {
 						const client = createClient();
-						const page = await client.getByUID("${model.id}", params.uid);
+						const page = await client
+							.getByUID("${model.id}", params.uid)
+							.catch(() => notFound());
 
 						return {
 							title: page.data.meta_title,
@@ -377,7 +378,7 @@ export const documentationRead: DocumentationReadHook<PluginOptions> = async (
 				`,
 			},
 			{
-				label: "Page Router",
+				label: "Pages Router",
 				content: source`
 					## Create your ${model.label}'s page component
 

--- a/packages/adapter-next/src/hooks/project-init.ts
+++ b/packages/adapter-next/src/hooks/project-init.ts
@@ -320,7 +320,6 @@ const createPreviewRoute = async ({
 		if (isTypeScriptProject) {
 			contents = source`
 				import { NextRequest } from "next/server";
-				import { draftMode } from "next/headers";
 				import { redirectToPreviewURL } from "@prismicio/next";
 
 				import { createClient } from "../../../prismicio";
@@ -328,22 +327,17 @@ const createPreviewRoute = async ({
 				export async function GET(request: NextRequest) {
 					const client = createClient();
 
-					draftMode().enable();
-
 					await redirectToPreviewURL({ client, request });
 				}
 			`;
 		} else {
 			contents = source`
-				import { draftMode } from "next/headers";
 				import { redirectToPreviewURL } from "@prismicio/next";
 
 				import { createClient } from "../../../prismicio";
 
 				export async function GET(request) {
 					const client = createClient();
-
-					draftMode().enable();
 
 					await redirectToPreviewURL({ client, request });
 				}

--- a/packages/adapter-next/test/__snapshots__/plugin-documentation-read.test.ts.snap
+++ b/packages/adapter-next/test/__snapshots__/plugin-documentation-read.test.ts.snap
@@ -1,0 +1,236 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`PageSnippet > App Router > return a snippet with JavaScript 1`] = `
+{
+  "content": "## Create your Foo Bar's page component
+
+Add a new route by creating an \`app/[uid]/page.js\` file. (If the route should be nested in a child directory, you can create the file in a directory, like \`app/marketing/[uid]/page.js\`.)
+
+Paste in this code:
+
+~~~js [app/[uid]/page.js]
+import { notFound } from \\"next/navigation\\";
+import { SliceZone } from \\"@prismicio/react\\";
+
+import { createClient } from \\"@/prismicio\\";
+import { components } from \\"@/slices\\";
+
+export default async function Page({ params }) {
+  const client = createClient();
+  const page = await client
+    .getByUID(\\"foo_bar\\", params.uid)
+    .catch(() => notFound());
+
+  return <SliceZone slices={page.data.slices} components={components} />;
+}
+
+export async function generateMetadata({ params }) {
+  const client = createClient();
+  const page = await client
+    .getByUID(\\"foo_bar\\", params.uid)
+    .catch(() => notFound());
+
+  return {
+    title: page.data.meta_title,
+    description: page.data.meta_description,
+  };
+}
+
+export async function generateStaticParams() {
+  const client = createClient();
+  const pages = await client.getAllByType(\\"foo_bar\\");
+
+  return pages.map((page) => {
+    return { uid: page.uid };
+  });
+}
+~~~
+
+Make sure all of your import paths are correct. See the [install guide](https://prismic.io/docs/setup-nextjs) for more information.",
+  "label": "App Router",
+}
+`;
+
+exports[`PageSnippet > App Router > return a snippet with TypeScript for TypeScript projects 1`] = `
+{
+  "content": "## Create your Foo Bar's page component
+
+Add a new route by creating an \`app/[uid]/page.tsx\` file. (If the route should be nested in a child directory, you can create the file in a directory, like \`app/marketing/[uid]/page.tsx\`.)
+
+Paste in this code:
+
+~~~tsx [app/[uid]/page.tsx]
+import { Metadata } from \\"next\\";
+import { notFound } from \\"next/navigation\\";
+import { SliceZone } from \\"@prismicio/react\\";
+
+import { createClient } from \\"@/prismicio\\";
+import { components } from \\"@/slices\\";
+
+type Params = { uid: string };
+
+export default async function Page({ params }: { params: Params }) {
+  const client = createClient();
+  const page = await client
+    .getByUID(\\"foo_bar\\", params.uid)
+    .catch(() => notFound());
+
+  return <SliceZone slices={page.data.slices} components={components} />;
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Params;
+}): Promise<Metadata> {
+  const client = createClient();
+  const page = await client
+    .getByUID(\\"foo_bar\\", params.uid)
+    .catch(() => notFound());
+
+  return {
+    title: page.data.meta_title,
+    description: page.data.meta_description,
+  };
+}
+
+export async function generateStaticParams() {
+  const client = createClient();
+  const pages = await client.getAllByType(\\"foo_bar\\");
+
+  return pages.map((page) => {
+    return { uid: page.uid };
+  });
+}
+~~~
+
+Make sure all of your import paths are correct. See the [install guide](https://prismic.io/docs/setup-nextjs) for more information.",
+  "label": "App Router",
+}
+`;
+
+exports[`PageSnippet > Pages Router > return a snippet with JavaScript 1`] = `
+{
+  "content": "## Create your Foo Bar's page component
+
+Add a new route by creating a \`pages/[uid].js\` file. (If the route should be nested in a child directory, you can create the file in a directory, like \`pages/marketing/[uid].js\`.)
+
+~~~js [pages/[uid].js]
+import Head from \\"next/head\\";
+import { isFilled, asLink } from \\"@prismicio/client\\";
+import { SliceZone } from \\"@prismicio/react\\";
+
+import { components } from \\"@/slices\\";
+import { createClient } from \\"@/prismicio\\";
+
+export default function Page({ page }) {
+  return (
+    <>
+      <Head>
+        <title>{page.data.meta_title}</title>
+        {isFilled.keyText(page.data.meta_description) ? (
+          <meta name=\\"description\\" content={page.data.meta_description} />
+        ) : null}
+      </Head>
+      <SliceZone slices={page.data.slices} components={components} />
+    </>
+  );
+}
+
+export async function getStaticProps({ params, previewData }) {
+  // The \`previewData\` parameter allows your app to preview
+  // drafts from the Page Builder.
+  const client = createClient({ previewData });
+
+  const page = await client.getByUID(\\"foo_bar\\", params.uid);
+
+  return {
+    props: { page },
+  };
+}
+
+export async function getStaticPaths() {
+  const client = createClient();
+
+  const pages = await client.getAllByType(\\"foo_bar\\");
+
+  return {
+    paths: pages.map((page) => {
+      return asLink(page);
+    }),
+    fallback: false,
+  };
+}
+~~~
+
+Make sure all of your import paths are correct. See the [install guide](https://prismic.io/docs/setup-nextjs) for more information.",
+  "label": "Pages Router",
+}
+`;
+
+exports[`PageSnippet > Pages Router > return a snippet with TypeScript for TypeScript projects 1`] = `
+{
+  "content": "## Create your Foo Bar's page component
+
+Add a new route by creating a \`pages/[uid].tsx\` file. (If the route should be nested in a child directory, you can create the file in a directory, like \`pages/marketing/[uid].tsx\`.)
+
+~~~tsx [pages/[uid].tsx]
+import { GetStaticPropsContext, InferGetStaticPropsType } from \\"next\\";
+import Head from \\"next/head\\";
+import { isFilled, asLink } from \\"@prismicio/client\\";
+import { SliceZone } from \\"@prismicio/react\\";
+
+import { components } from \\"@/slices\\";
+import { createClient } from \\"@/prismicio\\";
+
+type Params = { uid: string };
+
+export default function Page({
+  page,
+}: InferGetStaticPropsType<typeof getStaticProps>) {
+  return (
+    <>
+      <Head>
+        <title>{page.data.meta_title}</title>
+        {isFilled.keyText(page.data.meta_description) ? (
+          <meta name=\\"description\\" content={page.data.meta_description} />
+        ) : null}
+      </Head>
+      <SliceZone slices={page.data.slices} components={components} />
+    </>
+  );
+}
+
+export async function getStaticProps({
+  params,
+  previewData,
+}: GetStaticPropsContext<Params>) {
+  // The \`previewData\` parameter allows your app to preview
+  // drafts from the Page Builder.
+  const client = createClient({ previewData });
+
+  const page = await client.getByUID(\\"foo_bar\\", params!.uid);
+
+  return {
+    props: { page },
+  };
+}
+
+export async function getStaticPaths() {
+  const client = createClient();
+
+  const pages = await client.getAllByType(\\"foo_bar\\");
+
+  return {
+    paths: pages.map((page) => {
+      return asLink(page);
+    }),
+    fallback: false,
+  };
+}
+~~~
+
+Make sure all of your import paths are correct. See the [install guide](https://prismic.io/docs/setup-nextjs) for more information.",
+  "label": "Pages Router",
+}
+`;

--- a/packages/adapter-next/test/plugin-documentation-read.test.ts
+++ b/packages/adapter-next/test/plugin-documentation-read.test.ts
@@ -12,7 +12,10 @@ import * as path from "node:path";
 const mock = createMockFactory({ seed: import.meta.url });
 
 // Slice model to be used in general tests.
-const model = mock.model.customType({ id: "foo_bar" });
+const model = mock.model.customType({
+	id: "foo_bar",
+	repeatable: true,
+});
 
 describe("PageSnippet", () => {
 	describe("App Router", () => {

--- a/packages/adapter-next/test/plugin-documentation-read.test.ts
+++ b/packages/adapter-next/test/plugin-documentation-read.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+import { createMockFactory } from "@prismicio/mock";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+
+/**
+ * !!! DO NOT use this mock factory in tests !!!
+ *
+ * @remarks
+ * Its seed is not specific to be used outside the most general cases.
+ */
+const mock = createMockFactory({ seed: import.meta.url });
+
+// Slice model to be used in general tests.
+const model = mock.model.customType({ id: "foo_bar" });
+
+describe("PageSnippet", () => {
+	describe("App Router", () => {
+		it("return a snippet with TypeScript for TypeScript projects", async (ctx) => {
+			await fs.writeFile(
+				path.join(ctx.project.root, "tsconfig.json"),
+				JSON.stringify({}),
+			);
+
+			const res = await ctx.pluginRunner.callHook("documentation:read", {
+				kind: "PageSnippet",
+				data: {
+					model,
+				},
+			});
+
+			const item = res.data.flat().find((item) => item.label === "App Router");
+
+			expect(item).toMatchSnapshot();
+		});
+
+		it("return a snippet with JavaScript", async (ctx) => {
+			const res = await ctx.pluginRunner.callHook("documentation:read", {
+				kind: "PageSnippet",
+				data: {
+					model,
+				},
+			});
+
+			const item = res.data.flat().find((item) => item.label === "App Router");
+
+			expect(item).toMatchSnapshot();
+		});
+	});
+
+	describe("Pages Router", () => {
+		it("return a snippet with TypeScript for TypeScript projects", async (ctx) => {
+			await fs.writeFile(
+				path.join(ctx.project.root, "tsconfig.json"),
+				JSON.stringify({}),
+			);
+
+			const res = await ctx.pluginRunner.callHook("documentation:read", {
+				kind: "PageSnippet",
+				data: {
+					model,
+				},
+			});
+
+			const item = res.data
+				.flat()
+				.find((item) => item.label === "Pages Router");
+
+			expect(item).toMatchSnapshot();
+		});
+
+		it("return a snippet with JavaScript", async (ctx) => {
+			const res = await ctx.pluginRunner.callHook("documentation:read", {
+				kind: "PageSnippet",
+				data: {
+					model,
+				},
+			});
+
+			const item = res.data
+				.flat()
+				.find((item) => item.label === "Pages Router");
+
+			expect(item).toMatchSnapshot();
+		});
+	});
+});

--- a/packages/adapter-next/test/plugin-project-init.test.ts
+++ b/packages/adapter-next/test/plugin-project-init.test.ts
@@ -1178,7 +1178,7 @@ describe("Slice Simulator route", () => {
 });
 
 describe("/api/preview route", () => {
-	describe("App Route", () => {
+	describe("App Router", () => {
 		beforeEach(async (ctx) => {
 			await fs.mkdir(path.join(ctx.project.root, "app"), { recursive: true });
 		});
@@ -1198,15 +1198,12 @@ describe("/api/preview route", () => {
 			);
 
 			expect(contents).toMatchInlineSnapshot(`
-				"import { draftMode } from \\"next/headers\\";
-				import { redirectToPreviewURL } from \\"@prismicio/next\\";
+				"import { redirectToPreviewURL } from \\"@prismicio/next\\";
 
 				import { createClient } from \\"../../../prismicio\\";
 
 				export async function GET(request) {
 				  const client = createClient();
-
-				  draftMode().enable();
 
 				  await redirectToPreviewURL({ client, request });
 				}
@@ -1233,15 +1230,12 @@ describe("/api/preview route", () => {
 			);
 
 			expect(contents).toMatchInlineSnapshot(`
-				"import { draftMode } from \\"next/headers\\";
-				import { redirectToPreviewURL } from \\"@prismicio/next\\";
+				"import { redirectToPreviewURL } from \\"@prismicio/next\\";
 
 				import { createClient } from \\"../../../prismicio\\";
 
 				export async function GET(request) {
 				  const client = createClient();
-
-				  draftMode().enable();
 
 				  await redirectToPreviewURL({ client, request });
 				}
@@ -1270,15 +1264,12 @@ describe("/api/preview route", () => {
 
 			expect(contents).toMatchInlineSnapshot(`
 				"import { NextRequest } from \\"next/server\\";
-				import { draftMode } from \\"next/headers\\";
 				import { redirectToPreviewURL } from \\"@prismicio/next\\";
 
 				import { createClient } from \\"../../../prismicio\\";
 
 				export async function GET(request: NextRequest) {
 				  const client = createClient();
-
-				  draftMode().enable();
 
 				  await redirectToPreviewURL({ client, request });
 				}
@@ -1287,7 +1278,7 @@ describe("/api/preview route", () => {
 		});
 	});
 
-	describe("Pages Route", () => {
+	describe("Pages Router", () => {
 		test("creates a route handler", async (ctx) => {
 			const log = vi.fn();
 			const installDependencies = vi.fn();
@@ -1391,7 +1382,7 @@ describe("/api/preview route", () => {
 });
 
 describe("/api/exit-preview route", () => {
-	describe("App Route", () => {
+	describe("App Router", () => {
 		beforeEach(async (ctx) => {
 			await fs.mkdir(path.join(ctx.project.root, "app"), { recursive: true });
 		});
@@ -1485,7 +1476,7 @@ describe("/api/exit-preview route", () => {
 		});
 	});
 
-	describe("Pages Route", () => {
+	describe("Pages Router", () => {
 		test("creates a route handler", async (ctx) => {
 			const log = vi.fn();
 			const installDependencies = vi.fn();
@@ -1571,7 +1562,7 @@ describe("/api/exit-preview route", () => {
 });
 
 describe("/api/revalidate route", () => {
-	describe("App Route", () => {
+	describe("App Router", () => {
 		beforeEach(async (ctx) => {
 			await fs.mkdir(path.join(ctx.project.root, "app"), { recursive: true });
 		});
@@ -1674,7 +1665,7 @@ describe("/api/revalidate route", () => {
 		});
 	});
 
-	describe("Pages Route", () => {
+	describe("Pages Router", () => {
 		test("doesn't create a route handler", async (ctx) => {
 			const log = vi.fn();
 			const installDependencies = vi.fn();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This PR updates `@slicemachine/next`'s page snippet to support unpublished previews.

The following changes were made to fix the issue:

- Remove `export dynamicParams = false;` to support URLs that were not statically built.
- Add `.catch(() => notFound())` to `@prismicio/client` queries to properly report a 404 page rather than a 500.

Tests were missing for `documentation:read` and were added as part of this PR.

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->

🦚
