### PR TITLE
build(adapter-nuxt2): change bundling strategy to fully support webpack 4

### DIFF
--- a/packages/adapter-nuxt2/src/simulator/SliceSimulator.ts
+++ b/packages/adapter-nuxt2/src/simulator/SliceSimulator.ts
@@ -2,12 +2,6 @@ import Vue, { PropType, VNodeChildren } from "vue";
 import { CreateElement, ExtendedVue } from "vue/types/vue";
 
 import {
-	SliceSimulatorState,
-	SliceSimulatorOptions,
-	SliceSimulatorProps as BaseSliceSimulatorProps,
-} from "@prismicio/simulator/kit";
-import * as simulatorKit from "@prismicio/simulator/dist/kit.cjs";
-const {
 	getDefaultProps,
 	getDefaultSlices,
 	getDefaultMessage,
@@ -17,7 +11,10 @@ const {
 	simulatorRootClass,
 	StateEventType,
 	SimulatorManager,
-} = simulatorKit as unknown as typeof import("@prismicio/simulator/kit");
+	SliceSimulatorState,
+	SliceSimulatorOptions,
+	SliceSimulatorProps as BaseSliceSimulatorProps,
+} from "@prismicio/simulator/kit";
 
 export type SliceSimulatorProps = Omit<BaseSliceSimulatorProps, "state">;
 

--- a/packages/adapter-nuxt2/test/simulator-SliceSimulator.test.ts
+++ b/packages/adapter-nuxt2/test/simulator-SliceSimulator.test.ts
@@ -1,8 +1,7 @@
 import { test, expect } from "vitest";
 
-// Nuxt 2 is still under Webpack 4, not understanding subpath exports.
-// import { SliceSimulator } from "../src/simulator";
+import { SliceSimulator } from "../src/simulator";
 
 test.todo("renders a Slice Simulator instance", async () => {
-	expect(true /* SliceSimulator */).toBeTruthy();
+	expect(SliceSimulator).toBeTruthy();
 });

--- a/packages/adapter-nuxt2/vite.config.ts
+++ b/packages/adapter-nuxt2/vite.config.ts
@@ -4,7 +4,7 @@ import sdk from "vite-plugin-sdk";
 export default defineConfig({
 	plugins: [
 		sdk({
-			internalDependencies: ["fp-ts", "node-fetch"],
+			internalDependencies: ["fp-ts", "node-fetch", "@prismicio/simulator"],
 		}),
 	],
 	build: {


### PR DESCRIPTION
## Context

This is a follow-up PR to #1087. It appears changing the import is not enough to fully fix the issue with Nuxt 2 in all scenario, especially with Nuxt v2.17 (latest version to date of Nuxt 2).

## The Solution

<!--
Highlight explanations where the complexity in your development is.
Keep in mind that the reviewer might not have as much context as you do.
This is very important to make sure the review is thorough and the reviewer understand your changes.
-->

This PR changes the fix strategy to inlining `@prismicio/simulator`, which is not ideal but good enough for Nuxt 2 which will reach its EOL at the end of the year.

<details>
<summary>With the previous PR, we're stuck in that kind of back & forth loop with Nuxt v2.17</summary>

![image](https://github.com/prismicio/slice-machine/assets/25330882/ad70a46a-2e65-49f0-906a-b49e65945a22)
![image](https://github.com/prismicio/slice-machine/assets/25330882/d61074ce-fa6a-4c85-8005-a2ce2b7099c1)

</details>

## Impact / Dependencies

<!--
List all the impacts your development might have on internal and external features.
Ideally this should have been discussed prior to this development.

Link of any other PRs that are related to this development.
They should also be referenced in the ticket for reviews.
-->




## Checklist before requesting a review
- [x] I hereby declare my code ready for review.
- [ ] If it is a critical feature, I have added tests.
- [x] The CI is successful.
- [ ] If there could backward compatibility issues, it has been discussed and planned.




## [OPT] Preview

<!--
Visual aid of your work.
It can either be screenshots or a video.
This could help reviewers to get context quickly.
-->




<!--
A funny animal picture is welcome to close your PR!
You can find one here https://unsplash.com/s/photos/funny-animal-picture
-->