### PR TITLE
feat(init): Add starter download in the init

### DIFF
--- a/packages/init/package.json
+++ b/packages/init/package.json
@@ -55,6 +55,7 @@
 		"@lihbr/listr-update-renderer": "^0.5.3",
 		"@slicemachine/manager": "workspace:^",
 		"chalk": "^4.1.2",
+		"giget": "^1.1.2",
 		"globby": "^13.1.3",
 		"listr": "^0.14.3",
 		"log-symbols": "^4.1.0",

--- a/packages/init/src/cli.ts
+++ b/packages/init/src/cli.ts
@@ -5,7 +5,7 @@ import { createSliceMachineInitProcess } from "./SliceMachineInitProcess";
 
 const cli = meow(
 	`
-Prismic Slice Machine Init CLI
+Slice Machine init CLI help
 
 DOCUMENTATION
   https://prismic.io/docs
@@ -17,13 +17,15 @@ USAGE
   $ npx @slicemachine/init
 
 OPTIONS
-  --repository, -r        Specify a Prismic repository to use
+  --repository, -r         Specify a Prismic repository to use
+  --starter, -s            Specify a starter to use
+  --directory-name, -d     Name of a new directory for the starter
 
-  --no-push               For starters, prevent anything from being pushed
-  --no-push-slices        For starters, prevent slices from being pushed
-  --no-push-custom-types  For starters, prevent types from being pushed
-  --no-push-documents     For starters, prevent documents from being pushed
-  --no-start-slicemachine Prevents init from running SliceMachine
+  --no-push                Don't push anything to Prismic
+  --no-push-slices         Don't push slices to Prismic
+  --no-push-custom-types   Don't push types to Prismic
+  --no-push-documents      Don't push documents to Prismic
+  --no-start-slicemachine  Don't run Slice Machine
 
   --help, -h              Display CLI help
   --version, -v           Display CLI version
@@ -34,6 +36,14 @@ OPTIONS
 			repository: {
 				type: "string",
 				alias: "r",
+			},
+			starter: {
+				type: "string",
+				alias: "s",
+			},
+			directoryName: {
+				type: "string",
+				alias: "d",
 			},
 			push: {
 				type: "boolean",

--- a/packages/init/src/constants.ts
+++ b/packages/init/src/constants.ts
@@ -1,3 +1,5 @@
 // Those contants should be unique to the init script, if they are needed elsewhere then they should be extracted to the manager
 export const START_SCRIPT_KEY = "slicemachine";
 export const START_SCRIPT_VALUE = "start-slicemachine";
+export const GIGET_PROVIDER = "github";
+export const GIGET_ORGANIZATION = "prismicio-community";

--- a/packages/init/test/SliceMachineInitProcess-selectRepository.test.ts
+++ b/packages/init/test/SliceMachineInitProcess-selectRepository.test.ts
@@ -295,7 +295,7 @@ it("checks for new repository name to be available", async (ctx) => {
 	});
 });
 
-it("suggests new repository name based on package.json first", async (ctx) => {
+it("suggests new repository name based on directory name first", async (ctx) => {
 	await mockPrismicAPIs(ctx, initProcess, []);
 
 	await watchStd(async () => {
@@ -320,14 +320,14 @@ it("suggests new repository name based on package.json first", async (ctx) => {
 	// @ts-expect-error - Accessing protected property
 	expect(initProcess.context.repository).toMatchInlineSnapshot(`
 		{
-		  "domain": "package-base",
+		  "domain": "base",
 		  "exists": false,
 		}
 	`);
 });
 
-it("suggests new repository name based on directory name second", async (ctx) => {
-	await mockPrismicAPIs(ctx, initProcess, ["package-base"]);
+it("suggests new repository name based on package.json second", async (ctx) => {
+	await mockPrismicAPIs(ctx, initProcess, ["base"]);
 
 	await watchStd(async () => {
 		const stdin = mockStdin();
@@ -351,7 +351,7 @@ it("suggests new repository name based on directory name second", async (ctx) =>
 	// @ts-expect-error - Accessing protected property
 	expect(initProcess.context.repository).toMatchInlineSnapshot(`
 		{
-		  "domain": "base",
+		  "domain": "package-base",
 		  "exists": false,
 		}
 	`);

--- a/yarn.lock
+++ b/yarn.lock
@@ -7724,6 +7724,7 @@ __metadata:
     eslint-plugin-prettier: 4.2.1
     eslint-plugin-tsdoc: 0.2.17
     execa: 7.1.1
+    giget: ^1.1.2
     globby: ^13.1.3
     hook-std: 3.0.0
     listr: ^0.14.3


### PR DESCRIPTION
## Context

- Complete DT-1546

## The Solution

Specs in DT-1537

## Impact / Dependencies

- wroom and official docs will need to be updated but it's not breaking since we still support the old way

## Checklist before requesting a review
- [ ] I hereby declare my code ready for review.
- [ ] If it is a critical feature, I have added tests.
- [ ] The CI is successful.
- [ ] If there could backward compatibility issues, it has been discussed and planned.

## Preview

<img width="628" alt="Screenshot 2023-08-16 at 12 10 15" src="https://github.com/prismicio/slice-machine/assets/19946868/795b4a21-1c96-40d3-ad39-f34132649026">
<img width="601" alt="Screenshot 2023-08-16 at 11 31 37" src="https://github.com/prismicio/slice-machine/assets/19946868/7df2349b-d0a1-4f78-8e74-072906d91b2e">
<img width="494" alt="Screenshot 2023-08-16 at 11 02 57" src="https://github.com/prismicio/slice-machine/assets/19946868/49ab7e86-4855-42c6-acbf-ba102f48a203">
<img width="485" alt="Screenshot 2023-08-16 at 11 03 42" src="https://github.com/prismicio/slice-machine/assets/19946868/9dbad4e5-dcad-4f35-b3f3-7d0b3cff0b22">
<img width="430" alt="Screenshot 2023-08-16 at 11 23 32" src="https://github.com/prismicio/slice-machine/assets/19946868/aa371919-a44c-436e-8fd0-e05c5eeb9733">
<img width="608" alt="Screenshot 2023-08-16 at 10 45 29" src="https://github.com/prismicio/slice-machine/assets/19946868/7a18ec07-5352-4ad6-a265-010b4f12da17">

## To test:

- `cd packages/init`
- `yarn build`
- `yarn pack`
- `sudo npm install -g package.tgz`
- `npm exec @slicemachine/init -- --starter nextjs-starter-prismic-minimal-ts`
