### PR TITLE
fix(adapter-sveltekit): remove unused variables from the Slice component template

### DIFF
--- a/packages/adapter-sveltekit/src/hooks/slice-create.ts
+++ b/packages/adapter-sveltekit/src/hooks/slice-create.ts
@@ -39,12 +39,9 @@ const createComponentFile = async ({
 	if (isTypeScriptProject) {
 		contents = source`
 			<script lang="ts">
-				import type { Content, SliceZone } from '@prismicio/client';
+				import type { Content } from '@prismicio/client';
 
 				export let slice: Content.${pascalName}Slice;
-				export let slices: SliceZone;
-				export let index: number;
-				export let context: unknown;
 			</script>
 
 			<section data-slice-type={slice.slice_type} data-slice-variation={slice.variation}>
@@ -56,12 +53,6 @@ const createComponentFile = async ({
 			<script>
 				/** @type {import("@prismicio/client").Content.${pascalName}Slice} */
 				export let slice;
-				/** @type {import("@prismicio/client").SliceZone} */
-				export let slices;
-				/** @type {number} */
-				export let index;
-				/** @type {unknown} */
-				export let context;
 			</script>
 
 			<section data-slice-type={slice.slice_type} data-slice-variation={slice.variation}>

--- a/packages/adapter-sveltekit/test/plugin-slice-create.test.ts
+++ b/packages/adapter-sveltekit/test/plugin-slice-create.test.ts
@@ -203,12 +203,6 @@ test("component file has correct contents", async (ctx) => {
 		"<script>
 		  /** @type {import(\\"@prismicio/client\\").Content.QuxQuuxSlice} */
 		  export let slice;
-		  /** @type {import(\\"@prismicio/client\\").SliceZone} */
-		  export let slices;
-		  /** @type {number} */
-		  export let index;
-		  /** @type {unknown} */
-		  export let context;
 		</script>
 
 		<section
@@ -242,12 +236,9 @@ test("component file is correctly typed when TypeScript is enabled", async (ctx)
 	expect(contents).includes('<script lang="ts">');
 	expect(contents).toMatchInlineSnapshot(`
 		"<script lang=\\"ts\\">
-		  import type { Content, SliceZone } from \\"@prismicio/client\\";
+		  import type { Content } from \\"@prismicio/client\\";
 
 		  export let slice: Content.QuxQuuxSlice;
-		  export let slices: SliceZone;
-		  export let index: number;
-		  export let context: unknown;
 		</script>
 
 		<section


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This PR removes the `slices`, `index`, and `context` variables from `@slicemachine/adapter-sveltekit`'s Slice component template.

Those variables are often not used in components. They were notably not used in the template, which caused warnings in code editors and the Vite dev/build log.

If `slices`, `index`, and/or `context` is needed in a Slice component, the variables can still be added manually to access their data; `<SliceZone>` will continue to provide them as props.

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->
