### PR TITLE
feat(tracking): Track when slices or CTs are pushed from the init

### DIFF
--- a/packages/init/src/SliceMachineInitProcess.ts
+++ b/packages/init/src/SliceMachineInitProcess.ts
@@ -36,6 +36,7 @@ import { assertExists } from "./lib/assertExists";
 import {
 	GIGET_ORGANIZATION,
 	GIGET_PROVIDER,
+	SLICE_MACHINE_INIT_USER_AGENT,
 	START_SCRIPT_KEY,
 	START_SCRIPT_VALUE,
 } from "./constants";
@@ -1122,7 +1123,10 @@ ${chalk.cyan("?")} Your Prismic repository name`.replace("\n", ""),
 								task.title = `Pushing slices... (0/${slices.length})`;
 								await Promise.all(
 									slices.map(async (slice) => {
-										await this.manager.slices.pushSlice(slice);
+										await this.manager.slices.pushSlice({
+											...slice,
+											userAgent: SLICE_MACHINE_INIT_USER_AGENT,
+										});
 										pushed++;
 										task.title = `Pushing slices... (${pushed}/${slices.length})`;
 									}),
@@ -1163,7 +1167,10 @@ ${chalk.cyan("?")} Your Prismic repository name`.replace("\n", ""),
 								task.title = `Pushing types... (0/${ids.length})`;
 								await Promise.all(
 									ids.map(async (id) => {
-										await this.manager.customTypes.pushCustomType({ id });
+										await this.manager.customTypes.pushCustomType({
+											id,
+											userAgent: SLICE_MACHINE_INIT_USER_AGENT,
+										});
 										pushed++;
 										task.title = `Pushing types... (${pushed}/${ids.length})`;
 									}),

--- a/packages/init/src/constants.ts
+++ b/packages/init/src/constants.ts
@@ -3,3 +3,4 @@ export const START_SCRIPT_KEY = "slicemachine";
 export const START_SCRIPT_VALUE = "start-slicemachine";
 export const GIGET_PROVIDER = "github";
 export const GIGET_ORGANIZATION = "prismicio-community";
+export const SLICE_MACHINE_INIT_USER_AGENT = "slice-machine-init";

--- a/packages/manager/src/managers/customTypes/CustomTypesManager.ts
+++ b/packages/manager/src/managers/customTypes/CustomTypesManager.ts
@@ -47,6 +47,7 @@ type SliceMachineManagerReadCustomTypeReturnType = {
 
 type SliceMachineManagerPushCustomTypeArgs = {
 	id: string;
+	userAgent?: string;
 };
 
 type SliceMachineManagerReadCustomTypeMocksConfigArgs = {
@@ -234,7 +235,7 @@ export class CustomTypesManager extends BaseManager {
 				endpoint: API_ENDPOINTS.PrismicModels,
 				repositoryName: sliceMachineConfig.repositoryName,
 				token: authenticationToken,
-				userAgent: SLICE_MACHINE_USER_AGENT,
+				userAgent: args.userAgent || SLICE_MACHINE_USER_AGENT,
 				fetch,
 			});
 

--- a/packages/manager/src/managers/slices/SlicesManager.ts
+++ b/packages/manager/src/managers/slices/SlicesManager.ts
@@ -76,6 +76,7 @@ type SliceMachineManagerReadSliceReturnType = {
 type SliceMachineManagerPushSliceArgs = {
 	libraryID: string;
 	sliceID: string;
+	userAgent?: string;
 };
 
 export type SliceMachineManagerPushSliceReturnType = {
@@ -435,7 +436,7 @@ export class SlicesManager extends BaseManager {
 				endpoint: API_ENDPOINTS.PrismicModels,
 				repositoryName: sliceMachineConfig.repositoryName,
 				token: authenticationToken,
-				userAgent: SLICE_MACHINE_USER_AGENT,
+				userAgent: args.userAgent || SLICE_MACHINE_USER_AGENT,
 				fetch,
 			});
 


### PR DESCRIPTION
## Context

- Completes DT-1555


## The Solution

- Add a new userAgent for slice-machine-init

## Impact / Dependencies

- Need to wait merge and deployment of https://github.com/prismicio/customtypes-api/pull/67

## Checklist before requesting a review
- [x] I hereby declare my code ready for review.
- [ ] If it is a critical feature, I have added tests.
- [ ] The CI is successful.
- [ ] If there could backward compatibility issues, it has been discussed and planned.



<!--
A funny animal picture is welcome to close your PR!
You can find one here https://unsplash.com/s/photos/funny-animal-picture
-->