### PR TITLE
fix(adapter-sveltekit): create Slice index files in the correct location during `project:init`

### DIFF
--- a/packages/adapter-sveltekit/src/hooks/project-init.ts
+++ b/packages/adapter-sveltekit/src/hooks/project-init.ts
@@ -238,12 +238,20 @@ const modifySliceMachineConfig = async ({
 const upsertSliceLibraryIndexFiles = async (
 	context: SliceMachineContext<PluginOptions>,
 ) => {
-	if (!context.project.config.libraries) {
+	// We must use the `getProject()` helper to get the latest version of
+	// the project config. The config may have been modified in
+	// `modifySliceMachineConfig()` and will not be relfected in
+	// `context.project`.
+	// TODO: Automatically update the plugin runner's in-memory `project`
+	// object when `updateSliceMachineConfig()` is called.
+	const project = await context.helpers.getProject();
+
+	if (!project.config.libraries) {
 		return;
 	}
 
 	await Promise.all(
-		context.project.config.libraries?.map(async (libraryID) => {
+		project.config.libraries?.map(async (libraryID) => {
 			await upsertSliceLibraryIndexFile({ libraryID, ...context });
 		}),
 	);

--- a/packages/adapter-sveltekit/test/plugin-project-init.test.ts
+++ b/packages/adapter-sveltekit/test/plugin-project-init.test.ts
@@ -21,14 +21,13 @@ it("installs dependencies", async (ctx) => {
 });
 
 it("creates all Slice library index files", async (ctx) => {
-	ctx.project.config.libraries = ["./foo", "./bar"];
-	const pluginRunner = createSliceMachinePluginRunner({
-		project: ctx.project,
-		nativePlugins: {
-			[ctx.project.config.adapter.resolve]: adapter,
-		},
-	});
-	await pluginRunner.init();
+	await fs.writeFile(
+		path.join(ctx.project.root, "slicemachine.config.json"),
+		JSON.stringify({
+			...ctx.project.config,
+			libraries: ["./foo", "./bar"],
+		}),
+	);
 
 	await ctx.pluginRunner.callHook("project:init", {
 		log: vi.fn(),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This PR fixes a bug in `@slicemachine/adapter-sveltekit` where Slice library index files were generated in the incorrect location during the `project:init` hook.

The adapter's `project:init` hook handler modifies `slicemachine.config.json`'s default Slice library to `src/lib/slices`. The in-memory `project` object provided to the hook, however, does not contain those modifications.

This PR loads the project's config on-demand via the `getProject()` helper, allowing the hook to use the modified `slicemachine.config.json` and the latest default Slice library location.

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->
