### PR TITLE
feat(SlicesTemplates): Update slice:create hook to accept a custom co…

### DIFF
--- a/packages/adapter-next/src/hooks/slice-create.ts
+++ b/packages/adapter-next/src/hooks/slice-create.ts
@@ -32,15 +32,17 @@ const createComponentFile = async ({
 	const filename = `index.${extension}`;
 	const pascalName = pascalCase(data.model.name);
 
-	let contents: string;
+	let componentContents: string;
 
 	const isTypeScriptProject = await checkIsTypeScriptProject({
 		helpers,
 		options,
 	});
 
-	if (isTypeScriptProject) {
-		contents = stripIndent`
+	if (data.componentContents) {
+		componentContents = data.componentContents;
+	} else if (isTypeScriptProject) {
+		componentContents = stripIndent`
 			import { Content } from "@prismicio/client";
 			import { SliceComponentProps } from "@prismicio/react";
 
@@ -66,7 +68,7 @@ const createComponentFile = async ({
 			export default ${pascalName}
 		`;
 	} else {
-		contents = stripIndent`
+		componentContents = stripIndent`
 			/**
 			 * @typedef {import("@prismicio/client").Content.${pascalName}Slice} ${pascalName}Slice
 			 * @typedef {import("@prismicio/react").SliceComponentProps<${pascalName}Slice>} ${pascalName}Props
@@ -91,7 +93,7 @@ const createComponentFile = async ({
 		libraryID: data.libraryID,
 		model: data.model,
 		filename,
-		contents,
+		contents: componentContents,
 		format: options.format,
 		actions,
 		helpers,

--- a/packages/adapter-next/test/plugin-slice-create.test.ts
+++ b/packages/adapter-next/test/plugin-slice-create.test.ts
@@ -392,3 +392,26 @@ testGlobalContentTypes({
 		await pluginRunner.callHook("slice:create", { libraryID: "slices", model });
 	},
 });
+
+test("component file contains given contents instead of default one", async (ctx) => {
+	await ctx.pluginRunner.callHook("slice:create", {
+		libraryID: "slices",
+		model,
+		componentContents: `
+			export default function TestSliceCreate() {
+				return (
+					<div>Custom contents</div>
+				);
+			}
+		`,
+	});
+
+	const componentContents = await fs.readFile(
+		path.join(ctx.project.root, "slices", "QuxQuux", "index.js"),
+		"utf8",
+	);
+
+	expect(componentContents).toContain(
+		"export default function TestSliceCreate()",
+	);
+});

--- a/packages/adapter-nuxt/src/hooks/slice-create.ts
+++ b/packages/adapter-nuxt/src/hooks/slice-create.ts
@@ -29,15 +29,17 @@ const createComponentFile = async ({
 }: CreateComponentFileArgs) => {
 	const pascalName = pascalCase(data.model.name);
 
-	let contents: string;
+	let componentContents: string;
 
 	const isTypeScriptProject = await checkIsTypeScriptProject({
 		helpers,
 		options,
 	});
 
-	if (isTypeScriptProject) {
-		contents = stripIndent`
+	if (data.componentContents) {
+		componentContents = data.componentContents;
+	} else if (isTypeScriptProject) {
+		componentContents = stripIndent`
 			<script setup lang="ts">
 			import { Content } from "@prismicio/client";
 
@@ -58,7 +60,7 @@ const createComponentFile = async ({
 			</template>
 		`;
 	} else {
-		contents = stripIndent`
+		componentContents = stripIndent`
 			<script setup>
 			// The array passed to \`getSliceComponentProps\` is purely optional.
 			// Consider it as a visual hint for you when templating your slice.
@@ -80,7 +82,7 @@ const createComponentFile = async ({
 		libraryID: data.libraryID,
 		model: data.model,
 		filename: "index.vue",
-		contents,
+		contents: componentContents,
 		format: options.format,
 		actions,
 		helpers,

--- a/packages/adapter-nuxt/test/plugin-slice-create.test.ts
+++ b/packages/adapter-nuxt/test/plugin-slice-create.test.ts
@@ -243,3 +243,22 @@ testGlobalContentTypes({
 		await pluginRunner.callHook("slice:create", { libraryID: "slices", model });
 	},
 });
+
+test("component file contains given contents instead of default one", async (ctx) => {
+	await ctx.pluginRunner.callHook("slice:create", {
+		libraryID: "slices",
+		model,
+		componentContents: `
+			<template>
+				<div>TestSliceCreate</div>
+			</template>
+		`,
+	});
+
+	const componentContents = await fs.readFile(
+		path.join(ctx.project.root, "slices", "QuxQuux", "index.vue"),
+		"utf8",
+	);
+
+	expect(componentContents).toContain("<div>TestSliceCreate</div>");
+});

--- a/packages/adapter-nuxt2/src/hooks/slice-create.ts
+++ b/packages/adapter-nuxt2/src/hooks/slice-create.ts
@@ -25,7 +25,9 @@ const createComponentFile = async ({
 	actions,
 	options,
 }: CreateComponentFileArgs) => {
-	const contents = stripIndent`
+	const contents =
+		data.componentContents ??
+		stripIndent`
 		<template>
 			<section
 				:data-slice-type="slice.slice_type"

--- a/packages/adapter-nuxt2/test/plugin-slice-create.test.ts
+++ b/packages/adapter-nuxt2/test/plugin-slice-create.test.ts
@@ -240,3 +240,22 @@ testGlobalContentTypes({
 		await pluginRunner.callHook("slice:create", { libraryID: "slices", model });
 	},
 });
+
+test("component file contains given contents instead of default one", async (ctx) => {
+	await ctx.pluginRunner.callHook("slice:create", {
+		libraryID: "slices",
+		model,
+		componentContents: `
+			<template>
+				<div>TestSliceCreate</div>
+			</template>
+		`,
+	});
+
+	const componentContents = await fs.readFile(
+		path.join(ctx.project.root, "slices", "QuxQuux", "index.vue"),
+		"utf8",
+	);
+
+	expect(componentContents).toContain("<div>TestSliceCreate</div>");
+});

--- a/packages/adapter-sveltekit/src/hooks/slice-create.ts
+++ b/packages/adapter-sveltekit/src/hooks/slice-create.ts
@@ -29,15 +29,17 @@ const createComponentFile = async ({
 }: Args) => {
 	const pascalName = pascalCase(data.model.name);
 
-	let contents: string;
+	let componentContents: string;
 
 	const isTypeScriptProject = await checkIsTypeScriptProject({
 		helpers,
 		options,
 	});
 
-	if (isTypeScriptProject) {
-		contents = source`
+	if (data.componentContents) {
+		componentContents = data.componentContents;
+	} else if (isTypeScriptProject) {
+		componentContents = source`
 			<script lang="ts">
 				import type { Content } from '@prismicio/client';
 
@@ -49,7 +51,7 @@ const createComponentFile = async ({
 			</section>
 		`;
 	} else {
-		contents = source`
+		componentContents = source`
 			<script>
 				/** @type {import("@prismicio/client").Content.${pascalName}Slice} */
 				export let slice;
@@ -65,7 +67,7 @@ const createComponentFile = async ({
 		libraryID: data.libraryID,
 		model: data.model,
 		filename: "index.svelte",
-		contents,
+		contents: componentContents,
 		format: options.format,
 		actions,
 		helpers,

--- a/packages/adapter-sveltekit/test/plugin-slice-create.test.ts
+++ b/packages/adapter-sveltekit/test/plugin-slice-create.test.ts
@@ -310,3 +310,20 @@ testGlobalContentTypes({
 		await pluginRunner.callHook("slice:create", { libraryID: "slices", model });
 	},
 });
+
+test("component file contains given contents instead of default one", async (ctx) => {
+	await ctx.pluginRunner.callHook("slice:create", {
+		libraryID: "slices",
+		model,
+		componentContents: `
+			<div>TestSliceCreate</div>
+		`,
+	});
+
+	const componentContents = await fs.readFile(
+		path.join(ctx.project.root, "slices", "QuxQuux", "index.svelte"),
+		"utf8",
+	);
+
+	expect(componentContents).toContain("<div>TestSliceCreate</div>");
+});

--- a/packages/plugin-kit/src/hooks/slice-create.ts
+++ b/packages/plugin-kit/src/hooks/slice-create.ts
@@ -12,6 +12,7 @@ import type {
 export type SliceCreateHookData = {
 	libraryID: string;
 	model: SharedSlice;
+	componentContents?: string;
 };
 
 /**


### PR DESCRIPTION
## Context

- Completes DT-1573

## The Solution

The goal is to let the "slice:create" hook accept a new argument "contents" so it will be created with that instead of the default string there is.

It's the responsibility of the caller to give the correct JS or TS version

## Impact / Dependencies

- Not a breaking change

## Checklist before requesting a review
- [x] I hereby declare my code ready for review.
- [ ] If it is a critical feature, I have added tests.
- [ ] The CI is successful.
- [ ] If there could backward compatibility issues, it has been discussed and planned.
