### PR TITLE
feat(SlicesTemplates): Add from template button

### DIFF
--- a/cypress/e2e/user-flows/scenario_slice_association.cy.js
+++ b/cypress/e2e/user-flows/scenario_slice_association.cy.js
@@ -86,7 +86,8 @@ describe.skip("I am an existing SM user (Next) and I want to associate a Slice t
   it.skip("Add the Slice to the Custom Type", () => {
     cy.visit(`/custom-types/${customTypeId}`);
 
-    cy.get("[data-cy=update-slices]").click();
+    cy.contains("Add").click();
+    cy.contains("Add from your library").click();
     // forcing this because the input itself is invisible and an svg is displayed
     cy.get(`[data-cy=check-${sliceId}]`).click({ force: true });
     cy.get("[data-cy=update-slices-modal]").submit();

--- a/cypress/pages/customTypes/customTypeBuilder.js
+++ b/cypress/pages/customTypes/customTypeBuilder.js
@@ -6,7 +6,8 @@ class CustomTypeBuilder extends BaseBuilder {
   }
 
   get updateSliceZoneButton() {
-    return cy.get("[data-cy=update-slices]");
+    cy.contains("Add").click();
+    return cy.contains("Add from your library");
   }
 
   get headerCustomTypeName() {

--- a/packages/slice-machine/lib/builders/CustomTypeBuilder/SliceZone/index.tsx
+++ b/packages/slice-machine/lib/builders/CustomTypeBuilder/SliceZone/index.tsx
@@ -1,4 +1,13 @@
-import { Button, Box, Switch } from "@prismicio/editor-ui";
+import {
+  Button,
+  Box,
+  Switch,
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  Icon,
+} from "@prismicio/editor-ui";
 import { useEffect, useMemo, useState } from "react";
 import { useSelector } from "react-redux";
 import { BaseStyles } from "theme-ui";
@@ -100,6 +109,7 @@ const SliceZone: React.FC<SliceZoneProps> = ({
   sliceZone,
   tabId,
 }) => {
+  const isSlicesTemplatesSupported = true;
   const [formIsOpen, setFormIsOpen] = useState(false);
   const [isCreateSliceModalOpen, setIsCreateSliceModalOpen] = useState(false);
   const { remoteSlices, libraries, slices } = useSelector(
@@ -155,20 +165,40 @@ const SliceZone: React.FC<SliceZoneProps> = ({
         <ListHeader
           actions={
             sliceZone ? (
-              <>
-                <Button onClick={onCreateNewSlice} startIcon="add">
-                  New slice
-                </Button>
-                {availableSlices.length > 0 ? (
-                  <Button
-                    data-cy="update-slices"
-                    onClick={onAddNewSlice}
-                    startIcon="edit"
-                  >
-                    Update Slices
+              <DropdownMenu>
+                <DropdownMenuTrigger>
+                  <Button variant="secondary" startIcon="add">
+                    Add
                   </Button>
-                ) : undefined}
-              </>
+                </DropdownMenuTrigger>
+
+                <DropdownMenuContent align="end">
+                  <DropdownMenuItem
+                    startIcon={<Icon name="add" />}
+                    onSelect={onCreateNewSlice}
+                  >
+                    Create a new slice
+                  </DropdownMenuItem>
+
+                  {availableSlices.length > 0 ? (
+                    <DropdownMenuItem
+                      onSelect={onAddNewSlice}
+                      startIcon={<Icon name="folder" />}
+                    >
+                      Add from your library
+                    </DropdownMenuItem>
+                  ) : undefined}
+
+                  {isSlicesTemplatesSupported ? (
+                    <DropdownMenuItem
+                      onSelect={onAddNewSlice}
+                      startIcon={<Icon name="centerFocusWeak" />}
+                    >
+                      Add from template
+                    </DropdownMenuItem>
+                  ) : undefined}
+                </DropdownMenuContent>
+              </DropdownMenu>
             ) : undefined
           }
           toggle={
@@ -205,6 +235,7 @@ const SliceZone: React.FC<SliceZoneProps> = ({
             onAddNewSlice={onAddNewSlice}
             onCreateNewSlice={onCreateNewSlice}
             projectHasAvailableSlices={availableSlices.length > 0}
+            isSlicesTemplatesSupported={isSlicesTemplatesSupported}
           />
         )
       ) : undefined}

--- a/packages/slice-machine/lib/builders/CustomTypeBuilder/TabZone/index.tsx
+++ b/packages/slice-machine/lib/builders/CustomTypeBuilder/TabZone/index.tsx
@@ -1,5 +1,5 @@
 import { Box } from "@prismicio/editor-ui";
-import type { FC } from "react";
+import { FC, Suspense } from "react";
 import type { DropResult } from "react-beautiful-dnd";
 import { useSelector } from "react-redux";
 import type { AnyObjectSchema } from "yup";
@@ -165,17 +165,19 @@ const TabZone: FC<TabZoneProps> = ({
         isRepeatableCustomType={customType.repeatable}
       />
 
-      <SliceZone
-        customType={customType}
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-        tabId={tabId}
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-        sliceZone={sliceZone}
-        onRemoveSharedSlice={onRemoveSharedSlice}
-        onCreateSliceZone={onCreateSliceZone}
-        onDeleteSliceZone={onDeleteSliceZone}
-        onSelectSharedSlices={onSelectSharedSlices}
-      />
+      <Suspense>
+        <SliceZone
+          customType={customType}
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+          tabId={tabId}
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+          sliceZone={sliceZone}
+          onRemoveSharedSlice={onRemoveSharedSlice}
+          onCreateSliceZone={onCreateSliceZone}
+          onDeleteSliceZone={onDeleteSliceZone}
+          onSelectSharedSlices={onSelectSharedSlices}
+        />
+      </Suspense>
     </Box>
   );
 };

--- a/packages/slice-machine/lib/builders/common/Zone/index.jsx
+++ b/packages/slice-machine/lib/builders/common/Zone/index.jsx
@@ -1,4 +1,4 @@
-import { Button } from "@prismicio/editor-ui";
+import { Button, ButtonGroup } from "@prismicio/editor-ui";
 import { array, arrayOf, bool, func, object, shape, string } from "prop-types";
 import { useState } from "react";
 import { FaCode, FaPlus } from "react-icons/fa";
@@ -80,7 +80,7 @@ const Zone = ({
           actions={
             // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
             fields.length > 0 ? (
-              <>
+              <ButtonGroup size="medium" variant="secondary">
                 <Button onClick={() => setShowHints(!showHints)}>
                   {showHints ? "Hide" : "Show"} code snippets
                 </Button>
@@ -94,7 +94,7 @@ const Zone = ({
                 >
                   Add a new Field
                 </Button>
-              </>
+              </ButtonGroup>
             ) : undefined
           }
         >
@@ -107,7 +107,7 @@ const Zone = ({
             Actions={
               // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
               fields.length > 0 ? (
-                <>
+                <ButtonGroup size="medium" variant="secondary">
                   <ThemeUIButton
                     variant="buttons.lightSmall"
                     onClick={() => setShowHints(!showHints)}
@@ -139,7 +139,7 @@ const Zone = ({
                     />
                     Add a new Field
                   </ThemeUIButton>
-                </>
+                </ButtonGroup>
               ) : null
             }
           />

--- a/packages/slice-machine/src/components/List/List.css.ts
+++ b/packages/slice-machine/src/components/List/List.css.ts
@@ -26,5 +26,3 @@ export const header = style([
     },
   },
 ]);
-
-export const headerActions = sprinkles({ flexGrow: 1, justifyContent: "end" });

--- a/packages/slice-machine/src/components/List/List.tsx
+++ b/packages/slice-machine/src/components/List/List.tsx
@@ -1,4 +1,4 @@
-import { ButtonGroup, Text } from "@prismicio/editor-ui";
+import { Box, Text } from "@prismicio/editor-ui";
 import type { FC, PropsWithChildren, ReactNode } from "react";
 
 import * as styles from "./List.css";
@@ -23,12 +23,8 @@ export const ListHeader: FC<ListHeaderProps> = ({
       {children}
     </Text>
     {toggle}
-    <ButtonGroup
-      className={styles.headerActions}
-      size="medium"
-      variant="secondary"
-    >
+    <Box flexGrow={1} justifyContent="end">
       {actions}
-    </ButtonGroup>
+    </Box>
   </header>
 );

--- a/packages/slice-machine/src/features/customTypes/customTypesBuilder/SliceZoneBlankSlate.tsx
+++ b/packages/slice-machine/src/features/customTypes/customTypesBuilder/SliceZoneBlankSlate.tsx
@@ -13,12 +13,14 @@ export type SliceZoneBlankSlateProps = {
   onAddNewSlice: () => void;
   onCreateNewSlice: () => void;
   projectHasAvailableSlices: boolean;
+  isSlicesTemplatesSupported: boolean;
 };
 
 export const SliceZoneBlankSlate: FC<SliceZoneBlankSlateProps> = ({
   onCreateNewSlice,
   onAddNewSlice,
   projectHasAvailableSlices,
+  isSlicesTemplatesSupported,
 }) => {
   return (
     <Box justifyContent="center">
@@ -32,11 +34,16 @@ export const SliceZoneBlankSlate: FC<SliceZoneBlankSlateProps> = ({
           </BlankSlateDescription>
           <BlankSlateActions>
             <Button startIcon="add" onClick={onCreateNewSlice}>
-              New slice
+              Create a new slice
             </Button>
             {projectHasAvailableSlices && (
-              <Button startIcon="edit" onClick={onAddNewSlice}>
-                Update Slices
+              <Button startIcon="folder" onClick={onAddNewSlice}>
+                Add from your library
+              </Button>
+            )}
+            {isSlicesTemplatesSupported && (
+              <Button startIcon="centerFocusWeak" onClick={onAddNewSlice}>
+                Add from template
               </Button>
             )}
           </BlankSlateActions>

--- a/packages/slice-machine/test/pages/custom-types.test.tsx
+++ b/packages/slice-machine/test/pages/custom-types.test.tsx
@@ -28,7 +28,7 @@ describe("Custom Type Builder", () => {
     vi.clearAllMocks();
   });
 
-  beforeEach(async () => {
+  beforeEach(() => {
     mockRouter.setCurrentUrl("/");
   });
 
@@ -125,7 +125,7 @@ describe("Custom Type Builder", () => {
   test("should send a tracking event when the user adds a field", async () => {
     const customTypeId = "a-page";
 
-    Router.push({
+    void Router.push({
       pathname: "custom-types/[customTypeId]",
       query: { customTypeId },
     });
@@ -201,11 +201,14 @@ describe("Custom Type Builder", () => {
 
     const saveFieldButton = screen.getByText("Add");
 
-    await act(async () => {
+    // eslint-disable-next-line @typescript-eslint/await-thenable
+    await act(() => {
       fireEvent.click(saveFieldButton);
     });
 
+    // eslint-disable-next-line @typescript-eslint/unbound-method
     expect(SegmentClient.prototype.track).toHaveBeenCalledOnce();
+    // eslint-disable-next-line @typescript-eslint/unbound-method
     expect(SegmentClient.prototype.track).toHaveBeenCalledWith(
       expect.objectContaining({
         event: "SliceMachine Custom Type Field Added",
@@ -224,7 +227,7 @@ describe("Custom Type Builder", () => {
   test("should send a tracking event when the user adds a slice", async () => {
     const customTypeId = "a-page";
 
-    Router.push({
+    void Router.push({
       pathname: "custom-types/[customTypeId]",
       query: { customTypeId },
     });
@@ -295,26 +298,31 @@ describe("Custom Type Builder", () => {
       },
     });
 
-    const addButton = screen.getAllByText("Update Slices")[0];
-    await act(async () => {
+    const addButton = screen.getByText("Add from your library");
+    // eslint-disable-next-line @typescript-eslint/await-thenable
+    await act(() => {
       fireEvent.click(addButton);
     });
 
     const slicesToSelect = screen.getAllByTestId("slicezone-modal-item");
 
     for (const elem of slicesToSelect) {
-      await act(async () => {
+      // eslint-disable-next-line @typescript-eslint/await-thenable
+      await act(() => {
         fireEvent.click(elem);
       });
     }
 
     const saveButton = within(screen.getByRole("dialog")).getByText("Apply");
 
-    await act(async () => {
+    // eslint-disable-next-line @typescript-eslint/await-thenable
+    await act(() => {
       fireEvent.click(saveButton);
     });
 
+    // eslint-disable-next-line @typescript-eslint/unbound-method
     expect(SegmentClient.prototype.track).toHaveBeenCalledOnce();
+    // eslint-disable-next-line @typescript-eslint/unbound-method
     expect(SegmentClient.prototype.track).toHaveBeenCalledWith(
       expect.objectContaining({
         event: "SliceMachine Slicezone Updated",
@@ -352,7 +360,7 @@ describe("Custom Type Builder", () => {
 
     const customTypeId = "a-page";
 
-    Router.push({
+    void Router.push({
       pathname: "custom-types/[customTypeId]",
       query: { customTypeId },
     });
@@ -424,11 +432,13 @@ describe("Custom Type Builder", () => {
 
     const saveFieldButton = screen.getByText("Add");
 
-    await act(async () => {
+    act(() => {
       fireEvent.click(saveFieldButton);
     });
 
+    // eslint-disable-next-line @typescript-eslint/unbound-method
     expect(SegmentClient.prototype.track).toHaveBeenCalledOnce();
+    // eslint-disable-next-line @typescript-eslint/unbound-method
     expect(SegmentClient.prototype.track).toHaveBeenCalledWith(
       expect.objectContaining({
         event: "SliceMachine Custom Type Field Added",
@@ -445,12 +455,14 @@ describe("Custom Type Builder", () => {
 
     const saveCustomType = screen.getByTestId("builder-save-button");
 
-    await act(async () => {
+    act(() => {
       fireEvent.click(saveCustomType);
     });
 
-    await waitFor(async () => {
+    await waitFor(() => {
+      // eslint-disable-next-line @typescript-eslint/unbound-method
       expect(SegmentClient.prototype.track).toHaveBeenCalledTimes(2);
+      // eslint-disable-next-line @typescript-eslint/unbound-method
       expect(SegmentClient.prototype.track).toHaveBeenCalledWith(
         expect.objectContaining({
           event: "SliceMachine Custom Type Saved",
@@ -495,7 +507,7 @@ describe("Custom Type Builder", () => {
 
     const customTypeId = "a-page";
 
-    Router.push({
+    void Router.push({
       pathname: "custom-types/[customTypeId]",
       query: { customTypeId },
     });
@@ -561,27 +573,32 @@ describe("Custom Type Builder", () => {
     });
 
     const addButton = screen.getByText("Add a new field");
-    await act(async () => {
+    // eslint-disable-next-line @typescript-eslint/await-thenable
+    await act(() => {
       fireEvent.click(addButton);
     });
 
     const richText = screen.getByText("Rich Text");
-    await act(async () => {
+    // eslint-disable-next-line @typescript-eslint/await-thenable
+    await act(() => {
       fireEvent.click(richText);
     });
 
     const nameInput = screen.getByLabelText("label-input");
-    await act(async () => {
+    // eslint-disable-next-line @typescript-eslint/await-thenable
+    await act(() => {
       fireEvent.change(nameInput, { target: { value: "New Field" } });
     });
 
     const saveFieldButton = screen.getByText("Add");
-
-    await act(async () => {
+    // eslint-disable-next-line @typescript-eslint/await-thenable
+    await act(() => {
       fireEvent.click(saveFieldButton);
     });
 
+    // eslint-disable-next-line @typescript-eslint/unbound-method
     expect(SegmentClient.prototype.track).toHaveBeenCalledOnce();
+    // eslint-disable-next-line @typescript-eslint/unbound-method
     expect(SegmentClient.prototype.track).toHaveBeenCalledWith(
       expect.objectContaining({
         event: "SliceMachine Custom Type Field Added",
@@ -598,12 +615,13 @@ describe("Custom Type Builder", () => {
 
     const saveCustomType = screen.getByTestId("builder-save-button");
 
-    await act(async () => {
+    act(() => {
       fireEvent.click(saveCustomType);
     });
 
     await new Promise((r) => setTimeout(r, 500));
 
+    // eslint-disable-next-line @typescript-eslint/unbound-method
     expect(SegmentClient.prototype.track).toHaveBeenCalledOnce();
   });
 });


### PR DESCRIPTION
## Context

- Completes DT-1582

## The Solution

- Display a dropdown menu item in the slice zone header, as it will be in the future design
- Add a simple button in the slice zone blank slate

## Impact / Dependencies

- Need function to detect if slices templates is supported merged

## Checklist before requesting a review
- [ ] I hereby declare my code ready for review.
- [ ] If it is a critical feature, I have added tests.
- [ ] The CI is successful.
- [ ] If there could backward compatibility issues, it has been discussed and planned.

## Preview

![Screenshot 2023-08-30 at 20 06 29](https://github.com/prismicio/slice-machine/assets/19946868/1e75b92e-93c5-478e-800f-1924f33a89d1)
![Screenshot 2023-08-30 at 20 06 39](https://github.com/prismicio/slice-machine/assets/19946868/64e9d88c-872a-478b-a232-3cabbc0ca410)
