### PR TITLE
feat(sliceZone): Only Add dropdown in Slice Zone header

### DIFF
--- a/cypress/e2e/user-flows/transactional-push.cy.js
+++ b/cypress/e2e/user-flows/transactional-push.cy.js
@@ -115,11 +115,13 @@ describe.skip("I am an existing SM user and I want to push local changes", () =>
     cy.clearProject();
   });
 
-  it("show removed slice references", () => {
+  it("show removed slice references", async () => {
     cy.createSlice(slice.library, slice.id, slice.name);
     cy.createCustomType(customType.id, customType.name);
 
-    customTypeBuilder.goTo(customType.id).addSliceToSliceZone(slice.id).save();
+    customTypeBuilder.goTo(customType.id);
+
+    await customTypeBuilder.addSliceToSliceZone(slice.id).save();
 
     cy.clearSlices();
 

--- a/cypress/pages/customTypes/customTypeBuilder.js
+++ b/cypress/pages/customTypes/customTypeBuilder.js
@@ -6,7 +6,7 @@ class CustomTypeBuilder extends BaseBuilder {
   }
 
   get updateSliceZoneButton() {
-    return cy.get("[data-cy=update-slices]");
+    return cy.getByText("Add from libraries");
   }
 
   get headerCustomTypeName() {
@@ -28,7 +28,8 @@ class CustomTypeBuilder extends BaseBuilder {
     return this;
   }
 
-  addSliceToSliceZone(sliceId) {
+  async addSliceToSliceZone(sliceId) {
+    await cy.findByText(/Add/).click();
     this.updateSliceZoneButton.click();
     cy.get(`[data-cy=check-${sliceId}]`).click({ force: true });
     cy.get("[data-cy=update-slices-modal]").submit();

--- a/packages/slice-machine/lib/builders/CustomTypeBuilder/SliceZone/UpdateSliceZoneModal.tsx
+++ b/packages/slice-machine/lib/builders/CustomTypeBuilder/SliceZone/UpdateSliceZoneModal.tsx
@@ -1,3 +1,5 @@
+import { Text } from "theme-ui";
+
 import { ComponentUI } from "@lib/models/common/ComponentUI";
 import ModalFormCard from "../../../../components/ModalFormCard";
 import UpdateSliceZoneModalList from "./UpdateSliceZoneModalList";
@@ -8,7 +10,6 @@ interface UpdateSliceModalProps {
   close: () => void;
   onSubmit: (values: SliceZoneFormValues) => void;
   availableSlices: ReadonlyArray<ComponentUI>;
-  slicesInSliceZone: ReadonlyArray<ComponentUI>;
 }
 
 export type SliceZoneFormValues = {
@@ -21,11 +22,10 @@ const UpdateSliceZoneModal: React.FC<UpdateSliceModalProps> = ({
   close,
   onSubmit,
   availableSlices,
-  slicesInSliceZone,
 }) => {
   return (
     <ModalFormCard
-      buttonLabel="Apply"
+      buttonLabel="Add"
       isOpen={isOpen}
       formId={formId}
       close={close}
@@ -34,12 +34,24 @@ const UpdateSliceZoneModal: React.FC<UpdateSliceModalProps> = ({
         close();
       }}
       initialValues={{
-        sliceKeys: slicesInSliceZone.map((slice) => slice.model.id),
+        sliceKeys: [],
       }}
       content={{
-        title: "Update slices",
+        title: "Add from libraries",
       }}
       dataCy="update-slices-modal"
+      validate={(values) => {
+        if (values.sliceKeys.length === 0) {
+          return {
+            sliceKeys: "Select at least one slice to add",
+          };
+        }
+      }}
+      actionMessage={({ errors }) =>
+        errors.sliceKeys !== undefined ? (
+          <Text sx={{ color: "error" }}>{errors.sliceKeys}</Text>
+        ) : undefined
+      }
     >
       {({ values }) => (
         <UpdateSliceZoneModalList

--- a/packages/slice-machine/lib/builders/CustomTypeBuilder/SliceZone/index.tsx
+++ b/packages/slice-machine/lib/builders/CustomTypeBuilder/SliceZone/index.tsx
@@ -159,6 +159,13 @@ const SliceZone: React.FC<SliceZoneProps> = ({
     .filter((e) => e.type === "Slice")
     .map((e) => (e.payload as NonSharedSliceInSliceZone).key);
 
+  const availableSlicesToAdd = availableSlices.filter(
+    (slice) =>
+      !sharedSlicesInSliceZone.some(
+        (sharedSlice) => sharedSlice.model.id === slice.model.id
+      )
+  );
+
   const onAddNewSlice = () => {
     setIsUpdateSliceZoneModalOpen(true);
   };
@@ -182,7 +189,7 @@ const SliceZone: React.FC<SliceZoneProps> = ({
       <List>
         <ListHeader
           actions={
-            sliceZone && slicesInSliceZone.length > 0 ? (
+            sliceZone ? (
               <Box gap={8}>
                 <DropdownMenu>
                   <DropdownMenuTrigger>
@@ -201,27 +208,23 @@ const SliceZone: React.FC<SliceZoneProps> = ({
 
                     {availableSlicesTemplates.length > 0 ? (
                       <DropdownMenuItem
-                        onSelect={() => {
-                          openSlicesTemplatesModal();
-                        }}
+                        onSelect={openSlicesTemplatesModal}
                         startIcon={<Icon name="contentCopy" />}
                       >
-                        Slice template
+                        Slices templates
+                      </DropdownMenuItem>
+                    ) : undefined}
+
+                    {availableSlicesToAdd.length > 0 ? (
+                      <DropdownMenuItem
+                        onSelect={onAddNewSlice}
+                        startIcon={<Icon name="folder" />}
+                      >
+                        Libraries slices
                       </DropdownMenuItem>
                     ) : undefined}
                   </DropdownMenuContent>
                 </DropdownMenu>
-
-                {availableSlices.length > 0 ? (
-                  <Button
-                    data-cy="update-slices"
-                    onClick={onAddNewSlice}
-                    startIcon="edit"
-                    variant="secondary"
-                  >
-                    Update slices
-                  </Button>
-                ) : undefined}
               </Box>
             ) : undefined
           }
@@ -257,7 +260,7 @@ const SliceZone: React.FC<SliceZoneProps> = ({
             onAddNewSlice={onAddNewSlice}
             onCreateNewSlice={onCreateNewSlice}
             openSlicesTemplatesModal={openSlicesTemplatesModal}
-            projectHasAvailableSlices={availableSlices.length > 0}
+            projectHasAvailableSlices={availableSlicesToAdd.length > 0}
             isSlicesTemplatesSupported={availableSlicesTemplates.length > 0}
           />
         )
@@ -265,11 +268,13 @@ const SliceZone: React.FC<SliceZoneProps> = ({
       <UpdateSliceZoneModal
         isOpen={isUpdateSliceZoneModalOpen}
         formId={`tab-slicezone-form-${tabId}`}
-        availableSlices={availableSlices}
-        slicesInSliceZone={sharedSlicesInSliceZone}
+        availableSlices={availableSlicesToAdd}
         onSubmit={({ sliceKeys }) =>
           // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-          onSelectSharedSlices(sliceKeys, nonSharedSlicesKeysInSliceZone)
+          onSelectSharedSlices(
+            sliceKeys.concat(sharedSlicesInSliceZone.map((s) => s.model.id)),
+            nonSharedSlicesKeysInSliceZone
+          )
         }
         close={() => setIsUpdateSliceZoneModalOpen(false)}
       />

--- a/packages/slice-machine/test/pages/custom-types.test.tsx
+++ b/packages/slice-machine/test/pages/custom-types.test.tsx
@@ -313,7 +313,7 @@ describe("Custom Type Builder", () => {
       });
     }
 
-    const saveButton = within(screen.getByRole("dialog")).getByText("Apply");
+    const saveButton = within(screen.getByRole("dialog")).getByText("Add");
 
     // eslint-disable-next-line @typescript-eslint/await-thenable
     await act(() => {


### PR DESCRIPTION
## Context

- Completes DT-1598

## The Solution

- Remove Update slices button in Slice Zone header
- Update modal to only display non-added slices in slice zone
- Add a dropdown option to Add from libraries

## Impact / Dependencies

- None

## Checklist before requesting a review
- [x] I hereby declare my code ready for review.
- [ ] If it is a critical feature, I have added tests.
- [ ] The CI is successful.
- [ ] If there could backward compatibility issues, it has been discussed and planned.

##  Preview


https://github.com/prismicio/slice-machine/assets/19946868/0e67b21c-9dec-4c5a-8ada-227d3d8a0580

