### PR TITLE
feat(Page Type): Specific blank slate right after Page Type creation

### DIFF
--- a/cypress/pages/customTypes/customTypeBuilder.js
+++ b/cypress/pages/customTypes/customTypeBuilder.js
@@ -29,7 +29,7 @@ class CustomTypeBuilder extends BaseBuilder {
   }
 
   async addSliceToSliceZone(sliceId) {
-    await cy.findByText(/Add/).click();
+    await cy.findAllByText(/Add/)[0].click();
     this.updateSliceZoneButton.click();
     cy.get(`[data-cy=check-${sliceId}]`).click({ force: true });
     cy.get("[data-cy=update-slices-modal]").submit();

--- a/packages/slice-machine/lib/builders/CustomTypeBuilder/SliceZone/index.tsx
+++ b/packages/slice-machine/lib/builders/CustomTypeBuilder/SliceZone/index.tsx
@@ -11,6 +11,7 @@ import {
 import { useEffect, useMemo, useState } from "react";
 import { useSelector } from "react-redux";
 import { BaseStyles } from "theme-ui";
+import { useRouter } from "next/router";
 
 import { CreateSliceModal } from "@components/Forms/CreateSliceModal";
 import type {
@@ -114,6 +115,7 @@ const SliceZone: React.FC<SliceZoneProps> = ({
   sliceZone,
   tabId,
 }) => {
+  const { query, replace, pathname } = useRouter();
   const availableSlicesTemplates = useSlicesTemplates();
   const [isSlicesTemplatesModalOpen, setIsSlicesTemplatesModalOpen] =
     useState(false);
@@ -184,13 +186,23 @@ const SliceZone: React.FC<SliceZoneProps> = ({
     });
   };
 
+  const redirectToEditMode = () => {
+    if (query.newPageType === "true") {
+      void replace(
+        { pathname, query: { pageTypeId: query.pageTypeId } },
+        undefined,
+        { shallow: true }
+      );
+    }
+  };
+
   return (
-    <Box flexDirection="column">
-      <List>
-        <ListHeader
-          actions={
-            sliceZone ? (
-              <Box gap={8}>
+    <Box flexDirection="column" height="100%">
+      {query.newPageType === undefined ? (
+        <List>
+          <ListHeader
+            actions={
+              sliceZone ? (
                 <DropdownMenu>
                   <DropdownMenuTrigger>
                     <Button variant="secondary" startIcon="add">
@@ -211,7 +223,7 @@ const SliceZone: React.FC<SliceZoneProps> = ({
                         onSelect={openSlicesTemplatesModal}
                         startIcon={<Icon name="contentCopy" />}
                       >
-                        Slices templates
+                        Slice templates
                       </DropdownMenuItem>
                     ) : undefined}
 
@@ -225,27 +237,27 @@ const SliceZone: React.FC<SliceZoneProps> = ({
                     ) : undefined}
                   </DropdownMenuContent>
                 </DropdownMenu>
-              </Box>
-            ) : undefined
-          }
-          toggle={
-            customType.format !== "page" || tabId !== "Main" ? (
-              <Switch
-                checked={!!sliceZone}
-                onCheckedChange={(checked) => {
-                  if (checked) {
-                    onCreateSliceZone();
-                  } else {
-                    setIsDeleteSliceZoneModalOpen(true);
-                  }
-                }}
-              />
-            ) : undefined
-          }
-        >
-          Slice Zone
-        </ListHeader>
-      </List>
+              ) : undefined
+            }
+            toggle={
+              customType.format !== "page" || tabId !== "Main" ? (
+                <Switch
+                  checked={!!sliceZone}
+                  onCheckedChange={(checked) => {
+                    if (checked) {
+                      onCreateSliceZone();
+                    } else {
+                      setIsDeleteSliceZoneModalOpen(true);
+                    }
+                  }}
+                />
+              ) : undefined
+            }
+          >
+            Slice Zone
+          </ListHeader>
+        </List>
+      ) : undefined}
       {sliceZone ? (
         slicesInSliceZone.length > 0 ? (
           <BaseStyles>
@@ -269,13 +281,14 @@ const SliceZone: React.FC<SliceZoneProps> = ({
         isOpen={isUpdateSliceZoneModalOpen}
         formId={`tab-slicezone-form-${tabId}`}
         availableSlices={availableSlicesToAdd}
-        onSubmit={({ sliceKeys }) =>
+        onSubmit={({ sliceKeys }) => {
           // eslint-disable-next-line @typescript-eslint/no-unsafe-return
           onSelectSharedSlices(
             sliceKeys.concat(sharedSlicesInSliceZone.map((s) => s.model.id)),
             nonSharedSlicesKeysInSliceZone
-          )
-        }
+          );
+          redirectToEditMode();
+        }}
         close={() => setIsUpdateSliceZoneModalOpen(false)}
       />
       <SlicesTemplatesModal
@@ -302,6 +315,7 @@ const SliceZone: React.FC<SliceZoneProps> = ({
               );
 
               setIsSlicesTemplatesModalOpen(false);
+              redirectToEditMode();
             },
           })
         }

--- a/packages/slice-machine/lib/builders/CustomTypeBuilder/TabZone/index.tsx
+++ b/packages/slice-machine/lib/builders/CustomTypeBuilder/TabZone/index.tsx
@@ -3,6 +3,7 @@ import { FC, Suspense } from "react";
 import type { DropResult } from "react-beautiful-dnd";
 import { useSelector } from "react-redux";
 import type { AnyObjectSchema } from "yup";
+import { useRouter } from "next/router";
 
 import ctBuilderArray from "@lib/models/common/widgets/ctBuilderArray";
 import type {
@@ -47,6 +48,8 @@ const TabZone: FC<TabZoneProps> = ({
     deleteCustomTypeSharedSlice,
     replaceCustomTypeSharedSlice,
   } = useSliceMachineActions();
+
+  const { query } = useRouter();
 
   const { poolOfFields } = useSelector((store: SliceMachineStoreType) => ({
     poolOfFields: selectCurrentPoolOfFields(store),
@@ -138,7 +141,7 @@ const TabZone: FC<TabZoneProps> = ({
   };
 
   return (
-    <Box backgroundColor="grey2" flexDirection="column" gap={8}>
+    <Box backgroundColor="grey2" flexDirection="column" gap={8} height="100%">
       <ErrorBoundary>
         <Suspense
           fallback={
@@ -147,33 +150,36 @@ const TabZone: FC<TabZoneProps> = ({
             </Box>
           }
         >
-          <Zone
-            zoneType="customType"
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-            tabId={tabId}
-            title="Static Zone"
-            dataTip={""}
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-            fields={fields}
-            // @ts-expect-error propsType and typescript are incompatible on this type, we can remove the error when migrating the Zone component
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
-            poolOfFieldsToCheck={poolOfFields}
-            showHints={true}
-            EditModal={EditModal}
-            widgetsArray={ctBuilderArray}
-            onDeleteItem={onDeleteItem}
-            onSave={onSave}
-            onSaveNewField={onSaveNewField}
-            onDragEnd={onDragEnd}
-            renderHintBase={({ item }) =>
-              // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-member-access
-              `data${transformKeyAccessor(item.key)}`
-            }
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-argument
-            renderFieldAccessor={(key) => `data${transformKeyAccessor(key)}`}
-            dataCy="ct-static-zone"
-            isRepeatableCustomType={customType.repeatable}
-          />
+          {query.newPageType === undefined ? (
+            <Zone
+              zoneType="customType"
+              // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+              tabId={tabId}
+              title="Static Zone"
+              dataTip={""}
+              // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+              fields={fields}
+              // @ts-expect-error propsType and typescript are incompatible on this type, we can remove the error when migrating the Zone component
+              // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
+              poolOfFieldsToCheck={poolOfFields}
+              showHints={true}
+              EditModal={EditModal}
+              widgetsArray={ctBuilderArray}
+              onDeleteItem={onDeleteItem}
+              onSave={onSave}
+              onSaveNewField={onSaveNewField}
+              onDragEnd={onDragEnd}
+              renderHintBase={({ item }) =>
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-member-access
+                `data${transformKeyAccessor(item.key)}`
+              }
+              // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-argument
+              renderFieldAccessor={(key) => `data${transformKeyAccessor(key)}`}
+              dataCy="ct-static-zone"
+              isRepeatableCustomType={customType.repeatable}
+            />
+          ) : undefined}
+
           <SliceZone
             customType={customType}
             // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment

--- a/packages/slice-machine/lib/builders/CustomTypeBuilder/index.tsx
+++ b/packages/slice-machine/lib/builders/CustomTypeBuilder/index.tsx
@@ -1,5 +1,6 @@
 import { DropdownMenuItem, Icon } from "@prismicio/editor-ui";
 import { type FC, useState } from "react";
+import { useRouter } from "next/router";
 
 import type { CustomTypeSM } from "@lib/models/common/CustomType";
 import {
@@ -34,64 +35,82 @@ export const CustomTypeBuilder: FC<CustomTypeBuilderProps> = (props) => {
   const { createCustomTypeTab, updateCustomTypeTab, deleteCustomTypeTab } =
     useSliceMachineActions();
 
+  const { query } = useRouter();
+  const sliceZoneEmpty =
+    customType.tabs.find((tab) => tab.key === tabValue)?.sliceZone?.value
+      .length === 0;
+
   return (
     <>
-      <Window>
+      <Window
+        style={{
+          height: sliceZoneEmpty ? "100%" : undefined,
+        }}
+      >
         {customType.format === "page" ? <WindowFrame /> : undefined}
-        <WindowTabs onValueChange={setTabValue} value={tabValue}>
-          <WindowTabsList
-            onAddNewTab={() => {
-              setDialog({ type: "CREATE_CUSTOM_TYPE" });
-            }}
-          >
+        {query.newPageType === "true" ? (
+          <TabZone
+            customType={customType}
+            fields={customType.tabs[0].value}
+            sliceZone={customType.tabs[0].sliceZone}
+            tabId={customType.tabs[0].key}
+          />
+        ) : (
+          <WindowTabs onValueChange={setTabValue} value={tabValue}>
+            <WindowTabsList
+              onAddNewTab={() => {
+                setDialog({ type: "CREATE_CUSTOM_TYPE" });
+              }}
+            >
+              {customType.tabs.map((tab) => (
+                <WindowTabsTrigger
+                  key={tab.key}
+                  menu={
+                    <>
+                      <DropdownMenuItem
+                        onSelect={() => {
+                          setDialog({
+                            type: "UPDATE_CUSTOM_TYPE",
+                            tabKey: tab.key,
+                          });
+                        }}
+                        startIcon={<Icon name="edit" />}
+                      >
+                        Rename
+                      </DropdownMenuItem>
+                      <DropdownMenuItem
+                        color="tomato"
+                        disabled={customType.tabs.length <= 1}
+                        onSelect={() => {
+                          setDialog({
+                            type: "DELETE_CUSTOM_TYPE",
+                            tabKey: tab.key,
+                          });
+                        }}
+                        startIcon={<Icon name="delete" />}
+                      >
+                        Remove
+                      </DropdownMenuItem>
+                    </>
+                  }
+                  value={tab.key}
+                >
+                  {tab.key}
+                </WindowTabsTrigger>
+              ))}
+            </WindowTabsList>
             {customType.tabs.map((tab) => (
-              <WindowTabsTrigger
-                key={tab.key}
-                menu={
-                  <>
-                    <DropdownMenuItem
-                      onSelect={() => {
-                        setDialog({
-                          type: "UPDATE_CUSTOM_TYPE",
-                          tabKey: tab.key,
-                        });
-                      }}
-                      startIcon={<Icon name="edit" />}
-                    >
-                      Rename
-                    </DropdownMenuItem>
-                    <DropdownMenuItem
-                      color="tomato"
-                      disabled={customType.tabs.length <= 1}
-                      onSelect={() => {
-                        setDialog({
-                          type: "DELETE_CUSTOM_TYPE",
-                          tabKey: tab.key,
-                        });
-                      }}
-                      startIcon={<Icon name="delete" />}
-                    >
-                      Remove
-                    </DropdownMenuItem>
-                  </>
-                }
-                value={tab.key}
-              >
-                {tab.key}
-              </WindowTabsTrigger>
+              <WindowTabsContent key={tab.key} value={tab.key}>
+                <TabZone
+                  customType={customType}
+                  fields={tab.value}
+                  sliceZone={tab.sliceZone}
+                  tabId={tab.key}
+                />
+              </WindowTabsContent>
             ))}
-          </WindowTabsList>
-          {customType.tabs.map((tab) => (
-            <WindowTabsContent key={tab.key} value={tab.key}>
-              <TabZone
-                customType={customType}
-                fields={tab.value}
-                sliceZone={tab.sliceZone}
-                tabId={tab.key}
-              />
-            </WindowTabsContent>
-          ))}
-        </WindowTabs>
+          </WindowTabs>
+        )}
       </Window>
       {dialog?.type === "CREATE_CUSTOM_TYPE" ? (
         <CreateModal

--- a/packages/slice-machine/src/components/BlankSlate/BlankSlate.css.ts
+++ b/packages/slice-machine/src/components/BlankSlate/BlankSlate.css.ts
@@ -33,7 +33,7 @@ export const withBackground = style([
     backgroundSize: "cover",
     borderRadius: vars.borderRadius[0],
     borderStyle: vars.borderStyle.none,
-    height: "50vh",
+    height: "100%",
     maxWidth: "100%",
   },
 ]);

--- a/packages/slice-machine/src/features/customTypes/__tests__/CustomTypesTablePage.test.tsx
+++ b/packages/slice-machine/src/features/customTypes/__tests__/CustomTypesTablePage.test.tsx
@@ -93,7 +93,13 @@ describe.each(formats)(
       expect(await screen.findByText(newCustomType)).toBeVisible();
 
       // Check that the redirection has been done
-      expect(mockRouter.asPath).toEqual(`/${format}-types/${newCustomType}`);
+      if (format === "page") {
+        expect(mockRouter.asPath).toEqual(
+          `/${format}-types/${newCustomType}?newPageType=true`
+        );
+      } else {
+        expect(mockRouter.asPath).toEqual(`/${format}-types/${newCustomType}`);
+      }
     });
 
     test(`should delete a ${format} type from the table`, async (ctx) => {

--- a/packages/slice-machine/src/features/customTypes/customTypesBuilder/CustomTypesBuilderPage.tsx
+++ b/packages/slice-machine/src/features/customTypes/customTypesBuilder/CustomTypesBuilderPage.tsx
@@ -139,7 +139,7 @@ const CustomTypesBuilderPageWithProvider: React.FC<
         </AppLayoutActions>
       </AppLayoutHeader>
       <AppLayoutContent>
-        <Box flexDirection="column">
+        <Box flexDirection="column" height="100%">
           <CustomTypeBuilder customType={currentCustomType} />
         </Box>
       </AppLayoutContent>

--- a/packages/slice-machine/src/features/customTypes/customTypesBuilder/SliceZoneBlankSlate.tsx
+++ b/packages/slice-machine/src/features/customTypes/customTypesBuilder/SliceZoneBlankSlate.tsx
@@ -1,5 +1,14 @@
 import { FC } from "react";
-import { Box, Button } from "@prismicio/editor-ui";
+import {
+  Box,
+  Button,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+  Icon,
+} from "@prismicio/editor-ui";
+import { useRouter } from "next/router";
 
 import {
   BlankSlate,
@@ -24,8 +33,10 @@ export const SliceZoneBlankSlate: FC<SliceZoneBlankSlateProps> = ({
   projectHasAvailableSlices,
   isSlicesTemplatesSupported,
 }) => {
+  const { query } = useRouter();
+
   return (
-    <Box justifyContent="center">
+    <Box justifyContent="center" height="100%">
       <BlankSlate backgroundImage="/blank-slate-slice-zone.png">
         <BlankSlateContent>
           <BlankSlateTitle>Add slices</BlankSlateTitle>
@@ -35,22 +46,45 @@ export const SliceZoneBlankSlate: FC<SliceZoneBlankSlateProps> = ({
             code.
           </BlankSlateDescription>
           <BlankSlateActions>
-            <Button startIcon="add" onClick={onCreateNewSlice}>
-              Create a blank slice
-            </Button>
-            {isSlicesTemplatesSupported && (
-              <Button
-                startIcon="contentCopy"
-                onClick={openSlicesTemplatesModal}
-              >
-                Add from templates
-              </Button>
-            )}
-            {projectHasAvailableSlices && (
-              <Button startIcon="folder" onClick={onAddNewSlice}>
-                Add from libraries
-              </Button>
-            )}
+            <DropdownMenu>
+              <DropdownMenuTrigger data-testid="add-slice-dropdown">
+                <Button
+                  variant={
+                    query.newPageType === "true" ? "primary" : "secondary"
+                  }
+                  startIcon="add"
+                >
+                  Add
+                </Button>
+              </DropdownMenuTrigger>
+
+              <DropdownMenuContent align="start">
+                <DropdownMenuItem
+                  startIcon={<Icon name="add" />}
+                  onSelect={onCreateNewSlice}
+                >
+                  Blank slice
+                </DropdownMenuItem>
+
+                {isSlicesTemplatesSupported ? (
+                  <DropdownMenuItem
+                    onSelect={openSlicesTemplatesModal}
+                    startIcon={<Icon name="contentCopy" />}
+                  >
+                    Slice templates
+                  </DropdownMenuItem>
+                ) : undefined}
+
+                {projectHasAvailableSlices ? (
+                  <DropdownMenuItem
+                    onSelect={onAddNewSlice}
+                    startIcon={<Icon name="folder" />}
+                  >
+                    Libraries slices
+                  </DropdownMenuItem>
+                ) : undefined}
+              </DropdownMenuContent>
+            </DropdownMenu>
           </BlankSlateActions>
         </BlankSlateContent>
       </BlankSlate>

--- a/packages/slice-machine/src/modules/availableCustomTypes/index.ts
+++ b/packages/slice-machine/src/modules/availableCustomTypes/index.ts
@@ -243,7 +243,17 @@ export function* createCustomTypeSaga({
     yield call(saveCustomType, newCustomType);
     yield put(createCustomTypeCreator.success({ newCustomType }));
     yield put(modalCloseCreator());
-    yield put(push(customTypesConfig.getBuilderPagePathname(payload.id)));
+    yield put(
+      push({
+        pathname: customTypesConfig.getBuilderPagePathname(payload.id),
+        query:
+          newCustomType.format === "page"
+            ? {
+                newPageType: true,
+              }
+            : undefined,
+      })
+    );
     yield put(
       openToasterCreator({
         content: ToastMessageWithPath({

--- a/packages/slice-machine/test/pages/custom-types.test.tsx
+++ b/packages/slice-machine/test/pages/custom-types.test.tsx
@@ -4,9 +4,10 @@ import { describe, test, afterEach, beforeEach, expect, vi } from "vitest";
 import Router from "next/router";
 import mockRouter from "next-router-mock";
 import SegmentClient from "analytics-node";
+import userEvent from "@testing-library/user-event";
+
 import { createSliceMachineManager } from "@slicemachine/manager";
 import { createSliceMachineManagerMSWHandler } from "@slicemachine/manager/test";
-
 import pkg from "../../package.json";
 import {
   render,
@@ -298,11 +299,9 @@ describe("Custom Type Builder", () => {
       },
     });
 
-    const addButton = screen.getByText("Add from libraries");
-    // eslint-disable-next-line @typescript-eslint/await-thenable
-    await act(() => {
-      fireEvent.click(addButton);
-    });
+    const user = userEvent.setup();
+    await user.click(screen.getByTestId("add-slice-dropdown"));
+    await user.click(screen.getByText("Libraries slices"));
 
     const slicesToSelect = screen.getAllByTestId("slicezone-modal-item");
 

--- a/packages/slice-machine/test/src/modules/availableCustomTypes/index.test.ts
+++ b/packages/slice-machine/test/src/modules/availableCustomTypes/index.test.ts
@@ -236,7 +236,12 @@ describe("[Available Custom types module]", () => {
           createCustomTypeCreator.success({ newCustomType: customTypeCreated })
         );
       saga.next().put(modalCloseCreator());
-      saga.next().put(push("/custom-types/id"));
+      saga.next().put(
+        push({
+          pathname: "/custom-types/id",
+          query: undefined,
+        })
+      );
       saga
         .next()
         .inspect(


### PR DESCRIPTION
## Context

Completes DT-1578, DT-1566

## The Solution

- Add a new URL query "newPageType" at true when we are doing the redirection after the Page Type creation
- Handle a full page blank slate when "newPageType" URL query is at true

## Impact / Dependencies

- None

## Checklist before requesting a review
- [x] I hereby declare my code ready for review.
- [ ] If it is a critical feature, I have added tests.
- [ ] The CI is successful.
- [ ] If there could backward compatibility issues, it has been discussed and planned.

## Preview

https://github.com/prismicio/slice-machine/assets/19946868/2e685886-1aef-4f41-a7e1-25880a1cffb8

