### PR TITLE
fix(adapter-nuxt): page snippets & default localSliceSimulatorURL

### DIFF
--- a/packages/adapter-nuxt/src/hooks/documentation-read.ts
+++ b/packages/adapter-nuxt/src/hooks/documentation-read.ts
@@ -31,7 +31,9 @@ export const documentationRead: DocumentationReadHook<PluginOptions> = async (
 
 				const prismic = usePrismic();
 				const route = useRoute();
-				const { data: page } = useAsyncData(\`[${model.id}-uid-\${route.params.uid}]\`, () =>
+				const { data: page } = useAsyncData(\`[${
+					model.id
+				}-uid-\${route.params.uid}]\`, () =>
 					prismic.client.getByUID("${model.id}", route.params.uid${
 				isTypeScriptProject ? " as string" : ""
 			})

--- a/packages/adapter-nuxt/src/hooks/documentation-read.ts
+++ b/packages/adapter-nuxt/src/hooks/documentation-read.ts
@@ -31,7 +31,7 @@ export const documentationRead: DocumentationReadHook<PluginOptions> = async (
 
 				const prismic = usePrismic();
 				const route = useRoute();
-				const { data: page } = useAsyncData("[${model.id}-uid]", () =>
+				const { data: page } = useAsyncData(\`[${model.id}-uid-\${route.params.uid}]\`, () =>
 					prismic.client.getByUID("${model.id}", route.params.uid${
 				isTypeScriptProject ? " as string" : ""
 			})

--- a/packages/adapter-nuxt/src/hooks/project-init.ts
+++ b/packages/adapter-nuxt/src/hooks/project-init.ts
@@ -220,7 +220,7 @@ const modifySliceMachineConfig = async ({
 
 	// Add Slice Simulator URL.
 	project.config.localSliceSimulatorURL ||=
-		"http://localhost:3000/slice-simulator";
+		"http://127.0.0.1:3000/slice-simulator";
 
 	// Nest the default Slice Library in the src directory if it exists and
 	// is empty.

--- a/packages/adapter-nuxt/test/plugin-project-init.test.ts
+++ b/packages/adapter-nuxt/test/plugin-project-init.test.ts
@@ -331,7 +331,7 @@ describe("modify slicemachine.config.json", () => {
 		);
 
 		expect(contents.localSliceSimulatorURL).toBe(
-			"http://localhost:3000/slice-simulator",
+			"http://127.0.0.1:3000/slice-simulator",
 		);
 	});
 


### PR DESCRIPTION
## Context

1. @mdeclercq noticed an issue with dynamic page snippets `useAsyncData` key: https://prismic-team.slack.com/archives/C014VAACCQL/p1694613034173669
2. Nuxt 3.7 changed its default preferred URL (`localhost` still works, but is less performant on Windows now)

## The Solution

1. Fixed snippets
2. Changed default URL in the init hook

## Impact / Dependencies

N/A

## Checklist before requesting a review
- [x] I hereby declare my code ready for review.
- [x] If it is a critical feature, I have added tests.
- [x] The CI is successful.
- [x] If there could backward compatibility issues, it has been discussed and planned.
