### PR TITLE
fix(adapter-next): don't include route resolver configuration by default

### DIFF
--- a/packages/adapter-next/src/hooks/project-init.ts
+++ b/packages/adapter-next/src/hooks/project-init.ts
@@ -186,14 +186,15 @@ const createPrismicIOFile = async ({
 			 */
 			// TODO: Update the routes array to match your project's route structure.
 			const routes: prismic.ClientConfig["routes"] = [
-				{
-					type: "homepage",
-					path: "/",
-				},
-				{
-					type: "page",
-					path: "/:uid",
-				},
+				// Examples:
+				// {
+				// 	type: "homepage",
+				// 	path: "/",
+				// },
+				// {
+				// 	type: "page",
+				// 	path: "/:uid",
+				// },
 			];
 
 			${createClientContents}
@@ -218,14 +219,15 @@ const createPrismicIOFile = async ({
 			 */
 			// TODO: Update the routes array to match your project's route structure.
 			const routes = [
-				{
-					type: "homepage",
-					path: "/",
-				},
-				{
-					type: "page",
-					path: "/:uid",
-				},
+				// Examples:
+				// {
+				// 	type: "homepage",
+				// 	path: "/",
+				// },
+				// {
+				// 	type: "page",
+				// 	path: "/:uid",
+				// },
 			];
 
 			${createClientContents}

--- a/packages/adapter-next/test/plugin-project-init.test.ts
+++ b/packages/adapter-next/test/plugin-project-init.test.ts
@@ -265,14 +265,15 @@ describe("prismicio.js file", () => {
 				 */
 				// TODO: Update the routes array to match your project's route structure.
 				const routes = [
-				  {
-				    type: \\"homepage\\",
-				    path: \\"/\\",
-				  },
-				  {
-				    type: \\"page\\",
-				    path: \\"/:uid\\",
-				  },
+				  // Examples:
+				  // {
+				  // 	type: \\"homepage\\",
+				  // 	path: \\"/\\",
+				  // },
+				  // {
+				  // 	type: \\"page\\",
+				  // 	path: \\"/:uid\\",
+				  // },
 				];
 
 				/**
@@ -338,14 +339,15 @@ describe("prismicio.js file", () => {
 				 */
 				// TODO: Update the routes array to match your project's route structure.
 				const routes = [
-				  {
-				    type: \\"homepage\\",
-				    path: \\"/\\",
-				  },
-				  {
-				    type: \\"page\\",
-				    path: \\"/:uid\\",
-				  },
+				  // Examples:
+				  // {
+				  // 	type: \\"homepage\\",
+				  // 	path: \\"/\\",
+				  // },
+				  // {
+				  // 	type: \\"page\\",
+				  // 	path: \\"/:uid\\",
+				  // },
 				];
 
 				/**
@@ -409,14 +411,15 @@ describe("prismicio.js file", () => {
 				 */
 				// TODO: Update the routes array to match your project's route structure.
 				const routes: prismic.ClientConfig[\\"routes\\"] = [
-				  {
-				    type: \\"homepage\\",
-				    path: \\"/\\",
-				  },
-				  {
-				    type: \\"page\\",
-				    path: \\"/:uid\\",
-				  },
+				  // Examples:
+				  // {
+				  // 	type: \\"homepage\\",
+				  // 	path: \\"/\\",
+				  // },
+				  // {
+				  // 	type: \\"page\\",
+				  // 	path: \\"/:uid\\",
+				  // },
 				];
 
 				/**
@@ -482,14 +485,15 @@ describe("prismicio.js file", () => {
 				 */
 				// TODO: Update the routes array to match your project's route structure.
 				const routes: prismic.ClientConfig[\\"routes\\"] = [
-				  {
-				    type: \\"homepage\\",
-				    path: \\"/\\",
-				  },
-				  {
-				    type: \\"page\\",
-				    path: \\"/:uid\\",
-				  },
+				  // Examples:
+				  // {
+				  // 	type: \\"homepage\\",
+				  // 	path: \\"/\\",
+				  // },
+				  // {
+				  // 	type: \\"page\\",
+				  // 	path: \\"/:uid\\",
+				  // },
 				];
 
 				/**
@@ -554,14 +558,15 @@ describe("prismicio.js file", () => {
 				 */
 				// TODO: Update the routes array to match your project's route structure.
 				const routes = [
-				  {
-				    type: \\"homepage\\",
-				    path: \\"/\\",
-				  },
-				  {
-				    type: \\"page\\",
-				    path: \\"/:uid\\",
-				  },
+				  // Examples:
+				  // {
+				  // 	type: \\"homepage\\",
+				  // 	path: \\"/\\",
+				  // },
+				  // {
+				  // 	type: \\"page\\",
+				  // 	path: \\"/:uid\\",
+				  // },
 				];
 
 				/**
@@ -623,14 +628,15 @@ describe("prismicio.js file", () => {
 				 */
 				// TODO: Update the routes array to match your project's route structure.
 				const routes = [
-				  {
-				    type: \\"homepage\\",
-				    path: \\"/\\",
-				  },
-				  {
-				    type: \\"page\\",
-				    path: \\"/:uid\\",
-				  },
+				  // Examples:
+				  // {
+				  // 	type: \\"homepage\\",
+				  // 	path: \\"/\\",
+				  // },
+				  // {
+				  // 	type: \\"page\\",
+				  // 	path: \\"/:uid\\",
+				  // },
 				];
 
 				/**
@@ -694,14 +700,15 @@ describe("prismicio.js file", () => {
 				 */
 				// TODO: Update the routes array to match your project's route structure.
 				const routes: prismic.ClientConfig[\\"routes\\"] = [
-				  {
-				    type: \\"homepage\\",
-				    path: \\"/\\",
-				  },
-				  {
-				    type: \\"page\\",
-				    path: \\"/:uid\\",
-				  },
+				  // Examples:
+				  // {
+				  // 	type: \\"homepage\\",
+				  // 	path: \\"/\\",
+				  // },
+				  // {
+				  // 	type: \\"page\\",
+				  // 	path: \\"/:uid\\",
+				  // },
 				];
 
 				/**
@@ -763,14 +770,15 @@ describe("prismicio.js file", () => {
 				 */
 				// TODO: Update the routes array to match your project's route structure.
 				const routes: prismic.ClientConfig[\\"routes\\"] = [
-				  {
-				    type: \\"homepage\\",
-				    path: \\"/\\",
-				  },
-				  {
-				    type: \\"page\\",
-				    path: \\"/:uid\\",
-				  },
+				  // Examples:
+				  // {
+				  // 	type: \\"homepage\\",
+				  // 	path: \\"/\\",
+				  // },
+				  // {
+				  // 	type: \\"page\\",
+				  // 	path: \\"/:uid\\",
+				  // },
 				];
 
 				/**


### PR DESCRIPTION
## Context

This PR updates `@slicemachine/adapter-next` by removing the generated `prismicio.ts`'s default route resolver entries.

The entries were provided as an example for developers to update in their project, but it meant projects were not immediately runnable.


## The Solution

Remove the default entries. The existing entries were kept, but commented out, to continue to provide an example configuration.

Note that **API responses will always default to `null` without route resolver entries**. The adapter's page code snippet describes that users should add an entry to the project's route resolver.




## Impact / Dependencies

Developers will now be able to run a project immediately after running `@slicemachine/init`, even if it means they are still missing necessary route resolver configuration.




## Checklist before requesting a review
- [x] I hereby declare my code ready for review.
- [x] If it is a critical feature, I have added tests.
- [x] The CI is successful.
- [x] If there could backward compatibility issues, it has been discussed and planned.
