### PR TITLE
feat(Slice Zone): Save on click slice zone actions

### DIFF
--- a/packages/slice-machine/lib/builders/CustomTypeBuilder/SliceZone/UpdateSliceZoneModal.tsx
+++ b/packages/slice-machine/lib/builders/CustomTypeBuilder/SliceZone/UpdateSliceZoneModal.tsx
@@ -1,6 +1,8 @@
 import { Text } from "theme-ui";
+import { SharedSlice } from "@prismicio/types-internal/lib/customtypes";
 
 import { ComponentUI } from "@lib/models/common/ComponentUI";
+
 import ModalFormCard from "../../../../components/ModalFormCard";
 import UpdateSliceZoneModalList from "./UpdateSliceZoneModalList";
 
@@ -8,7 +10,7 @@ interface UpdateSliceModalProps {
   isOpen: boolean;
   formId: string;
   close: () => void;
-  onSubmit: (values: SliceZoneFormValues) => void;
+  onSubmit: (slices: SharedSlice[]) => Promise<void>;
   availableSlices: ReadonlyArray<ComponentUI>;
 }
 
@@ -30,8 +32,14 @@ const UpdateSliceZoneModal: React.FC<UpdateSliceModalProps> = ({
       formId={formId}
       close={close}
       onSubmit={(values: SliceZoneFormValues) => {
-        onSubmit(values);
-        close();
+        const { sliceKeys } = values;
+        const slices = sliceKeys
+          .map(
+            (sliceKey) =>
+              availableSlices.find((s) => s.model.id === sliceKey)?.model
+          )
+          .filter((slice) => slice !== undefined) as SharedSlice[];
+        void onSubmit(slices);
       }}
       initialValues={{
         sliceKeys: [],

--- a/packages/slice-machine/lib/builders/CustomTypeBuilder/SliceZone/index.tsx
+++ b/packages/slice-machine/lib/builders/CustomTypeBuilder/SliceZone/index.tsx
@@ -12,13 +12,12 @@ import { useEffect, useMemo, useState } from "react";
 import { useSelector } from "react-redux";
 import { BaseStyles } from "theme-ui";
 import { useRouter } from "next/router";
+import { toast } from "react-toastify";
+import { SharedSlice } from "@prismicio/types-internal/lib/customtypes";
 
+import { CustomTypeSM, CustomTypes } from "@lib/models/common/CustomType";
 import { CreateSliceModal } from "@components/Forms/CreateSliceModal";
-import type {
-  NonSharedSliceInSliceZone,
-  SliceZoneSlice,
-} from "@lib/models/common/CustomType/sliceZone";
-import type { CustomTypeSM } from "@lib/models/common/CustomType";
+import type { SliceZoneSlice } from "@lib/models/common/CustomType/sliceZone";
 import type { ComponentUI } from "@lib/models/common/ComponentUI";
 import type { LibraryUI } from "@lib/models/common/LibraryUI";
 import type { SlicesSM } from "@lib/models/common/Slices";
@@ -32,14 +31,14 @@ import {
 } from "@src/modules/slices";
 import type { SliceMachineStoreType } from "@src/redux/type";
 import { useSlicesTemplates } from "@src/features/slicesTemplates/useSlicesTemplates";
-import { createSlicesTemplates } from "@src/features/slicesTemplates/actions/createSlicesTemplates";
+import useSliceMachineActions from "@src/modules/useSliceMachineActions";
+import { addSlicesToSliceZone } from "@src/features/slices/actions/addSlicesToSliceZone";
+import { ToastMessageWithPath } from "@components/ToasterContainer";
 
 import { DeleteSliceZoneModal } from "./DeleteSliceZoneModal";
-import { SlicesList } from "./List";
 import UpdateSliceZoneModal from "./UpdateSliceZoneModal";
 import { SlicesTemplatesModal } from "./SlicesTemplatesModal";
-import { getState } from "@src/apiClient";
-import useSliceMachineActions from "@src/modules/useSliceMachineActions";
+import { SlicesList } from "./List";
 
 const mapAvailableAndSharedSlices = (
   sliceZone: SlicesSM,
@@ -100,8 +99,6 @@ interface SliceZoneProps {
   onCreateSliceZone: () => void;
   onDeleteSliceZone: () => void;
   onRemoveSharedSlice: (sliceId: string) => void;
-  // eslint-disable-next-line @typescript-eslint/ban-types
-  onSelectSharedSlices: Function;
   sliceZone?: SlicesSM | null | undefined;
   tabId: string;
 }
@@ -111,7 +108,6 @@ const SliceZone: React.FC<SliceZoneProps> = ({
   onCreateSliceZone,
   onDeleteSliceZone,
   onRemoveSharedSlice,
-  onSelectSharedSlices,
   sliceZone,
   tabId,
 }) => {
@@ -129,7 +125,8 @@ const SliceZone: React.FC<SliceZoneProps> = ({
       slices: getFrontendSlices(store),
     })
   );
-  const { createSliceSuccess } = useSliceMachineActions();
+  const { initCustomTypeStore, saveCustomTypeSuccess } =
+    useSliceMachineActions();
   const localLibraries: readonly LibraryUI[] = libraries.filter(
     (library) => library.isLocal
   );
@@ -156,11 +153,6 @@ const SliceZone: React.FC<SliceZoneProps> = ({
     .filter((e) => e.type === "SharedSlice")
     .map((e) => e.payload) as ReadonlyArray<ComponentUI>;
 
-  /* Preserve these keys in SliceZone */
-  const nonSharedSlicesKeysInSliceZone = slicesInSliceZone
-    .filter((e) => e.type === "Slice")
-    .map((e) => (e.payload as NonSharedSliceInSliceZone).key);
-
   const availableSlicesToAdd = availableSlices.filter(
     (slice) =>
       !sharedSlicesInSliceZone.some(
@@ -168,11 +160,11 @@ const SliceZone: React.FC<SliceZoneProps> = ({
       )
   );
 
-  const onAddNewSlice = () => {
+  const openUpdateSliceZoneModal = () => {
     setIsUpdateSliceZoneModalOpen(true);
   };
 
-  const onCreateNewSlice = () => {
+  const openCreateSliceModal = () => {
     setIsCreateSliceModalOpen(true);
   };
 
@@ -196,6 +188,29 @@ const SliceZone: React.FC<SliceZoneProps> = ({
     }
   };
 
+  const closeUpdateSliceZoneModal = () => {
+    setIsUpdateSliceZoneModalOpen(false);
+    redirectToEditMode();
+  };
+
+  const closeCreateSliceModal = () => {
+    setIsCreateSliceModalOpen(false);
+    redirectToEditMode();
+  };
+
+  const closeSlicesTemplatesModal = () => {
+    setIsSlicesTemplatesModalOpen(false);
+    redirectToEditMode();
+  };
+
+  const onAddSlicesToSliceZone = (newCustomType: CustomTypeSM) => {
+    // Reset selected custom type store to update slice zone and saving status
+    initCustomTypeStore(newCustomType, newCustomType);
+
+    // Update available custom type store with new custom type
+    saveCustomTypeSuccess(CustomTypes.fromSM(newCustomType));
+  };
+
   return (
     <Box flexDirection="column" height="100%">
       {query.newPageType === undefined ? (
@@ -213,7 +228,7 @@ const SliceZone: React.FC<SliceZoneProps> = ({
                   <DropdownMenuContent align="end">
                     <DropdownMenuItem
                       startIcon={<Icon name="add" size="large" />}
-                      onSelect={onCreateNewSlice}
+                      onSelect={openCreateSliceModal}
                       description="Start from scratch."
                     >
                       Create new
@@ -231,7 +246,7 @@ const SliceZone: React.FC<SliceZoneProps> = ({
 
                     {availableSlicesToAdd.length > 0 ? (
                       <DropdownMenuItem
-                        onSelect={onAddNewSlice}
+                        onSelect={openUpdateSliceZoneModal}
                         startIcon={<Icon name="folder" size="large" />}
                         description="Select from your own slices."
                       >
@@ -272,8 +287,8 @@ const SliceZone: React.FC<SliceZoneProps> = ({
           </BaseStyles>
         ) : (
           <SliceZoneBlankSlate
-            onAddNewSlice={onAddNewSlice}
-            onCreateNewSlice={onCreateNewSlice}
+            openUpdateSliceZoneModal={openUpdateSliceZoneModal}
+            openCreateSliceModal={openCreateSliceModal}
             openSlicesTemplatesModal={openSlicesTemplatesModal}
             projectHasAvailableSlices={availableSlicesToAdd.length > 0}
             isSlicesTemplatesSupported={availableSlicesTemplates.length > 0}
@@ -284,45 +299,39 @@ const SliceZone: React.FC<SliceZoneProps> = ({
         isOpen={isUpdateSliceZoneModalOpen}
         formId={`tab-slicezone-form-${tabId}`}
         availableSlices={availableSlicesToAdd}
-        onSubmit={({ sliceKeys }) => {
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-          onSelectSharedSlices(
-            sliceKeys.concat(sharedSlicesInSliceZone.map((s) => s.model.id)),
-            nonSharedSlicesKeysInSliceZone
-          );
-          redirectToEditMode();
+        onSubmit={async (slices: SharedSlice[]) => {
+          const newCustomType = await addSlicesToSliceZone({
+            customType,
+            tabId,
+            slices,
+          });
+          onAddSlicesToSliceZone(newCustomType);
+          closeUpdateSliceZoneModal();
+          toast.success("Slice(s) added to slice zone");
         }}
-        close={() => setIsUpdateSliceZoneModalOpen(false)}
+        close={closeUpdateSliceZoneModal}
       />
       <SlicesTemplatesModal
         isOpen={isSlicesTemplatesModalOpen}
         formId={`tab-slicezone-form-${tabId}`}
         availableSlicesTemplates={availableSlicesTemplates}
-        onSubmit={({ sliceKeys }) =>
-          void createSlicesTemplates({
-            templateIDs: sliceKeys,
-            localLibrariesNames: localLibraries.map((library) => library.name),
-            onSuccess: async (slicesIds: string[]) => {
-              // TODO(DT-1453): Remove the need of the global getState
-              const serverState = await getState();
-
-              // Update Redux store
-              createSliceSuccess(serverState.libraries);
-
-              // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-              onSelectSharedSlices(
-                slicesIds.concat(
-                  sharedSlicesInSliceZone.map((s) => s.model.id)
-                ),
-                nonSharedSlicesKeysInSliceZone
-              );
-
-              setIsSlicesTemplatesModalOpen(false);
-              redirectToEditMode();
-            },
-          })
-        }
-        close={() => setIsSlicesTemplatesModalOpen(false)}
+        localLibraries={localLibraries}
+        onSuccess={async (slices: SharedSlice[]) => {
+          const newCustomType = await addSlicesToSliceZone({
+            customType,
+            tabId,
+            slices,
+          });
+          onAddSlicesToSliceZone(newCustomType);
+          closeSlicesTemplatesModal();
+          toast.success(
+            <ToastMessageWithPath
+              message="Slice(s) added to slice zone and created at: "
+              path={`${localLibraries[0].name}/`}
+            />
+          );
+        }}
+        close={closeSlicesTemplatesModal}
       />
       <DeleteSliceZoneModal
         isDeleteSliceZoneModalOpen={isDeleteSliceZoneModalOpen}
@@ -336,13 +345,24 @@ const SliceZone: React.FC<SliceZoneProps> = ({
       />
       {localLibraries?.length !== 0 && isCreateSliceModalOpen && (
         <CreateSliceModal
-          onClose={() => {
-            setIsCreateSliceModalOpen(false);
+          onSuccess={async (newSlice: SharedSlice) => {
+            const newCustomType = await addSlicesToSliceZone({
+              customType,
+              tabId,
+              slices: [newSlice],
+            });
+            onAddSlicesToSliceZone(newCustomType);
+            closeCreateSliceModal();
+            toast.success(
+              <ToastMessageWithPath
+                message="Slice added to slice zone and created at: "
+                path={`${localLibraries[0].name}/${newSlice.name}/model.json`}
+              />
+            );
           }}
           localLibraries={localLibraries}
           remoteSlices={remoteSlices}
-          customType={customType}
-          tabId={tabId}
+          onClose={closeCreateSliceModal}
         />
       )}
     </Box>

--- a/packages/slice-machine/lib/builders/CustomTypeBuilder/TabZone/index.tsx
+++ b/packages/slice-machine/lib/builders/CustomTypeBuilder/TabZone/index.tsx
@@ -46,7 +46,6 @@ const TabZone: FC<TabZoneProps> = ({
     createSliceZone,
     deleteSliceZone,
     deleteCustomTypeSharedSlice,
-    replaceCustomTypeSharedSlice,
   } = useSliceMachineActions();
 
   const { query } = useRouter();
@@ -128,14 +127,6 @@ const TabZone: FC<TabZoneProps> = ({
     deleteSliceZone(tabId);
   };
 
-  const onSelectSharedSlices = (keys: string[], preserve: string[] = []) => {
-    void telemetry.track({
-      event: "custom-type:slice-zone-updated",
-      customTypeId: customType.id,
-    });
-    replaceCustomTypeSharedSlice(tabId, keys, preserve);
-  };
-
   const onRemoveSharedSlice = (sliceId: string) => {
     deleteCustomTypeSharedSlice(tabId, sliceId);
   };
@@ -189,7 +180,6 @@ const TabZone: FC<TabZoneProps> = ({
             onRemoveSharedSlice={onRemoveSharedSlice}
             onCreateSliceZone={onCreateSliceZone}
             onDeleteSliceZone={onDeleteSliceZone}
-            onSelectSharedSlices={onSelectSharedSlices}
           />
         </Suspense>
       </ErrorBoundary>

--- a/packages/slice-machine/lib/builders/common/EditModal/index.jsx
+++ b/packages/slice-machine/lib/builders/common/EditModal/index.jsx
@@ -272,7 +272,7 @@ const EditModal = ({ close, data, fields, onSave, zoneType }) => {
                       borderRadius: "4px",
                     }}
                   >
-                    Save
+                    Done
                   </Button>
                 </Flex>
               }

--- a/packages/slice-machine/lib/models/common/CustomType/sliceZone.ts
+++ b/packages/slice-machine/lib/models/common/CustomType/sliceZone.ts
@@ -30,24 +30,6 @@ export const SliceZone = {
       value,
     };
   },
-  replaceSharedSlice(
-    sz: SlicesSM,
-    keys: ReadonlyArray<string>,
-    preserve: ReadonlyArray<string> = []
-  ): SlicesSM {
-    const value = sz.value
-      .filter(({ key }) => preserve.includes(key))
-      .concat(
-        keys.map((key) => ({
-          key,
-          value: { type: "SharedSlice" },
-        }))
-      );
-    return {
-      ...sz,
-      value,
-    };
-  },
   removeSharedSlice(sz: SlicesSM, key: string): SlicesSM {
     const value = sz.value.filter(({ key: k }) => k !== key);
 

--- a/packages/slice-machine/pages/slices.tsx
+++ b/packages/slice-machine/pages/slices.tsx
@@ -3,6 +3,9 @@ import React, { useState } from "react";
 import Head from "next/head";
 import { BaseStyles, Flex, Text, Link } from "theme-ui";
 import { useSelector } from "react-redux";
+import { useRouter } from "next/router";
+import { toast } from "react-toastify";
+import { SharedSlice as SharedSliceType } from "@prismicio/types-internal/lib/customtypes";
 
 import { ComponentUI } from "@lib/models/common/ComponentUI";
 import { LibraryUI } from "@lib/models/common/LibraryUI";
@@ -30,8 +33,11 @@ import {
 } from "@src/modules/slices";
 import { useModelStatus } from "@src/hooks/useModelStatus";
 import { useScreenshotChangesModal } from "@src/hooks/useScreenshotChangesModal";
+import { SLICES_CONFIG } from "@src/features/slices/slicesConfig";
+import { SliceToastMessage } from "@components/ToasterContainer";
 
 const SlicesIndex: React.FunctionComponent = () => {
+  const router = useRouter();
   const { openRenameSliceModal, openDeleteSliceModal } =
     useSliceMachineActions();
 
@@ -225,6 +231,21 @@ const SlicesIndex: React.FunctionComponent = () => {
             <CreateSliceModal
               localLibraries={localLibraries}
               remoteSlices={remoteSlices}
+              onSuccess={(newSlice: SharedSliceType, libraryName: string) => {
+                // Redirect to the slice page
+                const variationId = newSlice.variations[0].id;
+                const sliceLocation = SLICES_CONFIG.getBuilderPagePathname({
+                  libraryName,
+                  sliceName: newSlice.name,
+                  variationId,
+                });
+                void router.push(sliceLocation);
+                toast.success(
+                  SliceToastMessage({
+                    path: `${libraryName}/${newSlice.name}/model.json`,
+                  })
+                );
+              }}
               onClose={() => {
                 setIsCreateSliceModalOpen(false);
               }}

--- a/packages/slice-machine/src/features/customTypes/customTypesBuilder/SliceZoneBlankSlate.tsx
+++ b/packages/slice-machine/src/features/customTypes/customTypesBuilder/SliceZoneBlankSlate.tsx
@@ -11,16 +11,16 @@ import {
 import { LightningIcon3D } from "@src/icons/LightningIcon3D";
 
 export type SliceZoneBlankSlateProps = {
-  onAddNewSlice: () => void;
-  onCreateNewSlice: () => void;
+  openUpdateSliceZoneModal: () => void;
+  openCreateSliceModal: () => void;
   openSlicesTemplatesModal: () => void;
   projectHasAvailableSlices: boolean;
   isSlicesTemplatesSupported: boolean;
 };
 
 export const SliceZoneBlankSlate: FC<SliceZoneBlankSlateProps> = ({
-  onCreateNewSlice,
-  onAddNewSlice,
+  openCreateSliceModal,
+  openUpdateSliceZoneModal,
   openSlicesTemplatesModal,
   projectHasAvailableSlices,
   isSlicesTemplatesSupported,
@@ -42,7 +42,7 @@ export const SliceZoneBlankSlate: FC<SliceZoneBlankSlateProps> = ({
             <ActionList>
               <ActionListItem
                 startIcon="add"
-                onClick={onCreateNewSlice}
+                onClick={openCreateSliceModal}
                 description="Start from scratch."
               >
                 Create new
@@ -59,7 +59,7 @@ export const SliceZoneBlankSlate: FC<SliceZoneBlankSlateProps> = ({
               {projectHasAvailableSlices ? (
                 <ActionListItem
                   startIcon="folder"
-                  onClick={onAddNewSlice}
+                  onClick={openUpdateSliceZoneModal}
                   description="Select from your own slices."
                 >
                   Select existing

--- a/packages/slice-machine/src/features/customTypes/customTypesMessages.ts
+++ b/packages/slice-machine/src/features/customTypes/customTypesMessages.ts
@@ -12,8 +12,6 @@ export const CUSTOM_TYPES_MESSAGES = {
     inputPlaceholder: `ID to query the page type in the API (e.g. 'BlogPost')`,
     blankSlateDescription:
       "Page types are models that your editors will use to create website pages in the Page Builder.",
-    createSliceFromTypeActionMessage:
-      "This action will save your current page type",
   },
   custom: {
     name: ({ start, plural }: CustomTypesMessagesNameArgs) =>
@@ -23,7 +21,5 @@ export const CUSTOM_TYPES_MESSAGES = {
     inputPlaceholder: `ID to query the custom type in the API (e.g. 'Author')`,
     blankSlateDescription:
       "Custom types are models that your editors can use to create menus or objects in the Page Builder.",
-    createSliceFromTypeActionMessage:
-      "This action will save your current custom type",
   },
 };

--- a/packages/slice-machine/src/features/slices/actions/addSlicesToSliceZone.ts
+++ b/packages/slice-machine/src/features/slices/actions/addSlicesToSliceZone.ts
@@ -1,0 +1,53 @@
+import { SharedSlice } from "@prismicio/types-internal/lib/customtypes";
+
+import { telemetry } from "@src/apiClient";
+import { managerClient } from "@src/managerClient";
+import { CustomTypeSM, CustomTypes } from "@lib/models/common/CustomType";
+
+export type AddSlicesToSliceZoneArgs = {
+  customType: CustomTypeSM;
+  tabId: string;
+  slices: SharedSlice[];
+};
+
+export async function addSlicesToSliceZone({
+  customType,
+  tabId,
+  slices,
+}: AddSlicesToSliceZoneArgs) {
+  let newCustomType: CustomTypeSM = { ...customType };
+
+  slices.forEach((slice) => {
+    newCustomType = {
+      ...newCustomType,
+      tabs: newCustomType.tabs.map((tab) =>
+        tab.key === tabId && tab.sliceZone
+          ? {
+              ...tab,
+              sliceZone: {
+                key: tab.sliceZone.key,
+                value: [
+                  ...tab.sliceZone.value,
+                  {
+                    key: slice.id,
+                    value: slice,
+                  },
+                ],
+              },
+            }
+          : tab
+      ),
+    };
+  });
+
+  await managerClient.customTypes.updateCustomType({
+    model: CustomTypes.fromSM(newCustomType),
+  });
+
+  void telemetry.track({
+    event: "custom-type:slice-zone-updated",
+    customTypeId: customType.id,
+  });
+
+  return newCustomType;
+}

--- a/packages/slice-machine/src/features/slices/actions/createSlice.ts
+++ b/packages/slice-machine/src/features/slices/actions/createSlice.ts
@@ -4,7 +4,6 @@ import { SharedSlice } from "@prismicio/types-internal/lib/customtypes";
 import { pascalize, snakelize } from "@lib/utils/str";
 import { managerClient } from "@src/managerClient";
 import { telemetry } from "@src/apiClient";
-import { SliceToastMessage } from "@components/ToasterContainer";
 
 type CreateSliceArgs = {
   sliceName: string;
@@ -33,12 +32,6 @@ export async function createSlice(args: CreateSliceArgs) {
     });
 
     await onSuccess(newSlice);
-
-    toast.success(
-      SliceToastMessage({
-        path: `${libraryName}/${newSlice.name}/model.json`,
-      })
-    );
   } catch (e) {
     const errorMessage = "Internal Error: Slice not created";
     console.error(errorMessage, e);

--- a/packages/slice-machine/src/modules/selectedCustomType/actions.ts
+++ b/packages/slice-machine/src/modules/selectedCustomType/actions.ts
@@ -16,7 +16,6 @@ export type SelectedCustomTypeActions =
   | ActionType<typeof createSliceZoneCreator>
   | ActionType<typeof deleteSliceZoneCreator>
   | ActionType<typeof addFieldIntoGroupCreator>
-  | ActionType<typeof replaceSharedSliceCreator>
   | ActionType<typeof replaceFieldIntoGroupCreator>
   | ActionType<typeof reorderFieldIntoGroupCreator>
   | ActionType<typeof deleteFieldIntoGroupCreator>
@@ -96,10 +95,6 @@ export type ReplaceSharedSliceCreatorPayload = {
   sliceKeys: string[];
   preserve: string[];
 };
-
-export const replaceSharedSliceCreator = createAction(
-  "CUSTOM_TYPE/REPLACE_SHARED_SLICE"
-)<ReplaceSharedSliceCreatorPayload>();
 
 export const deleteSharedSliceCreator = createAction(
   "CUSTOM_TYPE/DELETE_SHARED_SLICE"

--- a/packages/slice-machine/src/modules/selectedCustomType/reducer.ts
+++ b/packages/slice-machine/src/modules/selectedCustomType/reducer.ts
@@ -16,7 +16,6 @@ import {
   deleteSharedSliceCreator,
   reorderFieldCreator,
   replaceFieldCreator,
-  replaceSharedSliceCreator,
   addFieldIntoGroupCreator,
   deleteFieldIntoGroupCreator,
   reorderFieldIntoGroupCreator,
@@ -203,18 +202,6 @@ export const selectedCustomTypeReducer: Reducer<
       )((tab) => {
         return Tab.deleteSliceZone(tab);
       });
-    }
-    case getType(replaceSharedSliceCreator): {
-      const { tabId, sliceKeys, preserve } = action.payload;
-      return StateHelpers.updateTab(
-        state,
-        tabId
-      )((tab) =>
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-        Tab.updateSliceZone(tab)((sliceZone: SlicesSM) =>
-          SliceZone.replaceSharedSlice(sliceZone, sliceKeys, preserve)
-        )
-      );
     }
     case getType(deleteSharedSliceCreator): {
       const { tabId, sliceId } = action.payload;

--- a/packages/slice-machine/src/modules/useSliceMachineActions.ts
+++ b/packages/slice-machine/src/modules/useSliceMachineActions.ts
@@ -35,7 +35,6 @@ import {
   reorderFieldCreator,
   replaceFieldCreator,
   deleteSharedSliceCreator,
-  replaceSharedSliceCreator,
   createSliceZoneCreator,
   deleteSliceZoneCreator,
   saveCustomTypeCreator,
@@ -225,11 +224,6 @@ const useSliceMachineActions = () => {
     dispatch(deleteSliceZoneCreator({ tabId }));
   const deleteCustomTypeSharedSlice = (tabId: string, sliceId: string) =>
     dispatch(deleteSharedSliceCreator({ tabId, sliceId }));
-  const replaceCustomTypeSharedSlice = (
-    tabId: string,
-    sliceKeys: string[],
-    preserve: string[]
-  ) => dispatch(replaceSharedSliceCreator({ tabId, sliceKeys, preserve }));
   const addFieldIntoGroup = (
     tabId: string,
     groupId: string,
@@ -500,7 +494,6 @@ const useSliceMachineActions = () => {
     createSliceZone,
     deleteSliceZone,
     deleteCustomTypeSharedSlice,
-    replaceCustomTypeSharedSlice,
     addFieldIntoGroup,
     deleteFieldIntoGroup,
     reorderFieldIntoGroup,

--- a/packages/slice-machine/test/lib/models/common/CustomType/sliceZone.test.ts
+++ b/packages/slice-machine/test/lib/models/common/CustomType/sliceZone.test.ts
@@ -33,25 +33,6 @@ describe("Slice Zone", () => {
     });
   });
 
-  describe("Replace shared slices", () => {
-    it("removes the correct slice", () => {
-      const keyToPreserve = "slice_in_zone_1";
-      const newKeys = "new_slice_in_zone";
-
-      const result = SliceZone.replaceSharedSlice(
-        mockSliceZone,
-        [newKeys],
-        [keyToPreserve]
-      );
-
-      expect(result.value.map((slice) => slice.key)).toEqual([
-        keyToPreserve,
-        newKeys,
-      ]);
-      expect(result.value.length).toEqual(2);
-    });
-  });
-
   describe("Add shared slices", () => {
     it("adds a new slice to the slice zone", () => {
       const newKey = "new_slice_in_zone";

--- a/packages/slice-machine/test/src/modules/selectedCustomType/reducer.test.ts
+++ b/packages/slice-machine/test/src/modules/selectedCustomType/reducer.test.ts
@@ -11,7 +11,6 @@ import {
   initCustomTypeStoreCreator,
   reorderFieldCreator,
   replaceFieldCreator,
-  replaceSharedSliceCreator,
   updateTabCreator,
   cleanupCustomTypeStoreCreator,
 } from "@src/modules/selectedCustomType";
@@ -248,32 +247,6 @@ describe("[Selected Custom type module]", () => {
     expect(newTabState.sliceZone.value.length).toEqual(0);
     // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     expect(newTabState.sliceZone.key).toEqual("slices");
-  });
-  it("should place slices inside a slicezone given CUSTOM_TYPE/REPLACE_SHARED_SLICE action", () => {
-    // @ts-expect-error TS(2531) FIXME: Object is possibly 'null'.
-    const initialTab = dummyCustomTypesState.model.tabs[0];
-    const newState = selectedCustomTypeReducer(
-      dummyCustomTypesState,
-      createSliceZoneCreator({
-        tabId: initialTab.key,
-      })
-    );
-
-    const keys = ["Slice1", "Slice2", "Slice3", "Slice4"];
-
-    const newState2 = selectedCustomTypeReducer(
-      newState,
-      replaceSharedSliceCreator({
-        tabId: initialTab.key,
-        sliceKeys: keys,
-        preserve: [],
-      })
-    );
-
-    // @ts-expect-error TS(2531) FIXME: Object is possibly 'null'.
-    expect(newState2.model.tabs[0].sliceZone.value.map((e) => e.key)).toEqual(
-      keys
-    );
   });
   it("should update the field id into a custom type given CUSTOM_TYPE/REPLACE_FIELD action", () => {
     // @ts-expect-error TS(2531) FIXME: Object is possibly 'null'.


### PR DESCRIPTION
## Context

- Completes DT-1617

## The Solution

- Rework slice zone action to open and close the same way
- Create a new function to add slices in slice zone and push changes to manager
- Handle success in a proper to control each case
- Update the "Save" button to "Done" from edit field Modal 
- Don't redirect to slice builder after creating one from slice zone

## Impact / Dependencies

- Removed a slice machine action and reducer

## Checklist before requesting a review
- [x] I hereby declare my code ready for review.
- [ ] If it is a critical feature, I have added tests.
- [ ] The CI is successful.
- [ ] If there could backward compatibility issues, it has been discussed and planned.
