### PR TITLE
fix(adapter-next): prevent slice template hydration errors due to CSS (DT-1673)

### DIFF
--- a/packages/adapter-next/public/AlternateGrid/javascript.jsx
+++ b/packages/adapter-next/public/AlternateGrid/javascript.jsx
@@ -78,158 +78,159 @@ const PascalNameToReplace = ({ slice }) => {
 					)}
 				</div>
 			</div>
+			<style
+				dangerouslySetInnerHTML={{
+					__html: `
+            .es-bounded {
+                margin: 0px;
+                min-width: 0px;
+                position: relative;
+                padding: 8vw 1.25rem;
+            }
 
-			<style>
-				{`
-					.es-bounded {
-							margin: 0px;
-							min-width: 0px;
-							position: relative;
-							padding: 8vw 1.25rem;
-					}
+            .es-alternate-grid {
+                font-family: system-ui, sans-serif;
+                background-color: #fff;
+                color: #333;
+            }
 
-					.es-alternate-grid {
-							font-family: system-ui, sans-serif;
-							background-color: #fff;
-							color: #333;
-					}
-					
-					.es-alternate-grid__content {
-							display: grid;
-							gap: 1.5rem;
-							grid-auto-flow: dense;
-					}
-					
-					@media (min-width: 640px) {
-							.es-alternate-grid__content--with-image {
-									grid-template-columns: repeat(2, 1fr);
-							}
-					}
-					
-					@media (min-width: 1200px) {
-							.es-alternate-grid__content--with-image {
-									grid-template-columns: repeat(2, 1fr);
-							}
-					}
-					
-					.es-alternate-grid__image {
-							width: auto;
-							height: auto;
-							max-width: 100%;
-							align-self: center;
-					}
-					
-					.es-alternate-grid__image--left {
-							order: 1;
-					}
+            .es-alternate-grid__content {
+                display: grid;
+                gap: 1.5rem;
+                grid-auto-flow: dense;
+            }
 
-					.es-alternate-grid__image--left + div {
-							order: 2;
-					}
-					
-					.es-alternate-grid__image--right{
-							order: 2;
-					}
+            @media (min-width: 640px) {
+                .es-alternate-grid__content--with-image {
+            	grid-template-columns: repeat(2, 1fr);
+                }
+            }
 
-					.es-alternate-grid__image--right + div {
-							order: 1;
-					}
+            @media (min-width: 1200px) {
+                .es-alternate-grid__content--with-image {
+            	grid-template-columns: repeat(2, 1fr);
+                }
+            }
 
-					.es-alternate-grid__primary-content {
-							display: grid;
-							gap: 2rem;
-					}
-					
-					.es-alternate-grid__primary-content__intro {
-							display: grid;
-							gap: 0.5rem;
-					}
-					
-					.es-alternate-grid__primary-content__intro__eyebrow {
-							color: #8592e0;
-							font-size: 1.15rem;
-							font-weight: 500;
-							margin: 0;
-					}
-					
-					.es-alternate-grid__primary-content__intro__headline {
-							font-size: 1.625rem;
-							font-weight: 700;
-					}
+            .es-alternate-grid__image {
+                width: auto;
+                height: auto;
+                max-width: 100%;
+                align-self: center;
+            }
 
-					.es-alternate-grid__primary-content__intro__headline * {
-							margin: 0;
-					}
-					
-					@media (min-width: 640px) {
-							.es-alternate-grid__primary-content__intro__headline {
-									font-size: 2rem;
-							}
-					}
-					
-					@media (min-width: 1024px) {
-							.es-alternate-grid__primary-content__intro__headline {
-									font-size: 2.5rem;
-							}
-					}
-					
-					@media (min-width: 1200px) {
-							.es-alternate-grid__primary-content__intro__headline {
-									font-size: 2.75rem;
-							}
-					}
-					
-					.es-alternate-grid__primary-content__intro__description {
-							font-size: 1.15rem;
-							max-width: 38rem;
-					}
+            .es-alternate-grid__image--left {
+                order: 1;
+            }
 
-					.es-alternate-grid__primary-content__intro__description > p {
-							margin: 0;
-					}
-					
-					@media (min-width: 1200px) {
-							.es-alternate-grid__primary-content__intro__description {
-									font-size: 1.4rem;
-							}
-					}
-					
-					.es-alternate-grid__primary-content__items {
-							display: grid;
-							gap: 2rem;
-					}
-					
-					@media (min-width: 640px) {
-							.es-alternate-grid__primary-content__items {
-									grid-template-columns: repeat(2, 1fr);
-							}
-					}
-					
-					.es-alternate-grid__item {
-							display: grid;
-							align-content: start;
-					}
-					
-					.es-alternate-grid__item__heading {
-							font-weight: 700;
-							font-size: 1.17rem;
-							margin-top: 0;
-							margin-bottom: .5rem;
-					}
-					
-					.es-alternate-grid__item__heading * {
-							margin: 0;
-					}
-					
-					.es-alternate-grid__item__description {
-							font-size: 0.9rem;
-					}
-					
-					.es-alternate-grid__item__description * {
-							margin: 0;
-					}
-			`}
-			</style>
+            .es-alternate-grid__image--left + div {
+                order: 2;
+            }
+
+            .es-alternate-grid__image--right{
+                order: 2;
+            }
+
+            .es-alternate-grid__image--right + div {
+                order: 1;
+            }
+
+            .es-alternate-grid__primary-content {
+                display: grid;
+                gap: 2rem;
+            }
+
+            .es-alternate-grid__primary-content__intro {
+                display: grid;
+                gap: 0.5rem;
+            }
+
+            .es-alternate-grid__primary-content__intro__eyebrow {
+                color: #8592e0;
+                font-size: 1.15rem;
+                font-weight: 500;
+                margin: 0;
+            }
+
+            .es-alternate-grid__primary-content__intro__headline {
+                font-size: 1.625rem;
+                font-weight: 700;
+            }
+
+            .es-alternate-grid__primary-content__intro__headline * {
+                margin: 0;
+            }
+
+            @media (min-width: 640px) {
+                .es-alternate-grid__primary-content__intro__headline {
+            	font-size: 2rem;
+                }
+            }
+
+            @media (min-width: 1024px) {
+                .es-alternate-grid__primary-content__intro__headline {
+            	font-size: 2.5rem;
+                }
+            }
+
+            @media (min-width: 1200px) {
+                .es-alternate-grid__primary-content__intro__headline {
+            	font-size: 2.75rem;
+                }
+            }
+
+            .es-alternate-grid__primary-content__intro__description {
+                font-size: 1.15rem;
+                max-width: 38rem;
+            }
+
+            .es-alternate-grid__primary-content__intro__description > p {
+                margin: 0;
+            }
+
+            @media (min-width: 1200px) {
+                .es-alternate-grid__primary-content__intro__description {
+            	font-size: 1.4rem;
+                }
+            }
+
+            .es-alternate-grid__primary-content__items {
+                display: grid;
+                gap: 2rem;
+            }
+
+            @media (min-width: 640px) {
+                .es-alternate-grid__primary-content__items {
+            	grid-template-columns: repeat(2, 1fr);
+                }
+            }
+
+            .es-alternate-grid__item {
+                display: grid;
+                align-content: start;
+            }
+
+            .es-alternate-grid__item__heading {
+                font-weight: 700;
+                font-size: 1.17rem;
+                margin-top: 0;
+                margin-bottom: .5rem;
+            }
+
+            .es-alternate-grid__item__heading * {
+                margin: 0;
+            }
+
+            .es-alternate-grid__item__description {
+                font-size: 0.9rem;
+            }
+
+            .es-alternate-grid__item__description * {
+                margin: 0;
+            }
+          `,
+				}}
+			/>
 		</section>
 	);
 };

--- a/packages/adapter-next/public/CallToAction/javascript.jsx
+++ b/packages/adapter-next/public/CallToAction/javascript.jsx
@@ -46,89 +46,90 @@ const PascalNameToReplace = ({ slice }) => {
 					</PrismicNextLink>
 				)}
 			</div>
+			<style
+				dangerouslySetInnerHTML={{
+					__html: `
+            .es-bounded {
+              padding: 8vw 2rem;
+            }
 
-			<style>
-				{`
-					.es-bounded {
-						padding: 8vw 2rem;
-					}
-					
-					.es-bounded__content {
-						margin-left: auto;
-						margin-right: auto;
-					}
-					
-					@media screen and (min-width: 640px) {
-						.es-bounded__content {
-							max-width: 90%;
-						}
-					}
-					
-					@media screen and (min-width: 896px) {
-						.es-bounded__content {
-							max-width: 80%;
-						}
-					}
-					
-					@media screen and (min-width: 1280px) {
-						.es-bounded__content {
-							max-width: 75%;
-						}
-					}
-					
-					.es-call-to-action {
-						font-family: system-ui, sans-serif;
-						background-color: #fff;
-						color: #333;
-					}
-					
-					.es-call-to-action__image {
-						max-width: 14rem;
-						height: auto;
-						width: auto;
-						justify-self: ${alignment};
-					}
-					
-					.es-call-to-action__content {
-						display: grid;
-						gap: 1rem;
-						justify-items: ${alignment};
-					}
-					
-					.es-call-to-action__content__heading {
-						font-size: 2rem;
-						font-weight: 700;
-						text-align: ${alignment};
-					}
+            .es-bounded__content {
+              margin-left: auto;
+              margin-right: auto;
+            }
 
-					.es-call-to-action__content__heading * {
-						margin: 0;
-					}
-					
-					.es-call-to-action__content__paragraph {
-						font-size: 1.15rem;
-						max-width: 38rem;
-						text-align: ${alignment};
-					}
-					
-					.es-call-to-action__button {
-						justify-self: ${alignment};
-						border-radius: 0.25rem;
-						display: inline-block;
-						font-size: 0.875rem;
-						line-height: 1.3;
-						padding: 1rem 2.625rem;
-						text-align: ${alignment};
-						transition: background-color 100ms linear;
-						background-color: #16745f;
-						color: #fff;
-					}
-					
-					.es-call-to-action__button:hover {
-						background-color: #0d5e4c;
-					}
-				`}
-			</style>
+            @media screen and (min-width: 640px) {
+              .es-bounded__content {
+                max-width: 90%;
+              }
+            }
+
+            @media screen and (min-width: 896px) {
+              .es-bounded__content {
+                max-width: 80%;
+              }
+            }
+
+            @media screen and (min-width: 1280px) {
+              .es-bounded__content {
+                max-width: 75%;
+              }
+            }
+
+            .es-call-to-action {
+              font-family: system-ui, sans-serif;
+              background-color: #fff;
+              color: #333;
+            }
+
+            .es-call-to-action__image {
+              max-width: 14rem;
+              height: auto;
+              width: auto;
+              justify-self: ${alignment};
+            }
+
+            .es-call-to-action__content {
+              display: grid;
+              gap: 1rem;
+              justify-items: ${alignment};
+            }
+
+            .es-call-to-action__content__heading {
+              font-size: 2rem;
+              font-weight: 700;
+              text-align: ${alignment};
+            }
+
+            .es-call-to-action__content__heading * {
+              margin: 0;
+            }
+
+            .es-call-to-action__content__paragraph {
+              font-size: 1.15rem;
+              max-width: 38rem;
+              text-align: ${alignment};
+            }
+
+            .es-call-to-action__button {
+              justify-self: ${alignment};
+              border-radius: 0.25rem;
+              display: inline-block;
+              font-size: 0.875rem;
+              line-height: 1.3;
+              padding: 1rem 2.625rem;
+              text-align: ${alignment};
+              transition: background-color 100ms linear;
+              background-color: #16745f;
+              color: #fff;
+            }
+
+            .es-call-to-action__button:hover {
+              background-color: #0d5e4c;
+            }
+          `,
+				}}
+			/>
 		</section>
 	);
 };

--- a/packages/adapter-next/public/CustomerLogos/javascript.jsx
+++ b/packages/adapter-next/public/CustomerLogos/javascript.jsx
@@ -48,83 +48,84 @@ const PascalNameToReplace = ({ slice }) => {
 					{slice.primary.callToActionLabel || "Learn more..."}
 				</PrismicNextLink>
 			</div>
+			<style
+				dangerouslySetInnerHTML={{
+					__html: `
+            .es-bounded {
+              margin: 0px;
+              min-width: 0px;
+              position: relative;
+              padding: 8vw 1.25rem;
+            }
 
-			<style>
-				{`
-					.es-bounded {
-							margin: 0px;
-							min-width: 0px;
-							position: relative;
-							padding: 8vw 1.25rem;
-					}
+            .es-bounded__content {
+              min-width: 0px;
+              max-width: 90%;
+              margin: 0px auto;
+            }
 
-					.es-bounded__content {
-							min-width: 0px;
-							max-width: 90%;
-							margin: 0px auto;
-					}
+            .es-customer-logos {
+              font-family: system-ui, sans-serif;
+              background-color: #f4f0ec;
+              color: #333;
+            }
 
-					.es-customer-logos {
-							font-family: system-ui, sans-serif;
-							background-color: #f4f0ec;
-							color: #333;
-					}
-					
-					.es-customer-logos__content {
-							display: grid;
-							gap: 2rem;
-							justify-items: center;
-					}
-					
-					.es-customer-logos__heading {
-							color: #8592e0;
-							font-size: 1.5rem;
-							font-weight: 500;
-							text-align: center;
-					}
+            .es-customer-logos__content {
+              display: grid;
+              gap: 2rem;
+              justify-items: center;
+            }
 
-					.es-customer-logos__heading * {
-						margin: 0;
-					}			
-					
-					.es-customer-logos__logos {
-							display: grid;
-							grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
-							grid-column-gap: 1.25rem;
-							grid-row-gap: 2rem;
-							align-items: center;
-							list-style-type: none;
-							width: 100%;
-					}
-					
-					@media (min-width: 1200px) {
-							.es-customer-logos__logos {
-									margin-left: -3rem;
-							}
-					}
-					
-					.es-customer-logos__logo {
-							margin: 0;
-							display: flex;
-							justify-content: center;
-					}
-					
-					@media (min-width: 1200px) {
-							.es-customer-logos__logo {
-									margin-left: 3rem;
-							}
-					}
-					
-					.es-customer-logos__logo__link__image {
-							max-width: 10rem;
-					}
-					
-					.es-customer-logos__button {
-							justify-self: center;
-							text-decoration: underline;
-					}
-			`}
-			</style>
+            .es-customer-logos__heading {
+              color: #8592e0;
+              font-size: 1.5rem;
+              font-weight: 500;
+              text-align: center;
+            }
+
+            .es-customer-logos__heading * {
+            	margin: 0;
+            }
+
+            .es-customer-logos__logos {
+              display: grid;
+              grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+              grid-column-gap: 1.25rem;
+              grid-row-gap: 2rem;
+              align-items: center;
+              list-style-type: none;
+              width: 100%;
+            }
+
+            @media (min-width: 1200px) {
+              .es-customer-logos__logos {
+            		margin-left: -3rem;
+              }
+            }
+
+            .es-customer-logos__logo {
+              margin: 0;
+              display: flex;
+              justify-content: center;
+            }
+
+            @media (min-width: 1200px) {
+              .es-customer-logos__logo {
+            		margin-left: 3rem;
+              }
+            }
+
+            .es-customer-logos__logo__link__image {
+              max-width: 10rem;
+            }
+
+            .es-customer-logos__button {
+              justify-self: center;
+              text-decoration: underline;
+            }
+          `,
+				}}
+			/>
 		</section>
 	);
 };

--- a/packages/adapter-next/public/Hero/javascript.jsx
+++ b/packages/adapter-next/public/Hero/javascript.jsx
@@ -64,56 +64,57 @@ const PascalNameToReplace = ({ slice }) => {
 					</div>
 				</div>
 			</div>
-			<style>
-				{`
-          .es-bounded {
+			<style
+				dangerouslySetInnerHTML={{
+					__html: `
+            .es-bounded {
               margin: 0px;
               min-width: 0px;
               position: relative;
-          }
-  
-          .es-fullpage-hero {
+            }
+
+            .es-fullpage-hero {
               font-family: system-ui, sans-serif;
               background-color: #fff;
               color: #333;
-          }
-          
-          .es-fullpage-hero__image {
+            }
+
+            .es-fullpage-hero__image {
               max-width: 100%;
               height: auto;
               align-self: center;
-          }
-              
-          .es-fullpage-hero__image--left > div:first-child {
-              order: 1;
-          }
+            }
 
-          .es-fullpage-hero__image--left > div:nth-child(2) {
-              order: 2;
-          }
-          
-          .es-fullpage-hero__image--right > div:first-child {
-              order: 2;
-          }
-
-          .es-fullpage-hero__image--right > div:nth-child(2) {
+            .es-fullpage-hero__image--left > div:first-child {
               order: 1;
-          }
-          
-          .es-fullpage-hero__content {
+            }
+
+            .es-fullpage-hero__image--left > div:nth-child(2) {
+              order: 2;
+            }
+
+            .es-fullpage-hero__image--right > div:first-child {
+              order: 2;
+            }
+
+            .es-fullpage-hero__image--right > div:nth-child(2) {
+              order: 1;
+            }
+
+            .es-fullpage-hero__content {
               display: flex;
               flex-direction: column;
               gap: 2rem;
-          }
-          
-          .es-fullpage-hero__content-right {
+            }
+
+            .es-fullpage-hero__content-right {
               display: flex;
               flex-direction: column;
               justify-content: space-around;
               padding: 1.5rem;
-          }
-  
-          @media (min-width: 1080px) {
+            }
+
+            @media (min-width: 1080px) {
               .es-fullpage-hero__content {
                   flex-direction: row;
               }
@@ -121,63 +122,63 @@ const PascalNameToReplace = ({ slice }) => {
               .es-fullpage-hero__content > div {
                   width: 50%;
               }
-          }
-  
-          .es-fullpage-hero__content__intro {
+            }
+
+            .es-fullpage-hero__content__intro {
               display: grid;
               gap: 1rem;
-          }
-              
-          .es-fullpage-hero__content__intro__eyebrow {
+            }
+
+            .es-fullpage-hero__content__intro__eyebrow {
               color: #47C1AF;
               font-size: 1.15rem;
               font-weight: 500;
               margin: 0;
-          }
-              
-          .es-fullpage-hero__content__intro__headline {
+            }
+
+            .es-fullpage-hero__content__intro__headline {
               font-size: 1.625rem;
               font-weight: 700;
-          }
-  
-          .es-fullpage-hero__content__intro__headline * {
+            }
+
+            .es-fullpage-hero__content__intro__headline * {
               margin: 0;
-          }
-              
-          @media (min-width: 640px) {
+            }
+
+            @media (min-width: 640px) {
               .es-fullpage-hero__content__intro__headline {
                   font-size: 2rem;
               }
-          }
-              
-          @media (min-width: 1024px) {
+            }
+
+            @media (min-width: 1024px) {
               .es-fullpage-hero__content__intro__headline {
                   font-size: 2.5rem;
               }
-          }
-              
-          @media (min-width: 1200px) {
+            }
+
+            @media (min-width: 1200px) {
               .es-fullpage-hero__content__intro__headline {
                   font-size: 2.75rem;
               }
-          }
-              
-          .es-fullpage-hero__content__intro__description {
+            }
+
+            .es-fullpage-hero__content__intro__description {
               font-size: 1.15rem;
               max-width: 38rem;
-          }
-  
-          .es-fullpage-hero__content__intro__description > p {
+            }
+
+            .es-fullpage-hero__content__intro__description > p {
               margin: 0;
-          }
-              
-          @media (min-width: 1200px) {
+            }
+
+            @media (min-width: 1200px) {
               .es-fullpage-hero__content__intro__description {
                   font-size: 1.4rem;
               }
-          }
+            }
 
-          .es-call-to-action__link {
+            .es-call-to-action__link {
               justify-self: flex-start;
               border-radius: 0.25rem;
               font-size: 0.875rem;
@@ -186,13 +187,14 @@ const PascalNameToReplace = ({ slice }) => {
               transition: background-color 100ms linear;
               background-color: #16745f;
               color: #fff;
-          }
-          
-          .es-call-to-action__link:hover {
+            }
+
+            .es-call-to-action__link:hover {
               background-color: #0d5e4c;
-          }
-        `}
-			</style>
+            }
+          `,
+				}}
+			/>
 		</section>
 	);
 };


### PR DESCRIPTION
## Context

Fixes [DT-1673](https://linear.app/prismic/issue/DT-1673/aauser-i-expect-the-nextjs-slice-templates-to-work-without-hydration)

## The Solution

Replace `<style>...</style>` with `<style dangerouslySetInnerHTML={{ __html: "..." }} />`.

## Impact / Dependencies

New projects will not have the hydration error, but existing ones that added the slice templates will.

## Checklist before requesting a review

- [x] I hereby declare my code ready for review.
- [ ] If it is a critical feature, I have added tests.
- [x] The CI is successful.
- [x] If there could backward compatibility issues, it has been discussed and planned.
