### PR TITLE
fix(slice-machine): convert legacy slice dialog overflow (DT-1677)

### DIFF
--- a/packages/slice-machine/src/features/slices/convertLegacySlice/ConvertLegacySliceAsNewSliceDialog.tsx
+++ b/packages/slice-machine/src/features/slices/convertLegacySlice/ConvertLegacySliceAsNewSliceDialog.tsx
@@ -61,7 +61,10 @@ export const ConvertLegacySliceAsNewSliceDialog: FC<DialogProps> = ({
             return (
               <form id="convert-legacy-slice-as-new-slice-dialog">
                 <Box display="flex" flexDirection="column">
-                  <ScrollArea className={styles.scrollArea}>
+                  <ScrollArea
+                    className={styles.scrollArea}
+                    style={{ width: 448 }}
+                  >
                     <Text variant="normal" color="grey11">
                       This will create a new slice with the same fields. The new
                       slice will replace the legacy slice in all of your types,

--- a/packages/slice-machine/src/features/slices/convertLegacySlice/ConvertLegacySliceAsNewVariationDialog.tsx
+++ b/packages/slice-machine/src/features/slices/convertLegacySlice/ConvertLegacySliceAsNewVariationDialog.tsx
@@ -65,7 +65,10 @@ export const ConvertLegacySliceAsNewVariationDialog: FC<DialogProps> = ({
             return (
               <form id="convert-legacy-slice-as-new-variation-dialog">
                 <Box display="flex" flexDirection="column">
-                  <ScrollArea className={styles.scrollArea}>
+                  <ScrollArea
+                    className={styles.scrollArea}
+                    style={{ width: 448 }}
+                  >
                     <Text variant="normal" color="grey11">
                       If you have multiple slices that are similar, you can
                       combine them as variations of the same slice.

--- a/packages/slice-machine/src/features/slices/convertLegacySlice/ConvertLegacySliceMergeWithIdenticalDialog.tsx
+++ b/packages/slice-machine/src/features/slices/convertLegacySlice/ConvertLegacySliceMergeWithIdenticalDialog.tsx
@@ -49,7 +49,10 @@ export const ConvertLegacySliceMergeWithIdenticalDialog: FC<DialogProps> = ({
             return (
               <form id="convert-legacy-slice-merge-with-identical-dialog">
                 <Box display="flex" flexDirection="column">
-                  <ScrollArea className={styles.scrollArea}>
+                  <ScrollArea
+                    className={styles.scrollArea}
+                    style={{ width: 448 }}
+                  >
                     <Text variant="normal" color="grey11">
                       If you have multiple identical slices, you can merge them.
                       All of your content will be remapped to the target slice.


### PR DESCRIPTION
## Context

Overflow issue on the convert legacy slice dialog.

## Checklist before requesting a review
- [x] I hereby declare my code ready for review.
- [x] If it is a critical feature, I have added tests.
- [x] The CI is successful.
- [x] If there could backward compatibility issues, it has been discussed and planned.

<!--
A funny animal picture is welcome to close your PR!
You can find one here https://unsplash.com/s/photos/funny-animal-picture
-->