### PR TITLE
fix(init): Fix missing Sentry logs for init errors

### DIFF
--- a/packages/init/src/SliceMachineInitProcess.ts
+++ b/packages/init/src/SliceMachineInitProcess.ts
@@ -535,7 +535,7 @@ export class SliceMachineInitProcess {
 							tryAgainCommand = `${tryAgainCommand} --repository=${this.context.repository.domain}`;
 						}
 
-						await this.trackError(error.shortMessage);
+						await this.trackError(error);
 						console.error(
 							`\n\n${error.shortMessage}\n${error.stderr}\n\n${
 								logSymbols.error

--- a/packages/init/src/lib/setupSentry.ts
+++ b/packages/init/src/lib/setupSentry.ts
@@ -19,5 +19,8 @@ export function setupSentry(): void {
 		environment: isStableVersion
 			? import.meta.env.MODE || "production"
 			: "alpha",
+		// Increase the default truncation length of 250 to 2500 (x10)
+		// to have enough details in Sentry
+		maxValueLength: 2_500,
 	});
 }


### PR DESCRIPTION
## Context

- Part of DT-1685
  - It will not solve the issue, but ensure we have more details to solve it

## The Solution

- Add the whole error to Sentry when init fail because of deps installation
- Ensure the value display in Sentry is long enough to understand the error 

## Impact / Dependencies

- Sentry will have bigger payloads for the init project

## Checklist before requesting a review
- [x] I hereby declare my code ready for review.
- [ ] If it is a critical feature, I have added tests.
- [ ] The CI is successful.
- [ ] If there could backward compatibility issues, it has been discussed and planned.
