### PR TITLE
fix(page type): Fix problem when closing modals after creating a page type

### DIFF
--- a/packages/slice-machine/lib/builders/CustomTypeBuilder/SliceZone/index.tsx
+++ b/packages/slice-machine/lib/builders/CustomTypeBuilder/SliceZone/index.tsx
@@ -188,17 +188,14 @@ const SliceZone: React.FC<SliceZoneProps> = ({
 
   const closeUpdateSliceZoneModal = () => {
     setIsUpdateSliceZoneModalOpen(false);
-    redirectToEditMode();
   };
 
   const closeCreateSliceModal = () => {
     setIsCreateSliceModalOpen(false);
-    redirectToEditMode();
   };
 
   const closeSlicesTemplatesModal = () => {
     setIsSlicesTemplatesModalOpen(false);
-    redirectToEditMode();
   };
 
   const onAddSlicesToSliceZone = (newCustomType: CustomTypeSM) => {
@@ -311,6 +308,7 @@ const SliceZone: React.FC<SliceZoneProps> = ({
           });
           onAddSlicesToSliceZone(newCustomType);
           closeUpdateSliceZoneModal();
+          redirectToEditMode();
           toast.success("Slice(s) added to slice zone");
         }}
         close={closeUpdateSliceZoneModal}
@@ -328,6 +326,7 @@ const SliceZone: React.FC<SliceZoneProps> = ({
           });
           onAddSlicesToSliceZone(newCustomType);
           closeSlicesTemplatesModal();
+          redirectToEditMode();
           toast.success(
             <ToastMessageWithPath
               message="Slice template(s) added to slice zone and created at: "
@@ -357,6 +356,7 @@ const SliceZone: React.FC<SliceZoneProps> = ({
             });
             onAddSlicesToSliceZone(newCustomType);
             closeCreateSliceModal();
+            redirectToEditMode();
             toast.success(
               <ToastMessageWithPath
                 message="New slice added to slice zone and created at: "


### PR DESCRIPTION
## Context

- Fix a bug when you close a modal that allow you to add slice from the Page Type blank slate

## The Solution

- Only redirect after a success

## Impact / Dependencies

- None

## Checklist before requesting a review
- [x] I hereby declare my code ready for review.
- [ ] If it is a critical feature, I have added tests.
- [ ] The CI is successful.
- [ ] If there could backward compatibility issues, it has been discussed and planned.


