### PR TITLE
feat(adapter-sveltekit): support previews (DT-1678)

### DIFF
--- a/packages/adapter-sveltekit/src/hooks/documentation-read.ts
+++ b/packages/adapter-sveltekit/src/hooks/documentation-read.ts
@@ -32,8 +32,6 @@ export const documentationRead: DocumentationReadHook<PluginOptions> = async (
 			dataFileContent = source`
 				import { createClient } from "$lib/prismicio";
 
-				export const prerender = true;
-
 				export async function load({ params, fetch }) {
 					const client = createClient({ fetch });
 
@@ -58,8 +56,6 @@ export const documentationRead: DocumentationReadHook<PluginOptions> = async (
 			dataFileContent = source`
 				import { createClient } from "$lib/prismicio";
 
-				export const prerender = true;
-
 				export async function load({ params, fetch }) {
 					const client = createClient({ fetch });
 
@@ -68,6 +64,10 @@ export const documentationRead: DocumentationReadHook<PluginOptions> = async (
 					return {
 						page,
 					};
+				}
+
+				export async function entries() {
+					return [{}]
 				}
 			`;
 		}

--- a/packages/adapter-sveltekit/src/hooks/project-init.ts
+++ b/packages/adapter-sveltekit/src/hooks/project-init.ts
@@ -243,6 +243,8 @@ const createPreviewRouteDirectory = async ({
 
 		- \`/example-route\` (prerendered)
 		- \`/preview/example-route\` (server-rendered)
+
+		See <https://prismic.io/docs/svelte-preview> for more information.
 	`;
 
 	await writeProjectFile({

--- a/packages/adapter-sveltekit/src/hooks/project-init.ts
+++ b/packages/adapter-sveltekit/src/hooks/project-init.ts
@@ -86,7 +86,7 @@ const createPrismicIOFile = async ({
 			 *
 			 * @param config - Configuration for the Prismic client.
 			 */
-			export const createClient = (config: CreateClientConfig = {}) => {
+			export const createClient = ({ cookies, ...config }: CreateClientConfig = {}) => {
 				const client = prismic.createClient(repositoryName, {
 					routes,
 					...config,
@@ -134,7 +134,7 @@ const createPrismicIOFile = async ({
 			 *
 			 * @param {import('@prismicio/svelte/kit').CreateClientConfig} config - Configuration for the Prismic client.
 			 */
-			export const createClient = (config = {}) => {
+			export const createClient = ({ cookies, ...config } = {}) => {
 				const client = prismic.createClient(repositoryName, {
 					routes,
 					...config,

--- a/packages/adapter-sveltekit/test/__snapshots__/plugin-documentation-read.test.ts.snap
+++ b/packages/adapter-sveltekit/test/__snapshots__/plugin-documentation-read.test.ts.snap
@@ -11,8 +11,6 @@ Paste in this code:
 ~~~js [src/routes/[uid]/+page.server.js]
 import { createClient } from \\"$lib/prismicio\\";
 
-export const prerender = true;
-
 export async function load({ params, fetch }) {
   const client = createClient({ fetch });
 
@@ -67,8 +65,6 @@ Paste in this code:
 
 ~~~ts [src/routes/[uid]/+page.server.ts]
 import { createClient } from \\"$lib/prismicio\\";
-
-export const prerender = true;
 
 export async function load({ params, fetch }) {
   const client = createClient({ fetch });
@@ -125,8 +121,6 @@ Paste in this code:
 ~~~js [src/routes/single/+page.server.js]
 import { createClient } from \\"$lib/prismicio\\";
 
-export const prerender = true;
-
 export async function load({ params, fetch }) {
   const client = createClient({ fetch });
 
@@ -135,6 +129,10 @@ export async function load({ params, fetch }) {
   return {
     page,
   };
+}
+
+export async function entries() {
+  return [{}];
 }
 ~~~
 
@@ -172,8 +170,6 @@ Paste in this code:
 ~~~ts [src/routes/single/+page.server.ts]
 import { createClient } from \\"$lib/prismicio\\";
 
-export const prerender = true;
-
 export async function load({ params, fetch }) {
   const client = createClient({ fetch });
 
@@ -182,6 +178,10 @@ export async function load({ params, fetch }) {
   return {
     page,
   };
+}
+
+export async function entries() {
+  return [{}];
 }
 ~~~
 

--- a/packages/adapter-sveltekit/test/plugin-project-init.test.ts
+++ b/packages/adapter-sveltekit/test/plugin-project-init.test.ts
@@ -290,7 +290,7 @@ describe("prismicio.js file", () => {
 			 * @param {import(\\"@prismicio/svelte/kit\\").CreateClientConfig} config -
 			 *   Configuration for the Prismic client.
 			 */
-			export const createClient = (config = {}) => {
+			export const createClient = ({ cookies, ...config } = {}) => {
 			  const client = prismic.createClient(repositoryName, {
 			    routes,
 			    ...config,
@@ -357,7 +357,10 @@ describe("prismicio.js file", () => {
 			 *
 			 * @param config - Configuration for the Prismic client.
 			 */
-			export const createClient = (config: CreateClientConfig = {}) => {
+			export const createClient = ({
+			  cookies,
+			  ...config
+			}: CreateClientConfig = {}) => {
 			  const client = prismic.createClient(repositoryName, {
 			    routes,
 			    ...config,

--- a/packages/adapter-sveltekit/test/plugin-project-init.test.ts
+++ b/packages/adapter-sveltekit/test/plugin-project-init.test.ts
@@ -256,6 +256,7 @@ describe("prismicio.js file", () => {
 
 		expect(contents).toMatchInlineSnapshot(`
 			"import * as prismic from \\"@prismicio/client\\";
+			import { enableAutoPreviews } from \\"@prismicio/svelte/kit\\";
 			import config from \\"../../slicemachine.config.json\\";
 
 			/** The project's Prismic repository name. */
@@ -271,27 +272,31 @@ describe("prismicio.js file", () => {
 			 */
 			// TODO: Update the routes array to match your project's route structure.
 			const routes = [
-			  {
-			    type: \\"homepage\\",
-			    path: \\"/\\",
-			  },
-			  {
-			    type: \\"page\\",
-			    path: \\"/:uid\\",
-			  },
+			  // Examples:
+			  // {
+			  // 	type: \\"homepage\\",
+			  // 	path: \\"/\\",
+			  // },
+			  // {
+			  // 	type: \\"page\\",
+			  // 	path: \\"/:uid\\",
+			  // },
 			];
 
 			/**
 			 * Creates a Prismic client for the project's repository. The client is used to
 			 * query content from the Prismic API.
 			 *
-			 * @param {prismic.ClientConfig} config - Configuration for the Prismic client.
+			 * @param {import(\\"@prismicio/svelte/kit\\").CreateClientConfig} config -
+			 *   Configuration for the Prismic client.
 			 */
 			export const createClient = (config = {}) => {
 			  const client = prismic.createClient(repositoryName, {
 			    routes,
 			    ...config,
 			  });
+
+			  enableAutoPreviews({ client, cookies });
 
 			  return client;
 			};
@@ -321,6 +326,7 @@ describe("prismicio.js file", () => {
 
 		expect(contents).toMatchInlineSnapshot(`
 			"import * as prismic from \\"@prismicio/client\\";
+			import { CreateClientConfig, enableAutoPreviews } from \\"@prismicio/svelte/kit\\";
 			import config from \\"../../slicemachine.config.json\\";
 
 			/** The project's Prismic repository name. */
@@ -334,14 +340,15 @@ describe("prismicio.js file", () => {
 			 */
 			// TODO: Update the routes array to match your project's route structure.
 			const routes: prismic.ClientConfig[\\"routes\\"] = [
-			  {
-			    type: \\"homepage\\",
-			    path: \\"/\\",
-			  },
-			  {
-			    type: \\"page\\",
-			    path: \\"/:uid\\",
-			  },
+			  // Examples:
+			  // {
+			  // 	type: \\"homepage\\",
+			  // 	path: \\"/\\",
+			  // },
+			  // {
+			  // 	type: \\"page\\",
+			  // 	path: \\"/:uid\\",
+			  // },
 			];
 
 			/**
@@ -350,16 +357,216 @@ describe("prismicio.js file", () => {
 			 *
 			 * @param config - Configuration for the Prismic client.
 			 */
-			export const createClient = (config: prismic.ClientConfig = {}) => {
+			export const createClient = (config: CreateClientConfig = {}) => {
 			  const client = prismic.createClient(repositoryName, {
 			    routes,
 			    ...config,
 			  });
 
+			  enableAutoPreviews({ client, cookies });
+
 			  return client;
 			};
 			"
 		`);
+	});
+});
+
+describe("preview route directory", () => {
+	it("creates a preview route directory", async (ctx) => {
+		const log = vi.fn();
+		const installDependencies = vi.fn();
+
+		await ctx.pluginRunner.callHook("project:init", {
+			log,
+			installDependencies,
+		});
+
+		await expect(
+			fs.access(
+				path.join(ctx.project.root, "src", "routes", "[[preview=preview]]"),
+			),
+		).resolves.not.toThrow();
+	});
+
+	it("includes a README.md file", async (ctx) => {
+		const log = vi.fn();
+		const installDependencies = vi.fn();
+
+		await ctx.pluginRunner.callHook("project:init", {
+			log,
+			installDependencies,
+		});
+
+		const contents = await fs.readFile(
+			path.join(
+				ctx.project.root,
+				"src",
+				"routes",
+				"[[preview=preview]]",
+				"README.md",
+			),
+			"utf8",
+		);
+
+		// Ensure the file describes the purpose of the directory.
+		expect(contents).toMatch(/\/preview/i);
+	});
+
+	it("does not overwrite README file if it already exists", async (ctx) => {
+		const log = vi.fn();
+		const installDependencies = vi.fn();
+
+		const filePath = path.join(
+			ctx.project.root,
+			"src",
+			"routes",
+			"[[preview=preview]]",
+			"README.md",
+		);
+		const contents = "foo";
+
+		await fs.mkdir(path.dirname(filePath), { recursive: true });
+		await fs.writeFile(filePath, contents);
+
+		await ctx.pluginRunner.callHook("project:init", {
+			log,
+			installDependencies,
+		});
+
+		const postHookContents = await fs.readFile(filePath, "utf8");
+
+		expect(postHookContents).toBe(contents);
+	});
+});
+
+describe("preview route matcher", () => {
+	it("creates a preview.js file", async (ctx) => {
+		const log = vi.fn();
+		const installDependencies = vi.fn();
+
+		await ctx.pluginRunner.callHook("project:init", {
+			log,
+			installDependencies,
+		});
+
+		const contents = await fs.readFile(
+			path.join(ctx.project.root, "src", "params", "preview.js"),
+			"utf8",
+		);
+
+		expect(contents).toMatchInlineSnapshot(`
+			"export function match(param) {
+			  return param === \\"preview\\";
+			}
+			"
+		`);
+	});
+
+	it("does not overwrite preview.js file if it already exists", async (ctx) => {
+		const log = vi.fn();
+		const installDependencies = vi.fn();
+
+		const filePath = path.join(ctx.project.root, "src", "params", "preview.js");
+		const contents = "foo";
+
+		await fs.mkdir(path.dirname(filePath), { recursive: true });
+		await fs.writeFile(filePath, contents);
+
+		await ctx.pluginRunner.callHook("project:init", {
+			log,
+			installDependencies,
+		});
+
+		const postHookContents = await fs.readFile(filePath, "utf8");
+
+		expect(postHookContents).toBe(contents);
+	});
+
+	it("creates a preview.ts file when TypeScript is enabled", async (ctx) => {
+		ctx.project.config.adapter.options.typescript = true;
+		const pluginRunner = createSliceMachinePluginRunner({
+			project: ctx.project,
+			nativePlugins: {
+				[ctx.project.config.adapter.resolve]: adapter,
+			},
+		});
+		await pluginRunner.init();
+
+		const log = vi.fn();
+		const installDependencies = vi.fn();
+
+		await pluginRunner.callHook("project:init", {
+			log,
+			installDependencies,
+		});
+
+		const contents = await fs.readFile(
+			path.join(ctx.project.root, "src", "params", "preview.ts"),
+			"utf8",
+		);
+
+		expect(contents).toMatchInlineSnapshot(`
+			"export function match(param) {
+			  return param === \\"preview\\";
+			}
+			"
+		`);
+	});
+
+	it("formats the file by default", async (ctx) => {
+		const log = vi.fn();
+		const installDependencies = vi.fn();
+
+		await ctx.pluginRunner.callHook("project:init", {
+			log,
+			installDependencies,
+		});
+
+		const contents = await fs.readFile(
+			path.join(ctx.project.root, "src", "params", "preview.js"),
+			"utf8",
+		);
+
+		expect(contents).toBe(prettier.format(contents, { parser: "typescript" }));
+	});
+
+	it("does not format the file if formatting is disabled", async (ctx) => {
+		ctx.project.config.adapter.options.format = false;
+		const pluginRunner = createSliceMachinePluginRunner({
+			project: ctx.project,
+			nativePlugins: {
+				[ctx.project.config.adapter.resolve]: adapter,
+			},
+		});
+		await pluginRunner.init();
+
+		// Force unusual formatting to detect that formatting did not happen.
+		const prettierOptions = { printWidth: 10 };
+		await fs.writeFile(
+			path.join(ctx.project.root, ".prettierrc"),
+			JSON.stringify(prettierOptions),
+		);
+
+		const log = vi.fn();
+		const installDependencies = vi.fn();
+
+		await pluginRunner.callHook("project:init", {
+			log,
+			installDependencies,
+		});
+
+		const contents = await fs.readFile(
+			path.join(ctx.project.root, "src", "params", "preview.js"),
+			"utf8",
+		);
+
+		expect(contents).not.toBe(
+			prettier.format(contents, {
+				...prettierOptions,
+				parser: "typescript",
+			}),
+		);
 	});
 });
 
@@ -490,6 +697,137 @@ describe("Slice Simulator route", () => {
 				...prettierOptions,
 				plugins: ["prettier-plugin-svelte"],
 				parser: "svelte",
+			}),
+		);
+	});
+});
+
+describe("root layout server file", () => {
+	it("creates a root layout server file", async (ctx) => {
+		const log = vi.fn();
+		const installDependencies = vi.fn();
+
+		await ctx.pluginRunner.callHook("project:init", {
+			log,
+			installDependencies,
+		});
+
+		const contents = await fs.readFile(
+			path.join(ctx.project.root, "src", "routes", "+layout.server.js"),
+			"utf8",
+		);
+
+		expect(contents).toMatchInlineSnapshot(`
+			"export const prerender = \\"auto\\";
+			"
+		`);
+	});
+
+	it("does not overwrite root layout server file if it already exists", async (ctx) => {
+		const log = vi.fn();
+		const installDependencies = vi.fn();
+
+		const filePath = path.join(
+			ctx.project.root,
+			"src",
+			"routes",
+			"+layout.server.js",
+		);
+		const contents = "foo";
+
+		await fs.mkdir(path.dirname(filePath), { recursive: true });
+		await fs.writeFile(filePath, contents);
+
+		await ctx.pluginRunner.callHook("project:init", {
+			log,
+			installDependencies,
+		});
+
+		const postHookContents = await fs.readFile(filePath, "utf8");
+
+		expect(postHookContents).toBe(contents);
+	});
+
+	it("creates a preview.ts file when TypeScript is enabled", async (ctx) => {
+		ctx.project.config.adapter.options.typescript = true;
+		const pluginRunner = createSliceMachinePluginRunner({
+			project: ctx.project,
+			nativePlugins: {
+				[ctx.project.config.adapter.resolve]: adapter,
+			},
+		});
+		await pluginRunner.init();
+
+		const log = vi.fn();
+		const installDependencies = vi.fn();
+
+		await pluginRunner.callHook("project:init", {
+			log,
+			installDependencies,
+		});
+
+		const contents = await fs.readFile(
+			path.join(ctx.project.root, "src", "routes", "+layout.server.ts"),
+			"utf8",
+		);
+
+		expect(contents).toMatchInlineSnapshot(`
+			"export const prerender = \\"auto\\";
+			"
+		`);
+	});
+
+	it("formats the file by default", async (ctx) => {
+		const log = vi.fn();
+		const installDependencies = vi.fn();
+
+		await ctx.pluginRunner.callHook("project:init", {
+			log,
+			installDependencies,
+		});
+
+		const contents = await fs.readFile(
+			path.join(ctx.project.root, "src", "routes", "+layout.server.js"),
+			"utf8",
+		);
+
+		expect(contents).toBe(prettier.format(contents, { parser: "typescript" }));
+	});
+
+	it("does not format the file if formatting is disabled", async (ctx) => {
+		ctx.project.config.adapter.options.format = false;
+		const pluginRunner = createSliceMachinePluginRunner({
+			project: ctx.project,
+			nativePlugins: {
+				[ctx.project.config.adapter.resolve]: adapter,
+			},
+		});
+		await pluginRunner.init();
+
+		// Force unusual formatting to detect that formatting did not happen.
+		const prettierOptions = { printWidth: 10 };
+		await fs.writeFile(
+			path.join(ctx.project.root, ".prettierrc"),
+			JSON.stringify(prettierOptions),
+		);
+
+		const log = vi.fn();
+		const installDependencies = vi.fn();
+
+		await pluginRunner.callHook("project:init", {
+			log,
+			installDependencies,
+		});
+
+		const contents = await fs.readFile(
+			path.join(ctx.project.root, "src", "routes", "+layout.server.js"),
+			"utf8",
+		);
+
+		expect(contents).not.toBe(
+			prettier.format(contents, {
+				...prettierOptions,
+				parser: "typescript",
 			}),
 		);
 	});


### PR DESCRIPTION
## Context

[DT-1678](https://linear.app/prismic/issue/DT-1678/aauser-i-can-support-prismic-previews-in-my-sveltekit-website)




## The Solution

`@slicemachine/adapter-sveltekit` now performs the following in the `project:init` hook:

- Creates a `src/routes/[[preview=preview]]` directory with a `README.md` file.
- Creates a `src/params/preview.js` file to define the `preview` route matcher.
- Creates a `src/routes/+layout.server.js` file to set `prerender = "auto"` for the whole app.
- Creates a `src/routes/api/preview/+server.js` file that uses `@prismicio/svelte/kit`'s `redirectToPreviewURL()`.

`@slicemachine/adapter-sveltekit` also has a new page snippet that supports previews.

Finally, the `prismicio.js` file generated by `@slicemachine/adapter-sveltekit` now uses `@prismicio/svelte/kit`'s `enableAutoPreviews()`.




## Impact / Dependencies

SvelteKit developers will be able to implement previews in their app.




## Checklist before requesting a review
- [x] I hereby declare my code ready for review.
- [x] If it is a critical feature, I have added tests.
- [x] The CI is successful.
- [x] If there could backward compatibility issues, it has been discussed and planned.
