### PR TITLE
fix(plugin-kit): ignore empty slice folders (DT-1589)

### DIFF
--- a/packages/plugin-kit/src/createSliceMachinePluginRunner.ts
+++ b/packages/plugin-kit/src/createSliceMachinePluginRunner.ts
@@ -142,7 +142,8 @@ export class SliceMachinePluginRunner {
 				)(resolve);
 				plugin = raw.default || raw;
 			} catch (error) {
-				if (import.meta.env.DEV) {
+				// Only log in development and when plugin is unavailable through native plugins library (to prevent noise)
+				if (import.meta.env.DEV && !(resolve in this._nativePlugins)) {
 					console.error(error);
 				}
 			}

--- a/packages/plugin-kit/src/createSliceMachinePluginRunner.ts
+++ b/packages/plugin-kit/src/createSliceMachinePluginRunner.ts
@@ -142,8 +142,11 @@ export class SliceMachinePluginRunner {
 				)(resolve);
 				plugin = raw.default || raw;
 			} catch (error) {
-				// Only log in development and when plugin is unavailable through native plugins library (to prevent noise)
-				if (import.meta.env.DEV && !(resolve in this._nativePlugins)) {
+				// Only log in development, but not during tests when a native plugin matches.
+				if (
+					import.meta.env.DEV &&
+					!(import.meta.env.TEST && resolve in this._nativePlugins)
+				) {
 					console.error(error);
 				}
 			}


### PR DESCRIPTION
## Context

See: DT-1589

## The Solution

Refactored the shared `readSliceLibrary` helpers from the plugin kit to adopt the same strategy as `readCustomTypeLibrary` to deal with empty folders.

## How to QA

1. Get a project up and running with the latest Slice Machine alpha
2. Create an empty folder inside the `slices` folder
3. Restarting Slice Machine should yield no error

## Impact / Dependencies

This change will be propagated to adapters as the plugin kit is used by all of them for that kind of operations.

## Checklist before requesting a review
- [x] I hereby declare my code ready for review.
- [x] If it is a critical feature, I have added tests.
- [x] The CI is successful.
- [x] If there could backward compatibility issues, it has been discussed and planned.

<!--
A funny animal picture is welcome to close your PR!
You can find one here https://unsplash.com/s/photos/funny-animal-picture
-->