### PR TITLE
fix(slice-machine): reconcile state from filesystem when possible (#1100,DT-1705)

### DIFF
--- a/packages/slice-machine/src/hooks/useServerState.ts
+++ b/packages/slice-machine/src/hooks/useServerState.ts
@@ -46,7 +46,6 @@ const useServerState = () => {
     if (serverState && !canceled) {
       // If slice builder is untouched, update from server state.
       if (selectedSlice && !sliceIsTouched) {
-        console.log({ sliceIsTouched });
         const serverSlice = serverState.libraries
           .find((l) => l.name === selectedSlice?.from)
           ?.components.find((c) => c.model.id === selectedSlice?.model.id);

--- a/packages/slice-machine/src/hooks/useServerState.ts
+++ b/packages/slice-machine/src/hooks/useServerState.ts
@@ -1,22 +1,80 @@
 import { useEffect, useCallback } from "react";
-
-import ServerState from "@lib/models/server/ServerState";
-import useSliceMachineActions from "@src/modules/useSliceMachineActions";
-import { getState } from "@src/apiClient";
-import useSwr from "swr";
 import * as Sentry from "@sentry/nextjs";
+import { useSelector } from "react-redux";
+import useSwr from "swr";
+
+import { hasLocal } from "@lib/models/common/ModelData";
+import useSliceMachineActions from "@src/modules/useSliceMachineActions";
+import { isSelectedSliceTouched } from "@src/modules/selectedSlice/selectors";
+import { isSelectedCustomTypeTouched } from "@src/modules/selectedCustomType";
+import { SliceMachineStoreType } from "@src/redux/type";
+import ServerState from "@lib/models/server/ServerState";
+import { getState } from "@src/apiClient";
 
 const useServerState = () => {
-  const { refreshState } = useSliceMachineActions();
+  const { refreshState, initSliceStore, initCustomTypeStore } =
+    useSliceMachineActions();
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const handleRefreshState = useCallback(refreshState, []);
   const { data: serverState } = useSwr<ServerState>("getState", async () => {
     return await getState();
   });
 
+  // Whether or not current slice or custom type builder is touched, and its related server state.
+  const {
+    selectedSlice,
+    sliceIsTouched,
+    selectedCustomType,
+    customTypeIsTouched,
+  } = useSelector((store: SliceMachineStoreType) => ({
+    selectedSlice: store.selectedSlice,
+    sliceIsTouched: isSelectedSliceTouched(
+      store,
+      store.selectedSlice?.from ?? "",
+      store.selectedSlice?.model.id ?? "",
+    ),
+    selectedCustomType: Boolean(store.selectedCustomType?.initialModel.id)
+      ? store.availableCustomTypes[
+          store.selectedCustomType?.initialModel.id ?? ""
+        ]
+      : null,
+    customTypeIsTouched: isSelectedCustomTypeTouched(store),
+  }));
+
   useEffect(() => {
     let canceled = false;
     if (serverState && !canceled) {
+      // If slice builder is untouched, update from server state.
+      if (selectedSlice && !sliceIsTouched) {
+        console.log({ sliceIsTouched });
+        const serverSlice = serverState.libraries
+          .find((l) => l.name === selectedSlice?.from)
+          ?.components.find((c) => c.model.id === selectedSlice?.model.id);
+
+        if (serverSlice) {
+          initSliceStore(serverSlice);
+        }
+      }
+
+      // If custom type builder is untouched, update from server state.
+      if (
+        selectedCustomType &&
+        hasLocal(selectedCustomType) &&
+        !customTypeIsTouched
+      ) {
+        const serverCustomType = serverState.customTypes.find(
+          (customType) => customType.id === selectedCustomType.local.id,
+        );
+
+        if (serverCustomType) {
+          const remoteCustomType = serverState.remoteCustomTypes.find(
+            (customType) => customType.id === selectedCustomType.local.id,
+          );
+
+          initCustomTypeStore(serverCustomType, remoteCustomType);
+        }
+      }
+
       handleRefreshState(serverState);
 
       Sentry.setUser({ id: serverState.env.shortId });
@@ -29,6 +87,7 @@ const useServerState = () => {
     return () => {
       canceled = true;
     };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [serverState, handleRefreshState]);
 
   return;


### PR DESCRIPTION
## Context

_**See the Loom video below for a full walkthrough, should help understanding what's being made here.**_

Slice Machine UI has a "layered" kind of state for custom types and slices, from fresher and often-changing to more static and less-often-changing ones:
1. **"Browser state"**: in Slice Machine UI when we use the custom type or slice builder, this state lives in the browser's memory.
2. **"Filesystem state"**: in the user's project, this state is version-controlled with git.
3. **"Prismic state"**: on Prismic's server, this state is updated through the [custom type API](https://prismic.io/docs/custom-types-api).

The issue this PR addresses is that while we prefer changes to be made on in the UI (updating _state 1._ first), sometimes changes have to happen on the filesystem (updating _state 2._). This is often the case with richtext labels for example (#1100) because those cannot (yet) be configured through the UI.

When this happens this leads to some confusion in the UI because _state 2. (filesystem)_ goes ahead of state _1. (browser)_. The UI having no mechanism to resolve that kind of conflicts it leads to a surprising UX for users, sometime having them lose part of their work.

This PR (partially) fixes: #1100, DT-1705

## The Solution

This PR _**improves**_ the experience of users encountering the above scenario by allowing the UI the reconcile _states 1. and 2._ when _state 2. (filesystem)_ goes ahead of _state 1. (browser)_ and _state 1. (browser)_ was left untouched before _state 2. (filesystem)_ went ahead when working on custom types and slices.

```mermaid
flowchart TD;
    A(["State 2. (filesystem) changes"]);
    B{"Was state 1. (browser) touched?"};
    C["Update state 1. (browser)\nusing state 2. (filesystem)"];
    D["Do nothing, both states were\n updated and we don't have a\nconflict resolution mechanism.\nState 1. (browser) will overwrite\nstate 2. (filesystem) on save."];
    A --> B;
    B -- No --> C;
    B -- Yes --> D;
```

As stated by the above chart, this is not perfect as if both states were touched, _state 1. (browser)_ will overwrite _state 2. (filesystem)_. I don't think we want to develop a smart conflict resolution algorithm to improve that further, we'd rather want to invest more in the UI to make it more capable and reduce the need to update models from the file system.

---

I implemented the above in the `useServerState` hook which is the central point of the application where SWR is used and causing the initial issue (#1100). I'm not really sure there's a better workaround to update the Redux store properly here.

## Checklist before requesting a review
- [x] I hereby declare my code ready for review.
- [x] If it is a critical feature, I have added tests.
- [x] The CI is successful.
- [x] If there could backward compatibility issues, it has been discussed and planned.

## [OPT] Preview

https://www.loom.com/share/aa0371e2cb184660bf7cde958481fc10?sid=baa3677e-b0be-4d4f-9da5-ef47be462053

<!--
A funny animal picture is welcome to close your PR!
You can find one here https://unsplash.com/s/photos/funny-animal-picture
-->