### PR TITLE
fix(adapter-nuxt): nuxt 3.8 compatibility (DT-1709)

### DIFF
--- a/packages/adapter-nuxt/src/hooks/slice-create.ts
+++ b/packages/adapter-nuxt/src/hooks/slice-create.ts
@@ -41,7 +41,7 @@ const createComponentFile = async ({
 	} else if (isTypeScriptProject) {
 		contents = stripIndent`
 			<script setup lang="ts">
-			import { Content } from "@prismicio/client";
+			import { type Content } from "@prismicio/client";
 
 			// The array passed to \`getSliceComponentProps\` is purely optional.
 			// Consider it as a visual hint for you when templating your slice.


### PR DESCRIPTION
## Context

Nuxt 3.8.0 released last week turns TypeScript `verbatimModuleSyntax` on to accommodate some upstream requirements from Vue.js, see the release note "Type import changes" section: https://github.com/nuxt/nuxt/releases/tag/v3.8.0

Fixes: DT-1709

## The Solution

Update Nuxt 3 templates to import `Content` as a type:
```diff
- import { Content } from "@prismicio/client";
+ import { type Content } from "@prismicio/client";
```

## How to QA

1. Get a Nuxt 3.8.0 project up and running with the latest Slice Machine alpha
2. Create a slice
3. Check created slice component, it should have no errors inside it.

## Impact / Dependencies

Starters have been updated

## Checklist before requesting a review
- [x] I hereby declare my code ready for review.
- [x] If it is a critical feature, I have added tests.
- [x] The CI is successful.
- [x] If there could backward compatibility issues, it has been discussed and planned.





<!--
A funny animal picture is welcome to close your PR!
You can find one here https://unsplash.com/s/photos/funny-animal-picture
-->