### PR TITLE
fix(plugin-kit): limit concurrent file descriptors for adapters (DT-1707)

### DIFF
--- a/packages/plugin-kit/package.json
+++ b/packages/plugin-kit/package.json
@@ -68,6 +68,7 @@
 		"fs-extra": "11.1.1",
 		"io-ts": "^2.2.20",
 		"io-ts-reporters": "^2.0.1",
+		"p-limit": "^4.0.0",
 		"prettier": "^3.0.3",
 		"prismic-ts-codegen": "^0.1.19"
 	},

--- a/packages/plugin-kit/src/fs/deleteProjectFile.ts
+++ b/packages/plugin-kit/src/fs/deleteProjectFile.ts
@@ -1,6 +1,7 @@
 import * as fs from "node:fs/promises";
 
 import { SliceMachineHelpers } from "../createSliceMachineHelpers";
+import { fsLimit } from "./lib/fsLimit";
 
 export type DeleteProjectFileArgs = {
 	filename: string;
@@ -12,7 +13,7 @@ export const deleteProjectFile = async (
 ): Promise<string> => {
 	const filePath = args.helpers.joinPathFromRoot(args.filename);
 
-	await fs.rm(filePath, { recursive: true });
+	await fsLimit(() => fs.rm(filePath, { recursive: true }));
 
 	return filePath;
 };

--- a/packages/plugin-kit/src/fs/deleteProjectFile.ts
+++ b/packages/plugin-kit/src/fs/deleteProjectFile.ts
@@ -1,7 +1,6 @@
-import * as fs from "node:fs/promises";
-
 import { SliceMachineHelpers } from "../createSliceMachineHelpers";
-import { fsLimit } from "./lib/fsLimit";
+
+import * as fs from "./lib/fsLimit";
 
 export type DeleteProjectFileArgs = {
 	filename: string;
@@ -13,7 +12,7 @@ export const deleteProjectFile = async (
 ): Promise<string> => {
 	const filePath = args.helpers.joinPathFromRoot(args.filename);
 
-	await fsLimit(() => fs.rm(filePath, { recursive: true }));
+	await fs.rm(filePath, { recursive: true });
 
 	return filePath;
 };

--- a/packages/plugin-kit/src/fs/lib/checkPathExists.ts
+++ b/packages/plugin-kit/src/fs/lib/checkPathExists.ts
@@ -1,9 +1,10 @@
 import * as fs from "node:fs/promises";
 import { PathLike } from "node:fs";
+import { fsLimit } from "./fsLimit";
 
 export async function checkPathExists(path: PathLike): Promise<boolean> {
 	try {
-		await fs.access(path);
+		await fsLimit(() => fs.access(path));
 
 		return true;
 	} catch {

--- a/packages/plugin-kit/src/fs/lib/checkPathExists.ts
+++ b/packages/plugin-kit/src/fs/lib/checkPathExists.ts
@@ -1,10 +1,10 @@
-import * as fs from "node:fs/promises";
 import { PathLike } from "node:fs";
-import { fsLimit } from "./fsLimit";
+
+import * as fs from "./fsLimit";
 
 export async function checkPathExists(path: PathLike): Promise<boolean> {
 	try {
-		await fsLimit(() => fs.access(path));
+		await fs.access(path);
 
 		return true;
 	} catch {

--- a/packages/plugin-kit/src/fs/lib/fsLimit.ts
+++ b/packages/plugin-kit/src/fs/lib/fsLimit.ts
@@ -1,4 +1,12 @@
+import * as fs from "node:fs/promises";
 import pLimit from "p-limit";
+
+/**
+ * The parsed number value of the SM_FS_LIMIT environment variable.
+ */
+const SM_FS_LIMIT = Number.isNaN(Number(process.env.SM_FS_LIMIT))
+	? undefined
+	: Number(process.env.SM_FS_LIMIT);
 
 /**
  * The maximum number of concurrent file descriptors allowed to adapters to
@@ -7,9 +15,57 @@ import pLimit from "p-limit";
  * - MacOS default limit: 2560 (recent), 256 (old)
  * - Windows limit (per process): 2048
  */
-const CONCURRENT_FILE_DESCRIPTORS_LIMIT = 1024;
+const CONCURRENT_FILE_DESCRIPTORS_LIMIT = SM_FS_LIMIT ?? 1024;
 
 /**
  * Limit concurrent file descriptors for adapters.
  */
-export const fsLimit = pLimit(CONCURRENT_FILE_DESCRIPTORS_LIMIT);
+const fsLimit = pLimit(CONCURRENT_FILE_DESCRIPTORS_LIMIT);
+
+/**
+ * Wrap a function with `fsLimit()` to limit concurrent calls. All functions
+ * called with `wrapWithFSLimit()` share the same queue.
+ *
+ * @param fn - The function to wrap.
+ *
+ * @returns The wrapped function.
+ */
+const wrapWithFSLimit = <
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	TFn extends (...args: any[]) => any,
+>(
+	fn: TFn,
+): TFn => {
+	return ((...args) => fsLimit(() => fn(...args))) as TFn;
+};
+
+export const access = wrapWithFSLimit(fs.access);
+export const appendFile = wrapWithFSLimit(fs.appendFile);
+export const chmod = wrapWithFSLimit(fs.chmod);
+export const chown = wrapWithFSLimit(fs.chown);
+export const copyFile = wrapWithFSLimit(fs.copyFile);
+export const cp = wrapWithFSLimit(fs.cp);
+export const lchmod = wrapWithFSLimit(fs.lchmod);
+export const lchown = wrapWithFSLimit(fs.lchown);
+export const link = wrapWithFSLimit(fs.link);
+export const lstat = wrapWithFSLimit(fs.lstat);
+export const lutimes = wrapWithFSLimit(fs.lutimes);
+export const mkdir = wrapWithFSLimit(fs.mkdir);
+export const mkdtemp = wrapWithFSLimit(fs.mkdtemp);
+export const open = wrapWithFSLimit(fs.open);
+export const opendir = wrapWithFSLimit(fs.opendir);
+export const readFile = wrapWithFSLimit(fs.readFile);
+export const readdir = wrapWithFSLimit(fs.readdir);
+export const readlink = wrapWithFSLimit(fs.readlink);
+export const realpath = wrapWithFSLimit(fs.realpath);
+export const rename = wrapWithFSLimit(fs.rename);
+export const rm = wrapWithFSLimit(fs.rm);
+export const rmdir = wrapWithFSLimit(fs.rmdir);
+export const stat = wrapWithFSLimit(fs.stat);
+export const statfs = wrapWithFSLimit(fs.statfs);
+export const symlink = wrapWithFSLimit(fs.symlink);
+export const truncate = wrapWithFSLimit(fs.truncate);
+export const unlink = wrapWithFSLimit(fs.unlink);
+export const utimes = wrapWithFSLimit(fs.utimes);
+export const watch = wrapWithFSLimit(fs.watch);
+export const writeFile = wrapWithFSLimit(fs.writeFile);

--- a/packages/plugin-kit/src/fs/lib/fsLimit.ts
+++ b/packages/plugin-kit/src/fs/lib/fsLimit.ts
@@ -1,0 +1,15 @@
+import pLimit from "p-limit";
+
+/**
+ * The maximum number of concurrent file descriptors allowed to adapters to
+ * minimize issues like `EMFILE: too many open files`.
+ *
+ * - MacOS default limit: 2560 (recent), 256 (old)
+ * - Windows limit (per process): 2048
+ */
+const CONCURRENT_FILE_DESCRIPTORS_LIMIT = 1024;
+
+/**
+ * Limit concurrent file descriptors for adapters.
+ */
+export const fsLimit = pLimit(CONCURRENT_FILE_DESCRIPTORS_LIMIT);

--- a/packages/plugin-kit/src/fs/lib/readJSONFile.ts
+++ b/packages/plugin-kit/src/fs/lib/readJSONFile.ts
@@ -1,7 +1,8 @@
 import * as fs from "node:fs/promises";
+import { fsLimit } from "./fsLimit";
 
 export async function readJSONFile<T = unknown>(path: string): Promise<T> {
-	const contents = await fs.readFile(path, "utf8");
+	const contents = await fsLimit(() => fs.readFile(path, "utf8"));
 
 	return JSON.parse(contents);
 }

--- a/packages/plugin-kit/src/fs/lib/readJSONFile.ts
+++ b/packages/plugin-kit/src/fs/lib/readJSONFile.ts
@@ -1,8 +1,7 @@
-import * as fs from "node:fs/promises";
-import { fsLimit } from "./fsLimit";
+import * as fs from "./fsLimit";
 
 export async function readJSONFile<T = unknown>(path: string): Promise<T> {
-	const contents = await fsLimit(() => fs.readFile(path, "utf8"));
+	const contents = await fs.readFile(path, "utf8");
 
 	return JSON.parse(contents);
 }

--- a/packages/plugin-kit/src/fs/readCustomTypeLibrary.ts
+++ b/packages/plugin-kit/src/fs/readCustomTypeLibrary.ts
@@ -1,16 +1,15 @@
-import * as fs from "node:fs/promises";
 import * as path from "node:path";
 
 import { checkPathExists } from "./lib/checkPathExists";
 import { isCustomTypeModel } from "./lib/isCustomTypeModel";
 import { readJSONFile } from "./lib/readJSONFile";
+import * as fs from "./lib/fsLimit";
 
 import { CUSTOM_TYPE_MODEL_FILENAME } from "./constants";
 import {
 	buildCustomTypeLibraryDirectoryPath,
 	BuildCustomTypeLibraryDirectoryPathArgs,
 } from "./buildCustomTypeLibraryDirectoryPath";
-import { fsLimit } from "./lib/fsLimit";
 
 export type ReadCustomTypeLibraryArgs = BuildCustomTypeLibraryDirectoryPathArgs;
 
@@ -32,9 +31,7 @@ export const readCustomTypeLibrary = async (
 		};
 	}
 
-	const childDirs = await fsLimit(() =>
-		fs.readdir(libraryDir, { withFileTypes: true }),
-	);
+	const childDirs = await fs.readdir(libraryDir, { withFileTypes: true });
 
 	/**
 	 * Paths to models that could not be read due to invalid JSON.
@@ -45,10 +42,11 @@ export const readCustomTypeLibrary = async (
 	await Promise.all(
 		childDirs.map(async (childDir) => {
 			if (childDir.isDirectory()) {
-				const childDirContents = await fsLimit(() =>
-					fs.readdir(path.join(libraryDir, childDir.name), {
+				const childDirContents = await fs.readdir(
+					path.join(libraryDir, childDir.name),
+					{
 						withFileTypes: true,
-					}),
+					},
 				);
 				const isCustomTypeDir = childDirContents.some((entry) => {
 					return entry.isFile() && entry.name === CUSTOM_TYPE_MODEL_FILENAME;

--- a/packages/plugin-kit/src/fs/readCustomTypeLibrary.ts
+++ b/packages/plugin-kit/src/fs/readCustomTypeLibrary.ts
@@ -10,6 +10,7 @@ import {
 	buildCustomTypeLibraryDirectoryPath,
 	BuildCustomTypeLibraryDirectoryPathArgs,
 } from "./buildCustomTypeLibraryDirectoryPath";
+import { fsLimit } from "./lib/fsLimit";
 
 export type ReadCustomTypeLibraryArgs = BuildCustomTypeLibraryDirectoryPathArgs;
 
@@ -31,7 +32,9 @@ export const readCustomTypeLibrary = async (
 		};
 	}
 
-	const childDirs = await fs.readdir(libraryDir, { withFileTypes: true });
+	const childDirs = await fsLimit(() =>
+		fs.readdir(libraryDir, { withFileTypes: true }),
+	);
 
 	/**
 	 * Paths to models that could not be read due to invalid JSON.
@@ -42,11 +45,10 @@ export const readCustomTypeLibrary = async (
 	await Promise.all(
 		childDirs.map(async (childDir) => {
 			if (childDir.isDirectory()) {
-				const childDirContents = await fs.readdir(
-					path.join(libraryDir, childDir.name),
-					{
+				const childDirContents = await fsLimit(() =>
+					fs.readdir(path.join(libraryDir, childDir.name), {
 						withFileTypes: true,
-					},
+					}),
 				);
 				const isCustomTypeDir = childDirContents.some((entry) => {
 					return entry.isFile() && entry.name === CUSTOM_TYPE_MODEL_FILENAME;

--- a/packages/plugin-kit/src/fs/readProjectFile.ts
+++ b/packages/plugin-kit/src/fs/readProjectFile.ts
@@ -1,6 +1,7 @@
 import * as fs from "node:fs/promises";
 
 import { SliceMachineHelpers } from "../createSliceMachineHelpers";
+import { fsLimit } from "./lib/fsLimit";
 
 type BufferEncoding = Extract<Parameters<typeof fs.readFile>[1], string>;
 
@@ -20,5 +21,5 @@ export async function readProjectFile(
 ): Promise<Buffer | string> {
 	const filePath = args.helpers.joinPathFromRoot(args.filename);
 
-	return await fs.readFile(filePath, args.encoding);
+	return await fsLimit(() => fs.readFile(filePath, args.encoding));
 }

--- a/packages/plugin-kit/src/fs/readProjectFile.ts
+++ b/packages/plugin-kit/src/fs/readProjectFile.ts
@@ -1,7 +1,6 @@
-import * as fs from "node:fs/promises";
-
 import { SliceMachineHelpers } from "../createSliceMachineHelpers";
-import { fsLimit } from "./lib/fsLimit";
+
+import * as fs from "./lib/fsLimit";
 
 type BufferEncoding = Extract<Parameters<typeof fs.readFile>[1], string>;
 
@@ -21,5 +20,5 @@ export async function readProjectFile(
 ): Promise<Buffer | string> {
 	const filePath = args.helpers.joinPathFromRoot(args.filename);
 
-	return await fsLimit(() => fs.readFile(filePath, args.encoding));
+	return await fs.readFile(filePath, args.encoding);
 }

--- a/packages/plugin-kit/src/fs/readSliceLibrary.ts
+++ b/packages/plugin-kit/src/fs/readSliceLibrary.ts
@@ -10,6 +10,7 @@ import {
 	buildSliceLibraryDirectoryPath,
 	BuildSliceLibraryDirectoryPathArgs,
 } from "./buildSliceLibraryDirectoryPath";
+import { fsLimit } from "./lib/fsLimit";
 
 export type ReadSliceLibraryArgs = BuildSliceLibraryDirectoryPathArgs;
 
@@ -34,7 +35,9 @@ export const readSliceLibrary = async (
 		};
 	}
 
-	const childDirs = await fs.readdir(libraryDir, { withFileTypes: true });
+	const childDirs = await fsLimit(() =>
+		fs.readdir(libraryDir, { withFileTypes: true }),
+	);
 
 	/**
 	 * Paths to models that could not be read due to invalid JSON.
@@ -45,11 +48,10 @@ export const readSliceLibrary = async (
 	await Promise.all(
 		childDirs.map(async (childDir) => {
 			if (childDir.isDirectory()) {
-				const childDirContents = await fs.readdir(
-					path.join(libraryDir, childDir.name),
-					{
+				const childDirContents = await fsLimit(() =>
+					fs.readdir(path.join(libraryDir, childDir.name), {
 						withFileTypes: true,
-					},
+					}),
 				);
 				const isSliceDir = childDirContents.some((entry) => {
 					return entry.isFile() && entry.name === SHARED_SLICE_MODEL_FILENAME;

--- a/packages/plugin-kit/src/fs/readSliceLibrary.ts
+++ b/packages/plugin-kit/src/fs/readSliceLibrary.ts
@@ -1,16 +1,15 @@
-import * as fs from "node:fs/promises";
 import * as path from "node:path";
 
 import { checkPathExists } from "./lib/checkPathExists";
 import { isSharedSliceModel } from "./lib/isSharedSliceModel";
 import { readJSONFile } from "./lib/readJSONFile";
+import * as fs from "./lib/fsLimit";
 
 import { SHARED_SLICE_MODEL_FILENAME } from "./constants";
 import {
 	buildSliceLibraryDirectoryPath,
 	BuildSliceLibraryDirectoryPathArgs,
 } from "./buildSliceLibraryDirectoryPath";
-import { fsLimit } from "./lib/fsLimit";
 
 export type ReadSliceLibraryArgs = BuildSliceLibraryDirectoryPathArgs;
 
@@ -35,9 +34,7 @@ export const readSliceLibrary = async (
 		};
 	}
 
-	const childDirs = await fsLimit(() =>
-		fs.readdir(libraryDir, { withFileTypes: true }),
-	);
+	const childDirs = await fs.readdir(libraryDir, { withFileTypes: true });
 
 	/**
 	 * Paths to models that could not be read due to invalid JSON.
@@ -48,10 +45,11 @@ export const readSliceLibrary = async (
 	await Promise.all(
 		childDirs.map(async (childDir) => {
 			if (childDir.isDirectory()) {
-				const childDirContents = await fsLimit(() =>
-					fs.readdir(path.join(libraryDir, childDir.name), {
+				const childDirContents = await fs.readdir(
+					path.join(libraryDir, childDir.name),
+					{
 						withFileTypes: true,
-					}),
+					},
 				);
 				const isSliceDir = childDirContents.some((entry) => {
 					return entry.isFile() && entry.name === SHARED_SLICE_MODEL_FILENAME;

--- a/packages/plugin-kit/src/fs/readSliceModel.ts
+++ b/packages/plugin-kit/src/fs/readSliceModel.ts
@@ -1,16 +1,15 @@
 import { SharedSlice } from "@prismicio/types-internal/lib/customtypes";
-import * as fs from "node:fs/promises";
 import * as path from "node:path";
+
+import { SliceMachineHelpers } from "../createSliceMachineHelpers";
 
 import { checkPathExists } from "./lib/checkPathExists";
 import { isSharedSliceModel } from "./lib/isSharedSliceModel";
 import { readJSONFile } from "./lib/readJSONFile";
-
-import { SliceMachineHelpers } from "../createSliceMachineHelpers";
+import * as fs from "./lib/fsLimit";
 
 import { buildSliceLibraryDirectoryPath } from "./buildSliceLibraryDirectoryPath";
 import { SHARED_SLICE_MODEL_FILENAME } from "./constants";
-import { fsLimit } from "./lib/fsLimit";
 
 export type ReadSliceModelArgs = {
 	libraryID: string;
@@ -32,9 +31,7 @@ export const readSliceModel = async (
 	});
 
 	if (await checkPathExists(libraryDir)) {
-		const childDirs = await fsLimit(() =>
-			fs.readdir(libraryDir, { withFileTypes: true }),
-		);
+		const childDirs = await fs.readdir(libraryDir, { withFileTypes: true });
 
 		/**
 		 * Paths to models that could not be read due to invalid JSON.

--- a/packages/plugin-kit/src/fs/readSliceModel.ts
+++ b/packages/plugin-kit/src/fs/readSliceModel.ts
@@ -10,6 +10,7 @@ import { SliceMachineHelpers } from "../createSliceMachineHelpers";
 
 import { buildSliceLibraryDirectoryPath } from "./buildSliceLibraryDirectoryPath";
 import { SHARED_SLICE_MODEL_FILENAME } from "./constants";
+import { fsLimit } from "./lib/fsLimit";
 
 export type ReadSliceModelArgs = {
 	libraryID: string;
@@ -31,7 +32,9 @@ export const readSliceModel = async (
 	});
 
 	if (await checkPathExists(libraryDir)) {
-		const childDirs = await fs.readdir(libraryDir, { withFileTypes: true });
+		const childDirs = await fsLimit(() =>
+			fs.readdir(libraryDir, { withFileTypes: true }),
+		);
 
 		/**
 		 * Paths to models that could not be read due to invalid JSON.

--- a/packages/plugin-kit/src/fs/readSliceTemplateLibrary.ts
+++ b/packages/plugin-kit/src/fs/readSliceTemplateLibrary.ts
@@ -1,14 +1,14 @@
 import path from "node:path";
-import fs from "node:fs/promises";
 
 import { SharedSlice } from "@prismicio/types-internal/lib/customtypes";
 import { SharedSliceContent } from "@prismicio/types-internal/lib/content";
 
-import { checkIsTypeScriptProject } from "./checkIsTypeScriptProject";
 import { SliceMachineHelpers } from "../createSliceMachineHelpers";
-
 import { SliceTemplateLibraryReadHookReturnType } from "../hooks/sliceTemplateLibrary-read";
-import { fsLimit } from "./lib/fsLimit";
+
+import { checkIsTypeScriptProject } from "./checkIsTypeScriptProject";
+
+import * as fs from "./lib/fsLimit";
 
 export type ReadSliceTemplateLibraryArgs = {
 	helpers: SliceMachineHelpers;
@@ -47,9 +47,9 @@ export const readSliceTemplateLibrary = async (
 
 		const screenshotEntries = Object.entries(screenshotPaths);
 		const screenshotPromises = screenshotEntries.map(([key, filePath]) => {
-			return fsLimit(() =>
-				fs.readFile(path.join(dirName, filePath)).then((data) => [key, data]),
-			);
+			return fs
+				.readFile(path.join(dirName, filePath))
+				.then((data) => [key, data]);
 		});
 		const readScreenshots = await Promise.all(screenshotPromises);
 		const screenshots = Object.fromEntries(readScreenshots);
@@ -58,8 +58,9 @@ export const readSliceTemplateLibrary = async (
 			? componentFileNames.ts
 			: componentFileNames.js;
 
-		const componentContentsTemplate = await fsLimit(() =>
-			fs.readFile(path.join(dirName, model.name, fileName), "utf-8"),
+		const componentContentsTemplate = await fs.readFile(
+			path.join(dirName, model.name, fileName),
+			"utf-8",
 		);
 
 		return {

--- a/packages/plugin-kit/src/fs/readSliceTemplateLibrary.ts
+++ b/packages/plugin-kit/src/fs/readSliceTemplateLibrary.ts
@@ -8,6 +8,7 @@ import { checkIsTypeScriptProject } from "./checkIsTypeScriptProject";
 import { SliceMachineHelpers } from "../createSliceMachineHelpers";
 
 import { SliceTemplateLibraryReadHookReturnType } from "../hooks/sliceTemplateLibrary-read";
+import { fsLimit } from "./lib/fsLimit";
 
 export type ReadSliceTemplateLibraryArgs = {
 	helpers: SliceMachineHelpers;
@@ -46,9 +47,9 @@ export const readSliceTemplateLibrary = async (
 
 		const screenshotEntries = Object.entries(screenshotPaths);
 		const screenshotPromises = screenshotEntries.map(([key, filePath]) => {
-			return fs
-				.readFile(path.join(dirName, filePath))
-				.then((data) => [key, data]);
+			return fsLimit(() =>
+				fs.readFile(path.join(dirName, filePath)).then((data) => [key, data]),
+			);
 		});
 		const readScreenshots = await Promise.all(screenshotPromises);
 		const screenshots = Object.fromEntries(readScreenshots);
@@ -57,9 +58,8 @@ export const readSliceTemplateLibrary = async (
 			? componentFileNames.ts
 			: componentFileNames.js;
 
-		const componentContentsTemplate = await fs.readFile(
-			path.join(dirName, model.name, fileName),
-			"utf-8",
+		const componentContentsTemplate = await fsLimit(() =>
+			fs.readFile(path.join(dirName, model.name, fileName), "utf-8"),
 		);
 
 		return {

--- a/packages/plugin-kit/src/fs/renameSlice.ts
+++ b/packages/plugin-kit/src/fs/renameSlice.ts
@@ -7,7 +7,6 @@ import {
 	BuildSliceDirectoryPathArgs,
 } from "./buildSliceDirectoryPath";
 import { writeSliceModel, WriteSliceModelArgs } from "./writeSliceModel";
-import { fsLimit } from "./lib/fsLimit";
 
 export type RenameSliceArgs = {
 	actions: SliceMachineActions;
@@ -20,18 +19,16 @@ export const renameSlice = async (args: RenameSliceArgs): Promise<void> => {
 		sliceID: args.model.id,
 	});
 
-	await fsLimit(async () =>
-		fse.move(
-			await buildSliceDirectoryPath({
-				...args,
-				model: existingModel,
-				absolute: true,
-			}),
-			await buildSliceDirectoryPath({
-				...args,
-				absolute: true,
-			}),
-		),
+	await fse.move(
+		await buildSliceDirectoryPath({
+			...args,
+			model: existingModel,
+			absolute: true,
+		}),
+		await buildSliceDirectoryPath({
+			...args,
+			absolute: true,
+		}),
 	);
 
 	await writeSliceModel(args);

--- a/packages/plugin-kit/src/fs/renameSlice.ts
+++ b/packages/plugin-kit/src/fs/renameSlice.ts
@@ -7,6 +7,7 @@ import {
 	BuildSliceDirectoryPathArgs,
 } from "./buildSliceDirectoryPath";
 import { writeSliceModel, WriteSliceModelArgs } from "./writeSliceModel";
+import { fsLimit } from "./lib/fsLimit";
 
 export type RenameSliceArgs = {
 	actions: SliceMachineActions;
@@ -19,16 +20,18 @@ export const renameSlice = async (args: RenameSliceArgs): Promise<void> => {
 		sliceID: args.model.id,
 	});
 
-	await fse.move(
-		await buildSliceDirectoryPath({
-			...args,
-			model: existingModel,
-			absolute: true,
-		}),
-		await buildSliceDirectoryPath({
-			...args,
-			absolute: true,
-		}),
+	await fsLimit(async () =>
+		fse.move(
+			await buildSliceDirectoryPath({
+				...args,
+				model: existingModel,
+				absolute: true,
+			}),
+			await buildSliceDirectoryPath({
+				...args,
+				absolute: true,
+			}),
+		),
 	);
 
 	await writeSliceModel(args);

--- a/packages/plugin-kit/src/fs/writeProjectFile.ts
+++ b/packages/plugin-kit/src/fs/writeProjectFile.ts
@@ -2,6 +2,7 @@ import * as fs from "node:fs/promises";
 import * as path from "node:path";
 
 import { SliceMachineHelpers } from "../createSliceMachineHelpers";
+import { fsLimit } from "./lib/fsLimit";
 
 export type WriteProjectFileArgs = {
 	filename: string;
@@ -31,8 +32,8 @@ export const writeProjectFile = async (
 		);
 	}
 
-	await fs.mkdir(path.dirname(filePath), { recursive: true });
-	await fs.writeFile(filePath, contents);
+	await fsLimit(() => fs.mkdir(path.dirname(filePath), { recursive: true }));
+	await fsLimit(() => fs.writeFile(filePath, contents));
 
 	return filePath;
 };

--- a/packages/plugin-kit/src/fs/writeProjectFile.ts
+++ b/packages/plugin-kit/src/fs/writeProjectFile.ts
@@ -1,8 +1,8 @@
-import * as fs from "node:fs/promises";
 import * as path from "node:path";
 
 import { SliceMachineHelpers } from "../createSliceMachineHelpers";
-import { fsLimit } from "./lib/fsLimit";
+
+import * as fs from "./lib/fsLimit";
 
 export type WriteProjectFileArgs = {
 	filename: string;
@@ -32,8 +32,8 @@ export const writeProjectFile = async (
 		);
 	}
 
-	await fsLimit(() => fs.mkdir(path.dirname(filePath), { recursive: true }));
-	await fsLimit(() => fs.writeFile(filePath, contents));
+	await fs.mkdir(path.dirname(filePath), { recursive: true });
+	await fs.writeFile(filePath, contents);
 
 	return filePath;
 };

--- a/packages/plugin-kit/vite.config.ts
+++ b/packages/plugin-kit/vite.config.ts
@@ -4,7 +4,7 @@ import sdk from "vite-plugin-sdk";
 export default defineConfig({
 	plugins: [
 		sdk({
-			internalDependencies: ["fp-ts"],
+			internalDependencies: ["fp-ts", "p-limit"],
 		}),
 	],
 	build: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -8475,6 +8475,7 @@ __metadata:
     io-ts-types: 0.5.19
     monocle-ts: 2.3.13
     newtype-ts: 0.3.5
+    p-limit: ^4.0.0
     prettier: ^3.0.3
     prettier-plugin-jsdoc: 1.1.1
     prismic-ts-codegen: ^0.1.19


### PR DESCRIPTION
## Context

On projects with high numbers of slices, file descriptors limit can be reached when reading user's types.

Fixes: https://github.com/nuxt-modules/prismic/issues/201, DT-1707

## The Solution

This PR limits the amount of concurrent file descriptors allowed to adapters through their shared `plugin-kit/fs` helpers.

> [!IMPORTANT]
> I'm not really happy with this solution because it only addresses the issue by targeting the most file-system intensive part of Slice Machine. Limit could still be reached elsewhere. Also, determining a limit that works across all OS's is hard and there's no handy package available to dynamically fix it based on the current OS limitations.

## Impact / Dependencies

/

## How to QA

Try using Slice Machine with a large amount of slices. To help with that, here's an archive containing about 400 slices which should be reaching the limit on most systems: [231025_DT-1707.zip](https://github.com/prismicio/slice-machine/files/13167510/231025_DT-1707.zip)

## Checklist before requesting a review

- [x] I hereby declare my code ready for review.
- [x] If it is a critical feature, I have added tests.
- [x] The CI is successful.
- [x] If there could backward compatibility issues, it has been discussed and planned.

<!--
A funny animal picture is welcome to close your PR!
You can find one here https://unsplash.com/s/photos/funny-animal-picture
-->