### PR TITLE
fix(adapter-sveltekit): enforce Prettier >=3 for code formatting (DT-1711)

### DIFF
--- a/packages/adapter-sveltekit/package.json
+++ b/packages/adapter-sveltekit/package.json
@@ -109,6 +109,9 @@
 		"svelte": "^3.54.0 || ^4.0.0-next.0"
 	},
 	"peerDependenciesMeta": {
+		"prettier": {
+			"optional": true
+		},
 		"prettier-plugin-svelte": {
 			"optional": true
 		}

--- a/packages/adapter-sveltekit/package.json
+++ b/packages/adapter-sveltekit/package.json
@@ -104,7 +104,14 @@
 	},
 	"peerDependencies": {
 		"@sveltejs/kit": "^1",
+		"prettier": ">=3",
+		"prettier-plugin-svelte": ">=3",
 		"svelte": "^3.54.0 || ^4.0.0-next.0"
+	},
+	"peerDependenciesMeta": {
+		"prettier-plugin-svelte": {
+			"optional": true
+		}
 	},
 	"engines": {
 		"node": ">=14.15.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8329,7 +8329,12 @@ __metadata:
     vitest: 0.32.0
   peerDependencies:
     "@sveltejs/kit": ^1
+    prettier: ">=3"
+    prettier-plugin-svelte: ">=3"
     svelte: ^3.54.0 || ^4.0.0-next.0
+  peerDependenciesMeta:
+    prettier-plugin-svelte:
+      optional: true
   languageName: unknown
   linkType: soft
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -8333,6 +8333,8 @@ __metadata:
     prettier-plugin-svelte: ">=3"
     svelte: ^3.54.0 || ^4.0.0-next.0
   peerDependenciesMeta:
+    prettier:
+      optional: true
     prettier-plugin-svelte:
       optional: true
   languageName: unknown


### PR DESCRIPTION
## Context

[DT-1711](https://linear.app/prismic/issue/DT-1711/aauser-i-can-see-field-snippets-in-a-sveltekit-project)

https://github.com/prismicio/slice-machine/pull/1183 (DT-1614) broke field snippets in SvelteKit projects using Prettier 2 (latest is 3).

Prior to https://github.com/prismicio/slice-machine/pull/1183, SvelteKit projects were stuck using Prettier 2 and an old version of prettier-plugin-sveltekit.

Now that Slice Machine is upgrading to Prettier 3, SvelteKit projects must also use Prettier 3.

We don't see this problem in other adapters because they do not require custom Prettier plugins. Svelte is not a built-in language in Prettier, like JavaScript and TypeScript, which means we must use `prettier-plugin-svelte` when formatting code.

## The Solution

Require SvelteKit projects to use Prettier 3 and the latest version of `prettier-plugin-svelte` if the project uses them.

If the project does not use Prettier or the plugin, the adapter will still install it as a dependency; `prettier` and `prettier-plugin-svelte` are optional peer dependencies.

## Impact / Dependencies

All SvelteKit projects must update their version of Prettier and `prettier-plugin-svelte` to the latest versions if installed.

We must instruct SvelteKit developers to update Prettier alongside the Slice Machine update.

## Checklist before requesting a review

- [x] I hereby declare my code ready for review.
- [x] If it is a critical feature, I have added tests.
- [x] The CI is successful.
- [x] If there could backward compatibility issues, it has been discussed and planned.
