### PR TITLE
chore: fix cypress-setup.sh

### DIFF
--- a/cypress-setup.sh
+++ b/cypress-setup.sh
@@ -26,7 +26,7 @@ else
 fi
 
 rm -rf e2e-projects/cypress-next-app \
-&& yarn dlx --quiet create-next-app@13.4.6 --app --eslint --import-alias '@/*' --no-src-dir --tailwind --typescript --use-npm e2e-projects/cypress-next-app \
+&& yarn dlx --quiet create-next-app@13.5.4 --app --eslint --import-alias '@/*' --no-src-dir --tailwind --typescript --use-npm e2e-projects/cypress-next-app \
 && yarn dlx --quiet vite-node ./cypress/plugins/addAuth.ts -- ${EMAIL} ${PASSWORD} ${PRISMIC_URL} \
 && yarn dlx --quiet vite-node ./cypress/plugins/createRepo.ts -- "${_PRISMIC_REPO}" "${PASSWORD}" "${PRISMIC_URL}" \
 && yarn workspaces foreach --include '{@slicemachine/adapter-next,@slicemachine/init,@slicemachine/manager,@slicemachine/plugin-kit,slice-machine-ui,start-slicemachine}' --topological --verbose pack --out "${THIS_DIR}"/e2e-projects/cypress-next-app/%s-%v.tgz \


### PR DESCRIPTION
Our E2E tests can no longer run because:
1. Next.js 14 has just been released.
2. Our `cypress-setup.sh` script uses a version of `create-next-app` (version `13.4.6`) that always installs the latest version of Next.js.
3. Our `@slicemachine/adapter-next` package isn't compatible with Next.js 14.

Changing the version of `create-next-app` to `13.5.4` solves the issue, as it no longer installs the latest version of Next.js, but the version listed in its `package.json` file.