### PR TITLE
fix(slice-machine-ui): WindowTabsList overflowing the CustomTypesBuilderPage

### DIFF
--- a/packages/slice-machine/src/features/customTypes/customTypesBuilder/CustomTypesBuilderPage.tsx
+++ b/packages/slice-machine/src/features/customTypes/customTypesBuilder/CustomTypesBuilderPage.tsx
@@ -139,7 +139,7 @@ const CustomTypesBuilderPageWithProvider: React.FC<
         </AppLayoutActions>
       </AppLayoutHeader>
       <AppLayoutContent>
-        <Box flexDirection="column">
+        <Box flexDirection="column" minWidth={0}>
           <CustomTypeBuilder customType={currentCustomType} />
         </Box>
       </AppLayoutContent>


### PR DESCRIPTION
Completes DT-1717.