### PR TITLE
feat(manager): add `renameSliceVariation`, `deleteSliceVariation`, and `deleteSliceScreenshot` methods (DT-1724)

### DIFF
--- a/packages/manager/test/SliceMachineManager-slices-deleteSliceScreenshot.test.ts
+++ b/packages/manager/test/SliceMachineManager-slices-deleteSliceScreenshot.test.ts
@@ -1,0 +1,51 @@
+import { expect, it, vi } from "vitest";
+
+import { createTestPlugin } from "./__testutils__/createTestPlugin";
+import { createTestProject } from "./__testutils__/createTestProject";
+import { expectHookHandlerToHaveBeenCalledWithData } from "./__testutils__/expectHookHandlerToHaveBeenCalledWithData";
+
+import { createSliceMachineManager } from "../src";
+
+it("deletes a Slice variation's screenshot from assets", async () => {
+	const hookHandler = vi.fn();
+	const adapter = createTestPlugin({
+		setup: ({ hook }) => {
+			hook("slice:asset:delete", hookHandler);
+		},
+	});
+	const cwd = await createTestProject({ adapter });
+	const manager = createSliceMachineManager({
+		nativePlugins: { [adapter.meta.name]: adapter },
+		cwd,
+	});
+
+	await manager.plugins.initPlugins();
+
+	const res = await manager.slices.deleteSliceScreenshot({
+		libraryID: "foo",
+		sliceID: "bar",
+		variationID: "baz",
+	});
+
+	expect(res).toStrictEqual({
+		errors: [],
+	});
+	expectHookHandlerToHaveBeenCalledWithData(hookHandler, {
+		libraryID: "foo",
+		sliceID: "bar",
+		assetID: `screenshot-baz.png`,
+	});
+});
+
+it("throws if plugins have not been initialized", async () => {
+	const cwd = await createTestProject();
+	const manager = createSliceMachineManager({ cwd });
+
+	await expect(async () => {
+		await manager.slices.deleteSliceScreenshot({
+			libraryID: "foo",
+			sliceID: "bar",
+			variationID: "baz",
+		});
+	}).rejects.toThrow(/plugins have not been initialized/i);
+});

--- a/packages/manager/test/SliceMachineManager-slices-deleteSliceVariation.test.ts
+++ b/packages/manager/test/SliceMachineManager-slices-deleteSliceVariation.test.ts
@@ -1,0 +1,173 @@
+import { expect, it, vi } from "vitest";
+import { SharedSliceContent } from "@prismicio/types-internal/lib/content";
+
+import { createTestPlugin } from "./__testutils__/createTestPlugin";
+import { createTestProject } from "./__testutils__/createTestProject";
+import { expectHookHandlerToHaveBeenCalledWithData } from "./__testutils__/expectHookHandlerToHaveBeenCalledWithData";
+
+import { createSliceMachineManager } from "../src";
+
+const variationID = "baz";
+const sliceMock: SharedSliceContent = {
+	__TYPE__: "SharedSliceContent",
+	variation: variationID,
+	primary: {},
+	items: [],
+};
+
+it("updates slice model by calling plugins' `slice:update` hook", async (ctx) => {
+	const variationModel = ctx.mockPrismic.model.sharedSliceVariation({
+		id: variationID,
+	});
+	const sliceModel = ctx.mockPrismic.model.sharedSlice({
+		variations: [variationModel],
+	});
+	const newSliceModel = { ...sliceModel, variations: [] };
+	const mocks = [sliceMock];
+	const hookHandler = vi.fn();
+	const adapter = createTestPlugin({
+		setup: ({ hook }) => {
+			hook("slice:read", () => {
+				return { model: sliceModel };
+			});
+			hook("slice:update", hookHandler);
+			hook("slice:asset:read", () => {
+				return { data: Buffer.from(JSON.stringify(mocks)) };
+			});
+			hook("slice:asset:update", vi.fn());
+			hook("slice:asset:delete", vi.fn());
+		},
+	});
+	const cwd = await createTestProject({ adapter });
+	const manager = createSliceMachineManager({
+		nativePlugins: { [adapter.meta.name]: adapter },
+		cwd,
+	});
+
+	await manager.plugins.initPlugins();
+
+	const res = await manager.slices.deleteSliceVariation({
+		libraryID: "foo",
+		sliceID: "bar",
+		variationID,
+	});
+
+	expectHookHandlerToHaveBeenCalledWithData(hookHandler, {
+		libraryID: "foo",
+		model: newSliceModel,
+	});
+	expect(res).toStrictEqual({
+		errors: [],
+		assetsErrors: [],
+	});
+});
+
+it("cleans up variation screenshot by calling plugins' `slice:asset:delete` hook", async (ctx) => {
+	const variationModel = ctx.mockPrismic.model.sharedSliceVariation({
+		id: variationID,
+	});
+	const sliceModel = ctx.mockPrismic.model.sharedSlice({
+		variations: [variationModel],
+	});
+	const mocks = [sliceMock];
+	const hookHandler = vi.fn();
+	const adapter = createTestPlugin({
+		setup: ({ hook }) => {
+			hook("slice:read", () => {
+				return { model: sliceModel };
+			});
+			hook("slice:update", vi.fn());
+			hook("slice:asset:read", () => {
+				return { data: Buffer.from(JSON.stringify(mocks)) };
+			});
+			hook("slice:asset:update", vi.fn());
+			hook("slice:asset:delete", hookHandler);
+		},
+	});
+	const cwd = await createTestProject({ adapter });
+	const manager = createSliceMachineManager({
+		nativePlugins: { [adapter.meta.name]: adapter },
+		cwd,
+	});
+
+	await manager.plugins.initPlugins();
+
+	const res = await manager.slices.deleteSliceVariation({
+		libraryID: "foo",
+		sliceID: "bar",
+		variationID,
+	});
+
+	expectHookHandlerToHaveBeenCalledWithData(hookHandler, {
+		libraryID: "foo",
+		sliceID: "bar",
+		assetID: `screenshot-${variationID}.png`,
+	});
+	expect(res).toStrictEqual({
+		errors: [],
+		assetsErrors: [],
+	});
+});
+
+it("cleans up variation mocks by calling plugins' `slice:asset:update` hook", async (ctx) => {
+	const variationModel = ctx.mockPrismic.model.sharedSliceVariation({
+		id: variationID,
+	});
+	const sliceModel = ctx.mockPrismic.model.sharedSlice({
+		variations: [variationModel],
+	});
+	const mocks = [sliceMock];
+	const hookHandler = vi.fn();
+	const adapter = createTestPlugin({
+		setup: ({ hook }) => {
+			hook("slice:read", () => {
+				return { model: sliceModel };
+			});
+			hook("slice:update", vi.fn());
+			hook("slice:asset:read", () => {
+				return { data: Buffer.from(JSON.stringify(mocks)) };
+			});
+			hook("slice:asset:update", hookHandler);
+			hook("slice:asset:delete", vi.fn());
+		},
+	});
+	const cwd = await createTestProject({ adapter });
+	const manager = createSliceMachineManager({
+		nativePlugins: { [adapter.meta.name]: adapter },
+		cwd,
+	});
+
+	await manager.plugins.initPlugins();
+
+	const res = await manager.slices.deleteSliceVariation({
+		libraryID: "foo",
+		sliceID: "bar",
+		variationID,
+	});
+
+	expectHookHandlerToHaveBeenCalledWithData(hookHandler, {
+		libraryID: "foo",
+		sliceID: "bar",
+		asset: {
+			data: Buffer.from(JSON.stringify([])),
+			id: "mocks.json",
+		},
+	});
+	expect(res).toStrictEqual({
+		errors: [],
+		assetsErrors: [],
+	});
+});
+
+it("throws if plugins have not been initialized", async () => {
+	const cwd = await createTestProject();
+	const manager = createSliceMachineManager({ cwd });
+
+	await expect(async () => {
+		await manager.slices.deleteSliceVariation({
+			libraryID: "foo",
+			sliceID: "bar",
+			variationID,
+		});
+	}).rejects.toThrow(/plugins have not been initialized/i);
+});

--- a/packages/manager/test/SliceMachineManager-slices-readSliceScreenshot.test.ts
+++ b/packages/manager/test/SliceMachineManager-slices-readSliceScreenshot.test.ts
@@ -70,7 +70,7 @@ it("validates the adapter's return value", async () => {
 	});
 });
 
-it("ignores plugins that implement `custom-type:read:asset`", async () => {
+it("ignores plugins that implement `slice:asset:read`", async () => {
 	const imageData = Buffer.from("image-data");
 	const ignoredImageData = Buffer.from("ignored-image-data");
 	const adapter = createTestPlugin({

--- a/packages/manager/test/SliceMachineManager-slices-renameSliceVariation.test.ts
+++ b/packages/manager/test/SliceMachineManager-slices-renameSliceVariation.test.ts
@@ -1,0 +1,127 @@
+import { expect, it, vi } from "vitest";
+import { SharedSliceContent } from "@prismicio/types-internal/lib/content";
+
+import { createTestPlugin } from "./__testutils__/createTestPlugin";
+import { createTestProject } from "./__testutils__/createTestProject";
+import { expectHookHandlerToHaveBeenCalledWithData } from "./__testutils__/expectHookHandlerToHaveBeenCalledWithData";
+
+import { createSliceMachineManager } from "../src";
+
+const variationID = "baz";
+const variationName = "Baz";
+const newVariationID = "qux";
+const newVariationName = "Qux";
+const sliceMock: SharedSliceContent = {
+	__TYPE__: "SharedSliceContent",
+	variation: variationID,
+	primary: {},
+	items: [],
+};
+
+it("updates slice model by calling plugins' `slice:update` hook", async (ctx) => {
+	const variationModel = ctx.mockPrismic.model.sharedSliceVariation({
+		id: variationID,
+		name: variationName,
+	});
+	const sliceModel = ctx.mockPrismic.model.sharedSlice({
+		variations: [variationModel],
+	});
+	const newVariationModel = {
+		...variationModel,
+		name: newVariationName,
+	};
+	const newSliceModel = {
+		...sliceModel,
+		variations: [newVariationModel],
+	};
+	const mocks = [sliceMock];
+	const hookHandler = vi.fn();
+	const adapter = createTestPlugin({
+		setup: ({ hook }) => {
+			hook("slice:read", () => {
+				return { model: sliceModel };
+			});
+			hook("slice:update", hookHandler);
+			hook("slice:asset:read", () => {
+				return { data: Buffer.from(JSON.stringify(mocks)) };
+			});
+			hook("slice:asset:update", vi.fn());
+			hook("slice:asset:delete", vi.fn());
+		},
+	});
+	const cwd = await createTestProject({ adapter });
+	const manager = createSliceMachineManager({
+		nativePlugins: { [adapter.meta.name]: adapter },
+		cwd,
+	});
+
+	await manager.plugins.initPlugins();
+
+	const res = await manager.slices.renameSliceVariation({
+		libraryID: "foo",
+		sliceID: "bar",
+		variationID,
+		model: newVariationModel,
+	});
+
+	expectHookHandlerToHaveBeenCalledWithData(hookHandler, {
+		libraryID: "foo",
+		model: newSliceModel,
+	});
+	expect(res).toStrictEqual({
+		errors: [],
+		assetsErrors: [],
+	});
+});
+
+// TODO: Implement when we support renaming variation ID, see: DT-1708
+it.todo(
+	"renames variation screenshot by calling plugins' `slice:asset:delete` and `slice:asset:update` hooks",
+);
+
+// TODO: Implement when we support renaming variation ID, see: DT-1708
+it.todo(
+	"renames variation mocks by calling plugins' `slice:asset:update` hook",
+);
+
+// TODO: Implement when we support renaming variation ID, see: DT-1708
+it.todo("throws if renamed variation ID matches another existing variation");
+
+// TODO: Remove when we support renaming variation ID, see: DT-1708
+it("throws if variation ID is being renaming", async (ctx) => {
+	const adapter = createTestPlugin();
+	const cwd = await createTestProject({ adapter });
+	const manager = createSliceMachineManager({
+		nativePlugins: { [adapter.meta.name]: adapter },
+		cwd,
+	});
+
+	await manager.plugins.initPlugins();
+
+	await expect(async () => {
+		await manager.slices.renameSliceVariation({
+			libraryID: "foo",
+			sliceID: "bar",
+			variationID,
+			model: ctx.mockPrismic.model.sharedSliceVariation({
+				id: newVariationID,
+			}),
+		});
+	}).rejects.toThrow(
+		/renaming variation ID is not supported yet by the backend, only rename its name/i,
+	);
+});
+
+it("throws if plugins have not been initialized", async (ctx) => {
+	const cwd = await createTestProject();
+	const manager = createSliceMachineManager({ cwd });
+
+	await expect(async () => {
+		await manager.slices.renameSliceVariation({
+			libraryID: "foo",
+			sliceID: "bar",
+			variationID,
+			model: ctx.mockPrismic.model.sharedSliceVariation({ id: variationID }),
+		});
+	}).rejects.toThrow(/plugins have not been initialized/i);
+});


### PR DESCRIPTION
## Context

This PR adds the following methods to support DT-1658 and DT-1659 on the slice manager:
- `renameSliceVariation`
- `deleteSliceVariation`
- `deleteSliceScreenshot`

Resolves: DT-1724

## The Solution

Added methods

## Impact / Dependencies

<!--
List all the impacts your development might have on internal and external features.
Ideally this should have been discussed prior to this development.

Link of any other PRs that are related to this development.
They should also be referenced in the ticket for reviews.
-->

/


## Checklist before requesting a review
- [x] I hereby declare my code ready for review.
- [x] If it is a critical feature, I have added tests.
- [x] The CI is successful.
- [x] If there could backward compatibility issues, it has been discussed and planned.

<!--
A funny animal picture is welcome to close your PR!
You can find one here https://unsplash.com/s/photos/funny-animal-picture
-->