### PR TITLE
feat(slice-machine-ui): disable SSR

### DIFF
--- a/packages/slice-machine/pages/_app.tsx
+++ b/packages/slice-machine/pages/_app.tsx
@@ -23,7 +23,8 @@ import {
 } from "@prismicio/editor-ui";
 import { ConnectedRouter } from "connected-next-router";
 import type { NextPage } from "next";
-import App, { type AppContext, type AppInitialProps } from "next/app";
+import type { AppContext, AppInitialProps } from "next/app";
+import dynamic from "next/dynamic";
 import Head from "next/head";
 import Router from "next/router";
 import { type FC, type ReactNode, useEffect, useState, Suspense } from "react";
@@ -69,7 +70,7 @@ const RemoveDarkMode: FC<RemoveDarkModeProps> = ({ children }) => {
   return <>{children}</>;
 };
 
-function MyApp({
+function App({
   Component,
   pageProps,
 }: AppContextWithComponentLayout & AppInitialProps) {
@@ -171,8 +172,4 @@ function MyApp({
   );
 }
 
-MyApp.getInitialProps = async (appContext: AppContext) => {
-  return await App.getInitialProps(appContext);
-};
-
-export default MyApp;
+export default dynamic(() => Promise.resolve(App), { ssr: false });


### PR DESCRIPTION
Slice Machine UI uses React components from the Editor that aren't tested on the Node.js runtime. This is because they don't use Next.js and we can't ask them to support Server-Side Rendering just for us.

Moreover, Slice Machine UI doesn't take any benefit from SSR as we currently only use Next.js's file system based router and don't need SEO.

Consequently, to prevent further bugs and reduce work for the Editor team, I'm opening this pull request to disable SSR on all pages.