### PR TITLE
chore(sentry): Prevent Sentry error for quota reached

### DIFF
--- a/packages/init/src/lib/setupSentry.ts
+++ b/packages/init/src/lib/setupSentry.ts
@@ -19,8 +19,8 @@ export function setupSentry(): void {
 		environment: isStableVersion
 			? import.meta.env.MODE || "production"
 			: "alpha",
-		// Increase the default truncation length of 250 to 12500 (x50)
+		// Increase the default truncation length of 250 to 2500 (x10)
 		// to have enough details in Sentry
-		maxValueLength: 12_500,
+		maxValueLength: 2_500,
 	});
 }

--- a/packages/start-slicemachine/src/lib/setupSentry.ts
+++ b/packages/start-slicemachine/src/lib/setupSentry.ts
@@ -34,9 +34,9 @@ export const setupSentry = async (
 		environment: isStableVersion
 			? import.meta.env.MODE || "production"
 			: "alpha",
-		// Increase the default truncation length of 250 to 12500 (x50)
+		// Increase the default truncation length of 250 to 2500 (x10)
 		// to have enough details in Sentry
-		maxValueLength: 12_500,
+		maxValueLength: 2_500,
 	});
 	if (userProfile) {
 		Sentry.setUser({ id: userProfile.shortId });


### PR DESCRIPTION
## Context

- Seeing more Sentry errors with:

`{"detail":"Sentry dropped data due to a quota or internal rate limit being reached. This will not affect your application. See https://docs.sentry.io/product/accounts/quotas/ for more information."}`

## The Solution

- Reducing the amount of data sent to Sentry
- Checked from last versions, the increase didn't help me to understand the problem much more.

## Impact / Dependencies

- None

## Checklist before requesting a review
- [x] I hereby declare my code ready for review.
- [ ] If it is a critical feature, I have added tests.
- [ ] The CI is successful.
- [ ] If there could backward compatibility issues, it has been discussed and planned.
