### PR TITLE
fix(slice-machine-ui): environment-related UI bugs (DT-1808)

### DIFF
--- a/packages/slice-machine/src/components/Divider/Divider.css.ts
+++ b/packages/slice-machine/src/components/Divider/Divider.css.ts
@@ -1,5 +1,5 @@
 import { colors, sprinkles } from "@prismicio/editor-ui";
-import { style } from "@vanilla-extract/css";
+import { style, styleVariants } from "@vanilla-extract/css";
 
 const base = style([
   sprinkles({
@@ -9,7 +9,7 @@ const base = style([
   }),
 ]);
 
-export const variants = {
+export const variants = styleVariants({
   dashed: [
     base,
     sprinkles({
@@ -28,4 +28,4 @@ export const variants = {
         "linear-gradient(to right, color-mix(in srgb, currentColor, transparent 100%), currentColor, color-mix(in srgb, currentColor, transparent 100%))",
     },
   ],
-};
+});

--- a/packages/slice-machine/src/components/Divider/Divider.css.ts
+++ b/packages/slice-machine/src/components/Divider/Divider.css.ts
@@ -23,5 +23,9 @@ export const variants = styleVariants({
     sprinkles({
       height: 1,
     }),
+    {
+      backgroundImage:
+        "linear-gradient(to right, color-mix(in srgb, currentColor, transparent 100%), currentColor, color-mix(in srgb, currentColor, transparent 100%))",
+    },
   ],
 });

--- a/packages/slice-machine/src/components/Divider/Divider.css.ts
+++ b/packages/slice-machine/src/components/Divider/Divider.css.ts
@@ -23,9 +23,5 @@ export const variants = styleVariants({
     sprinkles({
       height: 1,
     }),
-    {
-      backgroundImage:
-        "linear-gradient(to right, color-mix(in srgb, currentColor 0%, transparent), currentColor, color-mix(in srgb, currentColor 0%, transparent))",
-    },
   ],
 });

--- a/packages/slice-machine/src/components/Divider/Divider.css.ts
+++ b/packages/slice-machine/src/components/Divider/Divider.css.ts
@@ -1,5 +1,5 @@
 import { colors, sprinkles } from "@prismicio/editor-ui";
-import { style, styleVariants } from "@vanilla-extract/css";
+import { style } from "@vanilla-extract/css";
 
 const base = style([
   sprinkles({
@@ -9,7 +9,7 @@ const base = style([
   }),
 ]);
 
-export const variants = styleVariants({
+export const variants = {
   dashed: [
     base,
     sprinkles({
@@ -28,4 +28,4 @@ export const variants = styleVariants({
         "linear-gradient(to right, color-mix(in srgb, currentColor, transparent 100%), currentColor, color-mix(in srgb, currentColor, transparent 100%))",
     },
   ],
-});
+};

--- a/packages/slice-machine/src/components/Divider/Divider.stories.tsx
+++ b/packages/slice-machine/src/components/Divider/Divider.stories.tsx
@@ -23,5 +23,8 @@ const meta = {
 export default meta;
 
 export const Default = {
-  args: {},
+  args: {
+    variant: "dashed",
+    color: "currentColor",
+  },
 } satisfies Story;

--- a/packages/slice-machine/src/components/Divider/Divider.tsx
+++ b/packages/slice-machine/src/components/Divider/Divider.tsx
@@ -20,19 +20,6 @@ export const Divider: FC<DividerProps> = (props) => {
         sprinkles({ color: colors[color] }),
         className,
       )}
-      style={
-        // Vanilla Extract does not compile the necessary `linear-gradient`
-        // correctly in production; the `0%` used in the style is "minified" to
-        // 0, which is invalid.
-        // TODO: Move these styles out of the `style` prop when Vanilla Extract
-        // is replaced.
-        variant === "edgeFaded"
-          ? {
-              backgroundImage:
-                "linear-gradient(to right, color-mix(in srgb, currentColor 0%, transparent), currentColor, color-mix(in srgb, currentColor 0%, transparent))",
-            }
-          : undefined
-      }
     />
   );
 };

--- a/packages/slice-machine/src/components/Divider/Divider.tsx
+++ b/packages/slice-machine/src/components/Divider/Divider.tsx
@@ -20,6 +20,19 @@ export const Divider: FC<DividerProps> = (props) => {
         sprinkles({ color: colors[color] }),
         className,
       )}
+      style={
+        // Vanilla Extract does not compile the necessary `linear-gradient`
+        // correctly in production; the `0%` used in the style is "minified" to
+        // 0, which is invalid.
+        // TODO: Move these styles out of the `style` prop when Vanilla Extract
+        // is replaced.
+        variant === "edgeFaded"
+          ? {
+              backgroundImage:
+                "linear-gradient(to right, color-mix(in srgb, currentColor 0%, transparent), currentColor, color-mix(in srgb, currentColor 0%, transparent))",
+            }
+          : undefined
+      }
     />
   );
 };

--- a/packages/slice-machine/src/components/PageLayout/PageLayout.css.ts
+++ b/packages/slice-machine/src/components/PageLayout/PageLayout.css.ts
@@ -1,5 +1,5 @@
 import { colors, sprinkles, vars } from "@prismicio/editor-ui";
-import { style, styleVariants } from "@vanilla-extract/css";
+import { style } from "@vanilla-extract/css";
 
 const grid = sprinkles({ all: "unset", display: "grid" });
 
@@ -30,11 +30,11 @@ export const borderTop = sprinkles({
   width: "100%",
 });
 
-export const borderTopColor = styleVariants({
-  purple: [sprinkles({ backgroundColor: colors.purple9 })],
-  indigo: [sprinkles({ backgroundColor: colors.indigo10 })],
-  amber: [sprinkles({ backgroundColor: colors.amber10 })],
-});
+export const borderTopColor = {
+  purple: sprinkles({ backgroundColor: colors.purple9 }),
+  indigo: sprinkles({ backgroundColor: colors.indigo10 }),
+  amber: sprinkles({ backgroundColor: colors.amber10 }),
+};
 
 export const pane = style([
   grid,

--- a/packages/slice-machine/src/components/PageLayout/PageLayout.css.ts
+++ b/packages/slice-machine/src/components/PageLayout/PageLayout.css.ts
@@ -24,6 +24,8 @@ export const root = style([
 ]);
 
 export const borderTop = sprinkles({
+  all: "unset",
+  display: "revert",
   height: 2,
   position: "fixed",
   top: 0,

--- a/packages/slice-machine/src/components/PageLayout/PageLayout.css.ts
+++ b/packages/slice-machine/src/components/PageLayout/PageLayout.css.ts
@@ -23,21 +23,17 @@ export const root = style([
   },
 ]);
 
-const borderTopBase = style([
-  sprinkles({
-    all: "unset",
-    display: "revert",
-    height: 2,
-    position: "fixed",
-    top: 0,
-  }),
-  { width: "inherit" },
-]);
+export const borderTop = sprinkles({
+  height: 2,
+  position: "fixed",
+  top: 0,
+  width: "100%",
+});
 
 export const borderTopColor = styleVariants({
-  purple: [borderTopBase, sprinkles({ backgroundColor: colors.purple9 })],
-  indigo: [borderTopBase, sprinkles({ backgroundColor: colors.indigo10 })],
-  amber: [borderTopBase, sprinkles({ backgroundColor: colors.amber10 })],
+  purple: [sprinkles({ backgroundColor: colors.purple9 })],
+  indigo: [sprinkles({ backgroundColor: colors.indigo10 })],
+  amber: [sprinkles({ backgroundColor: colors.amber10 })],
 });
 
 export const pane = style([

--- a/packages/slice-machine/src/components/PageLayout/PageLayout.stories.tsx
+++ b/packages/slice-machine/src/components/PageLayout/PageLayout.stories.tsx
@@ -31,6 +31,7 @@ export default meta;
 
 export const Default = {
   args: {
+    borderTopColor: "purple",
     children: (
       <>
         <PageLayoutPane />

--- a/packages/slice-machine/src/components/PageLayout/PageLayout.tsx
+++ b/packages/slice-machine/src/components/PageLayout/PageLayout.tsx
@@ -1,4 +1,5 @@
 import type { FC, PropsWithChildren } from "react";
+import clsx from "clsx";
 
 import * as styles from "./PageLayout.css";
 
@@ -13,7 +14,9 @@ export const PageLayout: FC<PageLayoutProps> = ({
 }) => (
   <div {...otherProps} className={styles.root}>
     {children}
-    <div className={styles.borderTopColor[borderTopColor]} />
+    <div
+      className={clsx(styles.borderTop, styles.borderTopColor[borderTopColor])}
+    />
   </div>
 );
 

--- a/packages/slice-machine/src/components/PageLayout/PageLayout.tsx
+++ b/packages/slice-machine/src/components/PageLayout/PageLayout.tsx
@@ -7,13 +7,13 @@ type PageLayoutProps = PropsWithChildren<{
 }>;
 
 export const PageLayout: FC<PageLayoutProps> = ({
-  borderTopColor,
+  borderTopColor = "purple",
   children,
   ...otherProps
 }) => (
   <div {...otherProps} className={styles.root}>
     {children}
-    <div className={styles.borderTopColor[borderTopColor ?? "purple"]} />
+    <div className={styles.borderTopColor[borderTopColor]} />
   </div>
 );
 

--- a/packages/slice-machine/src/components/PageLayout/PageLayout.tsx
+++ b/packages/slice-machine/src/components/PageLayout/PageLayout.tsx
@@ -13,11 +13,7 @@ export const PageLayout: FC<PageLayoutProps> = ({
 }) => (
   <div {...otherProps} className={styles.root}>
     {children}
-    <div
-      className={
-        borderTopColor ? styles.borderTopColor[borderTopColor] : undefined
-      }
-    />
+    <div className={styles.borderTopColor[borderTopColor ?? "purple"]} />
   </div>
 );
 


### PR DESCRIPTION
## Context

DT-1808

## The Solution

### `<Divider>` bug

The CSS `color-mix` function is used to make `currentColor` transparent, which is necessary to have a correct transparent gradient. Vanilla Extract (or whatever minifies our CSS) converts `0%` to `0` in production, which is invalid syntax within `color-mix`.

Interestingly, `100%` is not converted to `1`, so we can use `transparent 100%` instead of `currentColor 0%`.

### Top border bug

Default to the `purple` style. This regression accidentally came from a previous refactor.

## Impact / Dependencies

N/A

## Checklist before requesting a review

- [x] I hereby declare my code ready for review.
- [ ] If it is a critical feature, I have added tests.
- [x] The CI is successful.
- [ ] If there could backward compatibility issues, it has been discussed and planned.
