### PR TITLE
fix(slice-machine-ui): allow clicking on the "Login required" text in the environment switcher

### DIFF
--- a/packages/slice-machine/src/components/SideNav/SideNavEnvironmentSelector.css.ts
+++ b/packages/slice-machine/src/components/SideNav/SideNavEnvironmentSelector.css.ts
@@ -58,12 +58,3 @@ export const activeEnvironmentName = style([
     lineHeight: "1.25rem",
   },
 ]);
-
-export const actionRequiredLabel = style([
-  sprinkles({
-    color: colors.purple10,
-  }),
-  {
-    fontWeight: 500,
-  },
-]);

--- a/packages/slice-machine/src/components/SideNav/SideNavEnvironmentSelector.tsx
+++ b/packages/slice-machine/src/components/SideNav/SideNavEnvironmentSelector.tsx
@@ -7,6 +7,7 @@ import {
   DropdownMenuTrigger,
   Icon,
   IconButton,
+  InvisibleButton,
   Text,
 } from "@prismicio/editor-ui";
 import { Environment } from "@slicemachine/manager/client";
@@ -49,7 +50,12 @@ export const SideNavEnvironmentSelector: FC<SideNavEnvironmentSelectorProps> = (
           />
         )}
       </Box>
-      <Box flexGrow={1} flexDirection="column" overflow="hidden">
+      <Box
+        flexGrow={1}
+        flexDirection="column"
+        overflow="hidden"
+        alignItems="flex-start"
+      >
         {variant === "default" || variant === "unauthenticated" ? (
           <Text component="span" variant="small" color="grey11">
             Environment
@@ -57,9 +63,7 @@ export const SideNavEnvironmentSelector: FC<SideNavEnvironmentSelectorProps> = (
         ) : undefined}
 
         {variant === "unauthenticated" ? (
-          <Text component="span" className={styles.actionRequiredLabel}>
-            Login required
-          </Text>
+          <InvisibleButton buttonText="Login required" onClick={onLogInClick} />
         ) : undefined}
 
         {variant === "default" ? (


### PR DESCRIPTION
## Context

DT-1837

## The Solution

Use `@prismicio/editor-ui`'s `<InvisibleButton>` to render the button. Clicking the button opens the log in modal.

## Impact / Dependencies

None

## Checklist before requesting a review

- [x] I hereby declare my code ready for review.
- [ ] If it is a critical feature, I have added tests.
- [x] The CI is successful.
- [ ] If there could backward compatibility issues, it has been discussed and planned.
