### PR TITLE
refactor: use `@prismicio/custom-types-client`'s `fetchOptions` to send a User Agent

### DIFF
--- a/packages/manager/package.json
+++ b/packages/manager/package.json
@@ -65,7 +65,7 @@
 	},
 	"dependencies": {
 		"@antfu/ni": "^0.20.0",
-		"@prismicio/custom-types-client": "1.2.0-alpha.0",
+		"@prismicio/custom-types-client": "^1.2.0",
 		"@prismicio/mocks": "2.0.0",
 		"@prismicio/types-internal": "^2.2.0",
 		"@segment/analytics-node": "1.1.3",

--- a/packages/manager/src/managers/SliceMachineManager.ts
+++ b/packages/manager/src/managers/SliceMachineManager.ts
@@ -3,10 +3,7 @@ import {
 	CustomType,
 } from "@prismicio/types-internal/lib/customtypes";
 import { SharedSliceContent } from "@prismicio/types-internal/lib/content";
-import {
-	ForbiddenError,
-	UnauthorizedError,
-} from "@prismicio/custom-types-client";
+import * as prismicCustomTypesClient from "@prismicio/custom-types-client";
 import {
 	SliceMachinePlugin,
 	SliceMachinePluginRunner,
@@ -202,14 +199,16 @@ export class SliceMachineManager {
 							authError,
 						};
 					} catch (error) {
-						if (error instanceof ForbiddenError) {
+						if (error instanceof prismicCustomTypesClient.ForbiddenError) {
 							authError = {
 								name: "__stub__",
 								message: "__stub__",
 								reason: "__stub__",
 								status: 401,
 							};
-						} else if (error instanceof UnauthorizedError) {
+						} else if (
+							error instanceof prismicCustomTypesClient.UnauthorizedError
+						) {
 							authError = {
 								name: "__stub__",
 								message: "__stub__",

--- a/packages/manager/src/managers/customTypes/CustomTypesManager.ts
+++ b/packages/manager/src/managers/customTypes/CustomTypesManager.ts
@@ -235,8 +235,12 @@ export class CustomTypesManager extends BaseManager {
 				endpoint: API_ENDPOINTS.PrismicModels,
 				repositoryName,
 				token: authenticationToken,
-				userAgent: args.userAgent || SLICE_MACHINE_USER_AGENT,
 				fetch,
+				fetchOptions: {
+					headers: {
+						"User-Agent": args.userAgent || SLICE_MACHINE_USER_AGENT,
+					},
+				},
 			});
 
 			try {
@@ -323,8 +327,12 @@ export class CustomTypesManager extends BaseManager {
 			endpoint: API_ENDPOINTS.PrismicModels,
 			repositoryName,
 			token: authenticationToken,
-			userAgent: SLICE_MACHINE_USER_AGENT,
 			fetch,
+			fetchOptions: {
+				headers: {
+					"User-Agent": SLICE_MACHINE_USER_AGENT,
+				},
+			},
 		});
 
 		return await client.getAllCustomTypes();

--- a/packages/manager/src/managers/slices/SlicesManager.ts
+++ b/packages/manager/src/managers/slices/SlicesManager.ts
@@ -771,8 +771,12 @@ export class SlicesManager extends BaseManager {
 				endpoint: API_ENDPOINTS.PrismicModels,
 				repositoryName,
 				token: authenticationToken,
-				userAgent: args.userAgent || SLICE_MACHINE_USER_AGENT,
 				fetch,
+				fetchOptions: {
+					headers: {
+						"User-Agent": args.userAgent || SLICE_MACHINE_USER_AGENT,
+					},
+				},
 			});
 
 			try {
@@ -987,8 +991,12 @@ export class SlicesManager extends BaseManager {
 			endpoint: API_ENDPOINTS.PrismicModels,
 			repositoryName,
 			token: authenticationToken,
-			userAgent: SLICE_MACHINE_USER_AGENT,
 			fetch,
+			fetchOptions: {
+				headers: {
+					"User-Agent": SLICE_MACHINE_USER_AGENT,
+				},
+			},
 		});
 
 		return await client.getAllSharedSlices();

--- a/packages/manager/test/SliceMachineManager-customTypes-fetchRemoteCustomTypes.test.ts
+++ b/packages/manager/test/SliceMachineManager-customTypes-fetchRemoteCustomTypes.test.ts
@@ -38,7 +38,8 @@ it("fetches Custom Types from the Custom Types API", async (ctx) => {
 		onCustomTypeGetAll: (req, res, ctx) => {
 			if (
 				req.headers.get("repository") === sliceMachineConfig.repositoryName &&
-				req.headers.get("Authorization") === `Bearer ${authenticationToken}`
+				req.headers.get("Authorization") === `Bearer ${authenticationToken}` &&
+				req.headers.get("user-agent") === "slice-machine"
 			) {
 				return res(ctx.json(models));
 			}
@@ -84,7 +85,8 @@ it("fetches Custom Types from the Custom Types API using the currently set envir
 		onCustomTypeGetAll: (req, res, ctx) => {
 			if (
 				req.headers.get("repository") === "foo" &&
-				req.headers.get("Authorization") === `Bearer ${authenticationToken}`
+				req.headers.get("Authorization") === `Bearer ${authenticationToken}` &&
+				req.headers.get("user-agent") === "slice-machine"
 			) {
 				return res(ctx.json(models));
 			}

--- a/packages/manager/test/SliceMachineManager-prismicRepository-pushChanges.test.ts
+++ b/packages/manager/test/SliceMachineManager-prismicRepository-pushChanges.test.ts
@@ -132,7 +132,7 @@ it("pushes changes using the bulk API to the selected environment when an enviro
 	mockCustomTypesAPI(ctx, {
 		async onBulk(req, res, ctx) {
 			if (
-				req.headers.get("user-agent") === "slice-machine" ||
+				req.headers.get("user-agent") === "slice-machine" &&
 				req.headers.get("repository") === "foo"
 			) {
 				sentModel = await req.json();

--- a/packages/manager/test/SliceMachineManager-slices-fetchRemoteSlices.test.ts
+++ b/packages/manager/test/SliceMachineManager-slices-fetchRemoteSlices.test.ts
@@ -38,7 +38,8 @@ it("fetches Slices from the Custom Types API", async (ctx) => {
 		onSliceGetAll: (req, res, ctx) => {
 			if (
 				req.headers.get("repository") === sliceMachineConfig.repositoryName &&
-				req.headers.get("Authorization") === `Bearer ${authenticationToken}`
+				req.headers.get("Authorization") === `Bearer ${authenticationToken}` &&
+				req.headers.get("user-agent") === "slice-machine"
 			) {
 				return res(ctx.json(models));
 			}
@@ -84,7 +85,8 @@ it("fetches Slices from the Custom Types API using the currently set environment
 		onSliceGetAll: (req, res, ctx) => {
 			if (
 				req.headers.get("repository") === "foo" &&
-				req.headers.get("Authorization") === `Bearer ${authenticationToken}`
+				req.headers.get("Authorization") === `Bearer ${authenticationToken}` &&
+				req.headers.get("user-agent") === "slice-machine"
 			) {
 				return res(ctx.json(models));
 			}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5085,21 +5085,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@prismicio/custom-types-client@npm:1.2.0-alpha.0":
-  version: 1.2.0-alpha.0
-  resolution: "@prismicio/custom-types-client@npm:1.2.0-alpha.0"
+"@prismicio/custom-types-client@npm:^1.1.0, @prismicio/custom-types-client@npm:^1.2.0":
+  version: 1.2.0
+  resolution: "@prismicio/custom-types-client@npm:1.2.0"
   dependencies:
     "@prismicio/types": ^0.2.4
-  checksum: fa58201a97d211c3d5a691b7fe667e84382a6abb4b6e9ffc4bc27d33112ce4b776351b822155a707b97c07d63f93d994f3c55a93d0c9726972f74b3b4c103b09
-  languageName: node
-  linkType: hard
-
-"@prismicio/custom-types-client@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "@prismicio/custom-types-client@npm:1.1.0"
-  dependencies:
-    "@prismicio/types": ^0.2.4
-  checksum: e5befbfa85cbd6ab9811c2cae9eba35c138d30f5d87ad59087e5f109f7088e34ab38e6993651edee7359aca88997da2ed92996803fe40b56a37d5f2311d2e11c
+  checksum: b1344054a40dddee1845a65fc747d9208c1bdc8ef4ff368f9e75e602ea4781b9dbf1d22b5a74488a6702c5169370e567892ea484fdbbeac2247998abb0b329e2
   languageName: node
   linkType: hard
 
@@ -8608,7 +8599,7 @@ __metadata:
   resolution: "@slicemachine/manager@workspace:packages/manager"
   dependencies:
     "@antfu/ni": ^0.20.0
-    "@prismicio/custom-types-client": 1.2.0-alpha.0
+    "@prismicio/custom-types-client": ^1.2.0
     "@prismicio/mock": 0.2.0
     "@prismicio/mocks": 2.0.0
     "@prismicio/types-internal": ^2.2.0


### PR DESCRIPTION
## Context

DT-1764

## The Solution

Update `@prismicio/custom-types-client` to `v1.2.0`, which includes a new `fetchOptions` option (see prismicio/prismic-custom-types-client#9). `fetchOptions` allows for setting arbitrary `fetch()` options, including headers.

With the new option, we can replace the existing alpha `@prismicio/custom-types-client` API usage with the production version.

Test have been added/updated to check for the `User-Agent` header.

## Impact / Dependencies

None

## Checklist before requesting a review

- [x] I hereby declare my code ready for review.
- [x] If it is a critical feature, I have added tests.
- [x] The CI is successful.
- [ ] If there could backward compatibility issues, it has been discussed and planned.
