### PR TITLE
chore(manager): send environment kind with tracking events

### DIFF
--- a/packages/manager/src/lib/findEnvironment.ts
+++ b/packages/manager/src/lib/findEnvironment.ts
@@ -1,0 +1,14 @@
+import { Environment } from "../managers/prismicRepository/types";
+
+export const findEnvironment = (
+	environmentDomain: string | undefined,
+	environments: Environment[],
+): Environment | undefined => {
+	return environments?.find((environment) => {
+		if (environmentDomain === undefined) {
+			return environment.kind === "prod";
+		}
+
+		return environment.domain === environmentDomain;
+	});
+};

--- a/packages/manager/src/managers/project/ProjectManager.ts
+++ b/packages/manager/src/managers/project/ProjectManager.ts
@@ -15,6 +15,7 @@ import { DecodeError } from "../../lib/DecodeError";
 import { assertPluginsInitialized } from "../../lib/assertPluginsInitialized";
 import { decodeHookResult } from "../../lib/decodeHookResult";
 import { decodeSliceMachineConfig } from "../../lib/decodeSliceMachineConfig";
+import { findEnvironment } from "../../lib/findEnvironment";
 import { format } from "../../lib/format";
 import { installDependencies } from "../../lib/installDependencies";
 import { locateFileUpward } from "../../lib/locateFileUpward";
@@ -445,12 +446,9 @@ export class ProjectManager extends BaseManager {
 		// We can assume an environment cannot change its kind. If the
 		// environment exists in the cached list, we are confident it
 		// will not change.
-		const cachedActiveEnvironment = this._cachedEnvironments?.find(
-			(environment) => {
-				return activeEnvironmentDomain === undefined
-					? environment.kind === "prod"
-					: environment.domain === activeEnvironmentDomain;
-			},
+		const cachedActiveEnvironment = findEnvironment(
+			activeEnvironmentDomain,
+			this._cachedEnvironments || [],
 		);
 		if (cachedActiveEnvironment) {
 			return { activeEnvironment: cachedActiveEnvironment };
@@ -468,13 +466,10 @@ export class ProjectManager extends BaseManager {
 			this._cachedEnvironments = environments;
 		}
 
-		const activeEnvironment = this._cachedEnvironments?.find((environment) => {
-			if (activeEnvironmentDomain === undefined) {
-				return environment.kind === "prod";
-			}
-
-			return environment.domain === activeEnvironmentDomain;
-		});
+		const activeEnvironment = findEnvironment(
+			activeEnvironmentDomain,
+			this._cachedEnvironments || [],
+		);
 
 		if (!activeEnvironment) {
 			throw new UnexpectedDataError(

--- a/packages/manager/src/managers/project/ProjectManager.ts
+++ b/packages/manager/src/managers/project/ProjectManager.ts
@@ -25,13 +25,19 @@ import {
 	OnlyHookErrors,
 } from "../../types";
 
-import { SliceMachineError, InternalError, PluginError } from "../../errors";
+import {
+	SliceMachineError,
+	InternalError,
+	PluginError,
+	UnexpectedDataError,
+} from "../../errors";
 
 import { SLICE_MACHINE_CONFIG_FILENAME } from "../../constants/SLICE_MACHINE_CONFIG_FILENAME";
 import { TS_CONFIG_FILENAME } from "../../constants/TS_CONFIG_FILENAME";
 import { SLICE_MACHINE_NPM_PACKAGE_NAME } from "../../constants/SLICE_MACHINE_NPM_PACKAGE_NAME";
 
 import { BaseManager } from "../BaseManager";
+import { Environment } from "../prismicRepository/types";
 
 type ProjectManagerGetSliceMachineConfigPathArgs = {
 	ignoreCache?: boolean;
@@ -78,10 +84,15 @@ type ProjectManagerUpdateEnvironmentArgs = {
 	environment: string | undefined;
 };
 
+type ProjectManagerFetchActiveEnvironmentReturnType = {
+	activeEnvironment: Environment;
+};
+
 export class ProjectManager extends BaseManager {
 	private _cachedRoot: string | undefined;
 	private _cachedSliceMachineConfigPath: string | undefined;
 	private _cachedSliceMachineConfig: SliceMachineConfig | undefined;
+	private _cachedEnvironments: Environment[] | undefined;
 
 	async getSliceMachineConfigPath(
 		args?: ProjectManagerGetSliceMachineConfigPathArgs,
@@ -425,6 +436,55 @@ export class ProjectManager extends BaseManager {
 		return {
 			errors: hookResult.errors,
 		};
+	}
+
+	async fetchActiveEnvironment(): Promise<ProjectManagerFetchActiveEnvironmentReturnType> {
+		const { environment: activeEnvironmentDomain } =
+			await this.readEnvironment();
+
+		// We can assume an environment cannot change its kind. If the
+		// environment exists in the cached list, we are confident it
+		// will not change.
+		const cachedActiveEnvironment = this._cachedEnvironments?.find(
+			(environment) => {
+				return activeEnvironmentDomain === undefined
+					? environment.kind === "prod"
+					: environment.domain === activeEnvironmentDomain;
+			},
+		);
+		if (cachedActiveEnvironment) {
+			return { activeEnvironment: cachedActiveEnvironment };
+		}
+
+		// If the environment is not in the cached environments list, we
+		// must fetch a fresh list and set the cache.
+		const { environments } = await this.prismicRepository.fetchEnvironments();
+		// TODO: Remove the wrapping if statement when
+		// `this.prismicRepository.fetchEnvironments()` is able to throw
+		// normally. The method returns an object with an `error`
+		// property at the time of this writing, which means we need to
+		// check if the `environments` property exists.
+		if (environments) {
+			this._cachedEnvironments = environments;
+		}
+
+		const activeEnvironment = this._cachedEnvironments?.find((environment) => {
+			if (activeEnvironmentDomain === undefined) {
+				return environment.kind === "prod";
+			}
+
+			return environment.domain === activeEnvironmentDomain;
+		});
+
+		if (!activeEnvironment) {
+			throw new UnexpectedDataError(
+				`The active environment (${
+					activeEnvironmentDomain ?? "Production"
+				}) does not match one of the repository's environments.`,
+			);
+		}
+
+		return { activeEnvironment };
 	}
 
 	private async _assertAdapterSupportsEnvironments(): Promise<void> {

--- a/packages/manager/src/managers/telemetry/TelemetryManager.ts
+++ b/packages/manager/src/managers/telemetry/TelemetryManager.ts
@@ -13,6 +13,7 @@ import {
 	HumanSegmentEventTypes,
 	SegmentEvents,
 } from "./types";
+import { Environment } from "../prismicRepository/types";
 
 type TelemetryManagerInitTelemetryArgs = {
 	appName: string;
@@ -97,6 +98,19 @@ export class TelemetryManager extends BaseManager {
 			}
 		}
 
+		let environmentKind: Environment["kind"] | undefined = undefined;
+		if (this.project.checkSupportsEnvironments()) {
+			try {
+				const { activeEnvironment } =
+					await this.project.fetchActiveEnvironment();
+				environmentKind = activeEnvironment.kind;
+			} catch {
+				// noop - If we can't get the active environment, don't
+				// report any environment. This will happen when not
+				// authenticated.
+			}
+		}
+
 		const payload: {
 			event: HumanSegmentEventTypes;
 			userId?: string;
@@ -111,6 +125,7 @@ export class TelemetryManager extends BaseManager {
 			event: HumanSegmentEventType[event],
 			properties: {
 				nodeVersion: process.versions.node,
+				environmentKind,
 				...properties,
 			},
 			context: { ...this._context },

--- a/packages/slice-machine/src/modules/pushChangesSaga/trackPushChangesSuccess.ts
+++ b/packages/slice-machine/src/modules/pushChangesSaga/trackPushChangesSuccess.ts
@@ -88,5 +88,6 @@ export function trackPushChangesSuccess(params: trackingParameters) {
     missingScreenshots,
     duration: duration,
     hasDeletedDocuments: confirmDeleteDocuments,
+    _includeEnvironmentKind: true,
   });
 }


### PR DESCRIPTION
## Context

DT-1851

## The Solution

`@slicemachine/manager`'s `telemetry.track()` method can now send an `environmentKind` property containing the active environment's kind (one of `prod`, `stage`, or `dev`).

The property is populated only when the `_includeEnvironmentKind` argument is `true`:

```ts
manager.telemetry.track({
  event: "...",
  _includeEnvironmentKind: true,
})
```

The property is opt-in at this time because it requires at least one network request per session to fetch the list of the Prismic repository's environments. The request is cached and only re-fetched if the active environment domain is not present in the cache.

There are cases when we do not want to include the `environmentKind` property, such as during the `@slicemachine/init` process.

In the future, we may switch the property from being opt-in to opt-out.

### Handled edge cases

- When the project's Slice Machine adapter does not support environments, `environmentKind` will be set to `prod` when `_includeEnvironmentKind` is enabled.
- When the user is not logged in, the user is not not authorized, or a network failure occurs when fetching the environments, `environmentKind` will be set to a special `_unknown` value when `_includeEnvironmentKind` is enabled. We cannot fetch metadata about the environment without access to the repository's environments.

### Initial use case

As part of this PR, the `environmentKind` property will be included in the `changes:pushed` event.

## Impact / Dependencies

All tracking events will include this new non-breaking property regardless of where the tracking event was fired. That means events from Slice Machine UI, `@slicemachine/init`, and `start-slicemachine` will now report `environmentKind`.

## Checklist before requesting a review
- [x] I hereby declare my code ready for review.
- [x] If it is a critical feature, I have added tests.
- [x] The CI is successful.
- [ ] If there could backward compatibility issues, it has been discussed and planned.
