### PR TITLE
fix(adapter-svelte): support previews in `@slicemachine/init` (DT-1867)

### DIFF
--- a/packages/adapter-sveltekit/src/hooks/documentation-read.ts
+++ b/packages/adapter-sveltekit/src/hooks/documentation-read.ts
@@ -32,8 +32,8 @@ export const documentationRead: DocumentationReadHook<PluginOptions> = async (
 			dataFileContent = source`
 				import { createClient } from "$lib/prismicio";
 
-				export async function load({ params, fetch }) {
-					const client = createClient({ fetch });
+				export async function load({ params, fetch, cookies }) {
+					const client = createClient({ fetch, cookies });
 
 					const page = await client.getByUID("${model.id}", params.uid);
 
@@ -56,8 +56,8 @@ export const documentationRead: DocumentationReadHook<PluginOptions> = async (
 			dataFileContent = source`
 				import { createClient } from "$lib/prismicio";
 
-				export async function load({ params, fetch }) {
-					const client = createClient({ fetch });
+				export async function load({ params, fetch, cookies }) {
+					const client = createClient({ fetch, cookies });
 
 					const page = await client.getSingle("${model.id}");
 

--- a/packages/adapter-sveltekit/src/hooks/project-init.ts
+++ b/packages/adapter-sveltekit/src/hooks/project-init.ts
@@ -317,6 +317,40 @@ const createRootLayoutServerFile = async ({
 	});
 };
 
+const createRootLayoutFile = async ({
+	helpers,
+	options,
+}: SliceMachineContext<PluginOptions>) => {
+	const filename = path.join("src", "routes", "+layout.svelte");
+
+	if (await checkHasProjectFile({ filename, helpers })) {
+		return;
+	}
+
+	const contents = source`
+		<script>
+			import { PrismicPreview } from '@prismicio/svelte/kit';
+			import { repositoryName } from '$lib/prismicio';
+		</script>
+
+		<slot />
+		<PrismicPreview {repositoryName} />
+	`;
+
+	await writeProjectFile({
+		filename,
+		contents,
+		format: options.format,
+		formatOptions: {
+			prettier: {
+				plugins: ["prettier-plugin-svelte"],
+				parser: "svelte",
+			},
+		},
+		helpers,
+	});
+};
+
 const modifySliceMachineConfig = async ({
 	helpers,
 	options,
@@ -388,6 +422,7 @@ export const projectInit: ProjectInitHook<PluginOptions> = async (
 			createPreviewRouteDirectory(context),
 			createPreviewRouteMatcherFile(context),
 			createRootLayoutServerFile(context),
+			createRootLayoutFile(context),
 		]),
 	);
 

--- a/packages/adapter-sveltekit/test/__snapshots__/plugin-documentation-read.test.ts.snap
+++ b/packages/adapter-sveltekit/test/__snapshots__/plugin-documentation-read.test.ts.snap
@@ -11,8 +11,8 @@ Paste in this code:
 ~~~js [src/routes/[uid]/+page.server.js]
 import { createClient } from \\"$lib/prismicio\\";
 
-export async function load({ params, fetch }) {
-  const client = createClient({ fetch });
+export async function load({ params, fetch, cookies }) {
+  const client = createClient({ fetch, cookies });
 
   const page = await client.getByUID(\\"repeatable\\", params.uid);
 
@@ -66,8 +66,8 @@ Paste in this code:
 ~~~ts [src/routes/[uid]/+page.server.ts]
 import { createClient } from \\"$lib/prismicio\\";
 
-export async function load({ params, fetch }) {
-  const client = createClient({ fetch });
+export async function load({ params, fetch, cookies }) {
+  const client = createClient({ fetch, cookies });
 
   const page = await client.getByUID(\\"repeatable\\", params.uid);
 
@@ -121,8 +121,8 @@ Paste in this code:
 ~~~js [src/routes/single/+page.server.js]
 import { createClient } from \\"$lib/prismicio\\";
 
-export async function load({ params, fetch }) {
-  const client = createClient({ fetch });
+export async function load({ params, fetch, cookies }) {
+  const client = createClient({ fetch, cookies });
 
   const page = await client.getSingle(\\"single\\");
 
@@ -170,8 +170,8 @@ Paste in this code:
 ~~~ts [src/routes/single/+page.server.ts]
 import { createClient } from \\"$lib/prismicio\\";
 
-export async function load({ params, fetch }) {
-  const client = createClient({ fetch });
+export async function load({ params, fetch, cookies }) {
+  const client = createClient({ fetch, cookies });
 
   const page = await client.getSingle(\\"single\\");
 

--- a/packages/adapter-sveltekit/test/plugin-project-init.test.ts
+++ b/packages/adapter-sveltekit/test/plugin-project-init.test.ts
@@ -380,6 +380,81 @@ describe("prismicio.js file", () => {
 	});
 });
 
+describe("/api/preview route", () => {
+	it("creates an endpoint", async (ctx) => {
+		const log = vi.fn();
+		const installDependencies = vi.fn();
+
+		await ctx.pluginRunner.callHook("project:init", {
+			log,
+			installDependencies,
+		});
+
+		const contents = await fs.readFile(
+			path.join(
+				ctx.project.root,
+				"src",
+				"routes",
+				"api",
+				"preview",
+				"+server.js",
+			),
+			"utf8",
+		);
+
+		expect(contents).toMatchInlineSnapshot(`
+			"import { redirectToPreviewURL } from \\"@prismicio/svelte/kit\\";
+			import { createClient } from \\"$lib/prismicio.js\\";
+
+			export async function GET({ fetch, request, cookies }) {
+			  const client = createClient({ fetch });
+
+			  return await redirectToPreviewURL({ client, request, cookies });
+			}
+			"
+		`);
+	});
+
+	it("creates a TypeScript file when TypeScript is enabled", async (ctx) => {
+		const log = vi.fn();
+		const installDependencies = vi.fn();
+
+		await fs.writeFile(
+			path.join(ctx.project.root, "tsconfig.json"),
+			JSON.stringify({}),
+		);
+
+		await ctx.pluginRunner.callHook("project:init", {
+			log,
+			installDependencies,
+		});
+
+		const contents = await fs.readFile(
+			path.join(
+				ctx.project.root,
+				"src",
+				"routes",
+				"api",
+				"preview",
+				"+server.ts",
+			),
+			"utf8",
+		);
+
+		expect(contents).toMatchInlineSnapshot(`
+			"import { redirectToPreviewURL } from \\"@prismicio/svelte/kit\\";
+			import { createClient } from \\"$lib/prismicio.js\\";
+
+			export async function GET({ fetch, request, cookies }) {
+			  const client = createClient({ fetch });
+
+			  return await redirectToPreviewURL({ client, request, cookies });
+			}
+			"
+		`);
+	});
+});
+
 describe("preview route directory", () => {
 	it("creates a preview route directory", async (ctx) => {
 		const log = vi.fn();

--- a/packages/adapter-sveltekit/test/plugin-project-init.test.ts
+++ b/packages/adapter-sveltekit/test/plugin-project-init.test.ts
@@ -329,7 +329,10 @@ describe("prismicio.js file", () => {
 
 		expect(contents).toMatchInlineSnapshot(`
 			"import * as prismic from \\"@prismicio/client\\";
-			import { CreateClientConfig, enableAutoPreviews } from \\"@prismicio/svelte/kit\\";
+			import {
+			  type CreateClientConfig,
+			  enableAutoPreviews,
+			} from \\"@prismicio/svelte/kit\\";
 			import config from \\"../../slicemachine.config.json\\";
 
 			/**
@@ -404,7 +407,7 @@ describe("/api/preview route", () => {
 
 		expect(contents).toMatchInlineSnapshot(`
 			"import { redirectToPreviewURL } from \\"@prismicio/svelte/kit\\";
-			import { createClient } from \\"$lib/prismicio.js\\";
+			import { createClient } from \\"$lib/prismicio\\";
 
 			export async function GET({ fetch, request, cookies }) {
 			  const client = createClient({ fetch });
@@ -443,7 +446,7 @@ describe("/api/preview route", () => {
 
 		expect(contents).toMatchInlineSnapshot(`
 			"import { redirectToPreviewURL } from \\"@prismicio/svelte/kit\\";
-			import { createClient } from \\"$lib/prismicio.js\\";
+			import { createClient } from \\"$lib/prismicio\\";
 
 			export async function GET({ fetch, request, cookies }) {
 			  const client = createClient({ fetch });

--- a/packages/adapter-sveltekit/test/plugin-project-init.test.ts
+++ b/packages/adapter-sveltekit/test/plugin-project-init.test.ts
@@ -456,6 +456,104 @@ describe("/api/preview route", () => {
 			"
 		`);
 	});
+
+	it("does not overwrite the endpoint file if it already exists", async (ctx) => {
+		const log = vi.fn();
+		const installDependencies = vi.fn();
+
+		const filePath = path.join(
+			ctx.project.root,
+			"src",
+			"routes",
+			"api",
+			"preview",
+			"+server.js",
+		);
+		const contents = "foo";
+
+		await fs.mkdir(path.dirname(filePath), { recursive: true });
+		await fs.writeFile(filePath, contents);
+
+		await ctx.pluginRunner.callHook("project:init", {
+			log,
+			installDependencies,
+		});
+
+		const postHookContents = await fs.readFile(filePath, "utf8");
+
+		expect(postHookContents).toBe(contents);
+	});
+
+	it("formats the file by default", async (ctx) => {
+		const log = vi.fn();
+		const installDependencies = vi.fn();
+
+		await ctx.pluginRunner.callHook("project:init", {
+			log,
+			installDependencies,
+		});
+
+		const contents = await fs.readFile(
+			path.join(
+				ctx.project.root,
+				"src",
+				"routes",
+				"api",
+				"preview",
+				"+server.js",
+			),
+			"utf8",
+		);
+
+		expect(contents).toBe(
+			await prettier.format(contents, { parser: "typescript" }),
+		);
+	});
+
+	it("does not format the file if formatting is disabled", async (ctx) => {
+		ctx.project.config.adapter.options.format = false;
+		const pluginRunner = createSliceMachinePluginRunner({
+			project: ctx.project,
+			nativePlugins: {
+				[ctx.project.config.adapter.resolve]: adapter,
+			},
+		});
+		await pluginRunner.init();
+
+		// Force unusual formatting to detect that formatting did not happen.
+		const prettierOptions = { printWidth: 10 };
+		await fs.writeFile(
+			path.join(ctx.project.root, ".prettierrc"),
+			JSON.stringify(prettierOptions),
+		);
+
+		const log = vi.fn();
+		const installDependencies = vi.fn();
+
+		await pluginRunner.callHook("project:init", {
+			log,
+			installDependencies,
+		});
+
+		const contents = await fs.readFile(
+			path.join(
+				ctx.project.root,
+				"src",
+				"routes",
+				"api",
+				"preview",
+				"+server.js",
+			),
+			"utf8",
+		);
+
+		expect(contents).not.toBe(
+			await prettier.format(contents, {
+				...prettierOptions,
+				parser: "typescript",
+			}),
+		);
+	});
 });
 
 describe("preview route directory", () => {
@@ -918,6 +1016,120 @@ describe("root layout server file", () => {
 			await prettier.format(contents, {
 				...prettierOptions,
 				parser: "typescript",
+			}),
+		);
+	});
+});
+
+describe("root layout file", () => {
+	it("creates a root layout file", async (ctx) => {
+		const log = vi.fn();
+		const installDependencies = vi.fn();
+
+		await ctx.pluginRunner.callHook("project:init", {
+			log,
+			installDependencies,
+		});
+
+		const contents = await fs.readFile(
+			path.join(ctx.project.root, "src", "routes", "+layout.svelte"),
+			"utf8",
+		);
+
+		expect(contents).toMatchInlineSnapshot(`
+			"<script>
+			  import { PrismicPreview } from \\"@prismicio/svelte/kit\\";
+			  import { repositoryName } from \\"$lib/prismicio\\";
+			</script>
+
+			<slot />
+			<PrismicPreview {repositoryName} />
+			"
+		`);
+	});
+
+	it("does not overwrite root layout server file if it already exists", async (ctx) => {
+		const log = vi.fn();
+		const installDependencies = vi.fn();
+
+		const filePath = path.join(
+			ctx.project.root,
+			"src",
+			"routes",
+			"+layout.svelte",
+		);
+		const contents = "foo";
+
+		await fs.mkdir(path.dirname(filePath), { recursive: true });
+		await fs.writeFile(filePath, contents);
+
+		await ctx.pluginRunner.callHook("project:init", {
+			log,
+			installDependencies,
+		});
+
+		const postHookContents = await fs.readFile(filePath, "utf8");
+
+		expect(postHookContents).toBe(contents);
+	});
+
+	it("formats the file by default", async (ctx) => {
+		const log = vi.fn();
+		const installDependencies = vi.fn();
+
+		await ctx.pluginRunner.callHook("project:init", {
+			log,
+			installDependencies,
+		});
+
+		const contents = await fs.readFile(
+			path.join(ctx.project.root, "src", "routes", "+layout.svelte"),
+			"utf8",
+		);
+
+		expect(contents).toBe(
+			await prettier.format(contents, {
+				plugins: ["prettier-plugin-svelte"],
+				parser: "svelte",
+			}),
+		);
+	});
+
+	it("does not format the file if formatting is disabled", async (ctx) => {
+		ctx.project.config.adapter.options.format = false;
+		const pluginRunner = createSliceMachinePluginRunner({
+			project: ctx.project,
+			nativePlugins: {
+				[ctx.project.config.adapter.resolve]: adapter,
+			},
+		});
+		await pluginRunner.init();
+
+		// Force unusual formatting to detect that formatting did not happen.
+		const prettierOptions = { printWidth: 10 };
+		await fs.writeFile(
+			path.join(ctx.project.root, ".prettierrc"),
+			JSON.stringify(prettierOptions),
+		);
+
+		const log = vi.fn();
+		const installDependencies = vi.fn();
+
+		await pluginRunner.callHook("project:init", {
+			log,
+			installDependencies,
+		});
+
+		const contents = await fs.readFile(
+			path.join(ctx.project.root, "src", "routes", "+layout.svelte"),
+			"utf8",
+		);
+
+		expect(contents).not.toBe(
+			await prettier.format(contents, {
+				...prettierOptions,
+				plugins: ["prettier-plugin-svelte"],
+				parser: "svelte",
 			}),
 		);
 	});


### PR DESCRIPTION
## Context

DT-1867

## The Solution

Generate the necessary files. The file contents are based off the [SvelteKit starter files](https://github.com/prismicio-community/sveltekit-starter-prismic-minimal).

## Impact / Dependencies

This PR only affects projects that:

1. Have an existing or vanilla SvelteKit project.
2. Run `@slicemachine/init` to bootstrap their Prismic project without a prismic starter.

## Checklist before requesting a review
- [x] I hereby declare my code ready for review.
- [ ] If it is a critical feature, I have added tests.
- [ ] The CI is successful.
- [ ] If there could backward compatibility issues, it has been discussed and planned.
