### PR TITLE
chore: add missing build-essentials to publish-unstable

### DIFF
--- a/.github/workflows/publish-unstable.yml
+++ b/.github/workflows/publish-unstable.yml
@@ -20,6 +20,8 @@ jobs:
         uses: ./.github/actions/setup-node
       - name: Install dependencies
         run: yarn install
+      - name: Build essentials
+        uses: ./.github/actions/build-essential
       - name: Run publish script
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}


### PR DESCRIPTION
Fixes an issue where skipped workspaces could make other (non-skipped) workspaces unbuildable.