### PR TITLE
chore: remove the dry-run flag from the publish-stable workflow

### DIFF
--- a/.github/workflows/publish-stable.yml
+++ b/.github/workflows/publish-stable.yml
@@ -106,4 +106,4 @@ jobs:
               specifiers+="$package_name:$package_release_type "
             fi
           done
-          yarn publish stable --dry-run $specifiers
+          yarn publish stable $specifiers


### PR DESCRIPTION
The workflow passed on `main` with the `--dry-run` flag, so it should work fine next time we want to release.