### PR TITLE
fix: ESM error when using SST

### DIFF
--- a/packages/manager/src/lib/format.ts
+++ b/packages/manager/src/lib/format.ts
@@ -1,4 +1,4 @@
-import prettier from "prettier";
+import type prettier from "prettier";
 import { stripIndent } from "common-tags";
 
 type FormatOptions = {
@@ -16,6 +16,8 @@ export const format = async (
 	filePath: string,
 	options?: FormatOptions,
 ): Promise<string> => {
+	const prettier = await import("prettier");
+
 	let formatted = stripIndent(source);
 
 	const prettierOptions = await prettier.resolveConfig(filePath);

--- a/packages/plugin-kit/src/createSliceMachineHelpers.ts
+++ b/packages/plugin-kit/src/createSliceMachineHelpers.ts
@@ -1,7 +1,7 @@
 import * as path from "node:path";
 import * as fs from "node:fs/promises";
 
-import prettier from "prettier";
+import type prettier from "prettier";
 import { stripIndent } from "common-tags";
 
 import { decodeSliceMachineConfig } from "./lib/decodeSliceMachineConfig";
@@ -105,6 +105,8 @@ export class SliceMachineHelpers {
 		filePath?: string,
 		options?: FormatOptions,
 	): Promise<string> => {
+		const prettier = await import("prettier");
+
 		let formatted = stripIndent(source);
 
 		const prettierOptions = await prettier.resolveConfig(


### PR DESCRIPTION
## Context

This PR fixes an issue when `@slicemachine/manager` is used in an SST application.

## The Solution

Move `prettier` into a dynamic import. Prettier declares `__dirname` in its code, which conflicts with SST's `__dirname` definition.

## Impact / Dependencies

N/A

## Checklist before requesting a review

- [ ] I hereby declare my code ready for review.
- [ ] If it is a critical feature, I have added tests.
- [ ] The CI is successful.
- [ ] If there could backward compatibility issues, it has been discussed and planned.
