### PR TITLE
Fix telemetry check which prevents init from running

### DIFF
--- a/packages/init/src/SliceMachineInitProcess.ts
+++ b/packages/init/src/SliceMachineInitProcess.ts
@@ -133,10 +133,7 @@ export class SliceMachineInitProcess {
 					)}\n`,
 				);
 			}
-			await this.manager.telemetry.initTelemetry({
-				appName: pkg.name,
-				appVersion: pkg.version,
-			});
+
 			try {
 				await setupSentry();
 			} catch (error) {
@@ -144,6 +141,12 @@ export class SliceMachineInitProcess {
 				// because of failed tracking set up. We probably couldn't determine the
 				// Sentry environment.
 			}
+
+			await this.manager.telemetry.initTelemetry({
+				appName: pkg.name,
+				appVersion: pkg.version,
+			});
+
 			await this.manager.telemetry.track({
 				event: "command:init:start",
 				repository: this.options.repository,

--- a/packages/init/src/SliceMachineInitProcess.ts
+++ b/packages/init/src/SliceMachineInitProcess.ts
@@ -112,6 +112,13 @@ export class SliceMachineInitProcess {
 		);
 
 		try {
+			try {
+				await setupSentry();
+			} catch (error) {
+				// noop - We don't want to stop the user from using Slice Machine
+				// because of failed tracking set up. We probably couldn't determine the
+				// Sentry environment.
+			}
 			if (this.options.starter) {
 				await this.copyStarter();
 			} else if (this.options.directoryName) {
@@ -132,14 +139,6 @@ export class SliceMachineInitProcess {
 						"https://prismic.dev/slice-machine/telemetry",
 					)}\n`,
 				);
-			}
-
-			try {
-				await setupSentry();
-			} catch (error) {
-				// noop - We don't want to stop the user from using Slice Machine
-				// because of failed tracking set up. We probably couldn't determine the
-				// Sentry environment.
 			}
 
 			await this.manager.telemetry.initTelemetry({

--- a/packages/manager/src/managers/telemetry/TelemetryManager.ts
+++ b/packages/manager/src/managers/telemetry/TelemetryManager.ts
@@ -90,7 +90,7 @@ export class TelemetryManager extends BaseManager {
 		};
 
 		if (isTelemetryEnabled) {
-			await this.initExperiment();
+			this.initExperiment();
 		}
 
 		this._anonymousID = randomUUID();
@@ -272,15 +272,17 @@ export class TelemetryManager extends BaseManager {
 	async checkIsTelemetryEnabled(): Promise<boolean> {
 		let root: string;
 		try {
-			root = await this.project.getRoot();
-		} catch {
-			root = await this.project.suggestRoot();
-		}
+			root = await this.project
+				.getRoot()
+				.catch(() => this.project.suggestRoot());
 
-		return readPrismicrc(root).telemetry !== false;
+			return readPrismicrc(root).telemetry !== false;
+		} catch {
+			return false;
+		}
 	}
 
-	private async initExperiment(): Promise<void> {
+	private initExperiment(): void {
 		try {
 			this._experiment = Experiment.initializeRemote(API_TOKENS.AmplitudeKey);
 		} catch (error) {

--- a/packages/manager/src/managers/telemetry/TelemetryManager.ts
+++ b/packages/manager/src/managers/telemetry/TelemetryManager.ts
@@ -278,7 +278,7 @@ export class TelemetryManager extends BaseManager {
 
 			return readPrismicrc(root).telemetry !== false;
 		} catch {
-			return false;
+			return true;
 		}
 	}
 


### PR DESCRIPTION
We realised `checkIsTelemetryEnabled` sometimes broke, which triggered a catch that would try to track the error on Sentry, making the init crash because the check for telemetry happens before its instantiation. I could not reproduce so I safeguarded every line