### PR TITLE
feat(slice-machine-ui): enable multiple paragraphs in rich text fields by default

### DIFF
--- a/packages/slice-machine/lib/models/common/widgets/StructuredText/index.ts
+++ b/packages/slice-machine/lib/models/common/widgets/StructuredText/index.ts
@@ -51,7 +51,7 @@ export const StructuredTextWidget: Widget<RichText, typeof schema> = {
       label,
       placeholder: "",
       allowTargetBlank: true,
-      single: optionValues.join(","),
+      multi: optionValues.join(","),
     },
   }),
   // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment

--- a/playwright/pages/components/EditFieldDialog.ts
+++ b/playwright/pages/components/EditFieldDialog.ts
@@ -37,6 +37,10 @@ export class EditFieldDialog extends Dialog {
     return this.title.getByText(name, { exact: true });
   }
 
+  getFieldByLabel(label: string) {
+    return this.dialog.getByLabel(label, { exact: true });
+  }
+
   /**
    * Actions
    */

--- a/playwright/tests/fields/richText.spec.ts
+++ b/playwright/tests/fields/richText.spec.ts
@@ -1,0 +1,22 @@
+import { expect } from "@playwright/test";
+
+import { test } from "../../fixtures";
+
+test.run()(
+  "I can create a rich text field that allows multiple paragraphs by default",
+  async ({ customTypesBuilderPage, singleCustomType }) => {
+    await customTypesBuilderPage.goto(singleCustomType.name);
+    await customTypesBuilderPage.addStaticField({
+      type: "Rich Text",
+      name: "My Rich Text",
+      expectedId: "my_rich_text",
+    });
+    await customTypesBuilderPage.getEditFieldButton("my_rich_text").click();
+
+    await expect(
+      customTypesBuilderPage.editFieldDialog.getFieldByLabel(
+        "Allow multiple paragraphs",
+      ),
+    ).toHaveValue("on");
+  },
+);


### PR DESCRIPTION
## Context

DT-1841

## The Solution

Change the default field to use the `multi` property in place of the `single` property.

## Impact / Dependencies

All rich text fields will have "Allow multiple paragraphs" checked by default.

## Checklist before requesting a review
- [x] I hereby declare my code ready for review.
- [x] If it is a critical feature, I have added tests.
- [x] The CI is successful.
- [ ] If there could backward compatibility issues, it has been discussed and planned.
