### PR TITLE
fix(custom types): Keep slice zone always at the end of the section when adding a field

### DIFF
--- a/packages/slice-machine/src/domain/__tests__/customType.test.ts
+++ b/packages/slice-machine/src/domain/__tests__/customType.test.ts
@@ -393,32 +393,39 @@ describe("CustomTypeModel test suite", () => {
 
   it("addField should return the given custom type with the field added to the section", () => {
     expect(
-      CustomTypeModel.addField({
-        customType: mockCustomType,
-        sectionId: "mainSection",
-        newFieldId: "newField",
-        newField: {
-          config: {
-            label: "NewField",
-          },
-          type: "UID",
-        },
-      }),
-    ).toEqual({
-      ...mockCustomType,
-      json: {
-        ...mockCustomType.json,
-        mainSection: {
-          ...mainSection,
+      JSON.stringify(
+        CustomTypeModel.addField({
+          customType: mockCustomType,
+          sectionId: "mainSection",
+          newFieldId: "newField",
           newField: {
             config: {
               label: "NewField",
             },
             type: "UID",
           },
+        }),
+      ),
+    ).toEqual(
+      JSON.stringify({
+        ...mockCustomType,
+        json: {
+          ...mockCustomType.json,
+          mainSection: {
+            uid: mainSection.uid,
+            booleanField: mainSection.booleanField,
+            groupField: mainSection.groupField,
+            newField: {
+              config: {
+                label: "NewField",
+              },
+              type: "UID",
+            },
+            slices: mainSection.slices,
+          },
         },
-      },
-    });
+      }),
+    );
   });
 
   it("deleteField should return the given custom type without the field", () => {

--- a/packages/slice-machine/src/domain/customType.ts
+++ b/packages/slice-machine/src/domain/customType.ts
@@ -370,15 +370,32 @@ export function renameSection(
 
 export function addField(args: AddFieldArgs): CustomType {
   const { customType, sectionId, newField, newFieldId } = args;
+  const sectionJson = customType.json[sectionId];
+  const maybeSliceZoneEntry = getSectionSliceZoneEntry(customType, sectionId);
+
+  // Separate the fields into slices and non-slices
+  const sectionFields = Object.fromEntries(
+    Object.entries(sectionJson).filter(
+      ([_, value]) => value.type !== SlicesFieldType,
+    ),
+  );
+
+  const updatedSection = {
+    ...sectionFields,
+    // Add the new field to the section
+    [newFieldId]: newField,
+  };
+
+  // Merge the SlicesFieldType field back into the section, if it exists
+  if (maybeSliceZoneEntry !== undefined) {
+    const [sliceZoneKey, sliceZoneField] = maybeSliceZoneEntry;
+    updatedSection[sliceZoneKey] = sliceZoneField;
+  }
 
   const newCustomType = updateSection({
     customType,
     sectionId,
-    updatedSection: {
-      ...customType.json[sectionId],
-      // Add the new field to the section
-      [newFieldId]: newField,
-    },
+    updatedSection,
   });
 
   return newCustomType;


### PR DESCRIPTION
## Context

- Completes DT-1943

## The Solution

- Ensure the slice zone is always the last when adding a field
- Ensure test check the position with JSON.stringify

## Impact / Dependencies

- Old Page Builder will have the slice zone at the correct position