### PR TITLE
fix(sentry): Fix sentryFrontendTunnel error

### DIFF
--- a/packages/start-slicemachine/src/lib/sentryFrontendTunnel.ts
+++ b/packages/start-slicemachine/src/lib/sentryFrontendTunnel.ts
@@ -13,8 +13,10 @@ export const sentryFrontendTunnel: RequestHandler = async (req, res) => {
 			const pieces = envelope.split("\n");
 			const header = JSON.parse(pieces[0]);
 			const { host, pathname } = new URL(header.dsn);
-			const projectId =
-				(pathname?.endsWith("/") ? pathname.slice(0, -1) : pathname) ?? "";
+
+			// Remove start or end slashes from the pathname
+			const projectId = pathname?.replace(/^\/|\/$/g, "") ?? "";
+
 			const sentryUrl = `https://${host}/api/${projectId}/envelope/`;
 
 			const response = await fetch(sentryUrl, {


### PR DESCRIPTION
## Context

- Completes DT-1953

## The Solution

- Remove slashes in start or end of the pathname string as it can also be at the start of the pathname

Example of a current wrong request because of this bug: `https://0487h63.ingest.sentry.io/api//8749893864/envelope/`

## Impact / Dependencies

- Prevent a LOT of sentry errors
