### PR TITLE
Revert "Set dev env as active env in start-slicemachine (#1282)"

### DIFF
--- a/packages/start-slicemachine/src/StartSliceMachineProcess.ts
+++ b/packages/start-slicemachine/src/StartSliceMachineProcess.ts
@@ -124,13 +124,6 @@ export class StartSliceMachineProcess {
 				userID: profile.shortId,
 				intercomHash: profile.intercomHash,
 			});
-			try {
-				await this._setDevEnvAsActiveEnvironment();
-			} catch (error) {
-				if (import.meta.env.DEV) {
-					console.error("Could not set dev env as active environment", error);
-				}
-			}
 		}
 
 		if (profile) {
@@ -140,18 +133,6 @@ export class StartSliceMachineProcess {
 				// noop - We'll try again before uploading a screenshot.
 				this._sliceMachineManager.screenshots.initS3ACL(),
 			]);
-		}
-	}
-
-	private async _setDevEnvAsActiveEnvironment(): Promise<void> {
-		const { environments } =
-			await this._sliceMachineManager.prismicRepository.fetchEnvironments();
-
-		const maybeDevEnvironment = environments?.find((env) => env.kind === "dev");
-		if (maybeDevEnvironment !== undefined) {
-			await this._sliceMachineManager.project.updateEnvironment({
-				environment: maybeDevEnvironment.domain,
-			});
 		}
 	}
 


### PR DESCRIPTION
This reverts commit 3a9b25386a1b17c058f6874cad2b98beaba5f19c.

## Context

After some discussions with a user, we saw that this management brings more confusion than something else. We wanted to push the sandbox to be used more but it looks like a bug when you are using Slice Machine.