### PR TITLE
feat(tracking): Add tracking on slice machine start

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,6 +184,7 @@ jobs:
           yarn workspaces foreach --include '{@slicemachine/adapter-next,@slicemachine/manager,@slicemachine/plugin-kit,start-slicemachine}' --parallel --topological-dev run build
           yarn workspace slice-machine-ui pack --out ../../e2e-projects/next/sm.tgz
           yarn workspace cimsirp add -D ./sm.tgz
+          echo "telemetry=false" > ./e2e-projects/next/.prismicrc
 
       - name: Running E2E tests
         run: yarn test:e2e --shard ${{ matrix.shard }}

--- a/packages/manager/src/managers/git/GitManager.ts
+++ b/packages/manager/src/managers/git/GitManager.ts
@@ -1,5 +1,6 @@
 import * as t from "io-ts";
 import * as tt from "io-ts-types";
+import { execaCommandSync } from "execa";
 
 import fetch from "../../lib/fetch";
 import { decode } from "../../lib/decode";
@@ -461,6 +462,23 @@ export class GitManager extends BaseManager {
 					`Git provider not supported: ${args.provider}.`,
 				);
 			}
+		}
+	}
+
+	async detectGitProvider(): Promise<string> {
+		try {
+			const remoteUrl = execaCommandSync("git remote get-url origin");
+			const domainRegex = /(?:https?:\/\/|git@)([^:/]+)[/:]/i;
+			const match = remoteUrl.stdout.match(domainRegex);
+			const domain = match && match.length > 0 ? match[1] : "";
+
+			return domain;
+		} catch (error) {
+			if (import.meta.env.DEV) {
+				console.error("Failed to detect Git provider:", error);
+			}
+
+			return "_unknown";
 		}
 	}
 

--- a/packages/manager/src/managers/git/GitManager.ts
+++ b/packages/manager/src/managers/git/GitManager.ts
@@ -470,7 +470,7 @@ export class GitManager extends BaseManager {
 			const remoteUrl = execaCommandSync("git remote get-url origin");
 			const domainRegex = /(?:https?:\/\/|git@)([^:/]+)[/:]/i;
 			const match = remoteUrl.stdout.match(domainRegex);
-			const domain = match && match.length > 0 ? match[1] : "";
+			const domain = match?.[1] ?? "";
 
 			return domain;
 		} catch (error) {

--- a/packages/manager/src/managers/project/ProjectManager.ts
+++ b/packages/manager/src/managers/project/ProjectManager.ts
@@ -478,6 +478,34 @@ export class ProjectManager extends BaseManager {
 		return { activeEnvironment };
 	}
 
+	async detectVersionControlSystem(): Promise<string | "_unknown"> {
+		try {
+			const projectRoot = await this.getRoot();
+
+			if (existsSync(path.join(projectRoot, ".git"))) {
+				return "Git";
+			}
+
+			if (existsSync(path.join(projectRoot, ".svn"))) {
+				return "SVN";
+			}
+
+			if (existsSync(path.join(projectRoot, ".hg"))) {
+				return "Mercurial";
+			}
+
+			if (existsSync(path.join(projectRoot, "CVS"))) {
+				return "CVS";
+			}
+		} catch (error) {
+			if (import.meta.env.DEV) {
+				console.error("Failed to detect Version Control System:", error);
+			}
+		}
+
+		return "_unknown";
+	}
+
 	private async _assertAdapterSupportsEnvironments(): Promise<void> {
 		assertPluginsInitialized(this.sliceMachinePluginRunner);
 

--- a/packages/manager/src/managers/telemetry/TelemetryManager.ts
+++ b/packages/manager/src/managers/telemetry/TelemetryManager.ts
@@ -100,7 +100,7 @@ export class TelemetryManager extends BaseManager {
 	// TODO: Should `userId` be automatically populated by the logged in
 	// user? We already have their info via UserRepository.
 	async track(args: TelemetryManagerTrackArgs): Promise<void> {
-		const { event, repository, ...properties } = args;
+		const { event, repository, _includeEnvironmentKind, ...properties } = args;
 		let repositoryName = repository;
 
 		if (repositoryName === undefined) {
@@ -113,7 +113,7 @@ export class TelemetryManager extends BaseManager {
 
 		let environmentKind: Environment["kind"] | "_unknown" | undefined =
 			undefined;
-		if (args._includeEnvironmentKind) {
+		if (_includeEnvironmentKind) {
 			if (this.project.checkSupportsEnvironments()) {
 				try {
 					const { activeEnvironment } =

--- a/packages/manager/src/managers/telemetry/types.ts
+++ b/packages/manager/src/managers/telemetry/types.ts
@@ -298,6 +298,7 @@ type SliceMachineStart = SegmentEvent<
 		packageManager?: string;
 		projectPort?: string;
 		sliceMachineVersion?: string;
+		versionControlSystem?: string;
 	}
 >;
 

--- a/packages/manager/src/managers/telemetry/types.ts
+++ b/packages/manager/src/managers/telemetry/types.ts
@@ -31,6 +31,7 @@ export const SegmentEventType = {
 	devCollab_joinBetaClicked: "dev-collab:join-beta-clicked",
 	devCollab_setUpWorkflowOpened: "dev-collab:set-up-workflow-opened",
 	devCollab_workflowStubDisplayed: "dev-collab:workflow-stub-displayed",
+	sliceMachine_start: "slice-machine:start",
 } as const;
 type SegmentEventTypes =
 	(typeof SegmentEventType)[keyof typeof SegmentEventType];
@@ -74,6 +75,7 @@ export const HumanSegmentEventType = {
 		"SliceMachine Dev Collab Set Up Workflow Opened",
 	[SegmentEventType.devCollab_workflowStubDisplayed]:
 		"SliceMachine Dev Collab Workflow Stub Displayed",
+	[SegmentEventType.sliceMachine_start]: "SliceMachine Start",
 } as const;
 export type HumanSegmentEventTypes =
 	(typeof HumanSegmentEventType)[keyof typeof HumanSegmentEventType];
@@ -279,6 +281,26 @@ type DevCollabWorkflowStubDisplayed = SegmentEvent<
 	typeof SegmentEventType.devCollab_workflowStubDisplayed
 >;
 
+type SliceMachineStart = SegmentEvent<
+	typeof SegmentEventType.sliceMachine_start,
+	{
+		adapter?: string;
+		adapterVersion?: string;
+		gitProvider?: string;
+		isAdapterUpdateAvailable?: boolean;
+		isLoggedIn?: boolean;
+		isSliceMachineUpdateAvailable?: boolean;
+		isTypeScriptProject?: boolean;
+		nodeVersion?: string;
+		numberOfCustomTypes?: number;
+		numberOfSlices?: number;
+		osPlatform?: string;
+		packageManager?: string;
+		projectPort?: string;
+		sliceMachineVersion?: string;
+	}
+>;
+
 export type SegmentEvents =
 	| CommandInitStartSegmentEvent
 	| CommandInitIdentifySegmentEvent
@@ -306,4 +328,5 @@ export type SegmentEvents =
 	| SwitchEnvironmentSegmentEvent
 	| DevCollabJoinBetaClicked
 	| DevCollabSetUpWorkflowOpened
-	| DevCollabWorkflowStubDisplayed;
+	| DevCollabWorkflowStubDisplayed
+	| SliceMachineStart;

--- a/packages/start-slicemachine/src/StartSliceMachineProcess.ts
+++ b/packages/start-slicemachine/src/StartSliceMachineProcess.ts
@@ -250,6 +250,7 @@ export class StartSliceMachineProcess {
 			simulatorUrl,
 			sliceMachineVersion,
 			slices,
+			versionControlSystem,
 		] = await Promise.all([
 			safelyExecute(() => this._sliceMachineManager.project.getAdapterName()),
 			safelyExecute(() =>
@@ -279,6 +280,9 @@ export class StartSliceMachineProcess {
 				this._sliceMachineManager.versions.getRunningSliceMachineVersion(),
 			),
 			safelyExecute(() => this._sliceMachineManager.slices.readAllSlices()),
+			safelyExecute(() =>
+				this._sliceMachineManager.project.detectVersionControlSystem(),
+			),
 		]);
 
 		this._sliceMachineManager.telemetry.track({
@@ -300,6 +304,7 @@ export class StartSliceMachineProcess {
 			packageManager: packageManager?.replace("@", "[at]"),
 			projectPort: simulatorUrl ? new URL(simulatorUrl).port : undefined,
 			sliceMachineVersion,
+			versionControlSystem,
 		});
 	}
 }

--- a/packages/start-slicemachine/src/lib/safelyExecute.ts
+++ b/packages/start-slicemachine/src/lib/safelyExecute.ts
@@ -1,8 +1,8 @@
 export async function safelyExecute<T>(
-	operation: Promise<T>,
+	operation: () => Promise<T>,
 ): Promise<T | undefined> {
 	try {
-		return await operation;
+		return await operation();
 	} catch {
 		return undefined;
 	}

--- a/packages/start-slicemachine/src/lib/safelyExecute.ts
+++ b/packages/start-slicemachine/src/lib/safelyExecute.ts
@@ -1,0 +1,9 @@
+export async function safelyExecute<T>(
+	operation: Promise<T>,
+): Promise<T | undefined> {
+	try {
+		return await operation;
+	} catch {
+		return undefined;
+	}
+}


### PR DESCRIPTION
## Context

- Completes DT-1983

## To Do

- Test for new manager function to detect git provider

## The Solution

- Added a new manager function to detect git provider 
- Added a new event type for slice machine start
- Added all the properties that can be useful for us in order to see how our users use our product
- Fixed a bug that was adding `_includeEnvironmentKind` to the event payload

## Impact / Dependencies

- None, the start process is not longueur as it's done after