### PR TITLE
test(playwright): rename `data-cy` to `data-testid`

### DIFF
--- a/cypress/e2e/slices/00-create.cy.js
+++ b/cypress/e2e/slices/00-create.cy.js
@@ -30,9 +30,9 @@ describe.skip("Create Slices", () => {
     cy.get("#variation-add").submit();
 
     // remove widget
-    cy.get('[data-cy="slice-menu-button"]').first().click();
+    cy.get('[data-testid="slice-menu-button"]').first().click();
     cy.contains("Delete field").click();
-    cy.get('[data-cy="builder-save-button"]').should("not.be.disabled");
+    cy.get('[data-testid="builder-save-button"]').should("not.be.disabled");
 
     cy.contains("button", "Simulate").should("have.attr", "disabled");
     cy.contains("button", "Simulate").realHover();
@@ -65,7 +65,7 @@ describe.skip("Create Slices", () => {
     cy.getInputByLabel("Description").first().clear();
     cy.getInputByLabel("Description").first().type("👋");
 
-    cy.get("[data-cy=save-mock]").click();
+    cy.get("[data-testid=save-mock]").click();
 
     cy.wait(1000);
 
@@ -77,7 +77,7 @@ describe.skip("Create Slices", () => {
     cy.getInputByLabel("Description").first().clear();
     cy.getInputByLabel("Description").first().type("🎉");
 
-    cy.get("[data-cy=save-mock]").click();
+    cy.get("[data-testid=save-mock]").click();
 
     cy.wait(1000);
 
@@ -110,7 +110,7 @@ describe.skip("Create Slices", () => {
     sliceBuilder.addNewWidgetField("Title", "Key Text");
     sliceBuilder.addNewWidgetField("Description", "Rich Text");
 
-    cy.get('ul[data-cy="slice-non-repeatable-zone"] > li')
+    cy.get('ul[data-testid="slice-non-repeatable-zone"] > li')
       .eq(1)
       .contains("Description");
 
@@ -124,7 +124,7 @@ describe.skip("Create Slices", () => {
       .wait(1 * 1000)
       .trigger("keydown", { keyCode: 32, force: true });
 
-    cy.get('ul[data-cy="slice-non-repeatable-zone"] > li')
+    cy.get('ul[data-testid="slice-non-repeatable-zone"] > li')
       .eq(0)
       .contains("Description");
   });

--- a/cypress/helpers/customTypes.js
+++ b/cypress/helpers/customTypes.js
@@ -134,7 +134,7 @@ export function getWidgetFieldMenu(name) {
   return cy
     .contains("div", name)
     .parent()
-    .find("[data-cy='slice-menu-button']");
+    .find("[data-testid='slice-menu-button']");
 }
 
 /**

--- a/cypress/helpers/slices.js
+++ b/cypress/helpers/slices.js
@@ -37,7 +37,7 @@ export function createSlice(lib, id, name) {
  */
 export function renameSlice(actualName, newName) {
   slicesList.goTo();
-  cy.waitUntil(() => cy.get("[data-cy=slice-action-icon]"));
+  cy.waitUntil(() => cy.get("[data-testid=slice-action-icon]"));
 
   slicesList.getOptionDopDownButton(actualName).click();
 

--- a/cypress/pages/AddFieldModal.js
+++ b/cypress/pages/AddFieldModal.js
@@ -1,6 +1,6 @@
 class AddFieldModal {
   fieldTypeButton(fieldType) {
-    return cy.get(`[data-cy='${fieldType}']`);
+    return cy.get(`[data-testid='${fieldType}']`);
   }
 
   pickField(fieldType) {

--- a/cypress/pages/BaseBuilder.js
+++ b/cypress/pages/BaseBuilder.js
@@ -4,22 +4,22 @@ export class BaseBuilder {
   }
 
   get addStaticFieldButton() {
-    return cy.get(`[data-cy="add-Static-field"]`);
+    return cy.get(`[data-testid="add-Static-field"]`);
   }
 
   get NewField() {
     return {
-      inputName: () => cy.get("[data-cy=new-field-name-input]"),
-      inputId: () => cy.get("[data-cy=new-field-id-input]"),
-      submit: () => cy.get("[data-cy=new-field-form]").submit(),
+      inputName: () => cy.get("[data-testid=new-field-name-input]"),
+      inputId: () => cy.get("[data-testid=new-field-id-input]"),
+      submit: () => cy.get("[data-testid=new-field-form]").submit(),
     };
   }
 
   save() {
     this.saveButton.should("not.be.disabled");
     this.saveButton.click();
-    cy.get("[data-cy=builder-save-button-spinner]").should("be.visible");
-    cy.get("[data-cy=builder-save-button-icon]").should("be.visible");
+    cy.get("[data-testid=builder-save-button-spinner]").should("be.visible");
+    cy.get("[data-testid=builder-save-button-icon]").should("be.visible");
     this.saveButton.should("be.disabled");
     return this;
   }

--- a/cypress/pages/RenameModal.js
+++ b/cypress/pages/RenameModal.js
@@ -25,8 +25,8 @@ class RenameModal {
 class CustomTypeRenameModal extends RenameModal {
   constructor() {
     super(
-      "[data-cy=rename-custom-type-modal]",
-      '[data-cy="custom-type-name-input"]',
+      "[data-testid=rename-custom-type-modal]",
+      '[data-testid="custom-type-name-input"]',
     );
   }
 }
@@ -35,7 +35,10 @@ export const customTypeRenameModal = new CustomTypeRenameModal();
 
 class SliceRenameModal extends RenameModal {
   constructor() {
-    super("[data-cy=rename-slice-modal]", '[data-cy="slice-name-input"]');
+    super(
+      "[data-testid=rename-slice-modal]",
+      '[data-testid="slice-name-input"]',
+    );
   }
 }
 

--- a/cypress/pages/UpdateSliceZoneModal.js
+++ b/cypress/pages/UpdateSliceZoneModal.js
@@ -1,10 +1,10 @@
 class UpdateSliceZoneModal {
   get root() {
-    return cy.get("[data-cy=update-slices-modal]");
+    return cy.get("[data-testid=update-slices-modal]");
   }
 
   selectSlice(sliceId) {
-    cy.get(`[data-cy=shared-slice-card-${sliceId}]`).click();
+    cy.get(`[data-testid=shared-slice-card-${sliceId}]`).click();
     return this;
   }
 

--- a/cypress/pages/changes/changesPage.js
+++ b/cypress/pages/changes/changesPage.js
@@ -2,7 +2,7 @@ import { menu } from "../menu";
 
 class ChangesPage {
   get pushButton() {
-    return cy.get("[data-cy=push-changes]");
+    return cy.get("[data-testid=push-changes]");
   }
 
   get screenshotsButton() {

--- a/cypress/pages/changes/drawers/hardDeleteDocumentsDrawer.js
+++ b/cypress/pages/changes/drawers/hardDeleteDocumentsDrawer.js
@@ -6,7 +6,7 @@ class HardDeleteDocumentsDrawer extends BaseDrawer {
   }
 
   getAssociatedDocuments(ctName) {
-    return this.root.get(`[data-cy='AssociatedDocumentsCard-${ctName}']`);
+    return this.root.get(`[data-testid='AssociatedDocumentsCard-${ctName}']`);
   }
 }
 

--- a/cypress/pages/changes/drawers/referencesErrorDrawer.js
+++ b/cypress/pages/changes/drawers/referencesErrorDrawer.js
@@ -6,7 +6,7 @@ class ReferencesErrorDrawer extends BaseDrawer {
   }
 
   getCustomTypeReferencesCard(ctName) {
-    return this.root.get(`[data-cy='CustomTypesReferencesCard-${ctName}']`);
+    return this.root.get(`[data-testid='CustomTypesReferencesCard-${ctName}']`);
   }
 }
 

--- a/cypress/pages/changes/drawers/softDeleteDocumentsDrawer.js
+++ b/cypress/pages/changes/drawers/softDeleteDocumentsDrawer.js
@@ -6,7 +6,7 @@ class SoftDeleteDocumentsDrawer extends BaseDrawer {
   }
 
   getAssociatedDocuments(ctName) {
-    return this.root.get(`[data-cy='AssociatedDocumentsCard-${ctName}']`);
+    return this.root.get(`[data-testid='AssociatedDocumentsCard-${ctName}']`);
   }
 
   get pushButton() {

--- a/cypress/pages/customTypes/createCustomTypeModal.js
+++ b/cypress/pages/customTypes/createCustomTypeModal.js
@@ -1,14 +1,14 @@
 class CreateCustomTypeModal {
   get root() {
-    return cy.get("[data-cy=create-ct-modal]");
+    return cy.get("[data-testid=create-ct-modal]");
   }
 
   get nameInput() {
-    return cy.get("input[data-cy=ct-name-input]");
+    return cy.get("input[data-testid=ct-name-input]");
   }
 
   get idInput() {
-    return cy.get("input[data-cy=ct-id-input]");
+    return cy.get("input[data-testid=ct-id-input]");
   }
 
   submit() {

--- a/cypress/pages/customTypes/customTypeBuilder.js
+++ b/cypress/pages/customTypes/customTypeBuilder.js
@@ -2,7 +2,7 @@ import { BaseBuilder } from "../BaseBuilder";
 
 class CustomTypeBuilder extends BaseBuilder {
   get renameButton() {
-    return cy.get('[data-cy="edit-custom-type"]');
+    return cy.get('[data-testid="edit-custom-type"]');
   }
 
   get updateSliceZoneButton() {
@@ -10,11 +10,11 @@ class CustomTypeBuilder extends BaseBuilder {
   }
 
   get headerCustomTypeName() {
-    return cy.get('[data-cy="custom-type-secondary-breadcrumb"]');
+    return cy.get('[data-testid="custom-type-secondary-breadcrumb"]');
   }
 
   get staticZone() {
-    return cy.get("[data-cy=ct-static-zone]");
+    return cy.get("[data-testid=ct-static-zone]");
   }
 
   get successToast() {
@@ -31,8 +31,8 @@ class CustomTypeBuilder extends BaseBuilder {
   async addSliceToSliceZone(sliceId) {
     await cy.findAllByText(/Add slices/)[0].click();
     this.updateSliceZoneButton.click();
-    cy.get(`[data-cy=shared-slice-card-${sliceId}]`).click();
-    cy.get("[data-cy=update-slices-modal]").submit();
+    cy.get(`[data-testid=shared-slice-card-${sliceId}]`).click();
+    cy.get("[data-testid=update-slices-modal]").submit();
     return this;
   }
 

--- a/cypress/pages/customTypes/customTypesList.js
+++ b/cypress/pages/customTypes/customTypesList.js
@@ -1,14 +1,16 @@
 class CustomTypesList {
   get emptyStateButton() {
-    return cy.get("[data-cy=empty-state-main-button]");
+    return cy.get("[data-testid=empty-state-main-button]");
   }
 
   getOptionDopDownButton(id) {
-    return this.getCustomTypeRow(id).get('[data-cy="edit-custom-type-menu"]');
+    return this.getCustomTypeRow(id).get(
+      '[data-testid="edit-custom-type-menu"]',
+    );
   }
 
   get optionDopDownMenu() {
-    return cy.get('[data-cy="edit-custom-type-menu-dropdown"]');
+    return cy.get('[data-testid="edit-custom-type-menu-dropdown"]');
   }
 
   get deleteButton() {
@@ -24,7 +26,7 @@ class CustomTypesList {
   }
 
   getCustomTypeLabel(id) {
-    return cy.get(`[data-cy="custom-type-${id}-label"]`);
+    return cy.get(`[data-testid="custom-type-${id}-label"]`);
   }
 
   goTo() {

--- a/cypress/pages/menu.js
+++ b/cypress/pages/menu.js
@@ -1,6 +1,6 @@
 class Menu {
   changesNumber(options = {}) {
-    return cy.get("[data-cy=changes-number]", options);
+    return cy.get("[data-testid=changes-number]", options);
   }
 
   /**

--- a/cypress/pages/slices/createSliceModal.js
+++ b/cypress/pages/slices/createSliceModal.js
@@ -1,10 +1,10 @@
 class CreateSliceModal {
   get root() {
-    return cy.get("[data-cy=create-slice-modal]");
+    return cy.get("[data-testid=create-slice-modal]");
   }
 
   get nameInput() {
-    return cy.get("input[data-cy=slice-name-input]");
+    return cy.get("input[data-testid=slice-name-input]");
   }
 
   get submitButton() {

--- a/cypress/pages/slices/sliceBuilder.js
+++ b/cypress/pages/slices/sliceBuilder.js
@@ -2,27 +2,27 @@ import { BaseBuilder } from "../BaseBuilder";
 
 class SliceBuilder extends BaseBuilder {
   get renameButton() {
-    return cy.get('[data-cy="edit-slice-name"]');
+    return cy.get('[data-testid="edit-slice-name"]');
   }
 
   get headerSliceNameAndVariation() {
-    return cy.get('[data-cy="slice-and-variation-name-header"]');
+    return cy.get('[data-testid="slice-and-variation-name-header"]');
   }
 
   get staticZone() {
-    return cy.get("[data-cy=slice-non-repeatable-zone]");
+    return cy.get("[data-testid=slice-non-repeatable-zone]");
   }
 
   get addStaticFieldButton() {
-    return cy.get("[data-cy=add-Static-field]");
+    return cy.get("[data-testid=add-Static-field]");
   }
 
   get repeatableZone() {
-    return cy.get("[data-cy=slice-repeatable-zone]");
+    return cy.get("[data-testid=slice-repeatable-zone]");
   }
 
   get addRepeatableFieldButton() {
-    return cy.get("[data-cy=add-Repeatable-field]");
+    return cy.get("[data-testid=add-Repeatable-field]");
   }
 
   get addVariationButton() {
@@ -96,12 +96,12 @@ class SliceBuilder extends BaseBuilder {
    * @param {string} type Type of the widget.
    */
   addNewWidgetField(name, type) {
-    cy.get("[data-cy='add-Static-field']").click();
+    cy.get("[data-testid='add-Static-field']").click();
     cy.get("[aria-label='Widget Form Modal']").should("be.visible");
 
     cy.contains("div", type).click();
 
-    const nameInput = '[data-cy="new-field-name-input"]';
+    const nameInput = '[data-testid="new-field-name-input"]';
 
     cy.get(nameInput).clear();
     cy.get(nameInput).type(name).blur();
@@ -142,7 +142,7 @@ class SliceBuilder extends BaseBuilder {
   deleteWidgetField(name) {
     cy.contains("div", name)
       .parent()
-      .find("[data-cy='slice-menu-button']")
+      .find("[data-testid='slice-menu-button']")
       .click();
 
     cy.contains("div", "Delete field").click({ force: true });

--- a/cypress/pages/slices/slicesList.js
+++ b/cypress/pages/slices/slicesList.js
@@ -2,11 +2,11 @@ import { deleteModal } from "../DeleteModal";
 
 class SlicesList {
   get emptyStateButton() {
-    return cy.get("[data-cy=empty-state-main-button]");
+    return cy.get("[data-testid=empty-state-main-button]");
   }
 
   getOptionDopDownButton(sliceName) {
-    return this.getSliceCard(sliceName).get(`[data-cy=slice-action-icon]`);
+    return this.getSliceCard(sliceName).get(`[data-testid=slice-action-icon]`);
   }
 
   getSliceCard(sliceName) {
@@ -14,7 +14,7 @@ class SlicesList {
   }
 
   get optionDopDownMenu() {
-    return cy.get('[data-cy="slice-action-icon-dropdown"]');
+    return cy.get('[data-testid="slice-action-icon-dropdown"]');
   }
 
   get deleteButton() {

--- a/packages/slice-machine/components/AppLayout/index.tsx
+++ b/packages/slice-machine/components/AppLayout/index.tsx
@@ -51,7 +51,7 @@ const PageLayoutWithActiveEnvironment: FC<PropsWithChildren> = ({
   return (
     <PageLayout
       borderTopColor={borderTopColor}
-      data-cy={`app-layout-top-border-color-${borderTopColor}`}
+      data-testid={`app-layout-top-border-color-${borderTopColor}`}
       {...otherProps}
     >
       {children}

--- a/packages/slice-machine/components/Button/index.tsx
+++ b/packages/slice-machine/components/Button/index.tsx
@@ -13,9 +13,9 @@ export interface SmButtonProps extends ButtonProps {
 }
 
 // Small helper to allow us to target spinner and icon in the CY
-const testIdBuilder = (dataCy: string | undefined, id: string) => {
+const testIdBuilder = (testId: string | undefined, id: string) => {
   // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
-  if (dataCy) return `${dataCy}-${id}`;
+  if (testId) return `${testId}-${id}`;
   return "";
 };
 

--- a/packages/slice-machine/components/Button/index.tsx
+++ b/packages/slice-machine/components/Button/index.tsx
@@ -7,7 +7,7 @@ export interface SmButtonProps extends ButtonProps {
   label: string;
   Icon?: IconType;
   isLoading?: boolean;
-  "data-cy"?: string;
+  "data-testid"?: string;
   iconSize?: number;
   iconFill?: string;
 }
@@ -72,7 +72,7 @@ export const Button = forwardRef<HTMLButtonElement, SmButtonProps>(
           <Spinner
             size={iconSize}
             color={spinnerColor(variant)}
-            data-cy={cyIdBuilder(rest["data-cy"], "spinner")}
+            data-testid={cyIdBuilder(rest["data-testid"], "spinner")}
           />
           {Icon && label}
         </>
@@ -82,7 +82,7 @@ export const Button = forwardRef<HTMLButtonElement, SmButtonProps>(
             <Icon
               size={iconSize}
               fill={iconFill}
-              data-cy={cyIdBuilder(rest["data-cy"], "icon")}
+              data-testid={cyIdBuilder(rest["data-testid"], "icon")}
             />
           )}
           {label}

--- a/packages/slice-machine/components/Button/index.tsx
+++ b/packages/slice-machine/components/Button/index.tsx
@@ -13,7 +13,7 @@ export interface SmButtonProps extends ButtonProps {
 }
 
 // Small helper to allow us to target spinner and icon in the CY
-const cyIdBuilder = (dataCy: string | undefined, id: string) => {
+const testIdBuilder = (dataCy: string | undefined, id: string) => {
   // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
   if (dataCy) return `${dataCy}-${id}`;
   return "";
@@ -72,7 +72,7 @@ export const Button = forwardRef<HTMLButtonElement, SmButtonProps>(
           <Spinner
             size={iconSize}
             color={spinnerColor(variant)}
-            data-testid={cyIdBuilder(rest["data-testid"], "spinner")}
+            data-testid={testIdBuilder(rest["data-testid"], "spinner")}
           />
           {Icon && label}
         </>
@@ -82,7 +82,7 @@ export const Button = forwardRef<HTMLButtonElement, SmButtonProps>(
             <Icon
               size={iconSize}
               fill={iconFill}
-              data-testid={cyIdBuilder(rest["data-testid"], "icon")}
+              data-testid={testIdBuilder(rest["data-testid"], "icon")}
             />
           )}
           {label}

--- a/packages/slice-machine/components/CustomTypeTable/changesPage.tsx
+++ b/packages/slice-machine/components/CustomTypeTable/changesPage.tsx
@@ -81,7 +81,10 @@ export const CustomTypeTable: React.FC<CustomTypeTableProps> = ({
               key={customType.local.id}
               legacyBehavior
             >
-              <tr tabIndex={0} data-cy={`custom-type-${customType.local.id}`}>
+              <tr
+                tabIndex={0}
+                data-testid={`custom-type-${customType.local.id}`}
+              >
                 <CustomTypeChangeRow
                   ct={customType.local}
                   status={modelsStatuses.customTypes[customType.local.id]}
@@ -95,7 +98,7 @@ export const CustomTypeTable: React.FC<CustomTypeTableProps> = ({
             <tr
               tabIndex={0}
               className="disabled"
-              data-cy={`custom-type-${customType.remote.id}`}
+              data-testid={`custom-type-${customType.remote.id}`}
               key={customType.remote.id}
             >
               <CustomTypeChangeRow

--- a/packages/slice-machine/components/DeleteDocumentsDrawer/AssociatedDocumentsCard.tsx
+++ b/packages/slice-machine/components/DeleteDocumentsDrawer/AssociatedDocumentsCard.tsx
@@ -20,7 +20,7 @@ export const AssociatedDocumentsCard: React.FC<
       mb: 12,
     }}
     variant="drawerCard"
-    data-cy={`AssociatedDocumentsCard-${ctName}`}
+    data-testid={`AssociatedDocumentsCard-${ctName}`}
   >
     <Flex sx={{ flexDirection: "column" }}>
       <Text>{ctName}</Text>
@@ -55,7 +55,7 @@ export const CustomTypesReferencesCard: React.FC<{
       mb: 12,
     }}
     variant="drawerCard"
-    data-cy={`CustomTypesReferencesCard-${name}`}
+    data-testid={`CustomTypesReferencesCard-${name}`}
   >
     <Flex sx={{ flexDirection: "column" }}>
       <Text>{name}</Text>

--- a/packages/slice-machine/components/EmptyState/index.tsx
+++ b/packages/slice-machine/components/EmptyState/index.tsx
@@ -94,7 +94,7 @@ const EmptyState: React.FunctionComponent<Props> = ({
       >
         <Button
           onClick={onCreateNew}
-          data-cy="empty-state-main-button"
+          data-testid="empty-state-main-button"
           sx={{
             display: "flex",
             justifyContent: "center",

--- a/packages/slice-machine/components/Forms/CreateCustomTypeModal/CreateCustomTypeModal.tsx
+++ b/packages/slice-machine/components/Forms/CreateCustomTypeModal/CreateCustomTypeModal.tsx
@@ -130,7 +130,7 @@ export const CreateCustomTypeModal: React.FC<CreateCustomTypeModalProps> = ({
 
   return (
     <ModalFormCard
-      dataCy="create-ct-modal"
+      testId="create-ct-modal"
       isOpen={isOpen}
       widthInPx="530px"
       formId="create-custom-type"
@@ -204,7 +204,7 @@ export const CreateCustomTypeModal: React.FC<CreateCustomTypeModalProps> = ({
               start: true,
               plural: false,
             })} Name`}
-            dataCy="ct-name-input"
+            testId="ct-name-input"
             placeholder={`A display name for the ${customTypesMessages.name({
               start: false,
               plural: false,
@@ -215,7 +215,7 @@ export const CreateCustomTypeModal: React.FC<CreateCustomTypeModalProps> = ({
           />
           <InputBox
             name="id"
-            dataCy="ct-id-input"
+            testId="ct-id-input"
             label={`${customTypesMessages.name({
               start: true,
               plural: false,

--- a/packages/slice-machine/components/Forms/CreateSliceModal/CreateSliceModal.tsx
+++ b/packages/slice-machine/components/Forms/CreateSliceModal/CreateSliceModal.tsx
@@ -55,7 +55,7 @@ export const CreateSliceModal: FC<CreateSliceModalProps> = ({
 
   return (
     <ModalFormCard
-      dataCy="create-slice-modal"
+      testId="create-slice-modal"
       isOpen
       widthInPx="530px"
       isLoading={isCreatingSlice}
@@ -84,7 +84,7 @@ export const CreateSliceModal: FC<CreateSliceModalProps> = ({
             placeholder="Pascalised Slice API ID (e.g. TextBlock)"
             // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
             error={touched.sliceName ? errors.sliceName : undefined}
-            dataCy="slice-name-input"
+            testId="slice-name-input"
           />
           <Label htmlFor="from" sx={{ mb: 2 }}>
             Target Library

--- a/packages/slice-machine/components/Forms/RenameCustomTypeModal/RenameCustomTypeModal.tsx
+++ b/packages/slice-machine/components/Forms/RenameCustomTypeModal/RenameCustomTypeModal.tsx
@@ -67,7 +67,7 @@ export const RenameCustomTypeModal: React.FC<RenameCustomTypeModalProps> = ({
   return (
     <ModalFormCard
       isOpen
-      dataCy="rename-custom-type-modal"
+      testId="rename-custom-type-modal"
       widthInPx="530px"
       formId={`rename-custom-type-modal-${customTypeId}`}
       buttonLabel="Rename"
@@ -119,7 +119,7 @@ export const RenameCustomTypeModal: React.FC<RenameCustomTypeModalProps> = ({
               plural: false,
             })}`}
             error={errors.customTypeName}
-            dataCy="custom-type-name-input"
+            testId="custom-type-name-input"
           />
         </Box>
       )}

--- a/packages/slice-machine/components/Forms/RenameSliceModal/RenameSliceModal.tsx
+++ b/packages/slice-machine/components/Forms/RenameSliceModal/RenameSliceModal.tsx
@@ -51,7 +51,7 @@ export const RenameSliceModal: React.FC<RenameSliceModalProps> = ({
 
   return (
     <ModalFormCard<SliceModalValues>
-      dataCy="rename-slice-modal"
+      testId="rename-slice-modal"
       isOpen={isOpen}
       widthInPx="530px"
       formId={`rename-slice-modal-${slice?.model.id ?? ""}`}
@@ -77,7 +77,7 @@ export const RenameSliceModal: React.FC<RenameSliceModalProps> = ({
             placeholder="Pascalised Slice API ID (e.g. TextBlock)"
             // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
             error={touched.sliceName ? errors.sliceName : undefined}
-            dataCy="slice-name-input"
+            testId="slice-name-input"
           />
         </Box>
       )}

--- a/packages/slice-machine/components/Forms/RenameSliceModal/RenameSliceModal.tsx
+++ b/packages/slice-machine/components/Forms/RenameSliceModal/RenameSliceModal.tsx
@@ -73,7 +73,7 @@ export const RenameSliceModal: React.FC<RenameSliceModalProps> = ({
           <InputBox
             name="sliceName"
             label="Slice Name"
-            data-cy="slice-name-input"
+            data-testid="slice-name-input"
             placeholder="Pascalised Slice API ID (e.g. TextBlock)"
             // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
             error={touched.sliceName ? errors.sliceName : undefined}

--- a/packages/slice-machine/components/Forms/components/InputBox.tsx
+++ b/packages/slice-machine/components/Forms/components/InputBox.tsx
@@ -31,13 +31,13 @@ export const InputBox: React.FunctionComponent<InputBoxProps> = ({
       autoComplete="off"
       {...(onChange ? { onChange } : null)}
       // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
-      {...(dataCy ? { "data-cy": dataCy } : null)}
+      {...(dataCy ? { "data-testid": dataCy } : null)}
     />
     {/* eslint-disable-next-line @typescript-eslint/strict-boolean-expressions */}
     {error ? (
       <Text
         // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
-        data-cy={dataCy ? `${dataCy}-error` : "input-error"}
+        data-testid={dataCy ? `${dataCy}-error` : "input-error"}
         sx={{ color: "error", mt: 1 }}
       >
         {error}

--- a/packages/slice-machine/components/Forms/components/InputBox.tsx
+++ b/packages/slice-machine/components/Forms/components/InputBox.tsx
@@ -7,7 +7,7 @@ type InputBoxProps = {
   label: string;
   placeholder: string;
   error?: string;
-  dataCy?: string;
+  testId?: string;
   onChange?: (input: React.ChangeEvent<HTMLInputElement>) => void;
 };
 
@@ -16,7 +16,7 @@ export const InputBox: React.FunctionComponent<InputBoxProps> = ({
   label,
   placeholder,
   error,
-  dataCy,
+  testId,
   onChange,
 }) => (
   <Box mb={3}>
@@ -31,13 +31,13 @@ export const InputBox: React.FunctionComponent<InputBoxProps> = ({
       autoComplete="off"
       {...(onChange ? { onChange } : null)}
       // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
-      {...(dataCy ? { "data-testid": dataCy } : null)}
+      {...(testId ? { "data-testid": testId } : null)}
     />
     {/* eslint-disable-next-line @typescript-eslint/strict-boolean-expressions */}
     {error ? (
       <Text
         // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
-        data-testid={dataCy ? `${dataCy}-error` : "input-error"}
+        data-testid={testId ? `${testId}-error` : "input-error"}
         sx={{ color: "error", mt: 1 }}
       >
         {error}

--- a/packages/slice-machine/components/Forms/components/SelectRepeatable.tsx
+++ b/packages/slice-machine/components/Forms/components/SelectRepeatable.tsx
@@ -21,7 +21,7 @@ export const SelectRepeatable: FC<SelectRepeatableProps> = ({ format }) => {
           checked={field.value}
           // eslint-disable-next-line @typescript-eslint/no-empty-function
           onChange={() => {}}
-          data-cy="repeatable-type-radio-btn"
+          data-testid="repeatable-type-radio-btn"
         />
         <Box
           sx={{
@@ -39,7 +39,7 @@ export const SelectRepeatable: FC<SelectRepeatableProps> = ({ format }) => {
           checked={!field.value}
           // eslint-disable-next-line @typescript-eslint/no-empty-function
           onChange={() => {}}
-          data-cy="single-type-radio-btn"
+          data-testid="single-type-radio-btn"
         />
         <Box
           sx={{

--- a/packages/slice-machine/components/ItemHeader/index.tsx
+++ b/packages/slice-machine/components/ItemHeader/index.tsx
@@ -22,7 +22,7 @@ const ItemHeader: React.FC<{
     />
     <Text
       as="p"
-      data-cy="item-header-text"
+      data-testid="item-header-text"
       sx={{
         py: 0,
         px: 1,

--- a/packages/slice-machine/components/ListItem/Header.tsx
+++ b/packages/slice-machine/components/ListItem/Header.tsx
@@ -32,7 +32,7 @@ const ItemHeader: React.FC<ItemHeaderProps> = ({
       text={text}
       as="p"
       sx={{ py: 0, px: 1, fontWeight: "label", fontSize: "15px" }}
-      data-cy="field-name"
+      data-testid="field-name"
     />
     <Text
       as="p"
@@ -42,7 +42,7 @@ const ItemHeader: React.FC<ItemHeaderProps> = ({
         ml: 1,
         color: "textClear",
       }}
-      data-cy="field-id"
+      data-testid="field-id"
     >
       {sliceFieldName}
     </Text>

--- a/packages/slice-machine/components/ListItem/index.tsx
+++ b/packages/slice-machine/components/ListItem/index.tsx
@@ -34,7 +34,7 @@ interface ListItemProps<F extends TabField, S extends AnyObjectSchema> {
   CustomEditElements?: JSX.Element[];
   widget: Widget<F, S>;
   draggableId: string;
-  dataCy: string;
+  testId: string;
   isRepeatableCustomType?: boolean;
   children: React.ReactNode;
 }
@@ -51,7 +51,7 @@ function ListItem<F extends TabField, S extends AnyObjectSchema>({
   CustomEditElements,
   widget,
   draggableId,
-  dataCy,
+  testId,
   isRepeatableCustomType,
   children,
 }: ListItemProps<F, S>): JSX.Element {
@@ -68,7 +68,7 @@ function ListItem<F extends TabField, S extends AnyObjectSchema>({
         {(provided) => (
           <Fragment>
             <Li
-              data-testid={dataCy}
+              data-testid={testId}
               ref={provided.innerRef}
               {...provided.draggableProps}
               Component={Box}

--- a/packages/slice-machine/components/ListItem/index.tsx
+++ b/packages/slice-machine/components/ListItem/index.tsx
@@ -68,7 +68,7 @@ function ListItem<F extends TabField, S extends AnyObjectSchema>({
         {(provided) => (
           <Fragment>
             <Li
-              data-cy={dataCy}
+              data-testid={dataCy}
               ref={provided.innerRef}
               {...provided.draggableProps}
               Component={Box}
@@ -137,7 +137,7 @@ function ListItem<F extends TabField, S extends AnyObjectSchema>({
                           <Menu>
                             <MenuButton
                               className="sliceMenuButton"
-                              data-cy="field-menu-button"
+                              data-testid="field-menu-button"
                               style={{
                                 padding: "0",
                                 cursor: "pointer",

--- a/packages/slice-machine/components/ModalFormCard/index.tsx
+++ b/packages/slice-machine/components/ModalFormCard/index.tsx
@@ -104,7 +104,7 @@ function ModalCard<Values extends FormikValues>({
           return (
             <Form
               id={formId}
-              {...(dataCy != null ? { "data-cy": dataCy } : null)}
+              {...(dataCy != null ? { "data-testid": dataCy } : null)}
             >
               <Card
                 borderFooter

--- a/packages/slice-machine/components/ModalFormCard/index.tsx
+++ b/packages/slice-machine/components/ModalFormCard/index.tsx
@@ -48,7 +48,7 @@ type ModalCardProps<T extends FormikValues> = {
   cardProps?: ComponentPropsWithoutRef<typeof Card>;
   omitFooter?: boolean;
   isLoading?: boolean;
-  dataCy?: string;
+  testId?: string;
   actionMessage?: ((props: FormikProps<T>) => ReactNode) | ReactNode;
 };
 
@@ -66,7 +66,7 @@ function ModalCard<Values extends FormikValues>({
   omitFooter = false,
   isLoading = false,
   buttonLabel = "Save",
-  dataCy,
+  testId,
   actionMessage,
 }: ModalCardProps<Values>): JSX.Element {
   Modal.setAppElement("#__next");
@@ -106,7 +106,7 @@ function ModalCard<Values extends FormikValues>({
           return (
             <Form
               id={formId}
-              {...(dataCy != null ? { "data-testid": dataCy } : null)}
+              {...(testId != null ? { "data-testid": testId } : null)}
             >
               <Card
                 borderFooter

--- a/packages/slice-machine/components/Navigation/RunningVersion.tsx
+++ b/packages/slice-machine/components/Navigation/RunningVersion.tsx
@@ -7,7 +7,7 @@ export const RunningVersion: FC = () => {
   const sliceMachineRunningVersion = useSliceMachineRunningVersion();
 
   return (
-    <RightElement data-cy="slicemachine-version">
+    <RightElement data-testid="slicemachine-version">
       v{sliceMachineRunningVersion}
     </RightElement>
   );

--- a/packages/slice-machine/components/ReviewModal/ReviewForm.tsx
+++ b/packages/slice-machine/components/ReviewModal/ReviewForm.tsx
@@ -157,7 +157,7 @@ export const ReviewForm: FC<ReviewFormProps> = (props) => {
                   as={Textarea}
                   autoComplete="off"
                   sx={{ height: 80, mb: 3 }}
-                  data-cy="review-form-comment"
+                  data-testid="review-form-comment"
                 />
                 <Button
                   form={"review-form"}

--- a/packages/slice-machine/components/ReviewModal/ReviewFormSelect.tsx
+++ b/packages/slice-machine/components/ReviewModal/ReviewFormSelect.tsx
@@ -25,7 +25,7 @@ export const ReviewFormSelect: FC<FieldProps> = (props) => {
               color: "white",
             },
           }}
-          data-cy={`review-form-score-${rating}`}
+          data-testid={`review-form-score-${rating}`}
         >
           {rating}
         </Button>

--- a/packages/slice-machine/components/Simulator/components/Header/index.tsx
+++ b/packages/slice-machine/components/Simulator/components/Header/index.tsx
@@ -110,7 +110,7 @@ const Header: React.FunctionComponent<PropTypes> = ({
           </Flex>
         </Flex>
         <Button
-          data-cy="save-mock"
+          data-testid="save-mock"
           onClick={onSaveMock}
           label="Save mock content"
           disabled={savingMock || actionsDisabled}

--- a/packages/slice-machine/lib/builders/CustomTypeBuilder/SliceZone/UpdateSliceZoneModal.tsx
+++ b/packages/slice-machine/lib/builders/CustomTypeBuilder/SliceZone/UpdateSliceZoneModal.tsx
@@ -45,7 +45,7 @@ const UpdateSliceZoneModal: React.FC<UpdateSliceModalProps> = ({
       content={{
         title: "Select existing slices",
       }}
-      dataCy="update-slices-modal"
+      testId="update-slices-modal"
       validate={(values) => {
         if (values.sliceKeys.length === 0) {
           return {

--- a/packages/slice-machine/lib/builders/CustomTypeBuilder/SliceZone/index.tsx
+++ b/packages/slice-machine/lib/builders/CustomTypeBuilder/SliceZone/index.tsx
@@ -255,7 +255,7 @@ const SliceZone: React.FC<SliceZoneProps> = ({
                   }
                 }}
                 size="small"
-                data-cy="slice-zone-switch"
+                data-testid="slice-zone-switch"
               />
             ) : undefined
           }

--- a/packages/slice-machine/lib/builders/CustomTypeBuilder/TabZone/index.tsx
+++ b/packages/slice-machine/lib/builders/CustomTypeBuilder/TabZone/index.tsx
@@ -237,7 +237,7 @@ const TabZone: FC<TabZoneProps> = ({ tabId }) => {
                 // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-argument
                 `data${transformKeyAccessor(key)}`
               }
-              dataCy="static-zone-content"
+              testId="static-zone-content"
               isRepeatableCustomType={customType.repeatable}
             />
           ) : undefined}

--- a/packages/slice-machine/lib/builders/SliceBuilder/FieldZones/index.tsx
+++ b/packages/slice-machine/lib/builders/SliceBuilder/FieldZones/index.tsx
@@ -166,7 +166,7 @@ const FieldZones: FC = () => {
           // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
           `slice.primary${transformKeyAccessor(key)}`
         }
-        dataCy="static-zone-content"
+        testId="static-zone-content"
         isRepeatableCustomType={undefined}
       />
       <Zone
@@ -191,7 +191,7 @@ const FieldZones: FC = () => {
           // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
           `slice.items[i]${transformKeyAccessor(key)}`
         }
-        dataCy="slice-repeatable-zone"
+        testId="slice-repeatable-zone"
         isRepeatableCustomType={undefined}
       />
     </List>

--- a/packages/slice-machine/lib/builders/common/SelectFieldTypeModal/FieldTypeCard.jsx
+++ b/packages/slice-machine/lib/builders/common/SelectFieldTypeModal/FieldTypeCard.jsx
@@ -19,7 +19,7 @@ const FieldTypeCard = ({ title, description, icon: WidgetIcon, onSelect }) => {
         },
       }}
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-      data-cy={title}
+      data-testid={title}
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       onClick={onSelect}
     >

--- a/packages/slice-machine/lib/builders/common/Zone/Card/components/NewField.tsx
+++ b/packages/slice-machine/lib/builders/common/Zone/Card/components/NewField.tsx
@@ -119,7 +119,7 @@ const NewField: React.FC<NewField> = ({
       initialValues={initialValues}
     >
       {({ errors, values, setValues, setFieldValue, submitForm }) => (
-        <Form data-cy="new-field-form">
+        <Form data-testid="new-field-form">
           <Flex
             as="li"
             sx={{
@@ -192,7 +192,7 @@ const NewField: React.FC<NewField> = ({
                   width: "initial",
                 }}
                 aria-label="label-input"
-                data-cy="new-field-name-input"
+                data-testid="new-field-name-input"
               />
               <ErrorTooltip error={errors.label} />
             </Flex>
@@ -242,7 +242,7 @@ const NewField: React.FC<NewField> = ({
                   minWidth: "128px",
                   width: "initial",
                 }}
-                data-cy="new-field-id-input"
+                data-testid="new-field-id-input"
               />
               <ErrorTooltip error={errors.id} />
             </Flex>

--- a/packages/slice-machine/lib/builders/common/Zone/Card/index.jsx
+++ b/packages/slice-machine/lib/builders/common/Zone/Card/index.jsx
@@ -21,7 +21,7 @@ const FieldZone = ({
   newField,
   renderHintBase,
   isRepeatable,
-  dataCy,
+  testId,
   isRepeatableCustomType,
 }) => {
   return (
@@ -39,7 +39,7 @@ const FieldZone = ({
             ref={provided.innerRef}
             {...provided.droppableProps}
             // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-            data-testid={dataCy}
+            data-testid={testId}
             sx={{ paddingInline: "16px !important" }}
           >
             {
@@ -87,7 +87,7 @@ const FieldZone = ({
                   // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
                   isRepeatableCustomType,
                   // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/restrict-template-expressions, @typescript-eslint/no-unsafe-member-access
-                  dataCy: `list-item-${item.key}`,
+                  testId: `list-item-${item.key}`,
                 };
 
                 // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions

--- a/packages/slice-machine/lib/builders/common/Zone/Card/index.jsx
+++ b/packages/slice-machine/lib/builders/common/Zone/Card/index.jsx
@@ -39,7 +39,7 @@ const FieldZone = ({
             ref={provided.innerRef}
             {...provided.droppableProps}
             // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-            data-cy={dataCy}
+            data-testid={dataCy}
             sx={{ paddingInline: "16px !important" }}
           >
             {

--- a/packages/slice-machine/lib/builders/common/Zone/components/EmptyState/index.tsx
+++ b/packages/slice-machine/lib/builders/common/Zone/components/EmptyState/index.tsx
@@ -21,7 +21,7 @@ const ZoneEmptyState = ({
         color="grey"
         // eslint-disable-next-line @typescript-eslint/no-unsafe-return
         onClick={() => onEnterSelectMode()}
-        data-cy={`add-${zoneName}-field`}
+        data-testid={`add-${zoneName}-field`}
         startIcon="add"
       >
         Add a new field

--- a/packages/slice-machine/lib/builders/common/Zone/index.jsx
+++ b/packages/slice-machine/lib/builders/common/Zone/index.jsx
@@ -26,7 +26,7 @@ const Zone = ({
   dataTip /* text info to display as tip */,
   renderHintBase /* render base (eg. path to slice) content for hints */,
   renderFieldAccessor /* render field accessor (eg. slice.primary.title) */,
-  dataCy,
+  testId,
   isRepeatableCustomType,
 }) => {
   // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
@@ -141,7 +141,7 @@ const Zone = ({
               // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
               onDeleteItem={onDeleteItem}
               // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-              dataCy={dataCy}
+              testId={testId}
               // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
               isRepeatableCustomType={isRepeatableCustomType}
               newField={

--- a/packages/slice-machine/lib/builders/common/Zone/index.jsx
+++ b/packages/slice-machine/lib/builders/common/Zone/index.jsx
@@ -85,10 +85,10 @@ const Zone = ({
                 size="small"
                 // TODO(DT-1710): add the missing `flexShrink: 0` property to the Editor's Switch component.
                 style={{ flexShrink: 0 }}
-                data-cy="code-snippets-switch"
+                data-testid="code-snippets-switch"
               />
               <Button
-                data-cy={`add-${
+                data-testid={`add-${
                   // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
                   isRepeatable ? "Repeatable" : "Static"
                 }-field`}

--- a/packages/slice-machine/lib/models/common/widgets/Group/ListItem/index.jsx
+++ b/packages/slice-machine/lib/models/common/widgets/Group/ListItem/index.jsx
@@ -209,7 +209,7 @@ const CustomListItem = ({
                             `data.${groupItem.key}.${key}`,
                           // eslint-disable-next-line @typescript-eslint/restrict-template-expressions, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/restrict-template-expressions, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/restrict-template-expressions
                           draggableId: `group-${groupItem.key}-${item.key}-${index}`,
-                          dataCy: `list-item-group-${groupItem.key}-${item.key}`,
+                          testId: `list-item-group-${groupItem.key}-${item.key}`,
                         };
 
                         const HintElement = (

--- a/packages/slice-machine/pages/changes.tsx
+++ b/packages/slice-machine/pages/changes.tsx
@@ -146,7 +146,7 @@ const Changes: React.FunctionComponent = () => {
                 authStatus === AuthStatus.FORBIDDEN ||
                 isSyncing
               }
-              data-cy="push-changes"
+              data-testid="push-changes"
             >
               Push Changes
             </Button>

--- a/packages/slice-machine/pages/slices.tsx
+++ b/packages/slice-machine/pages/slices.tsx
@@ -83,7 +83,6 @@ const SlicesIndex: React.FunctionComponent = () => {
             <AppLayoutActions>
               <Button
                 data-testid="create-slice"
-                data-testid="create-slice"
                 onClick={() => {
                   setIsCreateSliceModalOpen(true);
                 }}

--- a/packages/slice-machine/pages/slices.tsx
+++ b/packages/slice-machine/pages/slices.tsx
@@ -83,7 +83,7 @@ const SlicesIndex: React.FunctionComponent = () => {
             <AppLayoutActions>
               <Button
                 data-testid="create-slice"
-                data-cy="create-slice"
+                data-testid="create-slice"
                 onClick={() => {
                   setIsCreateSliceModalOpen(true);
                 }}
@@ -248,7 +248,7 @@ const SlicesIndex: React.FunctionComponent = () => {
             onClose={() => {
               setIsRenameSliceModalOpen(false);
             }}
-            data-cy="rename-slice-modal"
+            data-testid="rename-slice-modal"
           />
           <DeleteSliceModal
             isOpen={isDeleteSliceModalOpen}

--- a/packages/slice-machine/src/components/SideNav/SideNavEnvironmentSelector.tsx
+++ b/packages/slice-machine/src/components/SideNav/SideNavEnvironmentSelector.tsx
@@ -55,7 +55,7 @@ export const SideNavEnvironmentSelector: FC<SideNavEnvironmentSelectorProps> = (
             kind={activeEnvironment?.kind ?? "prod"}
             asStatus={true}
             className={styles.activeEnvironmentDot}
-            data-cy="active-environment-dot"
+            data-testid="active-environment-dot"
           />
         )}
       </Box>
@@ -85,7 +85,7 @@ export const SideNavEnvironmentSelector: FC<SideNavEnvironmentSelectorProps> = (
           <Text
             component="span"
             className={styles.activeEnvironmentName}
-            data-cy="active-environment-name"
+            data-testid="active-environment-name"
           >
             {isProductionEnvironmentActive || activeEnvironment === undefined
               ? "Production"

--- a/packages/slice-machine/src/features/customTypes/customTypesBuilder/SliceZoneBlankSlate.tsx
+++ b/packages/slice-machine/src/features/customTypes/customTypesBuilder/SliceZoneBlankSlate.tsx
@@ -26,7 +26,11 @@ export const SliceZoneBlankSlate: FC<SliceZoneBlankSlateProps> = ({
   isSlicesTemplatesSupported,
 }) => {
   return (
-    <Box flexGrow={1} justifyContent="center" data-cy="slice-zone-blank-slate">
+    <Box
+      flexGrow={1}
+      justifyContent="center"
+      data-testid="slice-zone-blank-slate"
+    >
       <BlankSlate backgroundImage="/blank-slate-slice-zone.png">
         <BlankSlateContent>
           <Box justifyContent="center" padding={{ bottom: 16 }}>

--- a/packages/slice-machine/src/features/customTypes/customTypesTable/CustomTypesTablePage.tsx
+++ b/packages/slice-machine/src/features/customTypes/customTypesTable/CustomTypesTablePage.tsx
@@ -89,7 +89,7 @@ export const CustomTypesTablePage: FC<CustomTypesTablePageProps> = ({
               />
               <AppLayoutActions>
                 <Button
-                  data-cy="create-ct"
+                  data-testid="create-ct"
                   loading={isCreatingCustomType}
                   onClick={() => {
                     setIsCreateCustomTypeModalOpen(true);

--- a/packages/slice-machine/src/features/slices/convertLegacySlice/ConvertLegacySliceAsNewSliceDialog.tsx
+++ b/packages/slice-machine/src/features/slices/convertLegacySlice/ConvertLegacySliceAsNewSliceDialog.tsx
@@ -94,7 +94,7 @@ export const ConvertLegacySliceAsNewSliceDialog: FC<DialogProps> = ({
                             value.slice(0, 30),
                           )
                         }
-                        data-cy="slice-name-input"
+                        data-testid="slice-name-input"
                       />
                       <Text variant="normal" color="grey11">
                         A display name for the slice

--- a/packages/slice-machine/src/features/slices/convertLegacySlice/ConvertLegacySliceAsNewVariationDialog.tsx
+++ b/packages/slice-machine/src/features/slices/convertLegacySlice/ConvertLegacySliceAsNewVariationDialog.tsx
@@ -142,7 +142,7 @@ export const ConvertLegacySliceAsNewVariationDialog: FC<DialogProps> = ({
 
                           formik.setValues(values, true);
                         }}
-                        data-cy="variation-name-input"
+                        data-testid="variation-name-input"
                       />
                     </Box>
                     <Box display="flex" flexDirection="column" gap={4}>
@@ -165,7 +165,7 @@ export const ConvertLegacySliceAsNewVariationDialog: FC<DialogProps> = ({
                             camelCase(value.slice(0, 30)),
                           );
                         }}
-                        data-cy="variation-id-input"
+                        data-testid="variation-id-input"
                       />
                     </Box>
                   </ScrollArea>

--- a/packages/slice-machine/src/features/slices/convertLegacySlice/ConvertLegacySliceButton.tsx
+++ b/packages/slice-machine/src/features/slices/convertLegacySlice/ConvertLegacySliceButton.tsx
@@ -175,7 +175,7 @@ export const ConvertLegacySliceButton: FC<ConvertLegacySliceButtonProps> = ({
       <DropdownMenu>
         <DropdownMenuTrigger>
           <Button
-            data-cy="convert-legacy-slice"
+            data-testid="convert-legacy-slice"
             startIcon="refresh"
             endIcon="arrowDropDown"
             size="medium"

--- a/packages/slice-machine/src/features/slices/sliceCards/SharedSliceCard.tsx
+++ b/packages/slice-machine/src/features/slices/sliceCards/SharedSliceCard.tsx
@@ -115,7 +115,7 @@ export const SharedSliceCard: FC<SharedSliceCardProps> = (props) => {
     <Card
       aria-label={`${slice.model.name} ${variation.name} slice card`}
       checked={selected}
-      data-cy="shared-slice-card"
+      data-testid="shared-slice-card"
       data-testid="shared-slice-card"
       {...modeProps}
       {...variantProps}
@@ -167,7 +167,7 @@ export const SharedSliceCard: FC<SharedSliceCardProps> = (props) => {
               </DropdownMenuTrigger>
               <DropdownMenuContent
                 align="end"
-                data-cy="slice-action-icon-dropdown"
+                data-testid="slice-action-icon-dropdown"
               >
                 {canUpdateScreenshot && disableOverlay ? (
                   <DropdownMenuItem

--- a/packages/slice-machine/src/features/slices/sliceCards/SharedSliceCard.tsx
+++ b/packages/slice-machine/src/features/slices/sliceCards/SharedSliceCard.tsx
@@ -116,7 +116,6 @@ export const SharedSliceCard: FC<SharedSliceCardProps> = (props) => {
       aria-label={`${slice.model.name} ${variation.name} slice card`}
       checked={selected}
       data-testid="shared-slice-card"
-      data-testid="shared-slice-card"
       {...modeProps}
       {...variantProps}
     >

--- a/packages/slice-machine/test/pages/slices.test.tsx
+++ b/packages/slice-machine/test/pages/slices.test.tsx
@@ -337,19 +337,13 @@ describe("slices", () => {
       },
     });
 
-    const createOneButton = document.querySelector(
-      '[data-testid="create-slice"]',
-    );
+    const createOneButton = screen.getByTestId("create-slice");
     await act(async () => {
-      // @ts-expect-error TS(2345) FIXME: Argument of type 'Element | null' is not assignabl... Remove this comment to see the full error message
       fireEvent.click(createOneButton);
     });
 
-    const nameInput = document.querySelector(
-      '[data-testid="slice-name-input"]',
-    );
+    const nameInput = await screen.findByTestId("slice-name-input");
     await act(async () => {
-      // @ts-expect-error TS(2345) FIXME: Argument of type 'Element | null' is not assignabl... Remove this comment to see the full error message
       fireEvent.change(nameInput, { target: { value: "FooBar" } });
     });
 

--- a/packages/slice-machine/test/pages/slices.test.tsx
+++ b/packages/slice-machine/test/pages/slices.test.tsx
@@ -337,13 +337,17 @@ describe("slices", () => {
       },
     });
 
-    const createOneButton = document.querySelector('[data-cy="create-slice"]');
+    const createOneButton = document.querySelector(
+      '[data-testid="create-slice"]',
+    );
     await act(async () => {
       // @ts-expect-error TS(2345) FIXME: Argument of type 'Element | null' is not assignabl... Remove this comment to see the full error message
       fireEvent.click(createOneButton);
     });
 
-    const nameInput = document.querySelector('[data-cy="slice-name-input"]');
+    const nameInput = document.querySelector(
+      '[data-testid="slice-name-input"]',
+    );
     await act(async () => {
       // @ts-expect-error TS(2345) FIXME: Argument of type 'Element | null' is not assignabl... Remove this comment to see the full error message
       fireEvent.change(nameInput, { target: { value: "FooBar" } });

--- a/playwright/playwright.config.ts
+++ b/playwright/playwright.config.ts
@@ -57,9 +57,6 @@ const config = {
     // Collect trace when retrying the failed test.
     trace: "on-first-retry",
 
-    // Setup the test id attribute to be `data-cy` for `getByTestId`.
-    testIdAttribute: "data-cy",
-
     // Configure the browser permissions to access the clipboard API.
     permissions: ["clipboard-read", "clipboard-write"],
   },


### PR DESCRIPTION
## Context

Completes DT-1839

## The Solution

- Rename `data-cy` to `data-testid` in all files.
- Remove the `testIdAttribute` Playwright setting that changed `data-testid` to `data-cy`; the default value is `data-testid`.
- Rename `dataCy` props to `testId`.

## Impact / Dependencies

N/A

## Checklist before requesting a review

- [x] I hereby declare my code ready for review.
- [x] If it is a critical feature, I have added tests.
- [ ] The CI is successful.
- [ ] If there could backward compatibility issues, it has been discussed and planned.
