### PR TITLE
fix(sideNav): Rename side nav Tutorial / Academy link to Learn Prismic

### DIFF
--- a/packages/slice-machine/components/Navigation/index.test.tsx
+++ b/packages/slice-machine/components/Navigation/index.test.tsx
@@ -165,7 +165,7 @@ describe("Side Navigation", () => {
 
     renderSideNavigation();
 
-    const link = (await screen.findByText("Academy")).parentElement
+    const link = (await screen.findByText("Learn Prismic")).parentElement
       ?.parentElement as HTMLElement;
 
     await waitFor(() =>
@@ -181,7 +181,7 @@ describe("Side Navigation", () => {
   test("Video Item not next", async () => {
     renderSideNavigation();
 
-    const link = (await screen.findByText("Tutorial")).parentElement
+    const link = (await screen.findByText("Learn Prismic")).parentElement
       ?.parentElement as HTMLElement;
     expect(link).toHaveAttribute(
       "href",

--- a/packages/slice-machine/src/hooks/useMarketingContent.ts
+++ b/packages/slice-machine/src/hooks/useMarketingContent.ts
@@ -23,7 +23,7 @@ const CONTENT_BY_ADAPTER: Record<string, MarketingContent> = {
   "@slicemachine/adapter-next": {
     tutorial: {
       link: {
-        title: "Academy",
+        title: "Learn Prismic",
         url: "https://prismic.io/academy/prismic-and-nextjs",
       },
       tooltip: {
@@ -44,7 +44,7 @@ const CONTENT_BY_ADAPTER: Record<string, MarketingContent> = {
 const DEFAULT_CONTENT: MarketingContent = {
   tutorial: {
     link: {
-      title: "Tutorial",
+      title: "Learn Prismic",
       url: "https://youtube.com/playlist?list=PLUVZjQltoA3wnaQudcqQ3qdZNZ6hyfyhH",
     },
     tooltip: {

--- a/playwright/pages/components/Menu.ts
+++ b/playwright/pages/components/Menu.ts
@@ -10,7 +10,7 @@ export class Menu {
   readonly customTypesLink: Locator;
   readonly slicesLink: Locator;
   readonly changesLink: Locator;
-  readonly tutorialLink: Locator;
+  readonly learnPrismicLink: Locator;
   readonly settingsLink: Locator;
   readonly changelogLink: Locator;
   readonly appVersion: Locator;
@@ -50,8 +50,8 @@ export class Menu {
     this.changesLink = this.menu.getByRole("button", {
       name: "Review changes",
     });
-    this.tutorialLink = this.menu.getByRole("link", {
-      name: "Tutorials",
+    this.learnPrismicLink = this.menu.getByRole("link", {
+      name: "Learn Prismic",
       exact: true,
     });
     this.settingsLink = this.menu.getByRole("link", {

--- a/playwright/tests/common/sideNav.spec.ts
+++ b/playwright/tests/common/sideNav.spec.ts
@@ -108,7 +108,7 @@ test("I cannot see the updates available warning", async ({
   await expect(pageTypesTablePage.menu.updatesAvailableTitle).not.toBeVisible();
 });
 
-test.describe(() => {
+test.describe("Tutorial tooltip", () => {
   test.use({
     onboarded: false,
     reduxStorage: {
@@ -152,4 +152,18 @@ test.describe(() => {
       sliceMachinePage.menu.tutorialVideoTooltipTitle,
     ).not.toBeVisible();
   });
+});
+
+test("I can access the Academy from the 'Learn Prismic' link", async ({
+  pageTypesTablePage,
+}) => {
+  await pageTypesTablePage.goto();
+  await expect(pageTypesTablePage.menu.learnPrismicLink).toBeVisible();
+
+  await pageTypesTablePage.menu.learnPrismicLink.click();
+
+  const newTab = await pageTypesTablePage.page.waitForEvent("popup");
+  await newTab.waitForLoadState();
+
+  await expect(newTab).toHaveURL(/https:\/\/prismic.io\/academy*/);
 });

--- a/playwright/tests/common/sideNav.spec.ts
+++ b/playwright/tests/common/sideNav.spec.ts
@@ -154,16 +154,16 @@ test.describe("Tutorial tooltip", () => {
   });
 });
 
-test("I can access the Academy from the 'Learn Prismic' link", async ({
-  pageTypesTablePage,
+test('I can access the Academy from the "Learn Prismic" link', async ({
+  sliceMachinePage,
 }) => {
-  await pageTypesTablePage.goto();
-  await expect(pageTypesTablePage.menu.learnPrismicLink).toBeVisible();
+  await sliceMachinePage.gotoDefaultPage();
+  await expect(sliceMachinePage.menu.learnPrismicLink).toBeVisible();
 
-  await pageTypesTablePage.menu.learnPrismicLink.click();
+  await sliceMachinePage.menu.learnPrismicLink.click();
 
-  const newTab = await pageTypesTablePage.page.waitForEvent("popup");
+  const newTab = await sliceMachinePage.page.waitForEvent("popup");
   await newTab.waitForLoadState();
 
-  await expect(newTab).toHaveURL(/https:\/\/prismic.io\/academy*/);
+  await expect(newTab).toHaveTitle(/Prismic Academy/);
 });

--- a/playwright/tests/slices/sliceBuilderCommon.spec.ts
+++ b/playwright/tests/slices/sliceBuilderCommon.spec.ts
@@ -59,7 +59,7 @@ test("I can delete a variation", async ({ slice, sliceBuilderPage }) => {
   ).not.toBeVisible();
 });
 
-test.describe(() => {
+test.describe("Simulator tooltip", () => {
   test.use({ onboarded: false });
 
   test("I can close the simulator tooltip and it stays close", async ({


### PR DESCRIPTION
## Context

- DT-1987

## The Solution

- Rename Tutorial (Nuxt, SvelteKit) and Academy (Next) to "Learn Prismic".
- Added an e2e tests to check the link redirection
- Added titles for our Describe

## Impact / Dependencies

- None
