### PR TITLE
test(playwright): test the sidebar's repository and "Invite team" links

### DIFF
--- a/packages/slice-machine/components/Navigation/index.test.tsx
+++ b/packages/slice-machine/components/Navigation/index.test.tsx
@@ -98,7 +98,7 @@ describe("Side Navigation", () => {
     renderSideNavigation();
     expect(await screen.findByText("foo")).toBeVisible();
     expect(await screen.findByText("foo.prismic.io")).toBeVisible();
-    const link = await screen.findByTitle("Open prismic repository");
+    const link = await screen.findByTitle("Open Prismic repository");
     expect(link).toHaveAttribute("href", "https://foo.prismic.io");
     expect(link).toHaveAttribute("target", "_blank");
   });

--- a/packages/slice-machine/src/components/SideNav/SideNav.tsx
+++ b/packages/slice-machine/src/components/SideNav/SideNav.tsx
@@ -53,7 +53,7 @@ export const SideNavRepository: FC<SideNavRepositoryProps> = ({
         className={styles.repositoryLinkIcon}
         href={href}
         target="_blank"
-        title="Open prismic repository"
+        title="Open Prismic repository"
       >
         <OpenIcon />
       </a>

--- a/playwright/pages/components/Menu.ts
+++ b/playwright/pages/components/Menu.ts
@@ -6,10 +6,12 @@ export class Menu {
   readonly page: Page;
   readonly menu: Locator;
   readonly environmentSelector: EnvironmentSelector;
+  readonly repositoryLink: Locator;
   readonly pageTypesLink: Locator;
   readonly customTypesLink: Locator;
   readonly slicesLink: Locator;
   readonly changesLink: Locator;
+  readonly inviteTeamLink: Locator;
   readonly learnPrismicLink: Locator;
   readonly settingsLink: Locator;
   readonly changelogLink: Locator;
@@ -35,6 +37,10 @@ export class Menu {
      */
     this.environmentSelector = new EnvironmentSelector(page);
     this.menu = page.getByRole("navigation");
+    this.repositoryLink = this.menu.getByRole("link", {
+      name: "Open Prismic repository",
+      exact: true,
+    });
     this.pageTypesLink = this.menu.getByRole("link", {
       name: "Page types",
       exact: true,
@@ -49,6 +55,10 @@ export class Menu {
     });
     this.changesLink = this.menu.getByRole("button", {
       name: "Review changes",
+    });
+    this.inviteTeamLink = this.menu.getByRole("link", {
+      name: "Invite team",
+      exact: true,
     });
     this.learnPrismicLink = this.menu.getByRole("link", {
       name: "Learn Prismic",

--- a/playwright/tests/common/sideNav.spec.ts
+++ b/playwright/tests/common/sideNav.spec.ts
@@ -60,6 +60,28 @@ test("I can navigate through all menu entries", async ({
   );
 });
 
+test("I can access the repository using the open icon", async ({
+  sliceMachinePage,
+  procedures,
+}) => {
+  procedures.mock("getState", ({ data }) => {
+    const result = data as { env: { manifest: { apiEndpoint: string } } };
+    result.env.manifest.apiEndpoint =
+      "https://example-prismic-repo.cdn.prismic.io/api/v2";
+    return result;
+  });
+
+  await sliceMachinePage.gotoDefaultPage();
+  await expect(sliceMachinePage.menu.repositoryLink).toBeVisible();
+
+  await sliceMachinePage.menu.repositoryLink.click();
+
+  const newTab = await sliceMachinePage.page.waitForEvent("popup");
+  await newTab.waitForLoadState();
+
+  await expect(newTab).toHaveTitle("prismic.io - Example Prismic Repo");
+});
+
 test("I access the changelog from Slice Machine version", async ({
   pageTypesTablePage,
   changelogPage,
@@ -166,4 +188,29 @@ test('I can access the Academy from the "Learn Prismic" link', async ({
   await newTab.waitForLoadState();
 
   await expect(newTab).toHaveTitle(/Prismic Academy/);
+});
+
+test('I can access the repository\'s users page from the "Invite team" link', async ({
+  sliceMachinePage,
+  procedures,
+}) => {
+  procedures.mock("getState", ({ data }) => {
+    const result = data as { env: { manifest: { apiEndpoint: string } } };
+    result.env.manifest.apiEndpoint =
+      "https://example-prismic-repo.cdn.prismic.io/api/v2";
+    return result;
+  });
+
+  await sliceMachinePage.gotoDefaultPage();
+  await expect(sliceMachinePage.menu.inviteTeamLink).toBeVisible();
+
+  await sliceMachinePage.menu.inviteTeamLink.click();
+
+  const newTab = await sliceMachinePage.page.waitForEvent("popup");
+  await newTab.waitForLoadState();
+
+  // We cannot test the title since it only contains the repository's name.
+  await expect(newTab).toHaveURL(
+    "https://example-prismic-repo.prismic.io/settings/users",
+  );
 });

--- a/playwright/tests/common/sideNav.spec.ts
+++ b/playwright/tests/common/sideNav.spec.ts
@@ -74,9 +74,9 @@ test("I can access the repository using the open icon", async ({
   await sliceMachinePage.gotoDefaultPage();
   await expect(sliceMachinePage.menu.repositoryLink).toBeVisible();
 
+  const newTabPromise = sliceMachinePage.page.waitForEvent("popup");
   await sliceMachinePage.menu.repositoryLink.click();
-
-  const newTab = await sliceMachinePage.page.waitForEvent("popup");
+  const newTab = await newTabPromise;
   await newTab.waitForLoadState();
 
   await expect(newTab).toHaveTitle("prismic.io - Example Prismic Repo");
@@ -182,9 +182,9 @@ test('I can access the Academy from the "Learn Prismic" link', async ({
   await sliceMachinePage.gotoDefaultPage();
   await expect(sliceMachinePage.menu.learnPrismicLink).toBeVisible();
 
+  const newTabPromise = sliceMachinePage.page.waitForEvent("popup");
   await sliceMachinePage.menu.learnPrismicLink.click();
-
-  const newTab = await sliceMachinePage.page.waitForEvent("popup");
+  const newTab = await newTabPromise;
   await newTab.waitForLoadState();
 
   await expect(newTab).toHaveTitle(/Prismic Academy/);
@@ -204,9 +204,9 @@ test('I can access the repository\'s users page from the "Invite team" link', as
   await sliceMachinePage.gotoDefaultPage();
   await expect(sliceMachinePage.menu.inviteTeamLink).toBeVisible();
 
+  const newTabPromise = sliceMachinePage.page.waitForEvent("popup");
   await sliceMachinePage.menu.inviteTeamLink.click();
-
-  const newTab = await sliceMachinePage.page.waitForEvent("popup");
+  const newTab = await newTabPromise;
   await newTab.waitForLoadState();
 
   // We cannot test the title since it only contains the repository's name.


### PR DESCRIPTION
## Context

DT-1824

## The Solution

- Add a test for the repository link
- Add a test for the "Invite team" link

The "Invite team" test requires checking the opened window's URL rather than its title like the other tests. The title on the `/settings/users` page does not contain anything specific to the repository's user settings.

## Impact / Dependencies

N/A

## Checklist before requesting a review

- [x] I hereby declare my code ready for review.
- [x] If it is a critical feature, I have added tests.
- [ ] The CI is successful.
- [ ] If there could backward compatibility issues, it has been discussed and planned.
