### PR TITLE
test(playwright): update slice screenshot from the Changes page

### DIFF
--- a/playwright/README.md
+++ b/playwright/README.md
@@ -86,6 +86,7 @@ test("I can ...", async ({ sliceBuilderPage, slicesListPage }) => {
 You can also override default storage values:
 
 Example (redux):
+
 ```ts
 test.use({
   onboarded: false,
@@ -100,6 +101,7 @@ test("I can ...", async ({ sliceBuilderPage, slicesListPage }) => {
 ```
 
 Example (new way):
+
 ```ts
 test.use({
   onboarded: false,
@@ -299,6 +301,22 @@ test("I cannot see the updates available warning", async ({
 
 > [!NOTE]
 > Include the check within the goto function so you don't need to do it manually every time.
+
+### Enable Amplitude experiments as needed
+
+All Amplitude experiments are disabled by default to prevent unexpected test results. Tests should be pass regardless of the configured Prismic repository.
+
+To run tests with an experiment, enable the experiment in the test directly:
+
+```ts
+test("does something when the experiment is on", async ({ procedures }) => {
+  procedures.mock("getExperimentVariant", ({ data }) => {
+    if (data === "example-experiment-name") {
+      return { value: "on" };
+    }
+  });
+});
+```
 
 ### Write your own best practice for the team here...
 

--- a/playwright/fixtures/index.ts
+++ b/playwright/fixtures/index.ts
@@ -246,6 +246,11 @@ export const test = baseTest.extend<Options & Fixtures>({
    * Mocks
    */
   procedures: async ({ page }, use) => {
-    await use(await MockManagerProcedures.init(page));
+    const procedures = await MockManagerProcedures.init(page);
+
+    // Disable all experiments by default. Enable them in tests as needed.
+    procedures.mock("getExperimentVariant", () => undefined);
+
+    await use(procedures);
   },
 });

--- a/playwright/pages/ChangesPage.ts
+++ b/playwright/pages/ChangesPage.ts
@@ -1,8 +1,10 @@
 import { Locator, Page, expect } from "@playwright/test";
 
 import { SliceMachinePage } from "./SliceMachinePage";
+import { UpdateScreenshotDialog } from "./components/UpdateScreenshotDialog";
 
 export class ChangesPage extends SliceMachinePage {
+  readonly updateScreenshotDialog: UpdateScreenshotDialog;
   readonly breadcrumbLabel: Locator;
   readonly loginButton: Locator;
   readonly pushChangesButton: Locator;
@@ -23,6 +25,7 @@ export class ChangesPage extends SliceMachinePage {
     /**
      * Components
      */
+    this.updateScreenshotDialog = new UpdateScreenshotDialog(page);
 
     /**
      * Static locators
@@ -80,6 +83,10 @@ export class ChangesPage extends SliceMachinePage {
     return this.page.getByTestId(`custom-type-${id}`);
   }
 
+  getSlice(name: string) {
+    return this.page.getByLabel(new RegExp(`^${name} .* slice card$`));
+  }
+
   /**
    * Actions
    */
@@ -99,6 +106,25 @@ export class ChangesPage extends SliceMachinePage {
     await this.softLimitButton.click();
     await expect(this.softLimitTitle).not.toBeVisible();
     await this.checkPushedMessage();
+  }
+
+  async updateSliceScreenshot(name: string, fileName: string) {
+    await this.getSlice(name)
+      .getByRole("button", {
+        name: "Update screenshot",
+        exact: true,
+      })
+      .click();
+
+    await expect(
+      this.updateScreenshotDialog.screenshotPlaceholder,
+    ).toBeVisible();
+    await this.updateScreenshotDialog.updateScreenshot(fileName);
+    await expect(
+      this.updateScreenshotDialog.screenshotPlaceholder,
+    ).not.toBeVisible();
+
+    await this.updateScreenshotDialog.close();
   }
 
   /**

--- a/playwright/pages/ChangesPage.ts
+++ b/playwright/pages/ChangesPage.ts
@@ -83,8 +83,10 @@ export class ChangesPage extends SliceMachinePage {
     return this.page.getByTestId(`custom-type-${id}`);
   }
 
-  getSlice(name: string) {
-    return this.page.getByLabel(new RegExp(`^${name} .* slice card$`));
+  getSliceCard(name: string, variation = "Default") {
+    return this.page.getByLabel(`${name} ${variation} slice card`, {
+      exact: true,
+    });
   }
 
   /**
@@ -108,23 +110,10 @@ export class ChangesPage extends SliceMachinePage {
     await this.checkPushedMessage();
   }
 
-  async updateSliceScreenshot(name: string, fileName: string) {
-    await this.getSlice(name)
-      .getByRole("button", {
-        name: "Update screenshot",
-        exact: true,
-      })
+  async openUpdateSliceScreenshotDialog(name: string, variation?: string) {
+    await this.getSliceCard(name, variation)
+      .getByRole("button", { name: "Update screenshot", exact: true })
       .click();
-
-    await expect(
-      this.updateScreenshotDialog.screenshotPlaceholder,
-    ).toBeVisible();
-    await this.updateScreenshotDialog.updateScreenshot(fileName);
-    await expect(
-      this.updateScreenshotDialog.screenshotPlaceholder,
-    ).not.toBeVisible();
-
-    await this.updateScreenshotDialog.close();
   }
 
   /**

--- a/playwright/pages/components/Dialog.ts
+++ b/playwright/pages/components/Dialog.ts
@@ -52,7 +52,9 @@ export class Dialog {
   /**
    * Actions
    */
-  // Handle actions here
+  close() {
+    return this.closeButton.click();
+  }
 
   /**
    * Assertions

--- a/playwright/pages/components/Dialog.ts
+++ b/playwright/pages/components/Dialog.ts
@@ -52,9 +52,7 @@ export class Dialog {
   /**
    * Actions
    */
-  close() {
-    return this.closeButton.click();
-  }
+  // Handle actions here
 
   /**
    * Assertions

--- a/playwright/tests/changes/changes.spec.ts
+++ b/playwright/tests/changes/changes.spec.ts
@@ -1,4 +1,7 @@
-import { CustomType } from "@prismicio/types-internal/lib/customtypes";
+import {
+  CustomType,
+  SharedSlice,
+} from "@prismicio/types-internal/lib/customtypes";
 import { expect } from "@playwright/test";
 
 import { test } from "../../fixtures";
@@ -94,6 +97,22 @@ test("I can see the changes I have to push", async ({
   );
   await changesPage.checkCustomTypeApiId(customType.id);
   await changesPage.checkCustomTypeStatus(customType.id, "New");
+});
+
+test("I can update screenshots", async ({ changesPage, procedures, slice }) => {
+  procedures.mock("getState", ({ data }) => ({
+    ...(data as Record<string, unknown>),
+    remoteCustomTypes: [],
+    remoteSlices: [],
+    clientError: undefined,
+  }));
+  procedures.mock("git.fetchLinkedRepos", () => []);
+
+  await changesPage.goto();
+  await changesPage.updateSliceScreenshot(
+    slice.name,
+    "slice-screenshot-imageLeft",
+  );
 });
 
 test("I can push the changes I have", async ({ changesPage, procedures }) => {

--- a/playwright/tests/changes/changes.spec.ts
+++ b/playwright/tests/changes/changes.spec.ts
@@ -1,7 +1,4 @@
-import {
-  CustomType,
-  SharedSlice,
-} from "@prismicio/types-internal/lib/customtypes";
+import { CustomType } from "@prismicio/types-internal/lib/customtypes";
 import { expect } from "@playwright/test";
 
 import { test } from "../../fixtures";
@@ -106,6 +103,7 @@ test("I can update screenshots", async ({ changesPage, procedures, slice }) => {
     remoteSlices: [],
     clientError: undefined,
   }));
+  // Necessary to ensure the page is not logged out.
   procedures.mock("git.fetchLinkedRepos", () => []);
 
   await changesPage.goto();

--- a/playwright/tests/changes/changes.spec.ts
+++ b/playwright/tests/changes/changes.spec.ts
@@ -101,8 +101,6 @@ test("I can update screenshots", async ({ changesPage, procedures, slice }) => {
     ...(data as Record<string, unknown>),
     clientError: undefined,
   }));
-  // Necessary to ensure the page is not logged out.
-  procedures.mock("git.fetchLinkedRepos", () => []);
 
   await changesPage.goto();
   await changesPage.openUpdateSliceScreenshotDialog(slice.name);

--- a/playwright/tests/changes/changes.spec.ts
+++ b/playwright/tests/changes/changes.spec.ts
@@ -99,18 +99,23 @@ test("I can see the changes I have to push", async ({
 test("I can update screenshots", async ({ changesPage, procedures, slice }) => {
   procedures.mock("getState", ({ data }) => ({
     ...(data as Record<string, unknown>),
-    remoteCustomTypes: [],
-    remoteSlices: [],
     clientError: undefined,
   }));
   // Necessary to ensure the page is not logged out.
   procedures.mock("git.fetchLinkedRepos", () => []);
 
   await changesPage.goto();
-  await changesPage.updateSliceScreenshot(
-    slice.name,
+  await changesPage.openUpdateSliceScreenshotDialog(slice.name);
+
+  await expect(
+    changesPage.updateScreenshotDialog.screenshotPlaceholder,
+  ).toBeVisible();
+  await changesPage.updateScreenshotDialog.updateScreenshot(
     "slice-screenshot-imageLeft",
   );
+  await expect(
+    changesPage.updateScreenshotDialog.screenshotPlaceholder,
+  ).not.toBeVisible();
 });
 
 test("I can push the changes I have", async ({ changesPage, procedures }) => {


### PR DESCRIPTION
## Context

DT-1826

## The Solution

- Add a test that changes a slice's screenshot from the Changes page

We need to use a real slice (via the `slice` fixture) because the adapter processes the request. Doing it this way is preferred over mocking and validating every procedure that this action touches because we can verify it actually works as a user would use it.

## Impact / Dependencies

N/A

## Checklist before requesting a review

- [x] I hereby declare my code ready for review.
- [x] If it is a critical feature, I have added tests.
- [x] The CI is successful.
- [ ] If there could backward compatibility issues, it has been discussed and planned.
