### PR TITLE
feat: add `allowCaption` option to image fields

### DIFF
--- a/packages/manager/package.json
+++ b/packages/manager/package.json
@@ -67,7 +67,7 @@
 		"@antfu/ni": "^0.20.0",
 		"@prismicio/custom-types-client": "^1.2.0",
 		"@prismicio/mocks": "2.0.0",
-		"@prismicio/types-internal": "^2.2.0",
+		"@prismicio/types-internal": "^2.4.0-alpha.0",
 		"@segment/analytics-node": "1.1.3",
 		"@slicemachine/plugin-kit": "workspace:*",
 		"cookie": "^0.5.0",

--- a/packages/slice-machine/lib/builders/common/EditModal/Field.jsx
+++ b/packages/slice-machine/lib/builders/common/EditModal/Field.jsx
@@ -21,7 +21,7 @@ const WidgetFormField = ({ fieldName, formField, fields, initialValues }) => {
     <Box
       sx={{
         mt: 2,
-        alignItems: "center",
+        alignItems: "flex-start",
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
         ...(formField.type === FormTypes.CHECKBOX
           ? {

--- a/packages/slice-machine/lib/models/common/widgets/Image/Form.tsx
+++ b/packages/slice-machine/lib/models/common/widgets/Image/Form.tsx
@@ -31,7 +31,7 @@ const nullableNumberSchema = () => {
 const FormFields = {
   label: DefaultFields.label,
   id: DefaultFields.id,
-  allowCaption: CheckBox("Allow caption"),
+  allowCaption: CheckBox("Allow caption", false, false),
   constraint: {
     validate: () =>
       yup.object().defined().shape({

--- a/packages/slice-machine/lib/models/common/widgets/Image/Form.tsx
+++ b/packages/slice-machine/lib/models/common/widgets/Image/Form.tsx
@@ -16,6 +16,7 @@ import {
   ConstraintForm,
 } from "./components";
 import { TabFields } from "@lib/models/common/CustomType";
+import { CheckBox } from "@lib/forms/fields";
 
 const nullableNumberSchema = () => {
   return yup
@@ -30,6 +31,7 @@ const nullableNumberSchema = () => {
 const FormFields = {
   label: DefaultFields.label,
   id: DefaultFields.id,
+  allowCaption: CheckBox("Allow caption"),
   constraint: {
     validate: () =>
       yup.object().defined().shape({
@@ -103,6 +105,7 @@ type FieldValues = {
       height?: number;
     };
     thumbnails: Array<Thumbnail>;
+    allowCaption?: boolean;
   };
 };
 
@@ -129,16 +132,22 @@ const Form: React.FC<FormProps> = (props) => {
 
   return (
     <FlexGrid>
-      {Object.entries(FormFields).map(([key, field]) => (
-        <Col key={key}>
-          <WidgetFormField
-            fieldName={createFieldNameFromKey(key)}
-            formField={field}
-            fields={fields}
-            initialValues={initialValues}
-          />
-        </Col>
-      ))}
+      <Col>
+        <WidgetFormField
+          fieldName={createFieldNameFromKey("label")}
+          formField={FormFields.label}
+          fields={fields}
+          initialValues={initialValues}
+        />
+      </Col>
+      <Col>
+        <WidgetFormField
+          fieldName={createFieldNameFromKey("id")}
+          formField={FormFields.id}
+          fields={fields}
+          initialValues={initialValues}
+        />
+      </Col>
       <Col>
         <Label
           htmlFor="thumbnails"
@@ -209,6 +218,24 @@ const Form: React.FC<FormProps> = (props) => {
             )}
           />
         </Card>
+      </Col>
+      <Col>
+        <Label
+          variant="label.primary"
+          sx={{
+            mt: 1,
+            display: "flex",
+            alignItems: "center",
+          }}
+        >
+          Caption
+        </Label>
+        <WidgetFormField
+          fieldName={createFieldNameFromKey("allowCaption")}
+          formField={FormFields.allowCaption}
+          fields={fields}
+          initialValues={initialValues}
+        />
       </Col>
     </FlexGrid>
   );

--- a/packages/slice-machine/lib/models/common/widgets/Image/index.ts
+++ b/packages/slice-machine/lib/models/common/widgets/Image/index.ts
@@ -24,7 +24,8 @@ import { Image } from "@prismicio/types-internal/lib/customtypes/widgets/nestabl
           "height": 500
         }
       ],
-      "label": "Icon Image"
+      "label": "Icon Image",
+      "allowCaption": true
     }
   } */
 
@@ -55,6 +56,7 @@ export const ImageWidget: Widget<Image, typeof schema> = {
       label,
       constraint: {},
       thumbnails: [],
+      allowCaption: false,
     },
   }),
   FormFields,

--- a/packages/slice-machine/package.json
+++ b/packages/slice-machine/package.json
@@ -46,7 +46,7 @@
     "@prismicio/editor-ui": "0.4.25",
     "@prismicio/mocks": "2.0.0-alpha.2",
     "@prismicio/simulator": "0.1.4",
-    "@prismicio/types-internal": "2.2.0",
+    "@prismicio/types-internal": "2.4.0-alpha.0",
     "@radix-ui/react-hover-card": "1.0.6",
     "@radix-ui/react-tabs": "1.0.4",
     "@reach/menu-button": "0.18.0",

--- a/playwright/tests/fields/image.spec.ts
+++ b/playwright/tests/fields/image.spec.ts
@@ -1,0 +1,49 @@
+import { expect } from "@playwright/test";
+
+import { test } from "../../fixtures";
+
+test("I can create an image field that doesn't allow captions by default", async ({
+  customTypesBuilderPage,
+  singleCustomType,
+}) => {
+  await customTypesBuilderPage.goto(singleCustomType.name);
+  await customTypesBuilderPage.addStaticField({
+    type: "Image",
+    name: "My Image",
+    expectedId: "my_image",
+  });
+  await customTypesBuilderPage.getEditFieldButton("my_image").click();
+
+  await expect(
+    customTypesBuilderPage.editFieldDialog.getFieldByLabel("Allow caption"),
+  ).toHaveValue("false");
+});
+
+test("I can enable captions", async ({
+  customTypesBuilderPage,
+  singleCustomType,
+}) => {
+  const name = "My Image";
+  const id = "my_image";
+
+  await customTypesBuilderPage.goto(singleCustomType.name);
+  await customTypesBuilderPage.addStaticField({
+    type: "Image",
+    name,
+    expectedId: id,
+  });
+  await customTypesBuilderPage.getEditFieldButton(id).click();
+
+  await customTypesBuilderPage.editFieldDialog
+    .getFieldByLabel("Allow caption")
+    .setChecked(true);
+  await customTypesBuilderPage.editFieldDialog.submitButton.click();
+  await expect(
+    customTypesBuilderPage.editFieldDialog.getTitle(name),
+  ).not.toBeVisible();
+
+  await customTypesBuilderPage.getEditFieldButton(id).click();
+  await expect(
+    customTypesBuilderPage.editFieldDialog.getFieldByLabel("Allow caption"),
+  ).toHaveValue("true");
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -5635,6 +5635,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@prismicio/types-internal@npm:2.4.0-alpha.0, @prismicio/types-internal@npm:^2.4.0-alpha.0":
+  version: 2.4.0-alpha.0
+  resolution: "@prismicio/types-internal@npm:2.4.0-alpha.0"
+  dependencies:
+    monocle-ts: ^2.3.11
+    newtype-ts: ^0.3.5
+    tslib: ^2.3.1
+  peerDependencies:
+    "@types/uuid": ^9.0.2
+    fp-ts: ^2.11.8
+    io-ts: ^2.2.16
+    io-ts-types: ^0.5.16
+    uuid: ^9.0.0
+  checksum: d446d6aadc04da8f939fb88bc0ed47df0dbaddbd311a9b86c253d0b51b96a9dd2538e075aa66330d853e28ff848cdfa67ff0bc7268d446bba96c45b41e3968fb
+  languageName: node
+  linkType: hard
+
 "@prismicio/types-internal@npm:^1.0.1":
   version: 1.5.3
   resolution: "@prismicio/types-internal@npm:1.5.3"
@@ -8874,7 +8891,7 @@ __metadata:
     "@prismicio/custom-types-client": ^1.2.0
     "@prismicio/mock": 0.2.0
     "@prismicio/mocks": 2.0.0
-    "@prismicio/types-internal": ^2.2.0
+    "@prismicio/types-internal": ^2.4.0-alpha.0
     "@segment/analytics-node": 1.1.3
     "@size-limit/preset-small-lib": 8.2.4
     "@slicemachine/plugin-kit": "workspace:*"
@@ -30585,7 +30602,7 @@ __metadata:
     "@prismicio/editor-ui": 0.4.25
     "@prismicio/mocks": 2.0.0-alpha.2
     "@prismicio/simulator": 0.1.4
-    "@prismicio/types-internal": 2.2.0
+    "@prismicio/types-internal": 2.4.0-alpha.0
     "@radix-ui/react-hover-card": 1.0.6
     "@radix-ui/react-tabs": 1.0.4
     "@radix-ui/react-visually-hidden": 1.0.3


### PR DESCRIPTION
> [!IMPORTANT]
> Do not merge this PR. It is a proof-of-concept.

## Context

DT-2008

## The Solution

- Use an alpha version of `@prismicio/types-internal` that includes the `allowCaption` image field option.
- Add the `allowCaption` form field to the image widget.
- Adjust the edit dialog to render the checkbox in a reasonable location.

> [!NOTE]
> Since this is a proof-of-concept PR and will not be merged, we can ignore the failing Playwright test.

## Impact / Dependencies

This PR allows developers to configure image fields with a caption. The page builder needs to be updated to read this option.

## Checklist before requesting a review
- [ ] I hereby declare my code ready for review.
- [ ] If it is a critical feature, I have added tests.
- [ ] The CI is successful.
- [ ] If there could backward compatibility issues, it has been discussed and planned.

## [OPT] Preview

<img width="1012" alt="image" src="https://github.com/prismicio/slice-machine/assets/8601064/af493c4e-7642-404b-8cd7-a25cf6c7c653">
