### PR TITLE
feat: warn and inform users on development environment usage (DT-2092)

### DIFF
--- a/packages/manager/src/constants/API_ENDPOINTS.ts
+++ b/packages/manager/src/constants/API_ENDPOINTS.ts
@@ -41,11 +41,11 @@ export const API_ENDPOINTS: APIEndpoints = (() => {
 
 			if (missingAPIEndpoints.length > 0) {
 				console.error(
-					`You are running Slice Machine in development mode (SM_ENV=${APPLICATION_MODE.Development}) where API endpoints are configured via environment variables.
+					`You are running Slice Machine in development mode (SM_ENV=${
+						APPLICATION_MODE.Development
+					}) where API endpoints are configured via environment variables.
 
-The following endpoints were not configured: ${missingAPIEndpoints.join(
-						", ",
-					)}.
+The following endpoints were not configured: ${missingAPIEndpoints.join(", ")}.
 
 Configure them before continuing.`,
 				);
@@ -53,10 +53,14 @@ Configure them before continuing.`,
 				process.exit(1);
 			}
 
-			console.warn(`You are running Slice Machine in development mode (SM_ENV=${APPLICATION_MODE.Development}).
+			console.warn(`You are running Slice Machine in development mode (SM_ENV=${
+				APPLICATION_MODE.Development
+			}).
 
 The following API endpoints were configured via environment variables:
-${Object.entries(apiEndpoints).map(([name, endpoint]) => `  - ${name}: ${endpoint}`).join("\n")}
+${Object.entries(apiEndpoints)
+	.map(([name, endpoint]) => `  - ${name}: ${endpoint}`)
+	.join("\n")}
 
 If you didn't intend to run Slice Machine this way stop it immediately and unset the SM_ENV environment variable.`);
 

--- a/packages/manager/src/constants/API_ENDPOINTS.ts
+++ b/packages/manager/src/constants/API_ENDPOINTS.ts
@@ -41,13 +41,24 @@ export const API_ENDPOINTS: APIEndpoints = (() => {
 
 			if (missingAPIEndpoints.length > 0) {
 				console.error(
-					`You are running Slice Machine in development mode where API endpoints are configured via environment variables. The following endpoints were not configured: ${missingAPIEndpoints.join(
+					`You are running Slice Machine in development mode (SM_ENV=${APPLICATION_MODE.Development}) where API endpoints are configured via environment variables.
+
+The following endpoints were not configured: ${missingAPIEndpoints.join(
 						", ",
-					)}. Configure them before continuing.`,
+					)}.
+
+Configure them before continuing.`,
 				);
 
 				process.exit(1);
 			}
+
+			console.warn(`You are running Slice Machine in development mode (SM_ENV=${APPLICATION_MODE.Development}).
+
+The following API endpoints were configured via environment variables:
+${Object.entries(apiEndpoints).map(([name, endpoint]) => `  - ${name}: ${endpoint}`).join("\n")}
+
+If you didn't intend to run Slice Machine this way stop it immediately and unset the SM_ENV environment variable.`);
 
 			return apiEndpoints as APIEndpoints;
 		}

--- a/packages/manager/src/constants/API_ENDPOINTS.ts
+++ b/packages/manager/src/constants/API_ENDPOINTS.ts
@@ -62,7 +62,9 @@ ${Object.entries(apiEndpoints)
 	.map(([name, endpoint]) => `  - ${name}: ${endpoint}`)
 	.join("\n")}
 
-If you didn't intend to run Slice Machine this way stop it immediately and unset the SM_ENV environment variable.`);
+These endpoints are different than Slice Machine's normal endpoints and are not trusted.
+
+If you didn't intend to run Slice Machine this way, stop it immediately and unset the SM_ENV environment variable.`);
 
 			return apiEndpoints as APIEndpoints;
 		}


### PR DESCRIPTION
## Context

Running Slice Machine with `SM_ENV=development` allows any endpoints to be set through environment variables. This is useful for Prismic developers to develop locally and potentially dangerous for users ([more details on Linear](https://linear.app/prismic/issue/DT-2092/aadev-and-aauser-im-clearly-aware-im-using-the-development-environment)).

## The Solution

<!--
Highlight explanations where the complexity in your development is.
Keep in mind that the reviewer might not have as much context as you do.
This is very important to make sure the review is thorough and the reviewer understand your changes.
-->

This PR adds a clear warning that Slice Machine has been started in development mode, prompts the configured endpoints (useful for Prismic developers), and incentivize other users to exit immediately.

## Impact / Dependencies

<!--
List all the impacts your development might have on internal and external features.
Ideally this should have been discussed prior to this development.

Link of any other PRs that are related to this development.
They should also be referenced in the ticket for reviews.
-->

I didn't use chalk or any formatting as we want to keep the manager free of such dependencies (the manager is not an application). I think the warning is big and unusual enough to catch attention as-is?

## Checklist before requesting a review
- [x] I hereby declare my code ready for review.
- [ ] If it is a critical feature, I have added tests.
- [x] The CI is successful.
- [x] If there could backward compatibility issues, it has been discussed and planned.




## [OPT] Preview

<!--
Visual aid of your work.
It can either be screenshots or a video.
This could help reviewers to get context quickly.
-->

![image](https://github.com/prismicio/slice-machine/assets/25330882/4839111b-c513-41dc-8307-c3edc81d0f03)

Get a similar result by running the following inside an e2e project:
```bash
npx cross-env \
NODE_ENV=development \
SM_ENV=development \
wroom_endpoint=https://prismic.io/ \
authentication_server_endpoint=https://auth.prismic.io/ \
customtypesapi_endpoint=https://customtypes.prismic.io/ \
user_service_endpoint=https://user-service.prismic.io/ \
acl_provider_endpoint=https://0yyeb2g040.execute-api.us-east-1.amazonaws.com/prod/ \
npx start-slicemachine
```

<!--
A funny animal picture is welcome to close your PR!
You can find one here https://unsplash.com/s/photos/funny-animal-picture
-->