### PR TITLE
fix: don't hardcode repository name with Nuxt

### DIFF
--- a/packages/adapter-nuxt/package.json
+++ b/packages/adapter-nuxt/package.json
@@ -66,7 +66,7 @@
 		"fp-ts": "^2.13.1",
 		"io-ts": "^2.2.20",
 		"io-ts-types": "^0.5.19",
-		"magicast": "^0.2.1",
+		"magicast": "^0.3.3",
 		"monocle-ts": "^2.3.13",
 		"newtype-ts": "^0.3.5",
 		"pascal-case": "^3.1.2",

--- a/packages/adapter-nuxt/src/hooks/project-init.ts
+++ b/packages/adapter-nuxt/src/hooks/project-init.ts
@@ -11,7 +11,7 @@ import {
 	writeProjectFile,
 } from "@slicemachine/plugin-kit/fs";
 import { stripIndent } from "common-tags";
-import { loadFile, writeFile, type ASTNode } from "magicast";
+import { builders, generateCode, loadFile } from "magicast";
 
 import { rejectIfNecessary } from "../lib/rejectIfNecessary";
 import { checkIsTypeScriptProject } from "../lib/checkIsTypeScriptProject";
@@ -51,7 +51,7 @@ type ConfigurePrismicModuleArgs = SliceMachineContext<PluginOptions>;
 
 const configurePrismicModule = async ({
 	helpers,
-	project,
+	options,
 }: ConfigurePrismicModuleArgs) => {
 	let nuxtConfigFilename = "nuxt.config.js";
 
@@ -96,13 +96,34 @@ const configurePrismicModule = async ({
 	}
 
 	// Append Prismic module configuration
-	const endpoint = project.config.repositoryName;
+	const ENDPOINT_REPLACE_KEY = "___prismicEndpoint___";
+	const ENDPOINT_REPLACE_VALUE = "apiEndpoint || repositoryName";
 	if (!hasInlinedConfiguration) {
+		// Import Slice Machine configuration
+		mod.imports.$add({
+			from: "./slicemachine.config.json",
+			imported: "apiEndpoint",
+		});
+		mod.imports.$add({
+			from: "./slicemachine.config.json",
+			imported: "repositoryName",
+		});
+
+		// Add inline configuration
 		config.prismic ||= {};
-		config.prismic.endpoint = endpoint;
+		config.prismic.endpoint = builders.raw(ENDPOINT_REPLACE_KEY);
 	}
 
-	await writeFile(mod as unknown as ASTNode, nuxtConfigPath);
+	const ast = "$ast" in mod ? mod.$ast : mod;
+	let { code } = generateCode(ast);
+	// This is a workaround to magicast not supporting "LogicalExpression" node type
+	code = code.replace(ENDPOINT_REPLACE_KEY, ENDPOINT_REPLACE_VALUE);
+	await writeProjectFile({
+		filename: nuxtConfigFilename,
+		contents: code,
+		format: options.format,
+		helpers,
+	});
 };
 
 type CreateSliceSimulatorPageArgs = SliceMachineContext<PluginOptions>;

--- a/packages/adapter-nuxt/test/plugin-project-init.test.ts
+++ b/packages/adapter-nuxt/test/plugin-project-init.test.ts
@@ -72,6 +72,43 @@ describe("Prismic module", () => {
 			"
 		`);
 	});
+
+	test("overwrites existing endpoint", async (ctx) => {
+		const log = vi.fn();
+		const installDependencies = vi.fn();
+
+		const nuxtConfigPath = path.join(ctx.project.root, "nuxt.config.js");
+		await fs.writeFile(
+			nuxtConfigPath,
+			`
+export default defineNuxtConfig({
+  modules: ["@nuxtjs/prismic"],
+
+  prismic: {
+    endpoint: "example-prismic-repo",
+  },
+})
+`.trim(),
+		);
+
+		await ctx.pluginRunner.callHook("project:init", {
+			log,
+			installDependencies,
+		});
+
+		await expect(fs.readFile(nuxtConfigPath, "utf-8")).resolves
+			.toMatchInlineSnapshot(`
+			"import { apiEndpoint, repositoryName } from \\"./slicemachine.config.json\\";
+			export default defineNuxtConfig({
+			  modules: [\\"@nuxtjs/prismic\\"],
+
+			  prismic: {
+			    endpoint: apiEndpoint || repositoryName,
+			  },
+			});
+			"
+		`);
+	});
 });
 
 describe("Slice Simulator page", () => {

--- a/packages/adapter-nuxt/test/plugin-project-init.test.ts
+++ b/packages/adapter-nuxt/test/plugin-project-init.test.ts
@@ -35,12 +35,12 @@ describe("Prismic module", () => {
 
 		await expect(fs.readFile(nuxtConfigPath, "utf-8")).resolves
 			.toMatchInlineSnapshot(`
-			"import config from \\"./slicemachine.config.json\\";
+			"import { apiEndpoint, repositoryName } from \\"./slicemachine.config.json\\";
 			export default defineNuxtConfig({
 			  modules: [\\"@nuxtjs/prismic\\"],
 
 			  prismic: {
-			    endpoint: config.apiEndpoint || config.repositoryName,
+			    endpoint: apiEndpoint || repositoryName,
 			  },
 			});
 			"
@@ -61,12 +61,12 @@ describe("Prismic module", () => {
 
 		await expect(fs.readFile(nuxtConfigPath, "utf-8")).resolves
 			.toMatchInlineSnapshot(`
-			"import config from \\"./slicemachine.config.json\\";
+			"import { apiEndpoint, repositoryName } from \\"./slicemachine.config.json\\";
 			export default defineNuxtConfig({
 			  modules: [\\"@nuxtjs/prismic\\"],
 
 			  prismic: {
-			    endpoint: config.apiEndpoint || config.repositoryName,
+			    endpoint: apiEndpoint || repositoryName,
 			  },
 			});
 			"

--- a/packages/adapter-nuxt/test/plugin-project-init.test.ts
+++ b/packages/adapter-nuxt/test/plugin-project-init.test.ts
@@ -35,13 +35,15 @@ describe("Prismic module", () => {
 
 		await expect(fs.readFile(nuxtConfigPath, "utf-8")).resolves
 			.toMatchInlineSnapshot(`
-			"export default defineNuxtConfig({
+			"import config from \\"./slicemachine.config.json\\";
+			export default defineNuxtConfig({
 			  modules: [\\"@nuxtjs/prismic\\"],
 
 			  prismic: {
-			    endpoint: \\"qwerty\\"
-			  }
-			})"
+			    endpoint: config.apiEndpoint || config.repositoryName,
+			  },
+			});
+			"
 		`);
 	});
 
@@ -59,13 +61,15 @@ describe("Prismic module", () => {
 
 		await expect(fs.readFile(nuxtConfigPath, "utf-8")).resolves
 			.toMatchInlineSnapshot(`
-			"export default defineNuxtConfig({
+			"import config from \\"./slicemachine.config.json\\";
+			export default defineNuxtConfig({
 			  modules: [\\"@nuxtjs/prismic\\"],
 
 			  prismic: {
-			    endpoint: \\"qwerty\\"
-			  }
-			})"
+			    endpoint: config.apiEndpoint || config.repositoryName,
+			  },
+			});
+			"
 		`);
 	});
 });

--- a/packages/adapter-nuxt2/package.json
+++ b/packages/adapter-nuxt2/package.json
@@ -66,7 +66,7 @@
 		"fp-ts": "^2.13.1",
 		"io-ts": "^2.2.20",
 		"io-ts-types": "^0.5.19",
-		"magicast": "^0.2.1",
+		"magicast": "^0.3.3",
 		"monocle-ts": "^2.3.13",
 		"newtype-ts": "^0.3.5",
 		"pascal-case": "^3.1.2",

--- a/packages/adapter-nuxt2/test/plugin-project-init.test.ts
+++ b/packages/adapter-nuxt2/test/plugin-project-init.test.ts
@@ -35,14 +35,16 @@ describe("Prismic module", () => {
 
 		await expect(fs.readFile(nuxtConfigPath, "utf-8")).resolves
 			.toMatchInlineSnapshot(`
-			"export default {
+			"import config from \\"./slicemachine.config.json\\";
+			export default {
 			  buildModules: [\\"@nuxtjs/prismic\\"],
 
 			  prismic: {
-			    endpoint: \\"https://qwerty.cdn.prismic.io/api/v2\\",
-			    modern: true
-			  }
-			};"
+			    endpoint: config.apiEndpoint || config.repositoryName,
+			    modern: true,
+			  },
+			};
+			"
 		`);
 	});
 
@@ -60,14 +62,16 @@ describe("Prismic module", () => {
 
 		await expect(fs.readFile(nuxtConfigPath, "utf-8")).resolves
 			.toMatchInlineSnapshot(`
-			"export default {
+			"import config from \\"./slicemachine.config.json\\";
+			export default {
 			  buildModules: [\\"@nuxtjs/prismic\\"],
 
 			  prismic: {
-			    endpoint: \\"https://qwerty.cdn.prismic.io/api/v2\\",
-			    modern: true
-			  }
-			};"
+			    endpoint: config.apiEndpoint || config.repositoryName,
+			    modern: true,
+			  },
+			};
+			"
 		`);
 	});
 
@@ -83,7 +87,7 @@ describe("Prismic module", () => {
 			.mockImplementation(() => undefined);
 
 		const nuxtConfigPath = path.join(ctx.project.root, "nuxt.config.ts");
-		await fs.writeFile(nuxtConfigPath, "export default () => ({})");
+		await fs.writeFile(nuxtConfigPath, "module.exports = () => ({})");
 
 		await ctx.pluginRunner.callHook("project:init", {
 			log,

--- a/packages/adapter-nuxt2/test/plugin-project-init.test.ts
+++ b/packages/adapter-nuxt2/test/plugin-project-init.test.ts
@@ -75,6 +75,45 @@ describe("Prismic module", () => {
 		`);
 	});
 
+	test("overwrites existing endpoint", async (ctx) => {
+		const log = vi.fn();
+		const installDependencies = vi.fn();
+
+		const nuxtConfigPath = path.join(ctx.project.root, "nuxt.config.js");
+		await fs.writeFile(
+			nuxtConfigPath,
+			`
+export default {
+  buildModules: ["@nuxtjs/prismic"],
+
+  prismic: {
+    endpoint: "example-prismic-repo",
+		modern: true,
+  },
+}
+`.trim(),
+		);
+
+		await ctx.pluginRunner.callHook("project:init", {
+			log,
+			installDependencies,
+		});
+
+		await expect(fs.readFile(nuxtConfigPath, "utf-8")).resolves
+			.toMatchInlineSnapshot(`
+			"import { apiEndpoint, repositoryName } from \\"./slicemachine.config.json\\";
+			export default {
+			  buildModules: [\\"@nuxtjs/prismic\\"],
+
+			  prismic: {
+			    endpoint: apiEndpoint || repositoryName,
+			    modern: true,
+			  },
+			};
+			"
+		`);
+	});
+
 	test("warns user that Nuxt config could not be updated", async (ctx) => {
 		const log = vi.fn();
 		const installDependencies = vi.fn();

--- a/packages/adapter-nuxt2/test/plugin-project-init.test.ts
+++ b/packages/adapter-nuxt2/test/plugin-project-init.test.ts
@@ -35,12 +35,12 @@ describe("Prismic module", () => {
 
 		await expect(fs.readFile(nuxtConfigPath, "utf-8")).resolves
 			.toMatchInlineSnapshot(`
-			"import config from \\"./slicemachine.config.json\\";
+			"import { apiEndpoint, repositoryName } from \\"./slicemachine.config.json\\";
 			export default {
 			  buildModules: [\\"@nuxtjs/prismic\\"],
 
 			  prismic: {
-			    endpoint: config.apiEndpoint || config.repositoryName,
+			    endpoint: apiEndpoint || repositoryName,
 			    modern: true,
 			  },
 			};
@@ -62,12 +62,12 @@ describe("Prismic module", () => {
 
 		await expect(fs.readFile(nuxtConfigPath, "utf-8")).resolves
 			.toMatchInlineSnapshot(`
-			"import config from \\"./slicemachine.config.json\\";
+			"import { apiEndpoint, repositoryName } from \\"./slicemachine.config.json\\";
 			export default {
 			  buildModules: [\\"@nuxtjs/prismic\\"],
 
 			  prismic: {
-			    endpoint: config.apiEndpoint || config.repositoryName,
+			    endpoint: apiEndpoint || repositoryName,
 			    modern: true,
 			  },
 			};

--- a/scripts/play.ts
+++ b/scripts/play.ts
@@ -334,24 +334,6 @@ async function createPlayground(
     },
   );
 
-  // The Nuxt adapter edits the `endpoint` option as part of `@slicemachine/init`.
-  // We need to change it to the API endpoint to support different environments.
-  if (options.framework === "nuxt") {
-    const sliceMachineConfig: SliceMachineConfig = JSON.parse(
-      await fs.readFile(new URL("./slicemachine.config.json", dir), "utf8"),
-    );
-
-    if (sliceMachineConfig.apiEndpoint) {
-      const nuxtConfigPath = new URL("./nuxt.config.ts", dir);
-      const nuxtConfig = await fs.readFile(nuxtConfigPath, "utf8");
-      const newNuxtConfig = nuxtConfig.replace(
-        /endpoint: '.*',/,
-        `endpoint: '${sliceMachineConfig.apiEndpoint}',`,
-      );
-      await fs.writeFile(nuxtConfigPath, newNuxtConfig);
-    }
-  }
-
   // Commit all changes so new changes are reflected in Git.
   await exec("git", ["commit", "-am", "chore: init playground"], {
     cwd: dir,

--- a/yarn.lock
+++ b/yarn.lock
@@ -424,10 +424,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helper-string-parser@npm:^7.23.4":
+  version: 7.24.1
+  resolution: "@babel/helper-string-parser@npm:7.24.1"
+  checksum: 8404e865b06013979a12406aab4c0e8d2e377199deec09dfe9f57b833b0c9ce7b6e8c1c553f2da8d0bcd240c5005bd7a269f4fef0d628aeb7d5fe035c436fb67
+  languageName: node
+  linkType: hard
+
 "@babel/helper-validator-identifier@npm:^7.19.1, @babel/helper-validator-identifier@npm:^7.22.5":
   version: 7.22.5
   resolution: "@babel/helper-validator-identifier@npm:7.22.5"
   checksum: 7f0f30113474a28298c12161763b49de5018732290ca4de13cdaefd4fd0d635a6fe3f6686c37a02905fb1e64f21a5ee2b55140cf7b070e729f1bd66866506aea
+  languageName: node
+  linkType: hard
+
+"@babel/helper-validator-identifier@npm:^7.22.20":
+  version: 7.22.20
+  resolution: "@babel/helper-validator-identifier@npm:7.22.20"
+  checksum: 136412784d9428266bcdd4d91c32bcf9ff0e8d25534a9d94b044f77fe76bc50f941a90319b05aafd1ec04f7d127cd57a179a3716009ff7f3412ef835ada95bdc
   languageName: node
   linkType: hard
 
@@ -481,12 +495,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/parser@npm:^7.1.0, @babel/parser@npm:^7.13.16, @babel/parser@npm:^7.14.7, @babel/parser@npm:^7.16.4, @babel/parser@npm:^7.18.4, @babel/parser@npm:^7.20.15, @babel/parser@npm:^7.20.7, @babel/parser@npm:^7.21.3, @babel/parser@npm:^7.21.5, @babel/parser@npm:^7.21.8, @babel/parser@npm:^7.22.4, @babel/parser@npm:^7.22.5":
+"@babel/parser@npm:^7.1.0, @babel/parser@npm:^7.13.16, @babel/parser@npm:^7.14.7, @babel/parser@npm:^7.16.4, @babel/parser@npm:^7.18.4, @babel/parser@npm:^7.20.15, @babel/parser@npm:^7.20.7, @babel/parser@npm:^7.21.3, @babel/parser@npm:^7.21.5, @babel/parser@npm:^7.21.8, @babel/parser@npm:^7.22.5":
   version: 7.22.5
   resolution: "@babel/parser@npm:7.22.5"
   bin:
     parser: ./bin/babel-parser.js
   checksum: 470ebba516417ce8683b36e2eddd56dcfecb32c54b9bb507e28eb76b30d1c3e618fd0cfeee1f64d8357c2254514e1a19e32885cfb4e73149f4ae875436a6d59c
+  languageName: node
+  linkType: hard
+
+"@babel/parser@npm:^7.23.6":
+  version: 7.24.4
+  resolution: "@babel/parser@npm:7.24.4"
+  bin:
+    parser: ./bin/babel-parser.js
+  checksum: 94c9e3e592894cd6fc57c519f4e06b65463df9be5f01739bb0d0bfce7ffcf99b3c2fdadd44dc59cc858ba2739ce6e469813a941c2f2dfacf333a3b2c9c5c8465
   languageName: node
   linkType: hard
 
@@ -1951,7 +1974,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/types@npm:^7.0.0, @babel/types@npm:^7.2.0, @babel/types@npm:^7.20.2, @babel/types@npm:^7.20.7, @babel/types@npm:^7.21.3, @babel/types@npm:^7.21.5, @babel/types@npm:^7.22.4, @babel/types@npm:^7.22.5, @babel/types@npm:^7.4.4, @babel/types@npm:^7.8.3":
+"@babel/types@npm:^7.0.0, @babel/types@npm:^7.2.0, @babel/types@npm:^7.20.2, @babel/types@npm:^7.20.7, @babel/types@npm:^7.21.3, @babel/types@npm:^7.21.5, @babel/types@npm:^7.22.5, @babel/types@npm:^7.4.4, @babel/types@npm:^7.8.3":
   version: 7.22.5
   resolution: "@babel/types@npm:7.22.5"
   dependencies:
@@ -1959,6 +1982,17 @@ __metadata:
     "@babel/helper-validator-identifier": ^7.22.5
     to-fast-properties: ^2.0.0
   checksum: c13a9c1dc7d2d1a241a2f8363540cb9af1d66e978e8984b400a20c4f38ba38ca29f06e26a0f2d49a70bad9e57615dac09c35accfddf1bb90d23cd3e0a0bab892
+  languageName: node
+  linkType: hard
+
+"@babel/types@npm:^7.23.6":
+  version: 7.24.0
+  resolution: "@babel/types@npm:7.24.0"
+  dependencies:
+    "@babel/helper-string-parser": ^7.23.4
+    "@babel/helper-validator-identifier": ^7.22.20
+    to-fast-properties: ^2.0.0
+  checksum: 4b574a37d490f621470ff36a5afaac6deca5546edcb9b5e316d39acbb20998e9c2be42f3fc0bf2b55906fc49ff2a5a6a097e8f5a726ee3f708a0b0ca93aed807
   languageName: node
   linkType: hard
 
@@ -8629,7 +8663,7 @@ __metadata:
     fp-ts: ^2.13.1
     io-ts: ^2.2.20
     io-ts-types: ^0.5.19
-    magicast: ^0.2.1
+    magicast: ^0.3.3
     monocle-ts: ^2.3.13
     newtype-ts: ^0.3.5
     nuxt: 2.16.3
@@ -8671,7 +8705,7 @@ __metadata:
     fp-ts: ^2.13.1
     io-ts: ^2.2.20
     io-ts-types: ^0.5.19
-    magicast: ^0.2.1
+    magicast: ^0.3.3
     monocle-ts: ^2.3.13
     newtype-ts: ^0.3.5
     nuxt: 3.3.3
@@ -22544,14 +22578,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"magicast@npm:^0.2.1":
-  version: 0.2.9
-  resolution: "magicast@npm:0.2.9"
+"magicast@npm:^0.3.3":
+  version: 0.3.3
+  resolution: "magicast@npm:0.3.3"
   dependencies:
-    "@babel/parser": ^7.22.4
-    "@babel/types": ^7.22.4
-    recast: ^0.23.2
-  checksum: f87a012707261f4d0bcba0c4efdb971385d6d1cb9cb81c9da5da3a70397adfb790f5eff4bef598c294563776937b01498956bd46b5c4419d09a3f34076367818
+    "@babel/parser": ^7.23.6
+    "@babel/types": ^7.23.6
+    source-map-js: ^1.0.2
+  checksum: de2bfca38cf4a20e598cf0e48598d183ebe2a846b80c5f4a71950b4e501f27492b3d21111a4da3dcff8aa85c2acdf3900126a8867a030a9f2fbb3c7a0a0c78bc
   languageName: node
   linkType: hard
 
@@ -29154,7 +29188,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"recast@npm:^0.23.1, recast@npm:^0.23.2":
+"recast@npm:^0.23.1":
   version: 0.23.2
   resolution: "recast@npm:0.23.2"
   dependencies:


### PR DESCRIPTION
## Context

With Nuxt 2/3 we were hardcoding the repository name inside Nuxt config instead of sourcing it from Slice Machine configuration. This PR fixes it.

## The Solution

While [magicast](https://github.com/unjs/magicast) can not handle adding import statements, it still has some limitations regarding logical expressions, so I had to use the old (and not so clean 🙈) search & replace trick.

## Impact / Dependencies

<!--
List all the impacts your development might have on internal and external features.
Ideally this should have been discussed prior to this development.

Link of any other PRs that are related to this development.
They should also be referenced in the ticket for reviews.
-->




## Checklist before requesting a review
- [x] I hereby declare my code ready for review.
- [x] If it is a critical feature, I have added tests.
- [x] The CI is successful.
- [x] If there could backward compatibility issues, it has been discussed and planned.




## [OPT] Preview

<!--
Visual aid of your work.
It can either be screenshots or a video.
This could help reviewers to get context quickly.
-->




<!--
A funny animal picture is welcome to close your PR!
You can find one here https://unsplash.com/s/photos/funny-animal-picture
-->