### PR TITLE
refactor(slice-machine-ui): convert `RenameVariationModal` to CSS Modules

### DIFF
--- a/packages/slice-machine/components/Forms/RenameVariationModal/RenameVariationModal.css.ts
+++ b/packages/slice-machine/components/Forms/RenameVariationModal/RenameVariationModal.css.ts
@@ -1,7 +1,0 @@
-import { sprinkles } from "@prismicio/editor-ui";
-
-export const label = sprinkles({
-  display: "inline-flex",
-  alignItems: "center",
-  gap: 4,
-});

--- a/packages/slice-machine/components/Forms/RenameVariationModal/RenameVariationModal.module.css
+++ b/packages/slice-machine/components/Forms/RenameVariationModal/RenameVariationModal.module.css
@@ -1,0 +1,5 @@
+.label {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}

--- a/packages/slice-machine/components/Forms/RenameVariationModal/RenameVariationModal.tsx
+++ b/packages/slice-machine/components/Forms/RenameVariationModal/RenameVariationModal.tsx
@@ -15,7 +15,7 @@ import type { VariationSM } from "@lib/models/common/Slice";
 import { renameVariation } from "@src/features/slices/sliceBuilder/actions/renameVariation";
 import useSliceMachineActions from "@src/modules/useSliceMachineActions";
 
-import * as styles from "./RenameVariationModal.css";
+import styles from "./RenameVariationModal.module.css";
 import { useSliceState } from "@src/features/slices/sliceBuilder/SliceBuilderProvider";
 
 type RenameVariationModalProps = {


### PR DESCRIPTION
## Context

DT-2030

## The Solution

- Perform a 1:1 conversion from Vanilla Extract to CSS Modules.

## Impact / Dependencies

N/A

## Checklist before requesting a review
- [x] I hereby declare my code ready for review.
- [ ] If it is a critical feature, I have added tests.
- [x] The CI is successful.
- [ ] If there could backward compatibility issues, it has been discussed and planned.
