### PR TITLE
refactor(slice-machine-ui): convert `Navigation` to CSS Modules

### DIFF
--- a/packages/slice-machine/components/Navigation/index.css.ts
+++ b/packages/slice-machine/components/Navigation/index.css.ts
@@ -1,5 +1,0 @@
-import { sprinkles } from "@prismicio/editor-ui";
-
-export const environmentDivider = sprinkles({
-  marginBlock: 16,
-});

--- a/packages/slice-machine/components/Navigation/index.module.css
+++ b/packages/slice-machine/components/Navigation/index.module.css
@@ -1,0 +1,3 @@
+.environmentDivider {
+  margin-block: 16px;
+}

--- a/packages/slice-machine/components/Navigation/index.tsx
+++ b/packages/slice-machine/components/Navigation/index.tsx
@@ -32,7 +32,7 @@ import { Environment } from "./Environment";
 import { RunningVersion } from "./RunningVersion";
 import { UpdateBox } from "./UpdateBox";
 
-import * as styles from "./index.css";
+import styles from "./index.module.css";
 
 const Navigation: FC = () => {
   const { hasSeenTutorialsToolTip } = useSelector(


### PR DESCRIPTION
## Context

DT-2020

## The Solution

- Perform a 1:1 conversion from Vanilla Extract to CSS Modules.

## Impact / Dependencies

N/A

## Checklist before requesting a review
- [x] I hereby declare my code ready for review.
- [ ] If it is a critical feature, I have added tests.
- [ ] The CI is successful.
- [ ] If there could backward compatibility issues, it has been discussed and planned.
