### PR TITLE
feat(start-slicemachine): support `--host` option

### DIFF
--- a/packages/start-slicemachine/src/cli.ts
+++ b/packages/start-slicemachine/src/cli.ts
@@ -5,13 +5,14 @@ import * as pkg from "../package.json";
 type Args = {
 	open: boolean;
 	port: string;
+	host: string;
 	help: boolean;
 	version: boolean;
 };
 
 const args = mri<Args>(process.argv.slice(2), {
 	boolean: ["open", "help", "version"],
-	string: ["port"],
+	string: ["port", "host"],
 	alias: {
 		port: "p",
 		help: "h",
@@ -33,6 +34,7 @@ Usage:
 Options:
     --open         Open Slice Machine automatically
     --port, -p     Specify the port on which to run Slice Machine
+    --host         Specify the host on which to run Slice Machine
     --help, -h     Show help text
     --version, -v  Show version
 `.trim(),
@@ -63,6 +65,7 @@ import("./StartSliceMachineProcess").then(
 		const startSliceMachineProcess = createStartSliceMachineProcess({
 			open: args.open,
 			port,
+			host: args.host,
 		});
 
 		startSliceMachineProcess.run();


### PR DESCRIPTION
## Context

DT-2115

## The Solution

Add a `--host` option to `start-slicemachine`. The value is passed to `app.listen` to start the server on the given host.

If no `--host` option is provided, the system's default is used (effectively `127.0.0.1`/`localhost`).

## Impact / Dependencies

The `--host` option may allow access to Slice Machine through cloud-based or virtual machine sandboxes.

## Checklist before requesting a review
- [ ] I hereby declare my code ready for review.
- [ ] If it is a critical feature, I have added tests.
- [ ] The CI is successful.
- [ ] If there could backward compatibility issues, it has been discussed and planned.
