### PR TITLE
fix: restyle the field zone empty state

### DIFF
--- a/packages/slice-machine/src/components/List/List.css.ts
+++ b/packages/slice-machine/src/components/List/List.css.ts
@@ -50,6 +50,11 @@ export const header = style([
   }),
   {
     selectors: {
+      ["&:not(:first-child)"]: {
+        borderTopStyle: "solid",
+        borderTopColor: vars.color.greyLight6,
+        borderTopWidth: 1,
+      },
       [`${windowStyles.tabsContent} > ${root} > &:not(:first-child)`]: {
         marginTop: vars.space[16],
       },

--- a/packages/slice-machine/src/components/List/List.css.ts
+++ b/packages/slice-machine/src/components/List/List.css.ts
@@ -55,9 +55,6 @@ export const header = style([
         borderTopColor: vars.color.greyLight6,
         borderTopWidth: 1,
       },
-      [`${windowStyles.tabsContent} > ${root} > &:not(:first-child)`]: {
-        marginTop: vars.space[16],
-      },
     },
   },
 ]);

--- a/packages/slice-machine/src/legacy/lib/builders/CustomTypeBuilder/TabZone/index.tsx
+++ b/packages/slice-machine/src/legacy/lib/builders/CustomTypeBuilder/TabZone/index.tsx
@@ -242,6 +242,7 @@ const TabZone: FC<TabZoneProps> = ({ tabId }) => {
               }
               testId="static-zone-content"
               isRepeatableCustomType={customType.repeatable}
+              emptyStateActionTestId="add-Static-field"
             />
           ) : undefined}
 

--- a/packages/slice-machine/src/legacy/lib/builders/CustomTypeBuilder/TabZone/index.tsx
+++ b/packages/slice-machine/src/legacy/lib/builders/CustomTypeBuilder/TabZone/index.tsx
@@ -215,6 +215,7 @@ const TabZone: FC<TabZoneProps> = ({ tabId }) => {
           {query.newPageType === undefined ? (
             <Zone
               zoneType="customType"
+              zoneTypeFormat={customType.format ?? "custom"}
               // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
               tabId={tabId}
               title="Static Zone"

--- a/packages/slice-machine/src/legacy/lib/builders/SliceBuilder/FieldZones/index.tsx
+++ b/packages/slice-machine/src/legacy/lib/builders/SliceBuilder/FieldZones/index.tsx
@@ -212,7 +212,9 @@ const FieldZones: FC = () => {
         }
         testId="static-zone-content"
         isRepeatableCustomType={undefined}
-        emptyStateHeading="No fields"
+        emptyStateHeading={
+          groupsInSlicesExperiment.eligible ? undefined : "No fields"
+        }
         emptyStateActionTestId="add-Static-field"
       />
       {!groupsInSlicesExperiment.eligible || hasItems ? (

--- a/packages/slice-machine/src/legacy/lib/builders/SliceBuilder/FieldZones/index.tsx
+++ b/packages/slice-machine/src/legacy/lib/builders/SliceBuilder/FieldZones/index.tsx
@@ -213,6 +213,7 @@ const FieldZones: FC = () => {
         testId="static-zone-content"
         isRepeatableCustomType={undefined}
         emptyStateHeading="No fields"
+        emptyStateActionTestId="add-Static-field"
       />
       {!groupsInSlicesExperiment.eligible || hasItems ? (
         <Zone
@@ -241,6 +242,7 @@ const FieldZones: FC = () => {
           testId="slice-repeatable-zone"
           isRepeatableCustomType={undefined}
           emptyStateHeading="No fields"
+          emptyStateActionTestId="add-Repeatable-field"
         />
       ) : null}
       <Dialog

--- a/packages/slice-machine/src/legacy/lib/builders/SliceBuilder/FieldZones/index.tsx
+++ b/packages/slice-machine/src/legacy/lib/builders/SliceBuilder/FieldZones/index.tsx
@@ -211,6 +211,7 @@ const FieldZones: FC = () => {
         }
         testId="static-zone-content"
         isRepeatableCustomType={undefined}
+        addFieldButtonLabel="Add"
       />
       {!groupsInSlicesExperiment.eligible || hasItems ? (
         <Zone

--- a/packages/slice-machine/src/legacy/lib/builders/SliceBuilder/FieldZones/index.tsx
+++ b/packages/slice-machine/src/legacy/lib/builders/SliceBuilder/FieldZones/index.tsx
@@ -184,6 +184,7 @@ const FieldZones: FC = () => {
     <List>
       <Zone
         zoneType="slice"
+        zoneTypeFormat={undefined}
         tabId={undefined}
         title="Fields"
         dataTip={dataTipText}
@@ -211,10 +212,12 @@ const FieldZones: FC = () => {
         }
         testId="static-zone-content"
         isRepeatableCustomType={undefined}
+        emptyStateHeading="No fields"
       />
       {!groupsInSlicesExperiment.eligible || hasItems ? (
         <Zone
           zoneType="slice"
+          zoneTypeFormat={undefined}
           tabId={undefined}
           isRepeatable
           title="Repeatable Zone"
@@ -237,6 +240,7 @@ const FieldZones: FC = () => {
           }
           testId="slice-repeatable-zone"
           isRepeatableCustomType={undefined}
+          emptyStateHeading="No fields"
         />
       ) : null}
       <Dialog

--- a/packages/slice-machine/src/legacy/lib/builders/SliceBuilder/FieldZones/index.tsx
+++ b/packages/slice-machine/src/legacy/lib/builders/SliceBuilder/FieldZones/index.tsx
@@ -211,7 +211,6 @@ const FieldZones: FC = () => {
         }
         testId="static-zone-content"
         isRepeatableCustomType={undefined}
-        addFieldButtonLabel="Add"
       />
       {!groupsInSlicesExperiment.eligible || hasItems ? (
         <Zone

--- a/packages/slice-machine/src/legacy/lib/builders/common/Zone/components/ZoneEmptyState/ZoneEmptyState.module.css
+++ b/packages/slice-machine/src/legacy/lib/builders/common/Zone/components/ZoneEmptyState/ZoneEmptyState.module.css
@@ -1,4 +1,8 @@
 .root {
+  display: flex;
+  align-items: center;
+  flex-direction: column;
+  gap: 16px;
   background-color: var(--grey3);
   text-align: center;
   padding-top: 32px;

--- a/packages/slice-machine/src/legacy/lib/builders/common/Zone/components/ZoneEmptyState/ZoneEmptyState.module.css
+++ b/packages/slice-machine/src/legacy/lib/builders/common/Zone/components/ZoneEmptyState/ZoneEmptyState.module.css
@@ -1,0 +1,6 @@
+.root {
+  background-color: var(--grey3);
+  text-align: center;
+  padding-top: 32px;
+  padding-bottom: 32px;
+}

--- a/packages/slice-machine/src/legacy/lib/builders/common/Zone/components/ZoneEmptyState/ZoneEmptyState.module.css
+++ b/packages/slice-machine/src/legacy/lib/builders/common/Zone/components/ZoneEmptyState/ZoneEmptyState.module.css
@@ -1,10 +1,12 @@
 .root {
   display: flex;
-  align-items: center;
   flex-direction: column;
+  align-items: center;
+  justify-content: center;
   gap: 16px;
   background-color: var(--grey3);
   text-align: center;
   padding-top: 32px;
   padding-bottom: 32px;
+  min-height: 288px;
 }

--- a/packages/slice-machine/src/legacy/lib/builders/common/Zone/components/ZoneEmptyState/ZoneEmptyState.tsx
+++ b/packages/slice-machine/src/legacy/lib/builders/common/Zone/components/ZoneEmptyState/ZoneEmptyState.tsx
@@ -4,8 +4,8 @@ import { FC } from "react";
 import styles from "./ZoneEmptyState.module.css";
 
 type ZoneEmptyStateProps = {
-  onEnterSelectMode: () => void;
   zoneName: string;
+  onEnterSelectMode: () => void;
 };
 
 export const ZoneEmptyState: FC<ZoneEmptyStateProps> = (props) => {
@@ -25,7 +25,7 @@ export const ZoneEmptyState: FC<ZoneEmptyStateProps> = (props) => {
         data-testid={`add-${zoneName}-field`}
         startIcon="add"
       >
-        Add new
+        Add a field
       </Button>
     </div>
   );

--- a/packages/slice-machine/src/legacy/lib/builders/common/Zone/components/ZoneEmptyState/ZoneEmptyState.tsx
+++ b/packages/slice-machine/src/legacy/lib/builders/common/Zone/components/ZoneEmptyState/ZoneEmptyState.tsx
@@ -1,28 +1,33 @@
 import { Button, Text } from "@prismicio/editor-ui";
-import { FC } from "react";
+import { FC, ReactNode } from "react";
 
 import styles from "./ZoneEmptyState.module.css";
 
 type ZoneEmptyStateProps = {
-  zoneName: string;
+  zoneType: "custom type" | "page type" | "slice";
+  heading?: ReactNode;
   onEnterSelectMode: () => void;
 };
 
 export const ZoneEmptyState: FC<ZoneEmptyStateProps> = (props) => {
-  const { zoneName, onEnterSelectMode } = props;
+  const {
+    zoneType,
+    heading = `Your ${zoneType} has no fields yet`,
+    onEnterSelectMode,
+  } = props;
 
   return (
     <div className={styles.root}>
       <div>
-        <Text variant="bold">No fields</Text>
+        <Text variant="bold">{heading}</Text>
         <Text color="grey11">
-          Fields are inputs for content (e.g. text, images, links).
+          A field is an input for content (e.g. text, images, links).
         </Text>
       </div>
       <Button
         color="grey"
         onClick={() => onEnterSelectMode()}
-        data-testid={`add-${zoneName}-field`}
+        data-testid={`add-${zoneType.replace(" ", "-")}-field`}
         startIcon="add"
       >
         Add a field

--- a/packages/slice-machine/src/legacy/lib/builders/common/Zone/components/ZoneEmptyState/ZoneEmptyState.tsx
+++ b/packages/slice-machine/src/legacy/lib/builders/common/Zone/components/ZoneEmptyState/ZoneEmptyState.tsx
@@ -1,31 +1,32 @@
 import { Button, Text } from "@prismicio/editor-ui";
-import { Box } from "theme-ui";
+import { FC } from "react";
 
 import styles from "./ZoneEmptyState.module.css";
 
-export const ZoneEmptyState = ({
-  onEnterSelectMode,
-  zoneName,
-}: {
-  // eslint-disable-next-line @typescript-eslint/ban-types
-  onEnterSelectMode: Function;
+type ZoneEmptyStateProps = {
+  onEnterSelectMode: () => void;
   zoneName: string;
-}) => (
-  <div className={styles.root}>
-    <Text variant="bold">Add a new field here</Text>
-    <Text color="grey11">
-      Fields are inputs for content (e.g. text, images, links).
-    </Text>
-    <Box sx={{ display: "flex", justifyContent: "center", marginTop: 16 }}>
+};
+
+export const ZoneEmptyState: FC<ZoneEmptyStateProps> = (props) => {
+  const { zoneName, onEnterSelectMode } = props;
+
+  return (
+    <div className={styles.root}>
+      <div>
+        <Text variant="bold">No fields</Text>
+        <Text color="grey11">
+          Fields are inputs for content (e.g. text, images, links).
+        </Text>
+      </div>
       <Button
         color="grey"
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-return
         onClick={() => onEnterSelectMode()}
         data-testid={`add-${zoneName}-field`}
         startIcon="add"
       >
         Add new
       </Button>
-    </Box>
-  </div>
-);
+    </div>
+  );
+};

--- a/packages/slice-machine/src/legacy/lib/builders/common/Zone/components/ZoneEmptyState/ZoneEmptyState.tsx
+++ b/packages/slice-machine/src/legacy/lib/builders/common/Zone/components/ZoneEmptyState/ZoneEmptyState.tsx
@@ -6,14 +6,16 @@ import styles from "./ZoneEmptyState.module.css";
 type ZoneEmptyStateProps = {
   zoneType: "custom type" | "page type" | "slice";
   heading?: ReactNode;
-  onEnterSelectMode: () => void;
+  onActionClick: () => void;
+  actionTestId?: string;
 };
 
 export const ZoneEmptyState: FC<ZoneEmptyStateProps> = (props) => {
   const {
     zoneType,
     heading = `Your ${zoneType} has no fields yet`,
-    onEnterSelectMode,
+    onActionClick,
+    actionTestId,
   } = props;
 
   return (
@@ -26,8 +28,8 @@ export const ZoneEmptyState: FC<ZoneEmptyStateProps> = (props) => {
       </div>
       <Button
         color="grey"
-        onClick={() => onEnterSelectMode()}
-        data-testid={`add-${zoneType.replace(" ", "-")}-field`}
+        onClick={() => onActionClick()}
+        data-testid={actionTestId}
         startIcon="add"
       >
         Add a field

--- a/packages/slice-machine/src/legacy/lib/builders/common/Zone/components/ZoneEmptyState/ZoneEmptyState.tsx
+++ b/packages/slice-machine/src/legacy/lib/builders/common/Zone/components/ZoneEmptyState/ZoneEmptyState.tsx
@@ -1,7 +1,9 @@
-import { Button } from "@prismicio/editor-ui";
-import { Box, Heading, Text } from "theme-ui";
+import { Button, Text } from "@prismicio/editor-ui";
+import { Box } from "theme-ui";
 
-const ZoneEmptyState = ({
+import styles from "./ZoneEmptyState.module.css";
+
+export const ZoneEmptyState = ({
   onEnterSelectMode,
   zoneName,
 }: {
@@ -9,13 +11,11 @@ const ZoneEmptyState = ({
   onEnterSelectMode: Function;
   zoneName: string;
 }) => (
-  <Box sx={{ textAlign: "center", my: 4 }}>
-    <Heading as="h5">Add a new field here</Heading>
-    <Box sx={{ my: 2 }}>
-      <Text sx={{ color: "textClear" }}>
-        Fields are inputs for content (e.g. text, images, links).
-      </Text>
-    </Box>
+  <div className={styles.root}>
+    <Text variant="bold">Add a new field here</Text>
+    <Text color="grey11">
+      Fields are inputs for content (e.g. text, images, links).
+    </Text>
     <Box sx={{ display: "flex", justifyContent: "center", marginTop: 16 }}>
       <Button
         color="grey"
@@ -24,10 +24,8 @@ const ZoneEmptyState = ({
         data-testid={`add-${zoneName}-field`}
         startIcon="add"
       >
-        Add a new field
+        Add new
       </Button>
     </Box>
-  </Box>
+  </div>
 );
-
-export default ZoneEmptyState;

--- a/packages/slice-machine/src/legacy/lib/builders/common/Zone/components/ZoneEmptyState/index.tsx
+++ b/packages/slice-machine/src/legacy/lib/builders/common/Zone/components/ZoneEmptyState/index.tsx
@@ -1,0 +1,1 @@
+export { ZoneEmptyState } from "./ZoneEmptyState";

--- a/packages/slice-machine/src/legacy/lib/builders/common/Zone/index.jsx
+++ b/packages/slice-machine/src/legacy/lib/builders/common/Zone/index.jsx
@@ -32,6 +32,7 @@ const Zone = ({
   testId,
   isRepeatableCustomType,
   emptyStateHeading,
+  emptyStateActionTestId,
 }) => {
   // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
   const widgetsArrayWithCondUid = (() => {
@@ -128,7 +129,9 @@ const Zone = ({
             zoneType={getResolvedZoneType(zoneType, zoneTypeFormat)}
             // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
             heading={emptyStateHeading}
-            onEnterSelectMode={() => enterSelectMode()}
+            onActionClick={() => enterSelectMode()}
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+            actionTestId={emptyStateActionTestId}
           />
         ) : // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/strict-boolean-expressions
         fields.length > 0 || newFieldData ? (

--- a/packages/slice-machine/src/legacy/lib/builders/common/Zone/index.jsx
+++ b/packages/slice-machine/src/legacy/lib/builders/common/Zone/index.jsx
@@ -10,7 +10,7 @@ import { getContentTypeForTracking } from "@/utils/getContentTypeForTracking";
 import SelectFieldTypeModal from "../SelectFieldTypeModal";
 import Card from "./Card";
 import NewField from "./Card/components/NewField";
-import EmptyState from "./components/EmptyState";
+import { ZoneEmptyState } from "./components/ZoneEmptyState";
 
 const Zone = ({
   zoneType /* type of the zone: customType or slice */,
@@ -110,7 +110,7 @@ const Zone = ({
                 color="grey"
                 disabled={newFieldData !== null}
               >
-                Add a new field
+                Add
               </Button>
             </>
           ) : undefined
@@ -122,7 +122,7 @@ const Zone = ({
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/strict-boolean-expressions
         fields.length === 0 && !newFieldData ? (
           <BaseStyles>
-            <EmptyState
+            <ZoneEmptyState
               onEnterSelectMode={() => enterSelectMode()}
               // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
               zoneName={isRepeatable ? "Repeatable" : "Static"}

--- a/packages/slice-machine/src/legacy/lib/builders/common/Zone/index.jsx
+++ b/packages/slice-machine/src/legacy/lib/builders/common/Zone/index.jsx
@@ -30,7 +30,6 @@ const Zone = ({
   renderFieldAccessor /* render field accessor (eg. slice.primary.title) */,
   testId,
   isRepeatableCustomType,
-  addFieldButtonLabel = "Add a new field",
 }) => {
   // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
   const widgetsArrayWithCondUid = (() => {
@@ -111,7 +110,7 @@ const Zone = ({
                 color="grey"
                 disabled={newFieldData !== null}
               >
-                {addFieldButtonLabel}
+                Add a field
               </Button>
             </>
           ) : undefined

--- a/packages/slice-machine/src/legacy/lib/builders/common/Zone/index.jsx
+++ b/packages/slice-machine/src/legacy/lib/builders/common/Zone/index.jsx
@@ -30,6 +30,7 @@ const Zone = ({
   renderFieldAccessor /* render field accessor (eg. slice.primary.title) */,
   testId,
   isRepeatableCustomType,
+  addFieldButtonLabel = "Add a new field",
 }) => {
   // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
   const widgetsArrayWithCondUid = (() => {
@@ -110,7 +111,7 @@ const Zone = ({
                 color="grey"
                 disabled={newFieldData !== null}
               >
-                Add
+                {addFieldButtonLabel}
               </Button>
             </>
           ) : undefined

--- a/packages/slice-machine/src/legacy/lib/builders/common/Zone/index.jsx
+++ b/packages/slice-machine/src/legacy/lib/builders/common/Zone/index.jsx
@@ -14,6 +14,7 @@ import { ZoneEmptyState } from "./components/ZoneEmptyState";
 
 const Zone = ({
   zoneType /* type of the zone: customType or slice */,
+  zoneTypeFormat /* format of the zone: page or custom */,
   tabId,
   title /* text info to display in Card Header */,
   fields /* widgets registered in the zone */,
@@ -30,6 +31,7 @@ const Zone = ({
   renderFieldAccessor /* render field accessor (eg. slice.primary.title) */,
   testId,
   isRepeatableCustomType,
+  emptyStateHeading,
 }) => {
   // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
   const widgetsArrayWithCondUid = (() => {
@@ -121,13 +123,13 @@ const Zone = ({
       {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/strict-boolean-expressions
         fields.length === 0 && !newFieldData ? (
-          <BaseStyles>
-            <ZoneEmptyState
-              onEnterSelectMode={() => enterSelectMode()}
-              // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
-              zoneName={isRepeatable ? "Repeatable" : "Static"}
-            />
-          </BaseStyles>
+          <ZoneEmptyState
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+            zoneType={getResolvedZoneType(zoneType, zoneTypeFormat)}
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+            heading={emptyStateHeading}
+            onEnterSelectMode={() => enterSelectMode()}
+          />
         ) : // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/strict-boolean-expressions
         fields.length > 0 || newFieldData ? (
           <BaseStyles>
@@ -223,5 +225,21 @@ Zone.propTypes = {
     }),
   ),
 };
+
+/**
+ * Determines the resolved type of a given zone type.
+ *
+ * @param {"customType" | "slice"} zoneType - The type of the zone.
+ * @param {"page" | "custom"} [format] - The format of the zone type (if applicable).
+ *
+ * @returns {"custom type" | "page type" | "slice"}
+ */
+function getResolvedZoneType(zoneType, format) {
+  if (zoneType === "customType") {
+    return format === "page" ? "page type" : "custom type";
+  }
+
+  return zoneType;
+}
 
 export default Zone;


### PR DESCRIPTION
## Context

DT-2116

## The Solution

- Use a darker background color in the empty state.
- Update the empty state's text.
- Replace `theme-ui` with `@prismicio/editor-ui` and custom CSS.

## Impact / Dependencies

N/A

## Checklist before requesting a review
- [x] I hereby declare my code ready for review.
- [ ] If it is a critical feature, I have added tests.
- [x] The CI is successful.
- [ ] If there could backward compatibility issues, it has been discussed and planned.

## Preview

This PR affects all builder screens: custom types, page types, and slices.

### Slices

**Without fields**:
![localhost_9999_slices_ --src--slices_RichText_default](https://github.com/prismicio/slice-machine/assets/8601064/40090d04-a6de-4642-aa03-ea26e1cb322c)

**With the repeatable zone**
Note: This state will not be possible in the near future once the Repeatable Zone is no longer available. Emptying the zone will remove it.
![localhost_9999_slices_ --src--slices_RichText_default (3)](https://github.com/prismicio/slice-machine/assets/8601064/1848e10f-e713-4065-9ddd-4056b6384fee)

**With fields**:
![localhost_9999_slices_ --src--slices_RichText_default (1)](https://github.com/prismicio/slice-machine/assets/8601064/db606fa2-8982-4e8a-b535-d4fe469137ba)

**With fields and the repeatable zone**:
![localhost_9999_slices_ --src--slices_RichText_default (2)](https://github.com/prismicio/slice-machine/assets/8601064/86e67c22-d51d-4752-87fa-c210d74b3917)

### Page/Custom Types

**Without fields**:
![localhost_9999_custom-types](https://github.com/prismicio/slice-machine/assets/8601064/18d7ba15-1855-44c7-8d16-01d09942adcc)

**With fields**:
![localhost_9999_custom-types (1)](https://github.com/prismicio/slice-machine/assets/8601064/31041a65-d5fd-4ccb-80dc-f4bcd3bbf2cf)