### PR TITLE
feat: show code snippets for group fields

### DIFF
--- a/packages/adapter-next/src/hooks/snippet-read.ts
+++ b/packages/adapter-next/src/hooks/snippet-read.ts
@@ -15,6 +15,7 @@ const format = async (input: string, helpers: SliceMachineHelpers) => {
 		includeNewlineAtEnd: false,
 		prettier: {
 			parser: "typescript",
+			printWidth: 60,
 		},
 	});
 
@@ -86,9 +87,11 @@ export const snippetRead: SnippetReadHook<PluginOptions> = async (
 		case "Group": {
 			const code = await format(
 				stripIndent`
-					<>{${dotPath(fieldPath)}.map(item => (
-					  <>{/* Render content for item */}</>
-					))}</>
+					<>
+						{${dotPath(fieldPath)}.map((item) => {
+							// Render the item
+						})}
+					</>
 				`,
 				helpers,
 			);

--- a/packages/adapter-next/test/plugin-snippet-read.test.ts
+++ b/packages/adapter-next/test/plugin-snippet-read.test.ts
@@ -65,7 +65,12 @@ const testSnippet = (
 			expect(res).toStrictEqual({
 				label: "React",
 				language: "tsx",
-				code: (await prettier.format(expected, { parser: "typescript" }))
+				code: (
+					await prettier.format(expected, {
+						parser: "typescript",
+						printWidth: 60,
+					})
+				)
 					.replace(/[\r\n]+$/, "")
 					.replace(/;$/, ""),
 			});
@@ -96,9 +101,9 @@ testSnippet(
 
 testSnippet(
 	"group",
-	`<>{${model.id}.data.group.map((item) => (
-<>{/* Render content for item */}</>
-))}</>`,
+	`<>{${model.id}.data.group.map((item) => {
+// Render the item
+})}</>`,
 );
 
 testSnippet("image", `<PrismicNextImage field={${model.id}.data.image} />`);

--- a/packages/slice-machine/src/legacy/lib/builders/common/Zone/Card/index.jsx
+++ b/packages/slice-machine/src/legacy/lib/builders/common/Zone/Card/index.jsx
@@ -93,12 +93,6 @@ const FieldZone = ({
                   testId: `list-item-${item.key}`,
                 };
 
-                // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
-                if (widget.CustomListItem) {
-                  const { CustomListItem } = widget;
-                  return <CustomListItem {...props} />;
-                }
-
                 const HintElement = (
                   <Hint
                     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/restrict-template-expressions, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment
@@ -114,6 +108,15 @@ const FieldZone = ({
                     typeName={widget.CUSTOM_NAME || widget.TYPE_NAME}
                   />
                 );
+
+                // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
+                if (widget.CustomListItem) {
+                  const { CustomListItem } = widget;
+                  return (
+                    <CustomListItem {...props} HintElement={HintElement} />
+                  );
+                }
+
                 return <ListItem {...props} HintElement={HintElement} />;
               })
             }

--- a/packages/slice-machine/src/legacy/lib/models/common/widgets/Group/ListItem/index.jsx
+++ b/packages/slice-machine/src/legacy/lib/models/common/widgets/Group/ListItem/index.jsx
@@ -34,6 +34,7 @@ const CustomListItem = ({
   item: groupItem,
   draggableId,
   saveItem,
+  HintElement,
   ...rest
 }) => {
   const [selectMode, setSelectMode] = useState(false);
@@ -166,6 +167,7 @@ const CustomListItem = ({
         draggableId={draggableId}
         // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unused-vars, @typescript-eslint/restrict-template-expressions, @typescript-eslint/no-unsafe-member-access
         {...rest}
+        HintElement={HintElement}
         CustomEditElements={[
           <Button
             // eslint-disable-next-line @typescript-eslint/restrict-template-expressions, @typescript-eslint/no-unsafe-member-access

--- a/playwright/tests/pageTypes/pageTypeBuilderFields.spec.ts
+++ b/playwright/tests/pageTypes/pageTypeBuilderFields.spec.ts
@@ -208,6 +208,23 @@ test("I can see and copy the code snippets", async ({
   await pageTypesBuilderPage.copyCodeSnippet("my_rich_text");
 });
 
+test("I can see and copy the code snippets for groups", async ({
+  pageTypesBuilderPage,
+  reusablePageType,
+}) => {
+  await pageTypesBuilderPage.goto(reusablePageType.name);
+  await pageTypesBuilderPage.addStaticField({
+    type: "Group",
+    name: "My Group",
+    expectedId: "my_group",
+  });
+
+  await expect(pageTypesBuilderPage.codeSnippetsFieldSwitch).not.toBeChecked();
+  await pageTypesBuilderPage.codeSnippetsFieldSwitch.click();
+  await expect(pageTypesBuilderPage.codeSnippetsFieldSwitch).toBeChecked();
+  await pageTypesBuilderPage.copyCodeSnippet("my_group");
+});
+
 test("I cannot delete default UID field for reusable page type", async ({
   pageTypesBuilderPage,
   reusablePageType,

--- a/playwright/tests/slices/sliceBuilderFields.spec.ts
+++ b/playwright/tests/slices/sliceBuilderFields.spec.ts
@@ -329,3 +329,29 @@ test("I can see and copy the code snippets", async ({
   await expect(sliceBuilderPage.codeSnippetsFieldSwitch).toBeChecked();
   await sliceBuilderPage.copyCodeSnippet("my_rich_text", "static");
 });
+
+test("I can see and copy the code snippets for groups", async ({
+  sliceBuilderPage,
+  slice,
+  procedures,
+}) => {
+  procedures.mock(
+    "telemetry.getExperimentVariant",
+    ({ args }) =>
+      args[0] === "slicemachine-groups-in-slices" ? { value: "on" } : undefined,
+    { execute: false },
+  );
+
+  await sliceBuilderPage.goto(slice.name);
+  await sliceBuilderPage.addField({
+    type: "Group",
+    name: "My Group",
+    expectedId: "my_group",
+    zoneType: "static",
+  });
+
+  await expect(sliceBuilderPage.codeSnippetsFieldSwitch).not.toBeChecked();
+  await sliceBuilderPage.codeSnippetsFieldSwitch.click();
+  await expect(sliceBuilderPage.codeSnippetsFieldSwitch).toBeChecked();
+  await sliceBuilderPage.copyCodeSnippet("my_group", "static");
+});


### PR DESCRIPTION
## Context

DT-2104

## The Solution

- Render a code snippet for the group field.
- Simplify `@slicemachine/adapter-next`'s code snippet.

The adapters already provide a snippet for group fields. They were not displayed in the UI.

## Impact / Dependencies

N/A

## Checklist before requesting a review
- [x] I hereby declare my code ready for review.
- [ ] If it is a critical feature, I have added tests.
- [x] The CI is successful.
- [ ] If there could backward compatibility issues, it has been discussed and planned.

## [OPT] Preview

**Next.js**:
![localhost_9999_slices_ --slices_RichText_default (3)](https://github.com/prismicio/slice-machine/assets/8601064/0b639e60-9055-4532-bfb8-56c06ea47b45)

**Nuxt**:
![localhost_9999_slices_ --slices_RichText_default (4)](https://github.com/prismicio/slice-machine/assets/8601064/ad77f1d3-7664-41ba-a6a6-093bfaeda9fe)

**SvelteKit**:
![localhost_9999_slices_ --slices_RichText_default (5)](https://github.com/prismicio/slice-machine/assets/8601064/6da1637d-2f8f-42a0-a3bb-b275ac93b43b)