### PR TITLE
fix: update repeatable zone and group texts

### DIFF
--- a/packages/slice-machine/src/legacy/lib/builders/SliceBuilder/FieldZones/index.tsx
+++ b/packages/slice-machine/src/legacy/lib/builders/SliceBuilder/FieldZones/index.tsx
@@ -248,12 +248,12 @@ const FieldZones: FC = () => {
         <DialogContent>
           <Box padding={24} gap={12} flexDirection="column">
             <strong>
-              This action will permanently remove the Repeatable Zone from the{" "}
+              This action will permanently remove the repeatable zone from the{" "}
               {slice.model.name} slice.
             </strong>
             <div>
-              If you need repeatable fields again, use a repeatable group field
-              in place of the repeatable zone.
+              To reimplement repeatable fields later, use a group field instead
+              of the repeatable zone.
             </div>
           </Box>
           <DialogActions

--- a/packages/slice-machine/src/legacy/lib/models/common/widgets/Group/index.ts
+++ b/packages/slice-machine/src/legacy/lib/models/common/widgets/Group/index.ts
@@ -10,7 +10,7 @@ import CustomListItem from "./ListItem";
 const Meta = {
   icon: MdPlaylistAdd,
   title: "Group",
-  description: "A Group of Prismic fields",
+  description: "A repeatable set of fields",
 };
 
 const schema = yup.object().shape({


### PR DESCRIPTION
## Context

- https://prismic-team.slack.com/archives/C02L3FN3AJK/p1713446989591439?thread_ts=1713298354.266299&cid=C02L3FN3AJK
- https://prismic-team.slack.com/archives/C02G5CFFLR2/p1713261632956239?thread_ts=1712869312.778609&cid=C02G5CFFLR2

## The Solution

- Update the text shown when deleting the repeatable zone.
- Update the description of group fields.

Both pieces of text were provided by @samlfair

## How to validate
**Set up the test:**
1. Create a new playground: `yarn play --new`
2. In Slice Machine, create a new slice and add one field to its repeatable zone.
3. In Amplitude, enable the `slicemachine-groups-in-slices` flag for your repository.

**Verify:**
1. In Slice Machine, go back to the slice you created in the set up steps.
2. Delete the field in the repeatable zone and verify the repeatable zone removal message.
3. Open the "Add a field" modal and verify the group field's description.

## Impact / Dependencies

N/A

## Checklist before requesting a review
- [x] I hereby declare my code ready for review.
- [ ] If it is a critical feature, I have added tests.
- [ ] The CI is successful.
- [ ] If there could backward compatibility issues, it has been discussed and planned.
