### PR TITLE
chore(packages): Update prismic-types-internal to alpha 7

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
   "resolutions": {
     "connected-next-router/react-redux": "8.0.7",
     "react-beautiful-dnd/react-redux": "8.0.7",
-    "@prismicio/types-internal": "2.4.0-alpha.4"
+    "@prismicio/types-internal": "2.4.0-alpha.7"
   },
   "workspaces": [
     "e2e-projects/next",

--- a/packages/adapter-next/package.json
+++ b/packages/adapter-next/package.json
@@ -67,7 +67,7 @@
 	},
 	"dependencies": {
 		"@prismicio/simulator": "^0.1.4",
-		"@prismicio/types-internal": "^2.4.0-alpha.4",
+		"@prismicio/types-internal": "^2.4.0-alpha.7",
 		"@slicemachine/plugin-kit": "workspace:*",
 		"common-tags": "^1.8.2",
 		"fp-ts": "^2.13.1",

--- a/packages/adapter-nuxt/package.json
+++ b/packages/adapter-nuxt/package.json
@@ -60,7 +60,7 @@
 	},
 	"dependencies": {
 		"@prismicio/simulator": "^0.1.4",
-		"@prismicio/types-internal": "^2.4.0-alpha.4",
+		"@prismicio/types-internal": "^2.4.0-alpha.7",
 		"@slicemachine/plugin-kit": "workspace:*",
 		"common-tags": "^1.8.2",
 		"fp-ts": "^2.13.1",

--- a/packages/adapter-nuxt2/package.json
+++ b/packages/adapter-nuxt2/package.json
@@ -60,7 +60,7 @@
 	},
 	"dependencies": {
 		"@prismicio/simulator": "^0.1.4",
-		"@prismicio/types-internal": "^2.4.0-alpha.4",
+		"@prismicio/types-internal": "^2.4.0-alpha.7",
 		"@slicemachine/plugin-kit": "workspace:*",
 		"common-tags": "^1.8.2",
 		"fp-ts": "^2.13.1",

--- a/packages/adapter-sveltekit/package.json
+++ b/packages/adapter-sveltekit/package.json
@@ -63,7 +63,7 @@
 	},
 	"dependencies": {
 		"@prismicio/simulator": "^0.1.4",
-		"@prismicio/types-internal": "^2.4.0-alpha.4",
+		"@prismicio/types-internal": "^2.4.0-alpha.7",
 		"@slicemachine/plugin-kit": "workspace:*",
 		"common-tags": "^1.8.2",
 		"fp-ts": "^2.13.1",

--- a/packages/manager/package.json
+++ b/packages/manager/package.json
@@ -68,7 +68,7 @@
 		"@prismicio/client": "^7.5.0-alpha.0",
 		"@prismicio/custom-types-client": "1.3.1",
 		"@prismicio/mocks": "2.2.0-alpha.0",
-		"@prismicio/types-internal": "^2.4.0-alpha.4",
+		"@prismicio/types-internal": "^2.4.0-alpha.7",
 		"@segment/analytics-node": "1.1.3",
 		"@slicemachine/plugin-kit": "workspace:*",
 		"cookie": "^0.5.0",

--- a/packages/plugin-kit/package.json
+++ b/packages/plugin-kit/package.json
@@ -76,7 +76,7 @@
 	},
 	"devDependencies": {
 		"@prismicio/mock": "0.2.0",
-		"@prismicio/types-internal": "2.4.0-alpha.4",
+		"@prismicio/types-internal": "2.4.0-alpha.7",
 		"@size-limit/preset-small-lib": "8.2.4",
 		"@types/common-tags": "1.8.1",
 		"@types/fs-extra": "11.0.1",

--- a/packages/slice-machine/package.json
+++ b/packages/slice-machine/package.json
@@ -48,7 +48,7 @@
     "@prismicio/mock": "0.3.3",
     "@prismicio/mocks": "2.2.0-alpha.0",
     "@prismicio/simulator": "0.1.4",
-    "@prismicio/types-internal": "2.4.0-alpha.4",
+    "@prismicio/types-internal": "2.4.0-alpha.7",
     "@radix-ui/react-hover-card": "1.0.6",
     "@radix-ui/react-tabs": "1.0.4",
     "@reach/menu-button": "0.18.0",

--- a/packages/start-slicemachine/package.json
+++ b/packages/start-slicemachine/package.json
@@ -56,7 +56,7 @@
 	"bin": "./bin/start-slicemachine.js",
 	"dependencies": {
 		"@prismicio/mocks": "^2.2.0-alpha.0",
-		"@prismicio/types-internal": "^2.4.0-alpha.4",
+		"@prismicio/types-internal": "^2.4.0-alpha.7",
 		"@slicemachine/manager": "workspace:*",
 		"body-parser": "^1.20.2",
 		"chalk": "^4.1.2",

--- a/playwright/package.json
+++ b/playwright/package.json
@@ -15,7 +15,7 @@
   "devDependencies": {
     "@msgpack/msgpack": "2.8.0",
     "@playwright/test": "1.39.0",
-    "@prismicio/types-internal": "2.2.0",
+    "@prismicio/types-internal": "2.4.0-alpha.7",
     "@slicemachine/manager": "workspace:*",
     "@typescript-eslint/eslint-plugin": "5.55.0",
     "@typescript-eslint/parser": "5.55.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5625,9 +5625,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@prismicio/types-internal@npm:2.4.0-alpha.4":
-  version: 2.4.0-alpha.4
-  resolution: "@prismicio/types-internal@npm:2.4.0-alpha.4"
+"@prismicio/types-internal@npm:2.4.0-alpha.7":
+  version: 2.4.0-alpha.7
+  resolution: "@prismicio/types-internal@npm:2.4.0-alpha.7"
   dependencies:
     monocle-ts: ^2.3.11
     newtype-ts: ^0.3.5
@@ -5638,7 +5638,7 @@ __metadata:
     io-ts: ^2.2.16
     io-ts-types: ^0.5.16
     uuid: ^9.0.0
-  checksum: f965dc6458cfa23f7651171c91ad1b3b6907e969807cab387ba55e30a1f596b4410f9250ec8ec431634a6b847090abf15c1c2a75d86ebcbbcc60b26dec972ba9
+  checksum: ec2d0aa0d5974eccfdfc23b860c13fd7cb2d37cd81a2c579b0d578f007b760d04803c66b22003557ce5bfec8839e615e23c732367405e55c03f3317307606f58
   languageName: node
   linkType: hard
 
@@ -8561,7 +8561,7 @@ __metadata:
   dependencies:
     "@prismicio/mock": 0.2.0
     "@prismicio/simulator": ^0.1.4
-    "@prismicio/types-internal": ^2.4.0-alpha.4
+    "@prismicio/types-internal": ^2.4.0-alpha.7
     "@size-limit/preset-small-lib": 8.2.4
     "@slicemachine/plugin-kit": "workspace:*"
     "@types/common-tags": 1.8.1
@@ -8606,7 +8606,7 @@ __metadata:
   dependencies:
     "@prismicio/mock": 0.2.0
     "@prismicio/simulator": ^0.1.4
-    "@prismicio/types-internal": ^2.4.0-alpha.4
+    "@prismicio/types-internal": ^2.4.0-alpha.7
     "@size-limit/preset-small-lib": 8.2.4
     "@slicemachine/plugin-kit": "workspace:*"
     "@typescript-eslint/eslint-plugin": 5.55.0
@@ -8647,7 +8647,7 @@ __metadata:
   dependencies:
     "@prismicio/mock": 0.2.0
     "@prismicio/simulator": ^0.1.4
-    "@prismicio/types-internal": ^2.4.0-alpha.4
+    "@prismicio/types-internal": ^2.4.0-alpha.7
     "@size-limit/preset-small-lib": 8.2.4
     "@slicemachine/plugin-kit": "workspace:*"
     "@types/common-tags": 1.8.1
@@ -8689,7 +8689,7 @@ __metadata:
   dependencies:
     "@prismicio/mock": 0.2.0
     "@prismicio/simulator": ^0.1.4
-    "@prismicio/types-internal": ^2.4.0-alpha.4
+    "@prismicio/types-internal": ^2.4.0-alpha.7
     "@size-limit/preset-small-lib": 8.2.4
     "@slicemachine/plugin-kit": "workspace:*"
     "@sveltejs/kit": 2.0.0
@@ -8742,7 +8742,7 @@ __metadata:
   dependencies:
     "@msgpack/msgpack": 2.8.0
     "@playwright/test": 1.39.0
-    "@prismicio/types-internal": 2.2.0
+    "@prismicio/types-internal": 2.4.0-alpha.7
     "@slicemachine/manager": "workspace:*"
     "@typescript-eslint/eslint-plugin": 5.55.0
     "@typescript-eslint/parser": 5.55.0
@@ -8812,7 +8812,7 @@ __metadata:
     "@prismicio/custom-types-client": 1.3.1
     "@prismicio/mock": 0.2.0
     "@prismicio/mocks": 2.2.0-alpha.0
-    "@prismicio/types-internal": ^2.4.0-alpha.4
+    "@prismicio/types-internal": ^2.4.0-alpha.7
     "@segment/analytics-node": 1.1.3
     "@size-limit/preset-small-lib": 8.2.4
     "@slicemachine/plugin-kit": "workspace:*"
@@ -8870,7 +8870,7 @@ __metadata:
   dependencies:
     "@prismicio/client": ^7.5.0-alpha.0
     "@prismicio/mock": 0.2.0
-    "@prismicio/types-internal": 2.4.0-alpha.4
+    "@prismicio/types-internal": 2.4.0-alpha.7
     "@size-limit/preset-small-lib": 8.2.4
     "@types/common-tags": 1.8.1
     "@types/fs-extra": 11.0.1
@@ -30560,7 +30560,7 @@ __metadata:
     "@prismicio/mock": 0.3.3
     "@prismicio/mocks": 2.2.0-alpha.0
     "@prismicio/simulator": 0.1.4
-    "@prismicio/types-internal": 2.4.0-alpha.4
+    "@prismicio/types-internal": 2.4.0-alpha.7
     "@radix-ui/react-hover-card": 1.0.6
     "@radix-ui/react-tabs": 1.0.4
     "@radix-ui/react-visually-hidden": 1.0.3
@@ -31043,7 +31043,7 @@ __metadata:
   resolution: "start-slicemachine@workspace:packages/start-slicemachine"
   dependencies:
     "@prismicio/mocks": ^2.2.0-alpha.0
-    "@prismicio/types-internal": ^2.4.0-alpha.4
+    "@prismicio/types-internal": ^2.4.0-alpha.7
     "@size-limit/preset-small-lib": 8.2.4
     "@slicemachine/manager": "workspace:*"
     "@types/body-parser": 1.19.2


### PR DESCRIPTION
## Context

- Simply update prismic types internal in order to test with the last version of what we want to release

## The Solution

- I kept the override method used by Angelo that we should remove after release a minor version of prismic types internal
