### PR TITLE
chore: add custom `dev` script

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,15 +6,7 @@
   "packageManager": "yarn@3.6.0",
   "scripts": {
     "clean": "rimraf --glob '{e2e-projects/*/{.next,.svelte-kit},packages/*/{.next,.svelte-kit,build,coverage,dist,out,package.tgz,src/**/*.module.css.d.ts,storybook-static},playwright/{playwright-report,test-results}}'",
-    "dev": "concurrently --prefix-colors auto \"yarn:dev:*\"",
-    "dev:manager": "yarn workspace @slicemachine/manager dev",
-    "dev:start-slicemachine": "yarn workspace start-slicemachine dev",
-    "dev:plugin-kit": "yarn workspace @slicemachine/plugin-kit dev",
-    "dev:slice-machine-ui": "yarn workspace slice-machine-ui dev",
-    "dev:adapter-next": "yarn workspace @slicemachine/adapter-next dev",
-    "dev:adapter-sveltekit": "yarn workspace @slicemachine/adapter-sveltekit dev",
-    "dev:init": "yarn workspace @slicemachine/init dev",
-    "dev:e2e-next": "cd ./e2e-projects/next && yarn dev --port 8000",
+    "dev": "tsx scripts/dev.ts",
     "clean-e2e-projects": "git checkout e2e-projects/ && git clean -f e2e-projects/",
     "postinstall": "husky install",
     "build": "yarn workspaces foreach --topological-dev --verbose run build && yarn run test",
@@ -53,7 +45,8 @@
     "rimraf": "5.0.5",
     "semver": "7.3.8",
     "start-server-and-test": "1.15.5",
-    "tsx": "4.6.2"
+    "tsx": "4.6.2",
+    "zod": "3.23.5"
   },
   "lint-staged": {
     "**/packages/slice-machine/**/*.@(js|jsx|ts|tsx|)": [

--- a/scripts/dev.ts
+++ b/scripts/dev.ts
@@ -1,0 +1,289 @@
+import mri from "mri";
+import chalk from "chalk";
+import { z } from "zod";
+import { spawn } from "node:child_process";
+import { EventEmitter } from "node:events";
+
+import { exec, handleUncaughtException } from "./utils/commandUtils";
+
+/**
+ * A single output of the `yarn workspaces info` command.
+ */
+const Workspace = z.object({
+  name: z.string(),
+  location: z.string(),
+  workspaceDependencies: z.array(z.string()),
+  mismatchedWorkspaceDependencies: z.array(z.string()),
+});
+type Workspace = z.infer<typeof Workspace>;
+
+/**
+ * An `EventEmitter` used to track workspace build statuses.
+ */
+type BuildEmitter = Emitter<{
+  built: { workspace: Workspace };
+}>;
+
+main();
+
+type Args = {
+  help: boolean;
+  verbose: boolean;
+};
+
+/**
+ * Runs the command.
+ */
+async function main() {
+  process.on("uncaughtException", handleUncaughtException);
+
+  const args = mri<Args>(process.argv.slice(2), {
+    boolean: ["help", "verbose"],
+    alias: { h: "help", v: "verbose" },
+    default: {
+      help: false,
+      verbose: false,
+    },
+  });
+
+  if (args.help) {
+    console.info(
+      `
+Usage:
+    yarn dev [options...]
+
+Options:
+    --verbose, -v  Print all output from the dev scripts
+    --help, -h     Show help text
+`.trim(),
+    );
+
+    return;
+  }
+
+  const workspaces = await getWorkspaces();
+  const packages = workspaces.filter((workspace) =>
+    workspace.location.startsWith("packages/"),
+  );
+  const runningWorkspaces = new Set<string>();
+  const builtWorkspaces = new Set<string>();
+  const buildEmitter: BuildEmitter = createEmitter();
+  buildEmitter.on("built", () => {
+    if (packages.every((pkg) => builtWorkspaces.has(pkg.location))) {
+      console.info(chalk.green(`Ready and watching:`));
+
+      for (const builtWorkspace of builtWorkspaces) {
+        const workspace = workspaces.find((w) => w.location === builtWorkspace);
+
+        if (workspace) {
+          console.info(chalk.green` - ${workspace.name}`);
+        }
+      }
+    }
+  });
+
+  for (const pkg of packages) {
+    runWorkspace(
+      pkg,
+      { workspaces, buildEmitter, builtWorkspaces, runningWorkspaces },
+      { verbose: args.verbose },
+    );
+  }
+
+  process.off("uncaughtException", handleUncaughtException);
+}
+
+/**
+ * Runs a workspace's `dev` script.
+ *
+ * @param workspace - The `Workspace` with a `dev` script.
+ * @param ctx - Context used to keep track of the script's process.
+ * @param options - Options that affect the output.
+ */
+async function runWorkspace(
+  workspace: Workspace,
+  ctx: {
+    workspaces: Workspace[];
+    runningWorkspaces: Set<string>;
+    builtWorkspaces: Set<string>;
+    buildEmitter: BuildEmitter;
+  },
+  options: { verbose: boolean },
+) {
+  if (workspace.workspaceDependencies.length > 0) {
+    for (const dependencyLocation of workspace.workspaceDependencies) {
+      const dependencyWorkspace = ctx.workspaces.find(
+        (workspace) => workspace.location === dependencyLocation,
+      );
+
+      if (dependencyWorkspace) {
+        runWorkspace(dependencyWorkspace, ctx, options);
+      }
+    }
+
+    let resolve: () => void;
+    const dependenciesBuildPromise = new Promise<void>((res) => {
+      resolve = res;
+    });
+    ctx.buildEmitter.on("built", () => {
+      const allWorkspaceDependenciesAreBuilt =
+        workspace.workspaceDependencies.every((dependencyLocation) =>
+          ctx.builtWorkspaces.has(dependencyLocation),
+        );
+
+      if (allWorkspaceDependenciesAreBuilt) {
+        resolve();
+      }
+    });
+    await dependenciesBuildPromise;
+  }
+
+  if (ctx.runningWorkspaces.has(workspace.location)) {
+    return;
+  }
+
+  console.info(namespaceStr(workspace.name, "Starting initial build"));
+  ctx.runningWorkspaces.add(workspace.location);
+
+  const command = spawn("yarn", ["workspace", workspace.name, "dev"], {
+    env: { FORCE_COLOR: "true", ...process.env },
+  });
+
+  command.stdout.on("data", (data) => {
+    const str = data.toString();
+
+    if (options.verbose) {
+      console.log(
+        namespaceLines(workspace.name, removeTrailingNewLine(data.toString())),
+      );
+    }
+
+    if (
+      // Vite build success message
+      /built in \d+ms/.test(str) ||
+      // Next.js build success message
+      /compiled client and server successfully in \d+ ms/.test(str)
+    ) {
+      if (ctx.builtWorkspaces.has(workspace.location)) {
+        console.info(namespaceStr(workspace.name, "Finished build"));
+      } else {
+        console.info(
+          namespaceStr(workspace.name, "Finished initial build", {
+            color: chalk.blue,
+          }),
+        );
+      }
+
+      ctx.builtWorkspaces.add(workspace.location);
+      ctx.buildEmitter.emit("built", { workspace });
+    }
+  });
+
+  command.stderr.on("data", (data) => {
+    console.error(
+      namespaceLines(workspace.name, removeTrailingNewLine(data.toString()), {
+        color: chalk.red,
+      }),
+    );
+  });
+
+  command.on("exit", (code) => {
+    console.info(namespaceStr(workspace.name, `Exited (code: ${code})`));
+  });
+}
+
+type EventMap = Record<string, any>;
+type EventKey<T extends EventMap> = string & keyof T;
+type EventReceiver<T> = (params: T) => void;
+
+interface Emitter<T extends EventMap> {
+  on<K extends EventKey<T>>(eventName: K, fn: EventReceiver<T[K]>): void;
+  off<K extends EventKey<T>>(eventName: K, fn: EventReceiver<T[K]>): void;
+  emit<K extends EventKey<T>>(eventName: K, params: T[K]): void;
+}
+
+/**
+ * Creates a typed `EventEmitter`.
+ *
+ * @typeParam TEventMap - A map of event names to their arguments.
+ *
+ * @returns An `EventEmitter` typed with `TEventMap`.
+ */
+function createEmitter<TEventMap extends EventMap>(): Emitter<TEventMap> {
+  const emitter = new EventEmitter();
+
+  emitter.setMaxListeners(100);
+
+  return emitter;
+}
+
+/**
+ * Retrieve a list of workspaces in the project.
+ *
+ * @returns A list of workspaces in the project.
+ */
+async function getWorkspaces() {
+  const { stdout: rawList } = await exec("yarn", [
+    "workspaces",
+    "list",
+    "--json",
+    "--verbose",
+  ]);
+
+  // The first entry is the root-level workspace, which we will ignore.
+  return rawList
+    .split("\n")
+    .slice(1)
+    .map((item) => Workspace.parse(JSON.parse(item)));
+}
+
+/**
+ * Prefixes multiple lines using `namespaceStr`.
+ *
+ * @param namespace - The namespace to prefix.
+ * @param lines - The string or strings to be prefixed.
+ * @param options - Options that affect the output.
+ *
+ * @returns `lines` with each line prefixed with `namespace`.
+ */
+function namespaceLines(
+  namespace: string,
+  lines: string | string[],
+  args: { color?: chalk.Chalk } = {},
+) {
+  if (typeof lines === "string") {
+    lines = lines.split("\n");
+  }
+
+  return lines.map((line) => namespaceStr(namespace, line, args)).join("\n");
+}
+
+/**
+ * Prefixes a colored namespace to a given string.
+ *
+ * @param namespace - The namespace to prefix.
+ * @param str - The string to be prefixed.
+ * @param options - Options that affect the output.
+ *
+ * @returns `str` prefixed with `namespace`.
+ */
+function namespaceStr(
+  namespace: string,
+  str: string,
+  options: { color?: chalk.Chalk } = {},
+) {
+  const { color = chalk.gray } = options;
+
+  return `${color`[${namespace}]`} ${str}`;
+}
+
+/**
+ * Removes the trailing `\n` on a given string, if there is one.
+ *
+ * @param input - The string from which the trailing `\n` is removed.
+ *
+ * @returns `input` without a trailing `\n`.
+ */
+function removeTrailingNewLine(input: string) {
+  return input.replace(/\n$/, "");
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -29544,6 +29544,7 @@ __metadata:
     semver: 7.3.8
     start-server-and-test: 1.15.5
     tsx: 4.6.2
+    zod: 3.23.5
   dependenciesMeta:
     "@sentry/cli":
       built: true
@@ -34558,6 +34559,13 @@ __metadata:
   version: 3.21.4
   resolution: "zod@npm:3.21.4"
   checksum: f185ba87342ff16f7a06686767c2b2a7af41110c7edf7c1974095d8db7a73792696bcb4a00853de0d2edeb34a5b2ea6a55871bc864227dace682a0a28de33e1f
+  languageName: node
+  linkType: hard
+
+"zod@npm:3.23.5":
+  version: 3.23.5
+  resolution: "zod@npm:3.23.5"
+  checksum: 4b83c93c4d43640b31eb4289efedb23f303a272c39f8b492ee4b2fec1a1da0de078db3786a2e6cc08d6803f03e842af2ae16b430c7f2e0fea3eba16b72a9db36
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Context

TODO

## The Solution

- Add a custom `yarn dev` script that starts each workspace's `dev` script in topological order.
- Export a function that can be used by `yarn play` to automatically start the dev servers.

## Impact / Dependencies

This scripts sets a basis for a more stable `dev` script. It also should enable us to automatically start the `dev` watchers as part of the `yarn play` script.

## Checklist before requesting a review
- [ ] I hereby declare my code ready for review.
- [ ] If it is a critical feature, I have added tests.
- [ ] The CI is successful.
- [ ] If there could backward compatibility issues, it has been discussed and planned.
