### PR TITLE
feat(slice templates): Update slice templates with repeatable content to use a gorup instead of items

### DIFF
--- a/packages/adapter-next/public/AlternateGrid/javascript.jsx
+++ b/packages/adapter-next/public/AlternateGrid/javascript.jsx
@@ -58,9 +58,9 @@ const PascalNameToReplace = ({ slice }) => {
 							</div>
 						)}
 					</div>
-					{slice.items.length > 0 && (
+					{slice.primary.items.length > 0 && (
 						<div className="es-alternate-grid__primary-content__items">
-							{slice.items.map((item, i) => (
+							{slice.primary.items.map((item, i) => (
 								<div key={`item-${i + 1}`} className="es-alternate-grid__item">
 									{isFilled.richText(item.title) && (
 										<div className="es-alternate-grid__item__heading">

--- a/packages/adapter-next/public/AlternateGrid/typescript.tsx
+++ b/packages/adapter-next/public/AlternateGrid/typescript.tsx
@@ -55,9 +55,9 @@ const PascalNameToReplace = ({
 							</div>
 						)}
 					</div>
-					{slice.items.length > 0 && (
+					{slice.primary.items.length > 0 && (
 						<div className="es-alternate-grid__primary-content__items">
-							{slice.items.map((item, i) => (
+							{slice.primary.items.map((item, i) => (
 								<div key={`item-${i + 1}`} className="es-alternate-grid__item">
 									{isFilled.richText(item.title) && (
 										<div className="es-alternate-grid__item__heading">

--- a/packages/adapter-next/public/CustomerLogos/javascript.jsx
+++ b/packages/adapter-next/public/CustomerLogos/javascript.jsx
@@ -22,15 +22,15 @@ const PascalNameToReplace = ({ slice }) => {
 						<PrismicRichText field={slice.primary.eyebrowHeadline} />
 					</div>
 				)}
-				{slice.items.length > 0 && (
+				{slice.primary.logos.length > 0 && (
 					<ul className="es-customer-logos__logos">
-						{slice.items.map(
-							(item) =>
-								isFilled.image(item.image) && (
-									<li key={item.image.url} className="es-customer-logos__logo">
-										<PrismicNextLink field={item.link}>
+						{slice.primary.logos.map(
+							(logo) =>
+								isFilled.image(logo.image) && (
+									<li key={logo.image.url} className="es-customer-logos__logo">
+										<PrismicNextLink field={logo.link}>
 											<PrismicNextImage
-												field={item.image}
+												field={logo.image}
 												height={26}
 												width={160}
 												className="es-customer-logos__logo__link__image"

--- a/packages/adapter-next/public/CustomerLogos/typescript.tsx
+++ b/packages/adapter-next/public/CustomerLogos/typescript.tsx
@@ -20,15 +20,15 @@ const PascalNameToReplace = ({
 						<PrismicRichText field={slice.primary.eyebrowHeadline} />
 					</div>
 				)}
-				{slice.items.length > 0 && (
+				{slice.primary.logos.length > 0 && (
 					<ul className="es-customer-logos__logos">
-						{slice.items.map(
-							(item) =>
-								isFilled.image(item.image) && (
-									<li key={item.image.url} className="es-customer-logos__logo">
-										<PrismicNextLink field={item.link}>
+						{slice.primary.logos.map(
+							(logo) =>
+								isFilled.image(logo.image) && (
+									<li key={logo.image.url} className="es-customer-logos__logo">
+										<PrismicNextLink field={logo.link}>
 											<PrismicNextImage
-												field={item.image}
+												field={logo.image}
 												height={26}
 												width={160}
 												className="es-customer-logos__logo__link__image"

--- a/packages/adapter-next/src/sliceTemplates/AlternateGrid/index.ts
+++ b/packages/adapter-next/src/sliceTemplates/AlternateGrid/index.ts
@@ -71,120 +71,124 @@ export const mocks: SharedSliceContent[] = [
 				__TYPE__: "ImageContent",
 				thumbnails: {},
 			},
+			items: {
+				__TYPE__: "GroupContentType",
+				value: [
+					{
+						__TYPE__: "GroupItemContent",
+						value: [
+							[
+								"title",
+								{
+									__TYPE__: "StructuredTextContent",
+									value: [
+										{
+											type: "heading3",
+											content: {
+												text: "Integrate with the SliceZone",
+												spans: [],
+											},
+											direction: "ltr",
+										},
+									],
+								},
+							],
+							[
+								"description",
+								{
+									__TYPE__: "StructuredTextContent",
+									value: [
+										{
+											type: "paragraph",
+											content: {
+												text: "This component has been matched by the SliceZone. Its model has been fetched from SliceMachine next-adapter!",
+												spans: [],
+											},
+											direction: "ltr",
+										},
+									],
+								},
+							],
+						],
+					},
+					{
+						__TYPE__: "GroupItemContent",
+						value: [
+							[
+								"title",
+								{
+									__TYPE__: "StructuredTextContent",
+									value: [
+										{
+											type: "heading3",
+											content: {
+												text: "Create your own",
+												spans: [],
+											},
+											direction: "ltr",
+										},
+									],
+								},
+							],
+							[
+								"description",
+								{
+									__TYPE__: "StructuredTextContent",
+									value: [
+										{
+											type: "paragraph",
+											content: {
+												text: "Feel free to use this component fully, or use it as an example! We're adding templates as often as we can.",
+												spans: [],
+											},
+											direction: "ltr",
+										},
+									],
+								},
+							],
+						],
+					},
+					{
+						__TYPE__: "GroupItemContent",
+						value: [
+							[
+								"title",
+								{
+									__TYPE__: "StructuredTextContent",
+									value: [
+										{
+											type: "heading3",
+											content: {
+												text: "Add a variation",
+												spans: [],
+											},
+											direction: "ltr",
+										},
+									],
+								},
+							],
+							[
+								"description",
+								{
+									__TYPE__: "StructuredTextContent",
+									value: [
+										{
+											type: "paragraph",
+											content: {
+												text: 'This slice comes with a "Image Right" variation, which means editors can switch text/image direction!',
+												spans: [],
+											},
+											direction: "ltr",
+										},
+									],
+								},
+							],
+						],
+					},
+				],
+			},
 		},
-		items: [
-			{
-				__TYPE__: "GroupItemContent",
-				value: [
-					[
-						"title",
-						{
-							__TYPE__: "StructuredTextContent",
-							value: [
-								{
-									type: "heading3",
-									content: {
-										text: "Integrate with the SliceZone",
-										spans: [],
-									},
-									direction: "ltr",
-								},
-							],
-						},
-					],
-					[
-						"description",
-						{
-							__TYPE__: "StructuredTextContent",
-							value: [
-								{
-									type: "paragraph",
-									content: {
-										text: "This component has been matched by the SliceZone. Its model has been fetched from SliceMachine next-adapter!",
-										spans: [],
-									},
-									direction: "ltr",
-								},
-							],
-						},
-					],
-				],
-			},
-			{
-				__TYPE__: "GroupItemContent",
-				value: [
-					[
-						"title",
-						{
-							__TYPE__: "StructuredTextContent",
-							value: [
-								{
-									type: "heading3",
-									content: {
-										text: "Create your own",
-										spans: [],
-									},
-									direction: "ltr",
-								},
-							],
-						},
-					],
-					[
-						"description",
-						{
-							__TYPE__: "StructuredTextContent",
-							value: [
-								{
-									type: "paragraph",
-									content: {
-										text: "Feel free to use this component fully, or use it as an example! We're adding templates as often as we can.",
-										spans: [],
-									},
-									direction: "ltr",
-								},
-							],
-						},
-					],
-				],
-			},
-			{
-				__TYPE__: "GroupItemContent",
-				value: [
-					[
-						"title",
-						{
-							__TYPE__: "StructuredTextContent",
-							value: [
-								{
-									type: "heading3",
-									content: {
-										text: "Add a variation",
-										spans: [],
-									},
-									direction: "ltr",
-								},
-							],
-						},
-					],
-					[
-						"description",
-						{
-							__TYPE__: "StructuredTextContent",
-							value: [
-								{
-									type: "paragraph",
-									content: {
-										text: 'This slice comes with a "Image Right" variation, which means editors can switch text/image direction!',
-										spans: [],
-									},
-									direction: "ltr",
-								},
-							],
-						},
-					],
-				],
-			},
-		],
+		items: [],
 	},
 	{
 		__TYPE__: "SharedSliceContent",
@@ -250,52 +254,56 @@ export const mocks: SharedSliceContent[] = [
 				__TYPE__: "ImageContent",
 				thumbnails: {},
 			},
-		},
-		items: [
-			{
-				__TYPE__: "GroupItemContent",
+			items: {
+				__TYPE__: "GroupContentType",
 				value: [
-					[
-						"title",
-						{
-							__TYPE__: "StructuredTextContent",
-							value: [
+					{
+						__TYPE__: "GroupItemContent",
+						value: [
+							[
+								"title",
 								{
-									type: "heading3",
-									content: {
-										text: "Create a unique, high-performing site",
-										spans: [
-											{
-												type: "strong",
-												start: 9,
-												end: 15,
+									__TYPE__: "StructuredTextContent",
+									value: [
+										{
+											type: "heading3",
+											content: {
+												text: "Create a unique, high-performing site",
+												spans: [
+													{
+														type: "strong",
+														start: 9,
+														end: 15,
+													},
+												],
 											},
-										],
-									},
-									direction: "ltr",
+											direction: "ltr",
+										},
+									],
 								},
 							],
-						},
-					],
-					[
-						"description",
-						{
-							__TYPE__: "StructuredTextContent",
-							value: [
+							[
+								"description",
 								{
-									type: "paragraph",
-									content: {
-										text: "Prismic is the headless website builder designed to help developers and marketers create unique, high-performing websites that are easy to edit.",
-										spans: [],
-									},
-									direction: "ltr",
+									__TYPE__: "StructuredTextContent",
+									value: [
+										{
+											type: "paragraph",
+											content: {
+												text: "Prismic is the headless website builder designed to help developers and marketers create unique, high-performing websites that are easy to edit.",
+												spans: [],
+											},
+											direction: "ltr",
+										},
+									],
 								},
 							],
-						},
-					],
+						],
+					},
 				],
 			},
-		],
+		},
+		items: [],
 	},
 ];
 
@@ -348,25 +356,32 @@ export const model: SharedSlice = {
 						thumbnails: [],
 					},
 				},
-			},
-			items: {
-				title: {
-					type: "StructuredText",
+				items: {
+					type: "Group",
 					config: {
-						label: "title",
-						placeholder: "",
-						allowTargetBlank: true,
-						single: "heading2,heading3,heading4,heading5,heading6,strong,em",
-					},
-				},
-				description: {
-					type: "StructuredText",
-					config: {
-						label: "description",
-						placeholder: "",
-						allowTargetBlank: true,
-						multi:
-							"paragraph,preformatted,hyperlink,strong,em,list-item,o-list-item,rtl",
+						label: "items",
+						fields: {
+							title: {
+								type: "StructuredText",
+								config: {
+									label: "title",
+									placeholder: "",
+									allowTargetBlank: true,
+									single:
+										"heading2,heading3,heading4,heading5,heading6,strong,em",
+								},
+							},
+							description: {
+								type: "StructuredText",
+								config: {
+									label: "description",
+									placeholder: "",
+									allowTargetBlank: true,
+									multi:
+										"paragraph,preformatted,hyperlink,strong,em,list-item,o-list-item,rtl",
+								},
+							},
+						},
 					},
 				},
 			},
@@ -414,25 +429,32 @@ export const model: SharedSlice = {
 						thumbnails: [],
 					},
 				},
-			},
-			items: {
-				title: {
-					type: "StructuredText",
+				items: {
+					type: "Group",
 					config: {
-						label: "title",
-						placeholder: "",
-						allowTargetBlank: true,
-						single: "heading2,heading3,heading4,heading5,heading6,strong,em",
-					},
-				},
-				description: {
-					type: "StructuredText",
-					config: {
-						label: "description",
-						placeholder: "",
-						allowTargetBlank: true,
-						multi:
-							"paragraph,preformatted,hyperlink,strong,em,list-item,o-list-item,rtl",
+						label: "items",
+						fields: {
+							title: {
+								type: "StructuredText",
+								config: {
+									label: "title",
+									placeholder: "",
+									allowTargetBlank: true,
+									single:
+										"heading2,heading3,heading4,heading5,heading6,strong,em",
+								},
+							},
+							description: {
+								type: "StructuredText",
+								config: {
+									label: "description",
+									placeholder: "",
+									allowTargetBlank: true,
+									multi:
+										"paragraph,preformatted,hyperlink,strong,em,list-item,o-list-item,rtl",
+								},
+							},
+						},
 					},
 				},
 			},

--- a/packages/adapter-next/src/sliceTemplates/CallToAction/index.ts
+++ b/packages/adapter-next/src/sliceTemplates/CallToAction/index.ts
@@ -146,12 +146,7 @@ export const mocks: SharedSliceContent[] = [
 				value: "Learn more!",
 			},
 		},
-		items: [
-			{
-				__TYPE__: "GroupItemContent",
-				value: [],
-			},
-		],
+		items: [],
 	},
 ];
 

--- a/packages/adapter-next/src/sliceTemplates/CustomerLogos/index.ts
+++ b/packages/adapter-next/src/sliceTemplates/CustomerLogos/index.ts
@@ -36,218 +36,222 @@ export const mocks: SharedSliceContent[] = [
 					},
 				],
 			},
+			logos: {
+				__TYPE__: "GroupContentType",
+				value: [
+					{
+						__TYPE__: "GroupItemContent",
+						value: [
+							[
+								"image",
+								{
+									origin: {
+										id: "main",
+										url: "https://images.prismic.io/slicesexamples/95a608cd-8d3c-40c1-a554-0bec1b89eda5_logo-3.svg",
+										width: 2545,
+										height: 2545,
+									},
+									url: "https://images.prismic.io/slicesexamples/95a608cd-8d3c-40c1-a554-0bec1b89eda5_logo-3.svg",
+									width: 2545,
+									height: 2545,
+									edit: {
+										zoom: 1,
+										crop: {
+											x: 0,
+											y: 0,
+										},
+										background: "transparent",
+									},
+									credits: null,
+									alt: "Customer Logo",
+									__TYPE__: "ImageContent",
+									thumbnails: {},
+								},
+							],
+							[
+								"link",
+								{
+									__TYPE__: "LinkContent",
+									value: {
+										__TYPE__: "ExternalLink",
+										url: "http://twitter.com",
+									},
+								},
+							],
+						],
+					},
+					{
+						__TYPE__: "GroupItemContent",
+						value: [
+							[
+								"image",
+								{
+									url: "https://images.prismic.io/slicesexamples/b62a8629-f7f1-4d2e-885a-bd7c6bcff201_logo-2.svg",
+									origin: {
+										id: "xnRg3xDcNnE",
+										url: "https://images.prismic.io/slicesexamples/b62a8629-f7f1-4d2e-885a-bd7c6bcff201_logo-2.svg",
+										width: 7173,
+										height: 10041,
+									},
+									width: 7173,
+									height: 10041,
+									edit: {
+										background: "transparent",
+										zoom: 1,
+										crop: {
+											x: 0,
+											y: 0,
+										},
+									},
+									credits: null,
+									alt: "Customer Logo",
+									__TYPE__: "ImageContent",
+									thumbnails: {},
+								},
+							],
+							[
+								"link",
+								{
+									__TYPE__: "LinkContent",
+									value: {
+										__TYPE__: "ExternalLink",
+										url: "https://prismic.io",
+										target: "_blank",
+									},
+								},
+							],
+						],
+					},
+					{
+						__TYPE__: "GroupItemContent",
+						value: [
+							[
+								"image",
+								{
+									url: "https://images.prismic.io/slicesexamples/4360a72b-bfe4-4144-911c-597146f72c00_logo-5.svg",
+									origin: {
+										id: "U1iYwZ8Dx7k",
+										url: "https://images.prismic.io/slicesexamples/4360a72b-bfe4-4144-911c-597146f72c00_logo-5.svg",
+										width: 3337,
+										height: 4171,
+									},
+									width: 3337,
+									height: 4171,
+									edit: {
+										background: "transparent",
+										zoom: 1,
+										crop: {
+											x: 0,
+											y: 0,
+										},
+									},
+									credits: null,
+									alt: "Customer Logo",
+									__TYPE__: "ImageContent",
+									thumbnails: {},
+								},
+							],
+							[
+								"link",
+								{
+									__TYPE__: "LinkContent",
+									value: {
+										__TYPE__: "ExternalLink",
+										url: "https://prismic.io",
+										target: "",
+									},
+								},
+							],
+						],
+					},
+					{
+						__TYPE__: "GroupItemContent",
+						value: [
+							[
+								"image",
+								{
+									url: "https://images.prismic.io/slicesexamples/846576e2-c93c-40dd-8aaa-b97f4e99e7aa_logo-1.svg",
+									origin: {
+										id: "nibgG33H0F8",
+										url: "https://images.prismic.io/slicesexamples/846576e2-c93c-40dd-8aaa-b97f4e99e7aa_logo-1.svg",
+										width: 4000,
+										height: 6000,
+									},
+									width: 4000,
+									height: 6000,
+									edit: {
+										background: "transparent",
+										zoom: 1,
+										crop: {
+											x: 0,
+											y: 0,
+										},
+									},
+									credits: null,
+									alt: "Customer Logo",
+									__TYPE__: "ImageContent",
+									thumbnails: {},
+								},
+							],
+							[
+								"link",
+								{
+									__TYPE__: "LinkContent",
+									value: {
+										__TYPE__: "ExternalLink",
+										url: "https://prismic.io",
+										target: "",
+									},
+								},
+							],
+						],
+					},
+					{
+						__TYPE__: "GroupItemContent",
+						value: [
+							[
+								"image",
+								{
+									url: "https://images.prismic.io/slicesexamples/23461395-458d-41f5-be25-bac37a4ff53e_logo-6.svg",
+									origin: {
+										id: "nAOZCYcLND8",
+										url: "https://images.prismic.io/slicesexamples/23461395-458d-41f5-be25-bac37a4ff53e_logo-6.svg",
+										width: 2749,
+										height: 4124,
+									},
+									width: 2749,
+									height: 4124,
+									edit: {
+										background: "transparent",
+										zoom: 1,
+										crop: {
+											x: 0,
+											y: 0,
+										},
+									},
+									credits: null,
+									alt: "Customer Logo",
+									__TYPE__: "ImageContent",
+									thumbnails: {},
+								},
+							],
+							[
+								"link",
+								{
+									__TYPE__: "LinkContent",
+									value: {
+										__TYPE__: "ExternalLink",
+										url: "https://prismic.io",
+										target: "",
+									},
+								},
+							],
+						],
+					},
+				],
+			},
 		},
-		items: [
-			{
-				__TYPE__: "GroupItemContent",
-				value: [
-					[
-						"image",
-						{
-							origin: {
-								id: "main",
-								url: "https://images.prismic.io/slicesexamples/95a608cd-8d3c-40c1-a554-0bec1b89eda5_logo-3.svg",
-								width: 2545,
-								height: 2545,
-							},
-							url: "https://images.prismic.io/slicesexamples/95a608cd-8d3c-40c1-a554-0bec1b89eda5_logo-3.svg",
-							width: 2545,
-							height: 2545,
-							edit: {
-								zoom: 1,
-								crop: {
-									x: 0,
-									y: 0,
-								},
-								background: "transparent",
-							},
-							credits: null,
-							alt: "Customer Logo",
-							__TYPE__: "ImageContent",
-							thumbnails: {},
-						},
-					],
-					[
-						"link",
-						{
-							__TYPE__: "LinkContent",
-							value: {
-								__TYPE__: "ExternalLink",
-								url: "http://twitter.com",
-							},
-						},
-					],
-				],
-			},
-			{
-				__TYPE__: "GroupItemContent",
-				value: [
-					[
-						"image",
-						{
-							url: "https://images.prismic.io/slicesexamples/b62a8629-f7f1-4d2e-885a-bd7c6bcff201_logo-2.svg",
-							origin: {
-								id: "xnRg3xDcNnE",
-								url: "https://images.prismic.io/slicesexamples/b62a8629-f7f1-4d2e-885a-bd7c6bcff201_logo-2.svg",
-								width: 7173,
-								height: 10041,
-							},
-							width: 7173,
-							height: 10041,
-							edit: {
-								background: "transparent",
-								zoom: 1,
-								crop: {
-									x: 0,
-									y: 0,
-								},
-							},
-							credits: null,
-							alt: "Customer Logo",
-							__TYPE__: "ImageContent",
-							thumbnails: {},
-						},
-					],
-					[
-						"link",
-						{
-							__TYPE__: "LinkContent",
-							value: {
-								__TYPE__: "ExternalLink",
-								url: "https://prismic.io",
-								target: "_blank",
-							},
-						},
-					],
-				],
-			},
-			{
-				__TYPE__: "GroupItemContent",
-				value: [
-					[
-						"image",
-						{
-							url: "https://images.prismic.io/slicesexamples/4360a72b-bfe4-4144-911c-597146f72c00_logo-5.svg",
-							origin: {
-								id: "U1iYwZ8Dx7k",
-								url: "https://images.prismic.io/slicesexamples/4360a72b-bfe4-4144-911c-597146f72c00_logo-5.svg",
-								width: 3337,
-								height: 4171,
-							},
-							width: 3337,
-							height: 4171,
-							edit: {
-								background: "transparent",
-								zoom: 1,
-								crop: {
-									x: 0,
-									y: 0,
-								},
-							},
-							credits: null,
-							alt: "Customer Logo",
-							__TYPE__: "ImageContent",
-							thumbnails: {},
-						},
-					],
-					[
-						"link",
-						{
-							__TYPE__: "LinkContent",
-							value: {
-								__TYPE__: "ExternalLink",
-								url: "https://prismic.io",
-								target: "",
-							},
-						},
-					],
-				],
-			},
-			{
-				__TYPE__: "GroupItemContent",
-				value: [
-					[
-						"image",
-						{
-							url: "https://images.prismic.io/slicesexamples/846576e2-c93c-40dd-8aaa-b97f4e99e7aa_logo-1.svg",
-							origin: {
-								id: "nibgG33H0F8",
-								url: "https://images.prismic.io/slicesexamples/846576e2-c93c-40dd-8aaa-b97f4e99e7aa_logo-1.svg",
-								width: 4000,
-								height: 6000,
-							},
-							width: 4000,
-							height: 6000,
-							edit: {
-								background: "transparent",
-								zoom: 1,
-								crop: {
-									x: 0,
-									y: 0,
-								},
-							},
-							credits: null,
-							alt: "Customer Logo",
-							__TYPE__: "ImageContent",
-							thumbnails: {},
-						},
-					],
-					[
-						"link",
-						{
-							__TYPE__: "LinkContent",
-							value: {
-								__TYPE__: "ExternalLink",
-								url: "https://prismic.io",
-								target: "",
-							},
-						},
-					],
-				],
-			},
-			{
-				__TYPE__: "GroupItemContent",
-				value: [
-					[
-						"image",
-						{
-							url: "https://images.prismic.io/slicesexamples/23461395-458d-41f5-be25-bac37a4ff53e_logo-6.svg",
-							origin: {
-								id: "nAOZCYcLND8",
-								url: "https://images.prismic.io/slicesexamples/23461395-458d-41f5-be25-bac37a4ff53e_logo-6.svg",
-								width: 2749,
-								height: 4124,
-							},
-							width: 2749,
-							height: 4124,
-							edit: {
-								background: "transparent",
-								zoom: 1,
-								crop: {
-									x: 0,
-									y: 0,
-								},
-							},
-							credits: null,
-							alt: "Customer Logo",
-							__TYPE__: "ImageContent",
-							thumbnails: {},
-						},
-					],
-					[
-						"link",
-						{
-							__TYPE__: "LinkContent",
-							value: {
-								__TYPE__: "ExternalLink",
-								url: "https://prismic.io",
-								target: "",
-							},
-						},
-					],
-				],
-			},
-		],
+		items: [],
 	},
 ];
 
@@ -289,22 +293,28 @@ export const model: SharedSlice = {
 						select: null,
 					},
 				},
-			},
-			items: {
-				image: {
-					type: "Image",
+				logos: {
+					type: "Group",
 					config: {
-						label: "image",
-						constraint: {},
-						thumbnails: [],
-					},
-				},
-				link: {
-					type: "Link",
-					config: {
-						label: "link",
-						placeholder: "",
-						select: null,
+						label: "logos",
+						fields: {
+							image: {
+								type: "Image",
+								config: {
+									label: "image",
+									constraint: {},
+									thumbnails: [],
+								},
+							},
+							link: {
+								type: "Link",
+								config: {
+									label: "link",
+									placeholder: "",
+									select: null,
+								},
+							},
+						},
 					},
 				},
 			},

--- a/packages/adapter-next/src/sliceTemplates/Hero/index.ts
+++ b/packages/adapter-next/src/sliceTemplates/Hero/index.ts
@@ -161,12 +161,7 @@ export const mocks: SharedSliceContent[] = [
 				},
 			},
 		},
-		items: [
-			{
-				__TYPE__: "GroupItemContent",
-				value: [],
-			},
-		],
+		items: [],
 	},
 ];
 

--- a/packages/adapter-nuxt/public/AlternateGrid/javascript.vue
+++ b/packages/adapter-nuxt/public/AlternateGrid/javascript.vue
@@ -48,11 +48,11 @@ defineProps(getSliceComponentProps(["slice", "index", "slices", "context"]));
 					/>
 				</div>
 				<div
-					v-if="slice.items && slice.items.length"
+					v-if="slice.primary.items && slice.primary.items.length"
 					class="es-alternate-grid__primary-content__items"
 				>
 					<div
-						v-for="(item, i) in slice.items"
+						v-for="(item, i) in slice.primary.items"
 						:key="i"
 						class="es-alternate-grid__item"
 					>

--- a/packages/adapter-nuxt/public/AlternateGrid/typescript.vue
+++ b/packages/adapter-nuxt/public/AlternateGrid/typescript.vue
@@ -55,11 +55,11 @@ defineProps(
 					/>
 				</div>
 				<div
-					v-if="slice.items && slice.items.length"
+					v-if="slice.primary.items && slice.primary.items.length"
 					class="es-alternate-grid__primary-content__items"
 				>
 					<div
-						v-for="(item, i) in slice.items"
+						v-for="(item, i) in slice.primary.items"
 						:key="i"
 						class="es-alternate-grid__item"
 					>

--- a/packages/adapter-nuxt/public/CustomerLogos/javascript.vue
+++ b/packages/adapter-nuxt/public/CustomerLogos/javascript.vue
@@ -17,15 +17,18 @@ defineProps(getSliceComponentProps(["slice", "index", "slices", "context"]));
 			>
 				<PrismicRichText :field="slice.primary.eyebrowHeadline" />
 			</div>
-			<ul v-if="slice.items.length > 0" class="es-customer-logos__logos">
+			<ul
+				v-if="slice.primary.logos.length > 0"
+				class="es-customer-logos__logos"
+			>
 				<li
-					v-for="item in slice.items"
-					:key="item.image.url"
+					v-for="logo in slice.primary.logos"
+					:key="logo.image.url"
 					class="es-customer-logos__logo"
 				>
-					<PrismicLink :field="item.link">
+					<PrismicLink :field="logo.link">
 						<PrismicImage
-							:field="item.image"
+							:field="logo.image"
 							:height="26"
 							:width="160"
 							class="es-customer-logos__logo__link__image"

--- a/packages/adapter-nuxt/public/CustomerLogos/typescript.vue
+++ b/packages/adapter-nuxt/public/CustomerLogos/typescript.vue
@@ -24,15 +24,18 @@ defineProps(
 			>
 				<PrismicRichText :field="slice.primary.eyebrowHeadline" />
 			</div>
-			<ul v-if="slice.items.length > 0" class="es-customer-logos__logos">
+			<ul
+				v-if="slice.primary.logos.length > 0"
+				class="es-customer-logos__logos"
+			>
 				<li
-					v-for="item in slice.items"
-					:key="item.image.url"
+					v-for="logo in slice.primary.logos"
+					:key="logo.image.url"
 					class="es-customer-logos__logo"
 				>
-					<PrismicLink :field="item.link">
+					<PrismicLink :field="logo.link">
 						<PrismicImage
-							:field="item.image"
+							:field="logo.image"
 							:height="26"
 							:width="160"
 							class="es-customer-logos__logo__link__image"

--- a/packages/adapter-nuxt/src/sliceTemplates/AlternateGrid/index.ts
+++ b/packages/adapter-nuxt/src/sliceTemplates/AlternateGrid/index.ts
@@ -71,120 +71,124 @@ export const mocks: SharedSliceContent[] = [
 				__TYPE__: "ImageContent",
 				thumbnails: {},
 			},
+			items: {
+				__TYPE__: "GroupContentType",
+				value: [
+					{
+						__TYPE__: "GroupItemContent",
+						value: [
+							[
+								"title",
+								{
+									__TYPE__: "StructuredTextContent",
+									value: [
+										{
+											type: "heading3",
+											content: {
+												text: "Integrate with the SliceZone",
+												spans: [],
+											},
+											direction: "ltr",
+										},
+									],
+								},
+							],
+							[
+								"description",
+								{
+									__TYPE__: "StructuredTextContent",
+									value: [
+										{
+											type: "paragraph",
+											content: {
+												text: "This component has been matched by the SliceZone. Its model has been fetched from SliceMachine next-adapter!",
+												spans: [],
+											},
+											direction: "ltr",
+										},
+									],
+								},
+							],
+						],
+					},
+					{
+						__TYPE__: "GroupItemContent",
+						value: [
+							[
+								"title",
+								{
+									__TYPE__: "StructuredTextContent",
+									value: [
+										{
+											type: "heading3",
+											content: {
+												text: "Create your own",
+												spans: [],
+											},
+											direction: "ltr",
+										},
+									],
+								},
+							],
+							[
+								"description",
+								{
+									__TYPE__: "StructuredTextContent",
+									value: [
+										{
+											type: "paragraph",
+											content: {
+												text: "Feel free to use this component fully, or use it as an example! We're adding templates as often as we can.",
+												spans: [],
+											},
+											direction: "ltr",
+										},
+									],
+								},
+							],
+						],
+					},
+					{
+						__TYPE__: "GroupItemContent",
+						value: [
+							[
+								"title",
+								{
+									__TYPE__: "StructuredTextContent",
+									value: [
+										{
+											type: "heading3",
+											content: {
+												text: "Add a variation",
+												spans: [],
+											},
+											direction: "ltr",
+										},
+									],
+								},
+							],
+							[
+								"description",
+								{
+									__TYPE__: "StructuredTextContent",
+									value: [
+										{
+											type: "paragraph",
+											content: {
+												text: 'This slice comes with a "Image Right" variation, which means editors can switch text/image direction!',
+												spans: [],
+											},
+											direction: "ltr",
+										},
+									],
+								},
+							],
+						],
+					},
+				],
+			},
 		},
-		items: [
-			{
-				__TYPE__: "GroupItemContent",
-				value: [
-					[
-						"title",
-						{
-							__TYPE__: "StructuredTextContent",
-							value: [
-								{
-									type: "heading3",
-									content: {
-										text: "Integrate with the SliceZone",
-										spans: [],
-									},
-									direction: "ltr",
-								},
-							],
-						},
-					],
-					[
-						"description",
-						{
-							__TYPE__: "StructuredTextContent",
-							value: [
-								{
-									type: "paragraph",
-									content: {
-										text: "This component has been matched by the SliceZone. Its model has been fetched from SliceMachine next-adapter!",
-										spans: [],
-									},
-									direction: "ltr",
-								},
-							],
-						},
-					],
-				],
-			},
-			{
-				__TYPE__: "GroupItemContent",
-				value: [
-					[
-						"title",
-						{
-							__TYPE__: "StructuredTextContent",
-							value: [
-								{
-									type: "heading3",
-									content: {
-										text: "Create your own",
-										spans: [],
-									},
-									direction: "ltr",
-								},
-							],
-						},
-					],
-					[
-						"description",
-						{
-							__TYPE__: "StructuredTextContent",
-							value: [
-								{
-									type: "paragraph",
-									content: {
-										text: "Feel free to use this component fully, or use it as an example! We're adding templates as often as we can.",
-										spans: [],
-									},
-									direction: "ltr",
-								},
-							],
-						},
-					],
-				],
-			},
-			{
-				__TYPE__: "GroupItemContent",
-				value: [
-					[
-						"title",
-						{
-							__TYPE__: "StructuredTextContent",
-							value: [
-								{
-									type: "heading3",
-									content: {
-										text: "Add a variation",
-										spans: [],
-									},
-									direction: "ltr",
-								},
-							],
-						},
-					],
-					[
-						"description",
-						{
-							__TYPE__: "StructuredTextContent",
-							value: [
-								{
-									type: "paragraph",
-									content: {
-										text: 'This slice comes with a "Image Right" variation, which means editors can switch text/image direction!',
-										spans: [],
-									},
-									direction: "ltr",
-								},
-							],
-						},
-					],
-				],
-			},
-		],
+		items: [],
 	},
 	{
 		__TYPE__: "SharedSliceContent",
@@ -250,52 +254,56 @@ export const mocks: SharedSliceContent[] = [
 				__TYPE__: "ImageContent",
 				thumbnails: {},
 			},
-		},
-		items: [
-			{
-				__TYPE__: "GroupItemContent",
+			items: {
+				__TYPE__: "GroupContentType",
 				value: [
-					[
-						"title",
-						{
-							__TYPE__: "StructuredTextContent",
-							value: [
+					{
+						__TYPE__: "GroupItemContent",
+						value: [
+							[
+								"title",
 								{
-									type: "heading3",
-									content: {
-										text: "Create a unique, high-performing site",
-										spans: [
-											{
-												type: "strong",
-												start: 9,
-												end: 15,
+									__TYPE__: "StructuredTextContent",
+									value: [
+										{
+											type: "heading3",
+											content: {
+												text: "Create a unique, high-performing site",
+												spans: [
+													{
+														type: "strong",
+														start: 9,
+														end: 15,
+													},
+												],
 											},
-										],
-									},
-									direction: "ltr",
+											direction: "ltr",
+										},
+									],
 								},
 							],
-						},
-					],
-					[
-						"description",
-						{
-							__TYPE__: "StructuredTextContent",
-							value: [
+							[
+								"description",
 								{
-									type: "paragraph",
-									content: {
-										text: "Prismic is the headless website builder designed to help developers and marketers create unique, high-performing websites that are easy to edit.",
-										spans: [],
-									},
-									direction: "ltr",
+									__TYPE__: "StructuredTextContent",
+									value: [
+										{
+											type: "paragraph",
+											content: {
+												text: "Prismic is the headless website builder designed to help developers and marketers create unique, high-performing websites that are easy to edit.",
+												spans: [],
+											},
+											direction: "ltr",
+										},
+									],
 								},
 							],
-						},
-					],
+						],
+					},
 				],
 			},
-		],
+		},
+		items: [],
 	},
 ];
 
@@ -348,25 +356,32 @@ export const model: SharedSlice = {
 						thumbnails: [],
 					},
 				},
-			},
-			items: {
-				title: {
-					type: "StructuredText",
+				items: {
+					type: "Group",
 					config: {
-						label: "title",
-						placeholder: "",
-						allowTargetBlank: true,
-						single: "heading2,heading3,heading4,heading5,heading6,strong,em",
-					},
-				},
-				description: {
-					type: "StructuredText",
-					config: {
-						label: "description",
-						placeholder: "",
-						allowTargetBlank: true,
-						multi:
-							"paragraph,preformatted,hyperlink,strong,em,list-item,o-list-item,rtl",
+						label: "items",
+						fields: {
+							title: {
+								type: "StructuredText",
+								config: {
+									label: "title",
+									placeholder: "",
+									allowTargetBlank: true,
+									single:
+										"heading2,heading3,heading4,heading5,heading6,strong,em",
+								},
+							},
+							description: {
+								type: "StructuredText",
+								config: {
+									label: "description",
+									placeholder: "",
+									allowTargetBlank: true,
+									multi:
+										"paragraph,preformatted,hyperlink,strong,em,list-item,o-list-item,rtl",
+								},
+							},
+						},
 					},
 				},
 			},
@@ -414,25 +429,32 @@ export const model: SharedSlice = {
 						thumbnails: [],
 					},
 				},
-			},
-			items: {
-				title: {
-					type: "StructuredText",
+				items: {
+					type: "Group",
 					config: {
-						label: "title",
-						placeholder: "",
-						allowTargetBlank: true,
-						single: "heading2,heading3,heading4,heading5,heading6,strong,em",
-					},
-				},
-				description: {
-					type: "StructuredText",
-					config: {
-						label: "description",
-						placeholder: "",
-						allowTargetBlank: true,
-						multi:
-							"paragraph,preformatted,hyperlink,strong,em,list-item,o-list-item,rtl",
+						label: "items",
+						fields: {
+							title: {
+								type: "StructuredText",
+								config: {
+									label: "title",
+									placeholder: "",
+									allowTargetBlank: true,
+									single:
+										"heading2,heading3,heading4,heading5,heading6,strong,em",
+								},
+							},
+							description: {
+								type: "StructuredText",
+								config: {
+									label: "description",
+									placeholder: "",
+									allowTargetBlank: true,
+									multi:
+										"paragraph,preformatted,hyperlink,strong,em,list-item,o-list-item,rtl",
+								},
+							},
+						},
 					},
 				},
 			},

--- a/packages/adapter-nuxt/src/sliceTemplates/CallToAction/index.ts
+++ b/packages/adapter-nuxt/src/sliceTemplates/CallToAction/index.ts
@@ -146,12 +146,7 @@ export const mocks: SharedSliceContent[] = [
 				value: "Learn more!",
 			},
 		},
-		items: [
-			{
-				__TYPE__: "GroupItemContent",
-				value: [],
-			},
-		],
+		items: [],
 	},
 ];
 

--- a/packages/adapter-nuxt/src/sliceTemplates/CustomerLogos/index.ts
+++ b/packages/adapter-nuxt/src/sliceTemplates/CustomerLogos/index.ts
@@ -36,218 +36,222 @@ export const mocks: SharedSliceContent[] = [
 					},
 				],
 			},
+			logos: {
+				__TYPE__: "GroupContentType",
+				value: [
+					{
+						__TYPE__: "GroupItemContent",
+						value: [
+							[
+								"image",
+								{
+									origin: {
+										id: "main",
+										url: "https://images.prismic.io/slicesexamples/95a608cd-8d3c-40c1-a554-0bec1b89eda5_logo-3.svg",
+										width: 2545,
+										height: 2545,
+									},
+									url: "https://images.prismic.io/slicesexamples/95a608cd-8d3c-40c1-a554-0bec1b89eda5_logo-3.svg",
+									width: 2545,
+									height: 2545,
+									edit: {
+										zoom: 1,
+										crop: {
+											x: 0,
+											y: 0,
+										},
+										background: "transparent",
+									},
+									credits: null,
+									alt: "Customer Logo",
+									__TYPE__: "ImageContent",
+									thumbnails: {},
+								},
+							],
+							[
+								"link",
+								{
+									__TYPE__: "LinkContent",
+									value: {
+										__TYPE__: "ExternalLink",
+										url: "http://twitter.com",
+									},
+								},
+							],
+						],
+					},
+					{
+						__TYPE__: "GroupItemContent",
+						value: [
+							[
+								"image",
+								{
+									url: "https://images.prismic.io/slicesexamples/b62a8629-f7f1-4d2e-885a-bd7c6bcff201_logo-2.svg",
+									origin: {
+										id: "xnRg3xDcNnE",
+										url: "https://images.prismic.io/slicesexamples/b62a8629-f7f1-4d2e-885a-bd7c6bcff201_logo-2.svg",
+										width: 7173,
+										height: 10041,
+									},
+									width: 7173,
+									height: 10041,
+									edit: {
+										background: "transparent",
+										zoom: 1,
+										crop: {
+											x: 0,
+											y: 0,
+										},
+									},
+									credits: null,
+									alt: "Customer Logo",
+									__TYPE__: "ImageContent",
+									thumbnails: {},
+								},
+							],
+							[
+								"link",
+								{
+									__TYPE__: "LinkContent",
+									value: {
+										__TYPE__: "ExternalLink",
+										url: "https://prismic.io",
+										target: "_blank",
+									},
+								},
+							],
+						],
+					},
+					{
+						__TYPE__: "GroupItemContent",
+						value: [
+							[
+								"image",
+								{
+									url: "https://images.prismic.io/slicesexamples/4360a72b-bfe4-4144-911c-597146f72c00_logo-5.svg",
+									origin: {
+										id: "U1iYwZ8Dx7k",
+										url: "https://images.prismic.io/slicesexamples/4360a72b-bfe4-4144-911c-597146f72c00_logo-5.svg",
+										width: 3337,
+										height: 4171,
+									},
+									width: 3337,
+									height: 4171,
+									edit: {
+										background: "transparent",
+										zoom: 1,
+										crop: {
+											x: 0,
+											y: 0,
+										},
+									},
+									credits: null,
+									alt: "Customer Logo",
+									__TYPE__: "ImageContent",
+									thumbnails: {},
+								},
+							],
+							[
+								"link",
+								{
+									__TYPE__: "LinkContent",
+									value: {
+										__TYPE__: "ExternalLink",
+										url: "https://prismic.io",
+										target: "",
+									},
+								},
+							],
+						],
+					},
+					{
+						__TYPE__: "GroupItemContent",
+						value: [
+							[
+								"image",
+								{
+									url: "https://images.prismic.io/slicesexamples/846576e2-c93c-40dd-8aaa-b97f4e99e7aa_logo-1.svg",
+									origin: {
+										id: "nibgG33H0F8",
+										url: "https://images.prismic.io/slicesexamples/846576e2-c93c-40dd-8aaa-b97f4e99e7aa_logo-1.svg",
+										width: 4000,
+										height: 6000,
+									},
+									width: 4000,
+									height: 6000,
+									edit: {
+										background: "transparent",
+										zoom: 1,
+										crop: {
+											x: 0,
+											y: 0,
+										},
+									},
+									credits: null,
+									alt: "Customer Logo",
+									__TYPE__: "ImageContent",
+									thumbnails: {},
+								},
+							],
+							[
+								"link",
+								{
+									__TYPE__: "LinkContent",
+									value: {
+										__TYPE__: "ExternalLink",
+										url: "https://prismic.io",
+										target: "",
+									},
+								},
+							],
+						],
+					},
+					{
+						__TYPE__: "GroupItemContent",
+						value: [
+							[
+								"image",
+								{
+									url: "https://images.prismic.io/slicesexamples/23461395-458d-41f5-be25-bac37a4ff53e_logo-6.svg",
+									origin: {
+										id: "nAOZCYcLND8",
+										url: "https://images.prismic.io/slicesexamples/23461395-458d-41f5-be25-bac37a4ff53e_logo-6.svg",
+										width: 2749,
+										height: 4124,
+									},
+									width: 2749,
+									height: 4124,
+									edit: {
+										background: "transparent",
+										zoom: 1,
+										crop: {
+											x: 0,
+											y: 0,
+										},
+									},
+									credits: null,
+									alt: "Customer Logo",
+									__TYPE__: "ImageContent",
+									thumbnails: {},
+								},
+							],
+							[
+								"link",
+								{
+									__TYPE__: "LinkContent",
+									value: {
+										__TYPE__: "ExternalLink",
+										url: "https://prismic.io",
+										target: "",
+									},
+								},
+							],
+						],
+					},
+				],
+			},
 		},
-		items: [
-			{
-				__TYPE__: "GroupItemContent",
-				value: [
-					[
-						"image",
-						{
-							origin: {
-								id: "main",
-								url: "https://images.prismic.io/slicesexamples/95a608cd-8d3c-40c1-a554-0bec1b89eda5_logo-3.svg",
-								width: 2545,
-								height: 2545,
-							},
-							url: "https://images.prismic.io/slicesexamples/95a608cd-8d3c-40c1-a554-0bec1b89eda5_logo-3.svg",
-							width: 2545,
-							height: 2545,
-							edit: {
-								zoom: 1,
-								crop: {
-									x: 0,
-									y: 0,
-								},
-								background: "transparent",
-							},
-							credits: null,
-							alt: "Customer Logo",
-							__TYPE__: "ImageContent",
-							thumbnails: {},
-						},
-					],
-					[
-						"link",
-						{
-							__TYPE__: "LinkContent",
-							value: {
-								__TYPE__: "ExternalLink",
-								url: "http://twitter.com",
-							},
-						},
-					],
-				],
-			},
-			{
-				__TYPE__: "GroupItemContent",
-				value: [
-					[
-						"image",
-						{
-							url: "https://images.prismic.io/slicesexamples/b62a8629-f7f1-4d2e-885a-bd7c6bcff201_logo-2.svg",
-							origin: {
-								id: "xnRg3xDcNnE",
-								url: "https://images.prismic.io/slicesexamples/b62a8629-f7f1-4d2e-885a-bd7c6bcff201_logo-2.svg",
-								width: 7173,
-								height: 10041,
-							},
-							width: 7173,
-							height: 10041,
-							edit: {
-								background: "transparent",
-								zoom: 1,
-								crop: {
-									x: 0,
-									y: 0,
-								},
-							},
-							credits: null,
-							alt: "Customer Logo",
-							__TYPE__: "ImageContent",
-							thumbnails: {},
-						},
-					],
-					[
-						"link",
-						{
-							__TYPE__: "LinkContent",
-							value: {
-								__TYPE__: "ExternalLink",
-								url: "https://prismic.io",
-								target: "_blank",
-							},
-						},
-					],
-				],
-			},
-			{
-				__TYPE__: "GroupItemContent",
-				value: [
-					[
-						"image",
-						{
-							url: "https://images.prismic.io/slicesexamples/4360a72b-bfe4-4144-911c-597146f72c00_logo-5.svg",
-							origin: {
-								id: "U1iYwZ8Dx7k",
-								url: "https://images.prismic.io/slicesexamples/4360a72b-bfe4-4144-911c-597146f72c00_logo-5.svg",
-								width: 3337,
-								height: 4171,
-							},
-							width: 3337,
-							height: 4171,
-							edit: {
-								background: "transparent",
-								zoom: 1,
-								crop: {
-									x: 0,
-									y: 0,
-								},
-							},
-							credits: null,
-							alt: "Customer Logo",
-							__TYPE__: "ImageContent",
-							thumbnails: {},
-						},
-					],
-					[
-						"link",
-						{
-							__TYPE__: "LinkContent",
-							value: {
-								__TYPE__: "ExternalLink",
-								url: "https://prismic.io",
-								target: "",
-							},
-						},
-					],
-				],
-			},
-			{
-				__TYPE__: "GroupItemContent",
-				value: [
-					[
-						"image",
-						{
-							url: "https://images.prismic.io/slicesexamples/846576e2-c93c-40dd-8aaa-b97f4e99e7aa_logo-1.svg",
-							origin: {
-								id: "nibgG33H0F8",
-								url: "https://images.prismic.io/slicesexamples/846576e2-c93c-40dd-8aaa-b97f4e99e7aa_logo-1.svg",
-								width: 4000,
-								height: 6000,
-							},
-							width: 4000,
-							height: 6000,
-							edit: {
-								background: "transparent",
-								zoom: 1,
-								crop: {
-									x: 0,
-									y: 0,
-								},
-							},
-							credits: null,
-							alt: "Customer Logo",
-							__TYPE__: "ImageContent",
-							thumbnails: {},
-						},
-					],
-					[
-						"link",
-						{
-							__TYPE__: "LinkContent",
-							value: {
-								__TYPE__: "ExternalLink",
-								url: "https://prismic.io",
-								target: "",
-							},
-						},
-					],
-				],
-			},
-			{
-				__TYPE__: "GroupItemContent",
-				value: [
-					[
-						"image",
-						{
-							url: "https://images.prismic.io/slicesexamples/23461395-458d-41f5-be25-bac37a4ff53e_logo-6.svg",
-							origin: {
-								id: "nAOZCYcLND8",
-								url: "https://images.prismic.io/slicesexamples/23461395-458d-41f5-be25-bac37a4ff53e_logo-6.svg",
-								width: 2749,
-								height: 4124,
-							},
-							width: 2749,
-							height: 4124,
-							edit: {
-								background: "transparent",
-								zoom: 1,
-								crop: {
-									x: 0,
-									y: 0,
-								},
-							},
-							credits: null,
-							alt: "Customer Logo",
-							__TYPE__: "ImageContent",
-							thumbnails: {},
-						},
-					],
-					[
-						"link",
-						{
-							__TYPE__: "LinkContent",
-							value: {
-								__TYPE__: "ExternalLink",
-								url: "https://prismic.io",
-								target: "",
-							},
-						},
-					],
-				],
-			},
-		],
+		items: [],
 	},
 ];
 
@@ -289,22 +293,28 @@ export const model: SharedSlice = {
 						select: null,
 					},
 				},
-			},
-			items: {
-				image: {
-					type: "Image",
+				logos: {
+					type: "Group",
 					config: {
-						label: "image",
-						constraint: {},
-						thumbnails: [],
-					},
-				},
-				link: {
-					type: "Link",
-					config: {
-						label: "link",
-						placeholder: "",
-						select: null,
+						label: "logos",
+						fields: {
+							image: {
+								type: "Image",
+								config: {
+									label: "image",
+									constraint: {},
+									thumbnails: [],
+								},
+							},
+							link: {
+								type: "Link",
+								config: {
+									label: "link",
+									placeholder: "",
+									select: null,
+								},
+							},
+						},
 					},
 				},
 			},

--- a/packages/adapter-nuxt/src/sliceTemplates/Hero/index.ts
+++ b/packages/adapter-nuxt/src/sliceTemplates/Hero/index.ts
@@ -161,12 +161,7 @@ export const mocks: SharedSliceContent[] = [
 				},
 			},
 		},
-		items: [
-			{
-				__TYPE__: "GroupItemContent",
-				value: [],
-			},
-		],
+		items: [],
 	},
 ];
 

--- a/packages/adapter-sveltekit/public/AlternateGrid/javascript.svelte
+++ b/packages/adapter-sveltekit/public/AlternateGrid/javascript.svelte
@@ -54,9 +54,9 @@
 					</div>
 				{/if}
 			</div>
-			{#if slice.items && slice.items.length}
+			{#if slice.primary.items && slice.primary.items.length}
 				<div class="es-alternate-grid__primary-content__items">
-					{#each slice.items as item, i}
+					{#each slice.primary.items as item, i}
 						<div class="es-alternate-grid__item">
 							{#if isFilled.richText(item.title)}
 								<div class="es-alternate-grid__item__heading">

--- a/packages/adapter-sveltekit/public/AlternateGrid/typescript.svelte
+++ b/packages/adapter-sveltekit/public/AlternateGrid/typescript.svelte
@@ -51,9 +51,9 @@
 					</div>
 				{/if}
 			</div>
-			{#if slice.items && slice.items.length}
+			{#if slice.primary.items && slice.primary.items.length}
 				<div class="es-alternate-grid__primary-content__items">
-					{#each slice.items as item, i}
+					{#each slice.primary.items as item, i}
 						<div class="es-alternate-grid__item">
 							{#if isFilled.richText(item.title)}
 								<div class="es-alternate-grid__item__heading">

--- a/packages/adapter-sveltekit/public/CustomerLogos/javascript.svelte
+++ b/packages/adapter-sveltekit/public/CustomerLogos/javascript.svelte
@@ -23,14 +23,14 @@
 				<PrismicRichText field={slice.primary.eyebrowHeadline} />
 			</div>
 		{/if}
-		{#if slice.items.length > 0}
+		{#if slice.primary.logos.length > 0}
 			<ul class="es-customer-logos__logos">
-				{#each slice.items as item}
-					{#if isFilled.image(item.image)}
+				{#each slice.primary.logos as logo}
+					{#if isFilled.image(logo.image)}
 						<li class="es-customer-logos__logo">
-							<PrismicLink field={item.link}>
+							<PrismicLink field={logo.link}>
 								<PrismicImage
-									field={item.image}
+									field={logo.image}
 									class="es-customer-logos__logo__link__image"
 									height="26"
 									width="160"

--- a/packages/adapter-sveltekit/public/CustomerLogos/typescript.svelte
+++ b/packages/adapter-sveltekit/public/CustomerLogos/typescript.svelte
@@ -20,14 +20,14 @@
 				<PrismicRichText field={slice.primary.eyebrowHeadline} />
 			</div>
 		{/if}
-		{#if slice.items.length > 0}
+		{#if slice.primary.logos.length > 0}
 			<ul class="es-customer-logos__logos">
-				{#each slice.items as item}
-					{#if isFilled.image(item.image)}
+				{#each slice.primary.logos as logo}
+					{#if isFilled.image(logo.image)}
 						<li class="es-customer-logos__logo">
-							<PrismicLink field={item.link}>
+							<PrismicLink field={logo.link}>
 								<PrismicImage
-									field={item.image}
+									field={logo.image}
 									class="es-customer-logos__logo__link__image"
 									height="26"
 									width="160"

--- a/packages/adapter-sveltekit/src/sliceTemplates/AlternateGrid/index.ts
+++ b/packages/adapter-sveltekit/src/sliceTemplates/AlternateGrid/index.ts
@@ -71,120 +71,124 @@ export const mocks: SharedSliceContent[] = [
 				__TYPE__: "ImageContent",
 				thumbnails: {},
 			},
+			items: {
+				__TYPE__: "GroupContentType",
+				value: [
+					{
+						__TYPE__: "GroupItemContent",
+						value: [
+							[
+								"title",
+								{
+									__TYPE__: "StructuredTextContent",
+									value: [
+										{
+											type: "heading3",
+											content: {
+												text: "Integrate with the SliceZone",
+												spans: [],
+											},
+											direction: "ltr",
+										},
+									],
+								},
+							],
+							[
+								"description",
+								{
+									__TYPE__: "StructuredTextContent",
+									value: [
+										{
+											type: "paragraph",
+											content: {
+												text: "This component has been matched by the SliceZone. Its model has been fetched from SliceMachine next-adapter!",
+												spans: [],
+											},
+											direction: "ltr",
+										},
+									],
+								},
+							],
+						],
+					},
+					{
+						__TYPE__: "GroupItemContent",
+						value: [
+							[
+								"title",
+								{
+									__TYPE__: "StructuredTextContent",
+									value: [
+										{
+											type: "heading3",
+											content: {
+												text: "Create your own",
+												spans: [],
+											},
+											direction: "ltr",
+										},
+									],
+								},
+							],
+							[
+								"description",
+								{
+									__TYPE__: "StructuredTextContent",
+									value: [
+										{
+											type: "paragraph",
+											content: {
+												text: "Feel free to use this component fully, or use it as an example! We're adding templates as often as we can.",
+												spans: [],
+											},
+											direction: "ltr",
+										},
+									],
+								},
+							],
+						],
+					},
+					{
+						__TYPE__: "GroupItemContent",
+						value: [
+							[
+								"title",
+								{
+									__TYPE__: "StructuredTextContent",
+									value: [
+										{
+											type: "heading3",
+											content: {
+												text: "Add a variation",
+												spans: [],
+											},
+											direction: "ltr",
+										},
+									],
+								},
+							],
+							[
+								"description",
+								{
+									__TYPE__: "StructuredTextContent",
+									value: [
+										{
+											type: "paragraph",
+											content: {
+												text: 'This slice comes with a "Image Right" variation, which means editors can switch text/image direction!',
+												spans: [],
+											},
+											direction: "ltr",
+										},
+									],
+								},
+							],
+						],
+					},
+				],
+			},
 		},
-		items: [
-			{
-				__TYPE__: "GroupItemContent",
-				value: [
-					[
-						"title",
-						{
-							__TYPE__: "StructuredTextContent",
-							value: [
-								{
-									type: "heading3",
-									content: {
-										text: "Integrate with the SliceZone",
-										spans: [],
-									},
-									direction: "ltr",
-								},
-							],
-						},
-					],
-					[
-						"description",
-						{
-							__TYPE__: "StructuredTextContent",
-							value: [
-								{
-									type: "paragraph",
-									content: {
-										text: "This component has been matched by the SliceZone. Its model has been fetched from SliceMachine next-adapter!",
-										spans: [],
-									},
-									direction: "ltr",
-								},
-							],
-						},
-					],
-				],
-			},
-			{
-				__TYPE__: "GroupItemContent",
-				value: [
-					[
-						"title",
-						{
-							__TYPE__: "StructuredTextContent",
-							value: [
-								{
-									type: "heading3",
-									content: {
-										text: "Create your own",
-										spans: [],
-									},
-									direction: "ltr",
-								},
-							],
-						},
-					],
-					[
-						"description",
-						{
-							__TYPE__: "StructuredTextContent",
-							value: [
-								{
-									type: "paragraph",
-									content: {
-										text: "Feel free to use this component fully, or use it as an example! We're adding templates as often as we can.",
-										spans: [],
-									},
-									direction: "ltr",
-								},
-							],
-						},
-					],
-				],
-			},
-			{
-				__TYPE__: "GroupItemContent",
-				value: [
-					[
-						"title",
-						{
-							__TYPE__: "StructuredTextContent",
-							value: [
-								{
-									type: "heading3",
-									content: {
-										text: "Add a variation",
-										spans: [],
-									},
-									direction: "ltr",
-								},
-							],
-						},
-					],
-					[
-						"description",
-						{
-							__TYPE__: "StructuredTextContent",
-							value: [
-								{
-									type: "paragraph",
-									content: {
-										text: 'This slice comes with a "Image Right" variation, which means editors can switch text/image direction!',
-										spans: [],
-									},
-									direction: "ltr",
-								},
-							],
-						},
-					],
-				],
-			},
-		],
+		items: [],
 	},
 	{
 		__TYPE__: "SharedSliceContent",
@@ -250,52 +254,56 @@ export const mocks: SharedSliceContent[] = [
 				__TYPE__: "ImageContent",
 				thumbnails: {},
 			},
-		},
-		items: [
-			{
-				__TYPE__: "GroupItemContent",
+			items: {
+				__TYPE__: "GroupContentType",
 				value: [
-					[
-						"title",
-						{
-							__TYPE__: "StructuredTextContent",
-							value: [
+					{
+						__TYPE__: "GroupItemContent",
+						value: [
+							[
+								"title",
 								{
-									type: "heading3",
-									content: {
-										text: "Create a unique, high-performing site",
-										spans: [
-											{
-												type: "strong",
-												start: 9,
-												end: 15,
+									__TYPE__: "StructuredTextContent",
+									value: [
+										{
+											type: "heading3",
+											content: {
+												text: "Create a unique, high-performing site",
+												spans: [
+													{
+														type: "strong",
+														start: 9,
+														end: 15,
+													},
+												],
 											},
-										],
-									},
-									direction: "ltr",
+											direction: "ltr",
+										},
+									],
 								},
 							],
-						},
-					],
-					[
-						"description",
-						{
-							__TYPE__: "StructuredTextContent",
-							value: [
+							[
+								"description",
 								{
-									type: "paragraph",
-									content: {
-										text: "Prismic is the headless website builder designed to help developers and marketers create unique, high-performing websites that are easy to edit.",
-										spans: [],
-									},
-									direction: "ltr",
+									__TYPE__: "StructuredTextContent",
+									value: [
+										{
+											type: "paragraph",
+											content: {
+												text: "Prismic is the headless website builder designed to help developers and marketers create unique, high-performing websites that are easy to edit.",
+												spans: [],
+											},
+											direction: "ltr",
+										},
+									],
 								},
 							],
-						},
-					],
+						],
+					},
 				],
 			},
-		],
+		},
+		items: [],
 	},
 ];
 
@@ -348,25 +356,32 @@ export const model: SharedSlice = {
 						thumbnails: [],
 					},
 				},
-			},
-			items: {
-				title: {
-					type: "StructuredText",
+				items: {
+					type: "Group",
 					config: {
-						label: "title",
-						placeholder: "",
-						allowTargetBlank: true,
-						single: "heading2,heading3,heading4,heading5,heading6,strong,em",
-					},
-				},
-				description: {
-					type: "StructuredText",
-					config: {
-						label: "description",
-						placeholder: "",
-						allowTargetBlank: true,
-						multi:
-							"paragraph,preformatted,hyperlink,strong,em,list-item,o-list-item,rtl",
+						label: "items",
+						fields: {
+							title: {
+								type: "StructuredText",
+								config: {
+									label: "title",
+									placeholder: "",
+									allowTargetBlank: true,
+									single:
+										"heading2,heading3,heading4,heading5,heading6,strong,em",
+								},
+							},
+							description: {
+								type: "StructuredText",
+								config: {
+									label: "description",
+									placeholder: "",
+									allowTargetBlank: true,
+									multi:
+										"paragraph,preformatted,hyperlink,strong,em,list-item,o-list-item,rtl",
+								},
+							},
+						},
 					},
 				},
 			},
@@ -414,25 +429,32 @@ export const model: SharedSlice = {
 						thumbnails: [],
 					},
 				},
-			},
-			items: {
-				title: {
-					type: "StructuredText",
+				items: {
+					type: "Group",
 					config: {
-						label: "title",
-						placeholder: "",
-						allowTargetBlank: true,
-						single: "heading2,heading3,heading4,heading5,heading6,strong,em",
-					},
-				},
-				description: {
-					type: "StructuredText",
-					config: {
-						label: "description",
-						placeholder: "",
-						allowTargetBlank: true,
-						multi:
-							"paragraph,preformatted,hyperlink,strong,em,list-item,o-list-item,rtl",
+						label: "items",
+						fields: {
+							title: {
+								type: "StructuredText",
+								config: {
+									label: "title",
+									placeholder: "",
+									allowTargetBlank: true,
+									single:
+										"heading2,heading3,heading4,heading5,heading6,strong,em",
+								},
+							},
+							description: {
+								type: "StructuredText",
+								config: {
+									label: "description",
+									placeholder: "",
+									allowTargetBlank: true,
+									multi:
+										"paragraph,preformatted,hyperlink,strong,em,list-item,o-list-item,rtl",
+								},
+							},
+						},
 					},
 				},
 			},

--- a/packages/adapter-sveltekit/src/sliceTemplates/CallToAction/index.ts
+++ b/packages/adapter-sveltekit/src/sliceTemplates/CallToAction/index.ts
@@ -146,12 +146,7 @@ export const mocks: SharedSliceContent[] = [
 				value: "Learn more!",
 			},
 		},
-		items: [
-			{
-				__TYPE__: "GroupItemContent",
-				value: [],
-			},
-		],
+		items: [],
 	},
 ];
 

--- a/packages/adapter-sveltekit/src/sliceTemplates/CustomerLogos/index.ts
+++ b/packages/adapter-sveltekit/src/sliceTemplates/CustomerLogos/index.ts
@@ -36,218 +36,222 @@ export const mocks: SharedSliceContent[] = [
 					},
 				],
 			},
+			logos: {
+				__TYPE__: "GroupContentType",
+				value: [
+					{
+						__TYPE__: "GroupItemContent",
+						value: [
+							[
+								"image",
+								{
+									origin: {
+										id: "main",
+										url: "https://images.prismic.io/slicesexamples/95a608cd-8d3c-40c1-a554-0bec1b89eda5_logo-3.svg",
+										width: 2545,
+										height: 2545,
+									},
+									url: "https://images.prismic.io/slicesexamples/95a608cd-8d3c-40c1-a554-0bec1b89eda5_logo-3.svg",
+									width: 2545,
+									height: 2545,
+									edit: {
+										zoom: 1,
+										crop: {
+											x: 0,
+											y: 0,
+										},
+										background: "transparent",
+									},
+									credits: null,
+									alt: "Customer Logo",
+									__TYPE__: "ImageContent",
+									thumbnails: {},
+								},
+							],
+							[
+								"link",
+								{
+									__TYPE__: "LinkContent",
+									value: {
+										__TYPE__: "ExternalLink",
+										url: "http://twitter.com",
+									},
+								},
+							],
+						],
+					},
+					{
+						__TYPE__: "GroupItemContent",
+						value: [
+							[
+								"image",
+								{
+									url: "https://images.prismic.io/slicesexamples/b62a8629-f7f1-4d2e-885a-bd7c6bcff201_logo-2.svg",
+									origin: {
+										id: "xnRg3xDcNnE",
+										url: "https://images.prismic.io/slicesexamples/b62a8629-f7f1-4d2e-885a-bd7c6bcff201_logo-2.svg",
+										width: 7173,
+										height: 10041,
+									},
+									width: 7173,
+									height: 10041,
+									edit: {
+										background: "transparent",
+										zoom: 1,
+										crop: {
+											x: 0,
+											y: 0,
+										},
+									},
+									credits: null,
+									alt: "Customer Logo",
+									__TYPE__: "ImageContent",
+									thumbnails: {},
+								},
+							],
+							[
+								"link",
+								{
+									__TYPE__: "LinkContent",
+									value: {
+										__TYPE__: "ExternalLink",
+										url: "https://prismic.io",
+										target: "_blank",
+									},
+								},
+							],
+						],
+					},
+					{
+						__TYPE__: "GroupItemContent",
+						value: [
+							[
+								"image",
+								{
+									url: "https://images.prismic.io/slicesexamples/4360a72b-bfe4-4144-911c-597146f72c00_logo-5.svg",
+									origin: {
+										id: "U1iYwZ8Dx7k",
+										url: "https://images.prismic.io/slicesexamples/4360a72b-bfe4-4144-911c-597146f72c00_logo-5.svg",
+										width: 3337,
+										height: 4171,
+									},
+									width: 3337,
+									height: 4171,
+									edit: {
+										background: "transparent",
+										zoom: 1,
+										crop: {
+											x: 0,
+											y: 0,
+										},
+									},
+									credits: null,
+									alt: "Customer Logo",
+									__TYPE__: "ImageContent",
+									thumbnails: {},
+								},
+							],
+							[
+								"link",
+								{
+									__TYPE__: "LinkContent",
+									value: {
+										__TYPE__: "ExternalLink",
+										url: "https://prismic.io",
+										target: "",
+									},
+								},
+							],
+						],
+					},
+					{
+						__TYPE__: "GroupItemContent",
+						value: [
+							[
+								"image",
+								{
+									url: "https://images.prismic.io/slicesexamples/846576e2-c93c-40dd-8aaa-b97f4e99e7aa_logo-1.svg",
+									origin: {
+										id: "nibgG33H0F8",
+										url: "https://images.prismic.io/slicesexamples/846576e2-c93c-40dd-8aaa-b97f4e99e7aa_logo-1.svg",
+										width: 4000,
+										height: 6000,
+									},
+									width: 4000,
+									height: 6000,
+									edit: {
+										background: "transparent",
+										zoom: 1,
+										crop: {
+											x: 0,
+											y: 0,
+										},
+									},
+									credits: null,
+									alt: "Customer Logo",
+									__TYPE__: "ImageContent",
+									thumbnails: {},
+								},
+							],
+							[
+								"link",
+								{
+									__TYPE__: "LinkContent",
+									value: {
+										__TYPE__: "ExternalLink",
+										url: "https://prismic.io",
+										target: "",
+									},
+								},
+							],
+						],
+					},
+					{
+						__TYPE__: "GroupItemContent",
+						value: [
+							[
+								"image",
+								{
+									url: "https://images.prismic.io/slicesexamples/23461395-458d-41f5-be25-bac37a4ff53e_logo-6.svg",
+									origin: {
+										id: "nAOZCYcLND8",
+										url: "https://images.prismic.io/slicesexamples/23461395-458d-41f5-be25-bac37a4ff53e_logo-6.svg",
+										width: 2749,
+										height: 4124,
+									},
+									width: 2749,
+									height: 4124,
+									edit: {
+										background: "transparent",
+										zoom: 1,
+										crop: {
+											x: 0,
+											y: 0,
+										},
+									},
+									credits: null,
+									alt: "Customer Logo",
+									__TYPE__: "ImageContent",
+									thumbnails: {},
+								},
+							],
+							[
+								"link",
+								{
+									__TYPE__: "LinkContent",
+									value: {
+										__TYPE__: "ExternalLink",
+										url: "https://prismic.io",
+										target: "",
+									},
+								},
+							],
+						],
+					},
+				],
+			},
 		},
-		items: [
-			{
-				__TYPE__: "GroupItemContent",
-				value: [
-					[
-						"image",
-						{
-							origin: {
-								id: "main",
-								url: "https://images.prismic.io/slicesexamples/95a608cd-8d3c-40c1-a554-0bec1b89eda5_logo-3.svg",
-								width: 2545,
-								height: 2545,
-							},
-							url: "https://images.prismic.io/slicesexamples/95a608cd-8d3c-40c1-a554-0bec1b89eda5_logo-3.svg",
-							width: 2545,
-							height: 2545,
-							edit: {
-								zoom: 1,
-								crop: {
-									x: 0,
-									y: 0,
-								},
-								background: "transparent",
-							},
-							credits: null,
-							alt: "Customer Logo",
-							__TYPE__: "ImageContent",
-							thumbnails: {},
-						},
-					],
-					[
-						"link",
-						{
-							__TYPE__: "LinkContent",
-							value: {
-								__TYPE__: "ExternalLink",
-								url: "http://twitter.com",
-							},
-						},
-					],
-				],
-			},
-			{
-				__TYPE__: "GroupItemContent",
-				value: [
-					[
-						"image",
-						{
-							url: "https://images.prismic.io/slicesexamples/b62a8629-f7f1-4d2e-885a-bd7c6bcff201_logo-2.svg",
-							origin: {
-								id: "xnRg3xDcNnE",
-								url: "https://images.prismic.io/slicesexamples/b62a8629-f7f1-4d2e-885a-bd7c6bcff201_logo-2.svg",
-								width: 7173,
-								height: 10041,
-							},
-							width: 7173,
-							height: 10041,
-							edit: {
-								background: "transparent",
-								zoom: 1,
-								crop: {
-									x: 0,
-									y: 0,
-								},
-							},
-							credits: null,
-							alt: "Customer Logo",
-							__TYPE__: "ImageContent",
-							thumbnails: {},
-						},
-					],
-					[
-						"link",
-						{
-							__TYPE__: "LinkContent",
-							value: {
-								__TYPE__: "ExternalLink",
-								url: "https://prismic.io",
-								target: "_blank",
-							},
-						},
-					],
-				],
-			},
-			{
-				__TYPE__: "GroupItemContent",
-				value: [
-					[
-						"image",
-						{
-							url: "https://images.prismic.io/slicesexamples/4360a72b-bfe4-4144-911c-597146f72c00_logo-5.svg",
-							origin: {
-								id: "U1iYwZ8Dx7k",
-								url: "https://images.prismic.io/slicesexamples/4360a72b-bfe4-4144-911c-597146f72c00_logo-5.svg",
-								width: 3337,
-								height: 4171,
-							},
-							width: 3337,
-							height: 4171,
-							edit: {
-								background: "transparent",
-								zoom: 1,
-								crop: {
-									x: 0,
-									y: 0,
-								},
-							},
-							credits: null,
-							alt: "Customer Logo",
-							__TYPE__: "ImageContent",
-							thumbnails: {},
-						},
-					],
-					[
-						"link",
-						{
-							__TYPE__: "LinkContent",
-							value: {
-								__TYPE__: "ExternalLink",
-								url: "https://prismic.io",
-								target: "",
-							},
-						},
-					],
-				],
-			},
-			{
-				__TYPE__: "GroupItemContent",
-				value: [
-					[
-						"image",
-						{
-							url: "https://images.prismic.io/slicesexamples/846576e2-c93c-40dd-8aaa-b97f4e99e7aa_logo-1.svg",
-							origin: {
-								id: "nibgG33H0F8",
-								url: "https://images.prismic.io/slicesexamples/846576e2-c93c-40dd-8aaa-b97f4e99e7aa_logo-1.svg",
-								width: 4000,
-								height: 6000,
-							},
-							width: 4000,
-							height: 6000,
-							edit: {
-								background: "transparent",
-								zoom: 1,
-								crop: {
-									x: 0,
-									y: 0,
-								},
-							},
-							credits: null,
-							alt: "Customer Logo",
-							__TYPE__: "ImageContent",
-							thumbnails: {},
-						},
-					],
-					[
-						"link",
-						{
-							__TYPE__: "LinkContent",
-							value: {
-								__TYPE__: "ExternalLink",
-								url: "https://prismic.io",
-								target: "",
-							},
-						},
-					],
-				],
-			},
-			{
-				__TYPE__: "GroupItemContent",
-				value: [
-					[
-						"image",
-						{
-							url: "https://images.prismic.io/slicesexamples/23461395-458d-41f5-be25-bac37a4ff53e_logo-6.svg",
-							origin: {
-								id: "nAOZCYcLND8",
-								url: "https://images.prismic.io/slicesexamples/23461395-458d-41f5-be25-bac37a4ff53e_logo-6.svg",
-								width: 2749,
-								height: 4124,
-							},
-							width: 2749,
-							height: 4124,
-							edit: {
-								background: "transparent",
-								zoom: 1,
-								crop: {
-									x: 0,
-									y: 0,
-								},
-							},
-							credits: null,
-							alt: "Customer Logo",
-							__TYPE__: "ImageContent",
-							thumbnails: {},
-						},
-					],
-					[
-						"link",
-						{
-							__TYPE__: "LinkContent",
-							value: {
-								__TYPE__: "ExternalLink",
-								url: "https://prismic.io",
-								target: "",
-							},
-						},
-					],
-				],
-			},
-		],
+		items: [],
 	},
 ];
 
@@ -289,22 +293,28 @@ export const model: SharedSlice = {
 						select: null,
 					},
 				},
-			},
-			items: {
-				image: {
-					type: "Image",
+				logos: {
+					type: "Group",
 					config: {
-						label: "image",
-						constraint: {},
-						thumbnails: [],
-					},
-				},
-				link: {
-					type: "Link",
-					config: {
-						label: "link",
-						placeholder: "",
-						select: null,
+						label: "logos",
+						fields: {
+							image: {
+								type: "Image",
+								config: {
+									label: "image",
+									constraint: {},
+									thumbnails: [],
+								},
+							},
+							link: {
+								type: "Link",
+								config: {
+									label: "link",
+									placeholder: "",
+									select: null,
+								},
+							},
+						},
 					},
 				},
 			},

--- a/packages/adapter-sveltekit/src/sliceTemplates/Hero/index.ts
+++ b/packages/adapter-sveltekit/src/sliceTemplates/Hero/index.ts
@@ -161,12 +161,7 @@ export const mocks: SharedSliceContent[] = [
 				},
 			},
 		},
-		items: [
-			{
-				__TYPE__: "GroupItemContent",
-				value: [],
-			},
-		],
+		items: [],
 	},
 ];
 


### PR DESCRIPTION
## Context

- Completes DT-2086

## The Solution

- Updated slice template AlternateGrid to use a group in primary instead of items
  - group id: "items"
- Updated slice template CustomerLogos to use a group in primary instead of items
  - group id: "logos"
- Updated slice template CallToAction to remove unnecessary group item in mocks value

## Impact / Dependencies

- Should be merged ONLY when we are sure next release will be for group in slice!

## Checklist before requesting a review
- [x] I hereby declare my code ready for review.
- [ ] If it is a critical feature, I have added tests.
- [x] The CI is successful.
- [ ] If there could backward compatibility issues, it has been discussed and planned.

## Preview

![Screenshot 2024-05-12 at 23 58 21](https://github.com/prismicio/slice-machine/assets/19946868/fddd410b-34ee-4e87-9e4d-fc17710919f2)
![Screenshot 2024-05-12 at 23 58 31](https://github.com/prismicio/slice-machine/assets/19946868/7285ffaf-b752-44c4-b64e-b36974d511dd)
