### PR TITLE
feat: add support of svelte 5

### DIFF
--- a/packages/adapter-sveltekit/package.json
+++ b/packages/adapter-sveltekit/package.json
@@ -105,7 +105,7 @@
 		"@sveltejs/kit": "^1 || ^2",
 		"prettier": ">=3",
 		"prettier-plugin-svelte": ">=3",
-		"svelte": "^3.54.0 || ^4.0.0-next.0"
+		"svelte": "^3.54.0 || ^4.0.0-next.0 || ^5.0.0-next.1"
 	},
 	"peerDependenciesMeta": {
 		"prettier": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -8427,7 +8427,7 @@ __metadata:
     "@sveltejs/kit": ^1 || ^2
     prettier: ">=3"
     prettier-plugin-svelte: ">=3"
-    svelte: ^3.54.0 || ^4.0.0-next.0
+    svelte: ^3.54.0 || ^4.0.0-next.0 || ^5.0.0-next.1
   peerDependenciesMeta:
     prettier:
       optional: true


### PR DESCRIPTION
## Context

- Support Svelte 5 for @slicemachine/adapter-sveltekit

## The Solution

- Update peerDep to include `^5.0.0-next.1`

## Impact / Dependencies

- Unlock svelte 5 usage

## Checklist before requesting a review
- [ ] I hereby declare my code ready for review.
- [ ] If it is a critical feature, I have added tests.
- [ ] The CI is successful.
- [ ] If there could backward compatibility issues, it has been discussed and planned.