### PR TITLE
docs: delete repeatable zone modal warning

### DIFF
--- a/packages/slice-machine/src/legacy/lib/builders/SliceBuilder/FieldZones/index.tsx
+++ b/packages/slice-machine/src/legacy/lib/builders/SliceBuilder/FieldZones/index.tsx
@@ -246,14 +246,30 @@ const FieldZones: FC = () => {
         <DialogHeader icon="delete" title="Delete field" />
         <DialogContent>
           <Box padding={24} gap={12} flexDirection="column">
-            <strong>
-              This action will permanently remove the repeatable zone from the{" "}
-              {slice.model.name} slice {variation.name} variation.
-            </strong>
-            <div>
-              Other variations will be left untouched. To reimplement repeatable{" "}
-              fields later, use a group field instead of the repeatable zone.
-            </div>
+            {slice.model.variations.length > 1 ? (
+              <>
+                <strong>
+                  This action will permanently remove the repeatable zone from
+                  the {slice.model.name} slice {variation.name} variation.
+                </strong>
+                <div>
+                  Other variations will be left untouched. To reimplement
+                  repeatable fields later, use a group field instead of the
+                  repeatable zone.
+                </div>
+              </>
+            ) : (
+              <>
+                <strong>
+                  This action will permanently remove the repeatable zone from
+                  the {slice.model.name}
+                </strong>
+                <div>
+                  To reimplement repeatable fields later, use a group field
+                  instead of the repeatable zone.
+                </div>
+              </>
+            )}
           </Box>
           <DialogActions
             ok={{

--- a/packages/slice-machine/src/legacy/lib/builders/SliceBuilder/FieldZones/index.tsx
+++ b/packages/slice-machine/src/legacy/lib/builders/SliceBuilder/FieldZones/index.tsx
@@ -248,11 +248,11 @@ const FieldZones: FC = () => {
           <Box padding={24} gap={12} flexDirection="column">
             <strong>
               This action will permanently remove the repeatable zone from the{" "}
-              {slice.model.name} slice.
+              {slice.model.name} slice {variation.name} variation.
             </strong>
             <div>
-              To reimplement repeatable fields later, use a group field instead
-              of the repeatable zone.
+              Other variations will be left untouched. To reimplement repeatable{" "}
+              fields later, use a group field instead of the repeatable zone.
             </div>
           </Box>
           <DialogActions

--- a/packages/slice-machine/src/legacy/lib/builders/SliceBuilder/FieldZones/index.tsx
+++ b/packages/slice-machine/src/legacy/lib/builders/SliceBuilder/FieldZones/index.tsx
@@ -262,7 +262,7 @@ const FieldZones: FC = () => {
               <>
                 <strong>
                   This action will permanently remove the repeatable zone from
-                  the {slice.model.name}
+                  the {slice.model.name}.
                 </strong>
                 <div>
                   To reimplement repeatable fields later, use a group field


### PR DESCRIPTION
<!-- Please use a Conventional Commit in your PR title -->
<!-- https://conventionalcommits.org -->
<!-- e.g. "feat: support new field type" -->

**Resolves**: N/A

### Description

Reworks wording for the modal that appears when a user is about to delete its repeatable zone from a given slice variation to prevent confusion.

Additional context: https://prismic-team.slack.com/archives/CPG31MDL1/p1716448863601729
<!-- Describe your changes in detail. -->
<!-- Why is this change required? -->
<!-- What problem does it solve? -->

### Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- Don't hesitate to ask for help! -->

- [x] If my changes require tests, I added them.
- [x] If my changes affect backward compatibility, it has been discussed.
- [ ] If my changes require an update to the CONTRIBUTING.md guide, I updated it.

[^1]:
	Please use these labels when submitting a review:
	:question: #ask:&ensp;Ask a question.
	:bulb: #idea:&ensp;Suggest an idea.
	:warning: #issue:&ensp;Strongly suggest a change.
	:tada: #nice:&ensp;Share a compliment.