### PR TITLE
fix (next config): change `assert` to `with`

### DIFF
--- a/packages/slice-machine/next.config.mjs
+++ b/packages/slice-machine/next.config.mjs
@@ -1,7 +1,7 @@
 import { withSentryConfig } from "@sentry/nextjs";
 import semver from "semver";
 
-import pkg from "./package.json" assert { type: "json" };
+import pkg from "./package.json" with { type: "json" };
 
 const parsedPkgVersion = semver.parse(pkg.version);
 if (parsedPkgVersion === null) {

--- a/packages/slice-machine/next.config.mjs
+++ b/packages/slice-machine/next.config.mjs
@@ -1,7 +1,17 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as url from "node:url";
+
 import { withSentryConfig } from "@sentry/nextjs";
 import semver from "semver";
 
-import pkg from "./package.json" with { type: "json" };
+const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
+
+/** @type {{ name: string, version: string }} */
+// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+const pkg = JSON.parse(
+  fs.readFileSync(path.resolve(__dirname, "package.json"), "utf8"),
+);
 
 const parsedPkgVersion = semver.parse(pkg.version);
 if (parsedPkgVersion === null) {


### PR DESCRIPTION
<!-- Please use a Conventional Commit in your PR title -->
<!-- https://conventionalcommits.org -->
<!-- e.g. "feat: support new field type" -->

**Resolves**: [DT-2172](https://linear.app/prismic/issue/DT-2172/update-slice-machinenextconfigmjs-to-use-import-with-instead-of)

### Description

<!-- Describe your changes in detail. -->
<!-- Why is this change required? -->
<!-- What problem does it solve? -->

This fixes an error I had when running `yarn dev`. It was failing due to a changed ES proposal with `import assert`. It should now be `import with` as this PR updates.

### Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- Don't hesitate to ask for help! -->

- [ ] If my changes require tests, I added them.
- [ ] If my changes affect backward compatibility, it has been discussed.
- [ ] If my changes require an update to the CONTRIBUTING.md guide, I updated it.

### Preview

<!-- If your changes are visual, screenshots or videos are welcome! -->

N/A

### How to QA [^1]

<!-- When relevant, describe how to QA your changes. -->

<!-- Your favorite emoji is welcome to close your PR! -->

<!-- A note for reviewers: -->

[^1]:
	Please use these labels when submitting a review:
	:question: #ask:&ensp;Ask a question.
	:bulb: #idea:&ensp;Suggest an idea.
	:warning: #issue:&ensp;Strongly suggest a change.
	:tada: #nice:&ensp;Share a compliment.