### PR TITLE
fix: move default "Meta Title" to the first field

### DIFF
--- a/packages/slice-machine/src/domain/customType.ts
+++ b/packages/slice-machine/src/domain/customType.ts
@@ -538,6 +538,14 @@ const DEFAULT_MAIN_WITH_UID_AND_SLICE_ZONE: CustomType["json"] = {
 
 const DEFAULT_SEO_TAB: CustomType["json"] = {
   "SEO & Metadata": {
+    meta_title: {
+      config: {
+        label: "Meta Title",
+        placeholder:
+          "A title of the page used for social media and search engines",
+      },
+      type: "Text",
+    },
     meta_description: {
       config: {
         label: "Meta Description",
@@ -555,14 +563,6 @@ const DEFAULT_SEO_TAB: CustomType["json"] = {
         thumbnails: [],
       },
       type: "Image",
-    },
-    meta_title: {
-      config: {
-        label: "Meta Title",
-        placeholder:
-          "A title of the page used for social media and search engines",
-      },
-      type: "Text",
     },
   },
 };


### PR DESCRIPTION
<!-- Please use a Conventional Commit in your PR title -->
<!-- https://conventionalcommits.org -->
<!-- e.g. "feat: support new field type" -->

**Resolves**: https://prismic-team.slack.com/archives/CPG31MDL1/p1718373106971659

### Description

<!-- Describe your changes in detail. -->
<!-- Why is this change required? -->
<!-- What problem does it solve? -->

This PR moves the default "Meta Title" field to the first field in the "SEO & Meta" tab. The new order looks like this:

- Meta Title
- Meta Description
- Meta Image

This order follows the each field's natural informational hierarchy.

### Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- Don't hesitate to ask for help! -->

- [ ] If my changes require tests, I added them.
- [ ] If my changes affect backward compatibility, it has been discussed.
- [ ] If my changes require an update to the CONTRIBUTING.md guide, I updated it.

### Preview

<!-- If your changes are visual, screenshots or videos are welcome! -->

<img width="741" alt="image" src="https://github.com/prismicio/slice-machine/assets/8601064/06063ffb-0e35-4701-ac51-7c8d760a5c26">

### How to QA [^1]

<!-- When relevant, describe how to QA your changes. -->

1. Start Slice Machine:
   ```sh
   yarn dev

   # In a new terminal
   yarn play --new
   ```
2. Create a new page type.
3. Verify the "SEO & Meta" tab fields are in the new, correct order.

<!-- Your favorite emoji is welcome to close your PR! -->

<!-- A note for reviewers: -->

[^1]:
	Please use these labels when submitting a review:
	:question: #ask:&ensp;Ask a question.
	:bulb: #idea:&ensp;Suggest an idea.
	:warning: #issue:&ensp;Strongly suggest a change.
	:tada: #nice:&ensp;Share a compliment.
