### PR TITLE
feat: improve code snippet hints for groups & nested groups

### DIFF
--- a/packages/adapter-next/src/hooks/snippet-read.ts
+++ b/packages/adapter-next/src/hooks/snippet-read.ts
@@ -28,7 +28,7 @@ export const snippetRead: SnippetReadHook<PluginOptions> = async (
 	data,
 	{ helpers },
 ) => {
-	const { fieldPath, context } = data;
+	const { fieldPath, itemName } = data;
 
 	const label = "React";
 
@@ -88,8 +88,8 @@ export const snippetRead: SnippetReadHook<PluginOptions> = async (
 			const code = await format(
 				stripIndent`
 					<>
-						{${dotPath(fieldPath)}.map((${context?.subItemHintBase || "item"}) => {
-							// Render the ${context?.subItemHintBase || "item"}
+						{${dotPath(fieldPath)}.map((${itemName || "item"}) => {
+							// Render the ${itemName || "item"}
 						})}
 					</>
 				`,

--- a/packages/adapter-next/src/hooks/snippet-read.ts
+++ b/packages/adapter-next/src/hooks/snippet-read.ts
@@ -88,8 +88,8 @@ export const snippetRead: SnippetReadHook<PluginOptions> = async (
 			const code = await format(
 				stripIndent`
 					<>
-						{${dotPath(fieldPath)}.map((${itemName || "item"}) => {
-							// Render the ${itemName || "item"}
+						{${dotPath(fieldPath)}.map((${itemName}) => {
+							// Render the ${itemName}
 						})}
 					</>
 				`,

--- a/packages/adapter-next/src/hooks/snippet-read.ts
+++ b/packages/adapter-next/src/hooks/snippet-read.ts
@@ -28,7 +28,7 @@ export const snippetRead: SnippetReadHook<PluginOptions> = async (
 	data,
 	{ helpers },
 ) => {
-	const { fieldPath } = data;
+	const { fieldPath, context } = data;
 
 	const label = "React";
 
@@ -88,8 +88,8 @@ export const snippetRead: SnippetReadHook<PluginOptions> = async (
 			const code = await format(
 				stripIndent`
 					<>
-						{${dotPath(fieldPath)}.map((item) => {
-							// Render the item
+						{${dotPath(fieldPath)}.map((${context?.subItemHintBase || "item"}) => {
+							// Render the ${context?.subItemHintBase || "item"}
 						})}
 					</>
 				`,

--- a/packages/adapter-next/test/plugin-snippet-read.test.ts
+++ b/packages/adapter-next/test/plugin-snippet-read.test.ts
@@ -1,5 +1,6 @@
 import { test, expect } from "vitest";
 import { createMockFactory } from "@prismicio/mock";
+import { GroupFieldType } from "@prismicio/types-internal/lib/customtypes";
 import { Snippet } from "@slicemachine/plugin-kit";
 import prettier from "prettier";
 
@@ -36,6 +37,8 @@ const model = mock.model.customType({
 	},
 });
 
+const itemName = "item";
+
 const testSnippet = (
 	fieldName: keyof typeof model.json.Main,
 	expected: string | Snippet[],
@@ -46,6 +49,10 @@ const testSnippet = (
 		} = await ctx.pluginRunner.callHook("snippet:read", {
 			fieldPath: [model.id, "data", fieldName],
 			model: model.json.Main[fieldName],
+			itemName:
+				model.json.Main[fieldName].type === GroupFieldType
+					? itemName
+					: undefined,
 		});
 
 		if (Array.isArray(expected)) {
@@ -101,8 +108,8 @@ testSnippet(
 
 testSnippet(
 	"group",
-	`<>{${model.id}.data.group.map((item) => {
-// Render the item
+	`<>{${model.id}.data.group.map((${itemName}) => {
+// Render the ${itemName}
 })}</>`,
 );
 

--- a/packages/adapter-nuxt/src/hooks/snippet-read.ts
+++ b/packages/adapter-nuxt/src/hooks/snippet-read.ts
@@ -27,7 +27,7 @@ export const snippetRead: SnippetReadHook<PluginOptions> = async (
 	data,
 	{ helpers },
 ) => {
-	const { fieldPath, context } = data;
+	const { fieldPath, itemName } = data;
 
 	const label = "Vue";
 
@@ -102,10 +102,8 @@ export const snippetRead: SnippetReadHook<PluginOptions> = async (
 				language: "vue",
 				code: await format(
 					stripIndent`
-						<template v-for="${context?.subItemHintBase || "item"} in ${dotPath(
-							fieldPath,
-						)}">
-							{{ ${context?.subItemHintBase || "item"} }}
+						<template v-for="${itemName || "item"} in ${dotPath(fieldPath)}">
+							{{ ${itemName || "item"} }}
 						</template>
 					`,
 					helpers,

--- a/packages/adapter-nuxt/src/hooks/snippet-read.ts
+++ b/packages/adapter-nuxt/src/hooks/snippet-read.ts
@@ -102,8 +102,8 @@ export const snippetRead: SnippetReadHook<PluginOptions> = async (
 				language: "vue",
 				code: await format(
 					stripIndent`
-						<template v-for="${itemName || "item"} in ${dotPath(fieldPath)}">
-							{{ ${itemName || "item"} }}
+						<template v-for="${itemName} in ${dotPath(fieldPath)}">
+							{{ ${itemName} }}
 						</template>
 					`,
 					helpers,

--- a/packages/adapter-nuxt/src/hooks/snippet-read.ts
+++ b/packages/adapter-nuxt/src/hooks/snippet-read.ts
@@ -27,7 +27,7 @@ export const snippetRead: SnippetReadHook<PluginOptions> = async (
 	data,
 	{ helpers },
 ) => {
-	const { fieldPath } = data;
+	const { fieldPath, context } = data;
 
 	const label = "Vue";
 
@@ -102,8 +102,10 @@ export const snippetRead: SnippetReadHook<PluginOptions> = async (
 				language: "vue",
 				code: await format(
 					stripIndent`
-						<template v-for="item in ${dotPath(fieldPath)}">
-							{{ item }}
+						<template v-for="${context?.subItemHintBase || "item"} in ${dotPath(
+							fieldPath,
+						)}">
+							{{ ${context?.subItemHintBase || "item"} }}
 						</template>
 					`,
 					helpers,

--- a/packages/adapter-nuxt/test/plugin-snippet-read.test.ts
+++ b/packages/adapter-nuxt/test/plugin-snippet-read.test.ts
@@ -1,5 +1,6 @@
 import { test, expect } from "vitest";
 import { createMockFactory } from "@prismicio/mock";
+import { GroupFieldType } from "@prismicio/types-internal/lib/customtypes";
 import { Snippet } from "@slicemachine/plugin-kit";
 import prettier from "prettier";
 
@@ -36,6 +37,8 @@ const model = mock.model.customType({
 	},
 });
 
+const itemName = "item";
+
 const testSnippet = (
 	fieldName: keyof typeof model.json.Main,
 	expected: string | Snippet[],
@@ -46,6 +49,10 @@ const testSnippet = (
 		} = await ctx.pluginRunner.callHook("snippet:read", {
 			fieldPath: [model.id, "data", fieldName],
 			model: model.json.Main[fieldName],
+			itemName:
+				model.json.Main[fieldName].type === GroupFieldType
+					? itemName
+					: undefined,
 		});
 
 		if (Array.isArray(expected)) {
@@ -88,8 +95,8 @@ testSnippet("geoPoint", `{{${model.id}.data.geoPoint}}`);
 
 testSnippet(
 	"group",
-	`<template v-for="item in ${model.id}.data.group">
-	{{ item }}
+	`<template v-for="${itemName} in ${model.id}.data.group">
+	{{ ${itemName} }}
 </template>`,
 );
 

--- a/packages/adapter-nuxt2/src/hooks/snippet-read.ts
+++ b/packages/adapter-nuxt2/src/hooks/snippet-read.ts
@@ -27,7 +27,7 @@ export const snippetRead: SnippetReadHook<PluginOptions> = async (
 	data,
 	{ helpers },
 ) => {
-	const { fieldPath, context } = data;
+	const { fieldPath, itemName } = data;
 
 	const label = "Vue";
 
@@ -102,10 +102,8 @@ export const snippetRead: SnippetReadHook<PluginOptions> = async (
 				language: "vue",
 				code: await format(
 					stripIndent`
-						<template v-for="${context?.subItemHintBase || "item"} in ${dotPath(
-							fieldPath,
-						)}">
-							{{ ${context?.subItemHintBase || "item"} }}
+						<template v-for="${itemName || "item"} in ${dotPath(fieldPath)}">
+							{{ ${itemName || "item"} }}
 						</template>
 					`,
 					helpers,

--- a/packages/adapter-nuxt2/src/hooks/snippet-read.ts
+++ b/packages/adapter-nuxt2/src/hooks/snippet-read.ts
@@ -102,8 +102,8 @@ export const snippetRead: SnippetReadHook<PluginOptions> = async (
 				language: "vue",
 				code: await format(
 					stripIndent`
-						<template v-for="${itemName || "item"} in ${dotPath(fieldPath)}">
-							{{ ${itemName || "item"} }}
+						<template v-for="${itemName} in ${dotPath(fieldPath)}">
+							{{ ${itemName} }}
 						</template>
 					`,
 					helpers,

--- a/packages/adapter-nuxt2/src/hooks/snippet-read.ts
+++ b/packages/adapter-nuxt2/src/hooks/snippet-read.ts
@@ -27,7 +27,7 @@ export const snippetRead: SnippetReadHook<PluginOptions> = async (
 	data,
 	{ helpers },
 ) => {
-	const { fieldPath } = data;
+	const { fieldPath, context } = data;
 
 	const label = "Vue";
 
@@ -102,8 +102,10 @@ export const snippetRead: SnippetReadHook<PluginOptions> = async (
 				language: "vue",
 				code: await format(
 					stripIndent`
-						<template v-for="item in ${dotPath(fieldPath)}">
-							{{ item }}
+						<template v-for="${context?.subItemHintBase || "item"} in ${dotPath(
+							fieldPath,
+						)}">
+							{{ ${context?.subItemHintBase || "item"} }}
 						</template>
 					`,
 					helpers,

--- a/packages/adapter-nuxt2/test/plugin-snippet-read.test.ts
+++ b/packages/adapter-nuxt2/test/plugin-snippet-read.test.ts
@@ -1,5 +1,6 @@
 import { test, expect } from "vitest";
 import { createMockFactory } from "@prismicio/mock";
+import { GroupFieldType } from "@prismicio/types-internal/lib/customtypes";
 import { Snippet } from "@slicemachine/plugin-kit";
 import prettier from "prettier";
 
@@ -36,6 +37,8 @@ const model = mock.model.customType({
 	},
 });
 
+const itemName = "item";
+
 const testSnippet = (
 	fieldName: keyof typeof model.json.Main,
 	expected: string | Snippet[],
@@ -46,6 +49,10 @@ const testSnippet = (
 		} = await ctx.pluginRunner.callHook("snippet:read", {
 			fieldPath: [model.id, "data", fieldName],
 			model: model.json.Main[fieldName],
+			itemName:
+				model.json.Main[fieldName].type === GroupFieldType
+					? itemName
+					: undefined,
 		});
 
 		if (Array.isArray(expected)) {
@@ -88,8 +95,8 @@ testSnippet("geoPoint", `{{${model.id}.data.geoPoint}}`);
 
 testSnippet(
 	"group",
-	`<template v-for="item in ${model.id}.data.group">
-	{{ item }}
+	`<template v-for="${itemName} in ${model.id}.data.group">
+	{{ ${itemName} }}
 </template>`,
 );
 

--- a/packages/adapter-sveltekit/src/hooks/snippet-read.ts
+++ b/packages/adapter-sveltekit/src/hooks/snippet-read.ts
@@ -26,7 +26,7 @@ export const snippetRead: SnippetReadHook<PluginOptions> = async (
 	data,
 	{ helpers },
 ) => {
-	const { fieldPath } = data;
+	const { fieldPath, context } = data;
 
 	const label = "Svelte";
 
@@ -85,8 +85,8 @@ export const snippetRead: SnippetReadHook<PluginOptions> = async (
 		case "Group": {
 			const code = await format(
 				stripIndent`
-					{#each ${dotPath(fieldPath)} as item}
-						<!-- Render content for item -->
+					{#each ${dotPath(fieldPath)} as ${context?.subItemHintBase || "item"}}
+						<!-- Render content for ${context?.subItemHintBase || "item"} -->
 					{/each}
 				`,
 				helpers,

--- a/packages/adapter-sveltekit/src/hooks/snippet-read.ts
+++ b/packages/adapter-sveltekit/src/hooks/snippet-read.ts
@@ -26,7 +26,7 @@ export const snippetRead: SnippetReadHook<PluginOptions> = async (
 	data,
 	{ helpers },
 ) => {
-	const { fieldPath, context } = data;
+	const { fieldPath, itemName } = data;
 
 	const label = "Svelte";
 
@@ -85,8 +85,8 @@ export const snippetRead: SnippetReadHook<PluginOptions> = async (
 		case "Group": {
 			const code = await format(
 				stripIndent`
-					{#each ${dotPath(fieldPath)} as ${context?.subItemHintBase || "item"}}
-						<!-- Render content for ${context?.subItemHintBase || "item"} -->
+					{#each ${dotPath(fieldPath)} as ${itemName || "item"}}
+						<!-- Render content for ${itemName || "item"} -->
 					{/each}
 				`,
 				helpers,

--- a/packages/adapter-sveltekit/src/hooks/snippet-read.ts
+++ b/packages/adapter-sveltekit/src/hooks/snippet-read.ts
@@ -85,8 +85,8 @@ export const snippetRead: SnippetReadHook<PluginOptions> = async (
 		case "Group": {
 			const code = await format(
 				stripIndent`
-					{#each ${dotPath(fieldPath)} as ${itemName || "item"}}
-						<!-- Render content for ${itemName || "item"} -->
+					{#each ${dotPath(fieldPath)} as ${itemName}}
+						<!-- Render content for ${itemName} -->
 					{/each}
 				`,
 				helpers,

--- a/packages/adapter-sveltekit/test/plugin-snippet-read.test.ts
+++ b/packages/adapter-sveltekit/test/plugin-snippet-read.test.ts
@@ -1,5 +1,6 @@
 import { test, expect } from "vitest";
 import { createMockFactory } from "@prismicio/mock";
+import { GroupFieldType } from "@prismicio/types-internal/lib/customtypes";
 import { Snippet } from "@slicemachine/plugin-kit";
 import prettier from "prettier";
 
@@ -36,6 +37,8 @@ const model = mock.model.customType({
 	},
 });
 
+const itemName = "item";
+
 const prettierConfig: prettier.Options = {
 	plugins: ["prettier-plugin-svelte"],
 	parser: "svelte",
@@ -51,6 +54,10 @@ const testSnippet = (
 		} = await ctx.pluginRunner.callHook("snippet:read", {
 			fieldPath: [model.id, "data", fieldName],
 			model: model.json.Main[fieldName],
+			itemName:
+				model.json.Main[fieldName].type === GroupFieldType
+					? itemName
+					: undefined,
 		});
 
 		if (Array.isArray(expected)) {
@@ -96,8 +103,8 @@ testSnippet(
 
 testSnippet(
 	"group",
-	`{#each ${model.id}.data.group as item}
-	<!-- Render content for item -->
+	`{#each ${model.id}.data.group as ${itemName}}
+	<!-- Render content for ${itemName} -->
 {/each}`,
 );
 

--- a/packages/plugin-kit/src/hooks/snippet-read.ts
+++ b/packages/plugin-kit/src/hooks/snippet-read.ts
@@ -17,6 +17,11 @@ export type Snippet = {
 
 /**
  * Data provided to `snippet:read` hook handlers.
+ *
+ * The `itemName` string keeps slice machine as the single source of truth for
+ * the code snippet base names. Angelo suggested an improvement to `fieldPath`
+ * (linked below) that could be done in the future.
+ * https://github.com/prismicio/slice-machine/pull/1390#pullrequestreview-2123845118
  */
 export type SnippetReadHookData = {
 	fieldPath: string[];

--- a/packages/plugin-kit/src/hooks/snippet-read.ts
+++ b/packages/plugin-kit/src/hooks/snippet-read.ts
@@ -21,9 +21,7 @@ export type Snippet = {
 export type SnippetReadHookData = {
 	fieldPath: string[];
 	model: DynamicWidget;
-	context?: {
-		subItemHintBase?: string;
-	};
+	itemName?: string;
 };
 
 /**

--- a/packages/plugin-kit/src/hooks/snippet-read.ts
+++ b/packages/plugin-kit/src/hooks/snippet-read.ts
@@ -21,6 +21,9 @@ export type Snippet = {
 export type SnippetReadHookData = {
 	fieldPath: string[];
 	model: DynamicWidget;
+	context?: {
+		subItemHintBase?: string;
+	};
 };
 
 /**

--- a/packages/slice-machine/src/legacy/lib/builders/common/Zone/Card/components/Hints/index.tsx
+++ b/packages/slice-machine/src/legacy/lib/builders/common/Zone/Card/components/Hints/index.tsx
@@ -9,9 +9,15 @@ interface HintProps {
   show: boolean;
   item: Item;
   renderHintBase: RenderHintBaseFN;
+  subItemHintBase?: string;
 }
 
-const Hint: React.FC<HintProps> = ({ show, renderHintBase, item }) => {
+const Hint: React.FC<HintProps> = ({
+  show,
+  renderHintBase,
+  item,
+  subItemHintBase,
+}) => {
   const fieldPathString = renderHintBase({ item });
 
   // TODO: Call `swr`'s global `mutate` function when something changes to clear the cache.
@@ -20,6 +26,7 @@ const Hint: React.FC<HintProps> = ({ show, renderHintBase, item }) => {
     return await managerClient.snippets.readSnippets({
       fieldPath: fieldPathString.split("."),
       model: item.value,
+      context: { subItemHintBase },
     });
   });
 

--- a/packages/slice-machine/src/legacy/lib/builders/common/Zone/Card/components/Hints/index.tsx
+++ b/packages/slice-machine/src/legacy/lib/builders/common/Zone/Card/components/Hints/index.tsx
@@ -9,14 +9,14 @@ interface HintProps {
   show: boolean;
   item: Item;
   renderHintBase: RenderHintBaseFN;
-  subItemHintBase?: string;
+  hintItemName?: string;
 }
 
 const Hint: React.FC<HintProps> = ({
   show,
   renderHintBase,
   item,
-  subItemHintBase,
+  hintItemName,
 }) => {
   const fieldPathString = renderHintBase({ item });
 
@@ -26,7 +26,7 @@ const Hint: React.FC<HintProps> = ({
     return await managerClient.snippets.readSnippets({
       fieldPath: fieldPathString.split("."),
       model: item.value,
-      context: { subItemHintBase },
+      itemName: hintItemName,
     });
   });
 

--- a/packages/slice-machine/src/legacy/lib/builders/common/Zone/Card/index.jsx
+++ b/packages/slice-machine/src/legacy/lib/builders/common/Zone/Card/index.jsx
@@ -104,7 +104,7 @@ const FieldZone = ({
                     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
                     renderHintBase={renderHintBase}
                     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-                    subItemHintBase={widget.SUB_ITEM_HINT_BASE}
+                    hintItemName={widget.hintItemName}
                     Widgets={Widgets}
                     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/strict-boolean-expressions
                     typeName={widget.CUSTOM_NAME || widget.TYPE_NAME}

--- a/packages/slice-machine/src/legacy/lib/builders/common/Zone/Card/index.jsx
+++ b/packages/slice-machine/src/legacy/lib/builders/common/Zone/Card/index.jsx
@@ -103,6 +103,8 @@ const FieldZone = ({
                     isRepeatable={isRepeatable}
                     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
                     renderHintBase={renderHintBase}
+                    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+                    subItemHintBase={widget.SUB_ITEM_HINT_BASE}
                     Widgets={Widgets}
                     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/strict-boolean-expressions
                     typeName={widget.CUSTOM_NAME || widget.TYPE_NAME}

--- a/packages/slice-machine/src/legacy/lib/models/common/widgets/Group/ListItem/index.jsx
+++ b/packages/slice-machine/src/legacy/lib/models/common/widgets/Group/ListItem/index.jsx
@@ -238,7 +238,7 @@ export const CustomListItem = ({
                               // eslint-disable-next-line @typescript-eslint/restrict-template-expressions, @typescript-eslint/no-unsafe-member-access
                               `${hintBase}${transformKeyAccessor(item.key)}`
                             }
-                            subItemHintBase={widget.SUB_ITEM_HINT_BASE}
+                            hintItemName={widget.hintItemName}
                             Widgets={Widgets}
                             // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
                             typeName={widget.CUSTOM_NAME || widget.TYPE_NAME}

--- a/packages/slice-machine/src/legacy/lib/models/common/widgets/Group/ListItem/index.jsx
+++ b/packages/slice-machine/src/legacy/lib/models/common/widgets/Group/ListItem/index.jsx
@@ -28,6 +28,7 @@ export const CustomListItem = ({
   widget,
   Widgets,
   widgetsArray,
+  hintBase,
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   parentSnapshot,
   showHints,
@@ -235,8 +236,9 @@ export const CustomListItem = ({
                             isRepeatable={isRepeatable}
                             renderHintBase={({ item }) =>
                               // eslint-disable-next-line @typescript-eslint/restrict-template-expressions, @typescript-eslint/no-unsafe-member-access
-                              `item${transformKeyAccessor(item.key)}`
+                              `${hintBase}${transformKeyAccessor(item.key)}`
                             }
+                            subItemHintBase={widget.SUB_ITEM_HINT_BASE}
                             Widgets={Widgets}
                             // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
                             typeName={widget.CUSTOM_NAME || widget.TYPE_NAME}

--- a/packages/slice-machine/src/legacy/lib/models/common/widgets/Group/createGroupWidget.ts
+++ b/packages/slice-machine/src/legacy/lib/models/common/widgets/Group/createGroupWidget.ts
@@ -35,8 +35,8 @@ export type SchemaType = ReturnType<typeof createSchema>;
 type CreateGroupWidgetArgsBase<T extends TabField> = {
   schemaTypeRegex: RegExp;
   customListItem: (props: GroupListItemProps<T>) => JSX.Element;
+  hintItemName: string;
   customName?: string;
-  hintItemName?: string;
 };
 type CreateTopGroupWidgetArgs = CreateGroupWidgetArgsBase<GroupSM>;
 type CreateNestedGroupWidgetArgs = CreateGroupWidgetArgsBase<NestedGroupSM> & {

--- a/packages/slice-machine/src/legacy/lib/models/common/widgets/Group/createGroupWidget.ts
+++ b/packages/slice-machine/src/legacy/lib/models/common/widgets/Group/createGroupWidget.ts
@@ -36,6 +36,7 @@ type CreateGroupWidgetArgsBase<T extends TabField> = {
   schemaTypeRegex: RegExp;
   customListItem: (props: GroupListItemProps<T>) => JSX.Element;
   customName?: string;
+  hintItemName?: string;
 };
 type CreateTopGroupWidgetArgs = CreateGroupWidgetArgsBase<GroupSM>;
 type CreateNestedGroupWidgetArgs = CreateGroupWidgetArgsBase<NestedGroupSM> & {
@@ -57,6 +58,7 @@ export function createGroupWidget({
   schemaTypeRegex,
   customListItem,
   customName,
+  hintItemName,
 }: CreateGroupWidgetArgs):
   | Widget<GroupSM, SchemaType>
   | Widget<NestedGroupSM, SchemaType> {
@@ -76,5 +78,6 @@ export function createGroupWidget({
     CustomListItem: customListItem,
     TYPE_NAME: "Group",
     CUSTOM_NAME: customName,
+    hintItemName,
   };
 }

--- a/packages/slice-machine/src/legacy/lib/models/common/widgets/Group/index.tsx
+++ b/packages/slice-machine/src/legacy/lib/models/common/widgets/Group/index.tsx
@@ -48,6 +48,8 @@ export interface GroupListItemProps<F extends TabField> {
   HintElement: JSX.Element;
 }
 
+const subItemHintBase = "item";
+
 const GroupListItem = (props: GroupListItemProps<GroupSM>): JSX.Element => {
   const nestedGroupExperiment = useNestedGroupExperiment();
   const maybeFilteredWidgetsArray = nestedGroupExperiment.eligible
@@ -57,6 +59,7 @@ const GroupListItem = (props: GroupListItemProps<GroupSM>): JSX.Element => {
     <CustomListItem
       Widgets={Widgets}
       widgetsArray={maybeFilteredWidgetsArray}
+      hintBase={subItemHintBase}
       {...props}
     />
   );
@@ -65,4 +68,5 @@ const GroupListItem = (props: GroupListItemProps<GroupSM>): JSX.Element => {
 export const GroupWidget = createGroupWidget({
   schemaTypeRegex: /^Group$/,
   customListItem: GroupListItem,
+  subItemHintBase,
 });

--- a/packages/slice-machine/src/legacy/lib/models/common/widgets/Group/index.tsx
+++ b/packages/slice-machine/src/legacy/lib/models/common/widgets/Group/index.tsx
@@ -48,7 +48,7 @@ export interface GroupListItemProps<F extends TabField> {
   HintElement: JSX.Element;
 }
 
-const subItemHintBase = "item";
+const hintItemName = "item";
 
 const GroupListItem = (props: GroupListItemProps<GroupSM>): JSX.Element => {
   const nestedGroupExperiment = useNestedGroupExperiment();
@@ -59,7 +59,7 @@ const GroupListItem = (props: GroupListItemProps<GroupSM>): JSX.Element => {
     <CustomListItem
       Widgets={Widgets}
       widgetsArray={maybeFilteredWidgetsArray}
-      hintBase={subItemHintBase}
+      hintBase={hintItemName}
       {...props}
     />
   );
@@ -68,5 +68,5 @@ const GroupListItem = (props: GroupListItemProps<GroupSM>): JSX.Element => {
 export const GroupWidget = createGroupWidget({
   schemaTypeRegex: /^Group$/,
   customListItem: GroupListItem,
-  subItemHintBase,
+  hintItemName,
 });

--- a/packages/slice-machine/src/legacy/lib/models/common/widgets/NestedGroup/index.tsx
+++ b/packages/slice-machine/src/legacy/lib/models/common/widgets/NestedGroup/index.tsx
@@ -21,12 +21,20 @@ const widgetsArray = [
   Widgets.Text,
 ];
 
+const subItemHintBase = "subItem";
+
 const NestedGroupListItem = (props: GroupListItemProps<NestedGroupSM>) => (
-  <CustomListItem Widgets={Widgets} widgetsArray={widgetsArray} {...props} />
+  <CustomListItem
+    Widgets={Widgets}
+    widgetsArray={widgetsArray}
+    hintBase={subItemHintBase}
+    {...props}
+  />
 );
 
 export const NestedGroupWidget = createGroupWidget({
   schemaTypeRegex: /^NestedGroup$/,
   customListItem: NestedGroupListItem,
   customName: "NestedGroup",
+  subItemHintBase,
 });

--- a/packages/slice-machine/src/legacy/lib/models/common/widgets/NestedGroup/index.tsx
+++ b/packages/slice-machine/src/legacy/lib/models/common/widgets/NestedGroup/index.tsx
@@ -21,13 +21,13 @@ const widgetsArray = [
   Widgets.Text,
 ];
 
-const subItemHintBase = "subItem";
+const hintItemName = "subItem";
 
 const NestedGroupListItem = (props: GroupListItemProps<NestedGroupSM>) => (
   <CustomListItem
     Widgets={Widgets}
     widgetsArray={widgetsArray}
-    hintBase={subItemHintBase}
+    hintBase={hintItemName}
     {...props}
   />
 );
@@ -36,5 +36,5 @@ export const NestedGroupWidget = createGroupWidget({
   schemaTypeRegex: /^NestedGroup$/,
   customListItem: NestedGroupListItem,
   customName: "NestedGroup",
-  subItemHintBase,
+  hintItemName,
 });

--- a/packages/slice-machine/src/legacy/lib/models/common/widgets/Widget.ts
+++ b/packages/slice-machine/src/legacy/lib/models/common/widgets/Widget.ts
@@ -16,7 +16,7 @@ export interface Widget<F extends TabField, S extends AnyObjectSchema> {
   // eslint-disable-next-line @typescript-eslint/ban-types
   FormFields: {};
   CUSTOM_NAME?: string;
-  SUB_ITEM_HINT_BASE?: string;
+  hintItemName?: string;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   CustomListItem?: (props: any) => React.ReactElement;
   // eslint-disable-next-line @typescript-eslint/ban-types, @typescript-eslint/no-explicit-any

--- a/packages/slice-machine/src/legacy/lib/models/common/widgets/Widget.ts
+++ b/packages/slice-machine/src/legacy/lib/models/common/widgets/Widget.ts
@@ -1,10 +1,11 @@
 import { FieldType } from "@prismicio/types-internal/lib/customtypes";
+import { GroupFieldType } from "@prismicio/types-internal/lib/customtypes/widgets";
 import { IconType } from "react-icons";
 import { AnyObjectSchema } from "yup";
 
 import { TabField } from "@/legacy/lib/models/common/CustomType";
 
-export interface Widget<F extends TabField, S extends AnyObjectSchema> {
+interface WidgetBase<F extends TabField, S extends AnyObjectSchema> {
   TYPE_NAME: FieldType;
   create: (label: string) => F;
   Meta: {
@@ -16,13 +17,27 @@ export interface Widget<F extends TabField, S extends AnyObjectSchema> {
   // eslint-disable-next-line @typescript-eslint/ban-types
   FormFields: {};
   CUSTOM_NAME?: string;
-  hintItemName?: string;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   CustomListItem?: (props: any) => React.ReactElement;
   // eslint-disable-next-line @typescript-eslint/ban-types, @typescript-eslint/no-explicit-any
   Form?: (props: any) => React.ReactNode;
   prepareInitialValues?: (props: F["config"]) => F["config"];
 }
+
+interface GroupWidget<F extends TabField, S extends AnyObjectSchema>
+  extends WidgetBase<F, S> {
+  TYPE_NAME: typeof GroupFieldType;
+  hintItemName: string;
+}
+
+interface NonGroupWidget<F extends TabField, S extends AnyObjectSchema>
+  extends WidgetBase<F, S> {
+  TYPE_NAME: Exclude<FieldType, typeof GroupFieldType>;
+}
+
+export type Widget<F extends TabField, S extends AnyObjectSchema> =
+  | GroupWidget<F, S>
+  | NonGroupWidget<F, S>;
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-explicit-any, @typescript-eslint/no-explicit-any
 export type AnyWidget = Widget<any, any>;

--- a/packages/slice-machine/src/legacy/lib/models/common/widgets/Widget.ts
+++ b/packages/slice-machine/src/legacy/lib/models/common/widgets/Widget.ts
@@ -16,6 +16,7 @@ export interface Widget<F extends TabField, S extends AnyObjectSchema> {
   // eslint-disable-next-line @typescript-eslint/ban-types
   FormFields: {};
   CUSTOM_NAME?: string;
+  SUB_ITEM_HINT_BASE?: string;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   CustomListItem?: (props: any) => React.ReactElement;
   // eslint-disable-next-line @typescript-eslint/ban-types, @typescript-eslint/no-explicit-any

--- a/packages/slice-machine/src/legacy/lib/models/common/widgets/Widget.ts
+++ b/packages/slice-machine/src/legacy/lib/models/common/widgets/Widget.ts
@@ -1,9 +1,9 @@
 import { FieldType } from "@prismicio/types-internal/lib/customtypes";
-import { GroupFieldType } from "@prismicio/types-internal/lib/customtypes/widgets";
 import { IconType } from "react-icons";
 import { AnyObjectSchema } from "yup";
 
 import { TabField } from "@/legacy/lib/models/common/CustomType";
+import { GroupSM, NestedGroupSM } from "@/legacy/lib/models/common/Group";
 
 interface WidgetBase<F extends TabField, S extends AnyObjectSchema> {
   TYPE_NAME: FieldType;
@@ -24,20 +24,13 @@ interface WidgetBase<F extends TabField, S extends AnyObjectSchema> {
   prepareInitialValues?: (props: F["config"]) => F["config"];
 }
 
-interface GroupWidget<F extends TabField, S extends AnyObjectSchema>
-  extends WidgetBase<F, S> {
-  TYPE_NAME: typeof GroupFieldType;
-  hintItemName: string;
-}
-
-interface NonGroupWidget<F extends TabField, S extends AnyObjectSchema>
-  extends WidgetBase<F, S> {
-  TYPE_NAME: Exclude<FieldType, typeof GroupFieldType>;
-}
-
-export type Widget<F extends TabField, S extends AnyObjectSchema> =
-  | GroupWidget<F, S>
-  | NonGroupWidget<F, S>;
+export type Widget<F extends TabField, S extends AnyObjectSchema> = F extends
+  | GroupSM
+  | NestedGroupSM
+  ? WidgetBase<F, S> & {
+      hintItemName: string;
+    }
+  : WidgetBase<F, S>;
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-explicit-any, @typescript-eslint/no-explicit-any
 export type AnyWidget = Widget<any, any>;

--- a/yarn.lock
+++ b/yarn.lock
@@ -5091,8 +5091,12 @@ __metadata:
 "@prismicio/client@npm:7.6.0-alpha.0":
   version: 7.6.0-alpha.0
   resolution: "@prismicio/client@npm:7.6.0-alpha.0"
+"@prismicio/client@npm:7.6.0-alpha.0":
+  version: 7.6.0-alpha.0
+  resolution: "@prismicio/client@npm:7.6.0-alpha.0"
   dependencies:
     imgix-url-builder: ^0.0.4
+  checksum: 298cfa33efdc5d90862e9435500327829010afcaacece1c2dbf12d45ac1e1b4b9fe87c5912788a8de8793b5fceed54bd1caea3eb1932fa12dc355b0112e2aa1b
   checksum: 298cfa33efdc5d90862e9435500327829010afcaacece1c2dbf12d45ac1e1b4b9fe87c5912788a8de8793b5fceed54bd1caea3eb1932fa12dc355b0112e2aa1b
   languageName: node
   linkType: hard
@@ -5100,8 +5104,12 @@ __metadata:
 "@prismicio/custom-types-client@npm:2.1.0-alpha.0":
   version: 2.1.0-alpha.0
   resolution: "@prismicio/custom-types-client@npm:2.1.0-alpha.0"
+"@prismicio/custom-types-client@npm:2.1.0-alpha.0":
+  version: 2.1.0-alpha.0
+  resolution: "@prismicio/custom-types-client@npm:2.1.0-alpha.0"
   peerDependencies:
     "@prismicio/client": ">=7"
+  checksum: e790eb675a48d6d33befb435ba7b7debaa3f63b49bbd4ddd9db1df1dcfa976b069990de9e230559587be4d945e72d11525abd4537b558e246ac73b319174b8b3
   checksum: e790eb675a48d6d33befb435ba7b7debaa3f63b49bbd4ddd9db1df1dcfa976b069990de9e230559587be4d945e72d11525abd4537b558e246ac73b319174b8b3
   languageName: node
   linkType: hard
@@ -5234,6 +5242,7 @@ __metadata:
   linkType: hard
 
 "@prismicio/helpers@npm:^2.3.9":
+"@prismicio/helpers@npm:^2.3.9":
   version: 2.3.9
   resolution: "@prismicio/helpers@npm:2.3.9"
   dependencies:
@@ -5262,6 +5271,17 @@ __metadata:
   peerDependencies:
     "@prismicio/client": ^7
   checksum: 4bcb9a8ae5446b807627e759cde19991d555cc48ba16baaddfe62f466793369ad539bafe3c54264b24395eac6a05267c8b54dfff53b7430045ebece73fa3c704
+  languageName: node
+  linkType: hard
+
+"@prismicio/mock@npm:0.3.7-alpha.1":
+  version: 0.3.7-alpha.1
+  resolution: "@prismicio/mock@npm:0.3.7-alpha.1"
+  dependencies:
+    change-case: ^5.4.4
+  peerDependencies:
+    "@prismicio/client": ^7
+  checksum: a8d05adb329bfadd00ccf02d81d1a19ea9051724298e9fde8f23996a03980a398b28a2cba24e4e34d3f44ab7b4562454fde2bb85c7ee23a4b5bc641f1c8a511b
   languageName: node
   linkType: hard
 
@@ -8350,6 +8370,7 @@ __metadata:
     "@antfu/ni": ^0.20.0
     "@prismicio/client": ^7.5.0
     "@prismicio/custom-types-client": 2.1.0-alpha.0
+    "@prismicio/custom-types-client": 2.1.0-alpha.0
     "@prismicio/mock": 0.2.0
     "@prismicio/mocks": ^2.2.0
     "@prismicio/types-internal": 2.5.0-alpha.4
@@ -8410,6 +8431,8 @@ __metadata:
   dependencies:
     "@prismicio/client": v7.6.0-alpha.0
     "@prismicio/mock": 0.3.7-alpha.1
+    "@prismicio/client": v7.6.0-alpha.0
+    "@prismicio/mock": 0.3.7-alpha.1
     "@prismicio/types-internal": 2.5.0-alpha.4
     "@size-limit/preset-small-lib": 8.2.4
     "@types/common-tags": 1.8.1
@@ -8435,7 +8458,7 @@ __metadata:
     p-limit: ^4.0.0
     prettier: ^3.0.3
     prettier-plugin-jsdoc: 1.1.1
-    prismic-ts-codegen: 0.1.21-alpha.0
+    prismic-ts-codegen: v0.1.21-alpha.0
     size-limit: 8.2.4
     typescript: 4.9.5
     vite: 4.3.9
@@ -27040,6 +27063,33 @@ __metadata:
   linkType: hard
 
 "prismic-ts-codegen@npm:0.1.21-alpha.0":
+  version: 0.1.21-alpha.0
+  resolution: "prismic-ts-codegen@npm:0.1.21-alpha.0"
+  dependencies:
+    "@prismicio/custom-types-client": ^1.1.0
+    common-tags: ^1.8.2
+    fast-glob: ^3.2.12
+    jiti: ^1.18.2
+    joi: ^17.9.2
+    meow: ^12.0.1
+    node-fetch: ^3.3.1
+    pascal-case: ^3.1.2
+    quick-lru: ^6.1.1
+  peerDependencies:
+    "@prismicio/client": ^6.6 || ^7
+    "@prismicio/types": ^0.2.8
+  peerDependenciesMeta:
+    "@prismicio/client":
+      optional: true
+    "@prismicio/types":
+      optional: true
+  bin:
+    prismic-ts-codegen: bin/prismic-ts-codegen.js
+  checksum: 0dac0d18086facb475ee14d2851adbe1bf4c3ac05cf93bd20aae80bcdf9efbd6f455a1cd88c5aa8cb10bce07b03fc0dd270838d6f8c9682fa81c02840a124a1b
+  languageName: node
+  linkType: hard
+
+"prismic-ts-codegen@npm:v0.1.21-alpha.0":
   version: 0.1.21-alpha.0
   resolution: "prismic-ts-codegen@npm:0.1.21-alpha.0"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -5091,12 +5091,8 @@ __metadata:
 "@prismicio/client@npm:7.6.0-alpha.0":
   version: 7.6.0-alpha.0
   resolution: "@prismicio/client@npm:7.6.0-alpha.0"
-"@prismicio/client@npm:7.6.0-alpha.0":
-  version: 7.6.0-alpha.0
-  resolution: "@prismicio/client@npm:7.6.0-alpha.0"
   dependencies:
     imgix-url-builder: ^0.0.4
-  checksum: 298cfa33efdc5d90862e9435500327829010afcaacece1c2dbf12d45ac1e1b4b9fe87c5912788a8de8793b5fceed54bd1caea3eb1932fa12dc355b0112e2aa1b
   checksum: 298cfa33efdc5d90862e9435500327829010afcaacece1c2dbf12d45ac1e1b4b9fe87c5912788a8de8793b5fceed54bd1caea3eb1932fa12dc355b0112e2aa1b
   languageName: node
   linkType: hard
@@ -5104,12 +5100,8 @@ __metadata:
 "@prismicio/custom-types-client@npm:2.1.0-alpha.0":
   version: 2.1.0-alpha.0
   resolution: "@prismicio/custom-types-client@npm:2.1.0-alpha.0"
-"@prismicio/custom-types-client@npm:2.1.0-alpha.0":
-  version: 2.1.0-alpha.0
-  resolution: "@prismicio/custom-types-client@npm:2.1.0-alpha.0"
   peerDependencies:
     "@prismicio/client": ">=7"
-  checksum: e790eb675a48d6d33befb435ba7b7debaa3f63b49bbd4ddd9db1df1dcfa976b069990de9e230559587be4d945e72d11525abd4537b558e246ac73b319174b8b3
   checksum: e790eb675a48d6d33befb435ba7b7debaa3f63b49bbd4ddd9db1df1dcfa976b069990de9e230559587be4d945e72d11525abd4537b558e246ac73b319174b8b3
   languageName: node
   linkType: hard
@@ -5242,7 +5234,6 @@ __metadata:
   linkType: hard
 
 "@prismicio/helpers@npm:^2.3.9":
-"@prismicio/helpers@npm:^2.3.9":
   version: 2.3.9
   resolution: "@prismicio/helpers@npm:2.3.9"
   dependencies:
@@ -5271,17 +5262,6 @@ __metadata:
   peerDependencies:
     "@prismicio/client": ^7
   checksum: 4bcb9a8ae5446b807627e759cde19991d555cc48ba16baaddfe62f466793369ad539bafe3c54264b24395eac6a05267c8b54dfff53b7430045ebece73fa3c704
-  languageName: node
-  linkType: hard
-
-"@prismicio/mock@npm:0.3.7-alpha.1":
-  version: 0.3.7-alpha.1
-  resolution: "@prismicio/mock@npm:0.3.7-alpha.1"
-  dependencies:
-    change-case: ^5.4.4
-  peerDependencies:
-    "@prismicio/client": ^7
-  checksum: a8d05adb329bfadd00ccf02d81d1a19ea9051724298e9fde8f23996a03980a398b28a2cba24e4e34d3f44ab7b4562454fde2bb85c7ee23a4b5bc641f1c8a511b
   languageName: node
   linkType: hard
 
@@ -8370,7 +8350,6 @@ __metadata:
     "@antfu/ni": ^0.20.0
     "@prismicio/client": ^7.5.0
     "@prismicio/custom-types-client": 2.1.0-alpha.0
-    "@prismicio/custom-types-client": 2.1.0-alpha.0
     "@prismicio/mock": 0.2.0
     "@prismicio/mocks": ^2.2.0
     "@prismicio/types-internal": 2.5.0-alpha.4
@@ -8431,8 +8410,6 @@ __metadata:
   dependencies:
     "@prismicio/client": v7.6.0-alpha.0
     "@prismicio/mock": 0.3.7-alpha.1
-    "@prismicio/client": v7.6.0-alpha.0
-    "@prismicio/mock": 0.3.7-alpha.1
     "@prismicio/types-internal": 2.5.0-alpha.4
     "@size-limit/preset-small-lib": 8.2.4
     "@types/common-tags": 1.8.1
@@ -8458,7 +8435,7 @@ __metadata:
     p-limit: ^4.0.0
     prettier: ^3.0.3
     prettier-plugin-jsdoc: 1.1.1
-    prismic-ts-codegen: v0.1.21-alpha.0
+    prismic-ts-codegen: 0.1.21-alpha.0
     size-limit: 8.2.4
     typescript: 4.9.5
     vite: 4.3.9
@@ -27063,33 +27040,6 @@ __metadata:
   linkType: hard
 
 "prismic-ts-codegen@npm:0.1.21-alpha.0":
-  version: 0.1.21-alpha.0
-  resolution: "prismic-ts-codegen@npm:0.1.21-alpha.0"
-  dependencies:
-    "@prismicio/custom-types-client": ^1.1.0
-    common-tags: ^1.8.2
-    fast-glob: ^3.2.12
-    jiti: ^1.18.2
-    joi: ^17.9.2
-    meow: ^12.0.1
-    node-fetch: ^3.3.1
-    pascal-case: ^3.1.2
-    quick-lru: ^6.1.1
-  peerDependencies:
-    "@prismicio/client": ^6.6 || ^7
-    "@prismicio/types": ^0.2.8
-  peerDependenciesMeta:
-    "@prismicio/client":
-      optional: true
-    "@prismicio/types":
-      optional: true
-  bin:
-    prismic-ts-codegen: bin/prismic-ts-codegen.js
-  checksum: 0dac0d18086facb475ee14d2851adbe1bf4c3ac05cf93bd20aae80bcdf9efbd6f455a1cd88c5aa8cb10bce07b03fc0dd270838d6f8c9682fa81c02840a124a1b
-  languageName: node
-  linkType: hard
-
-"prismic-ts-codegen@npm:v0.1.21-alpha.0":
   version: 0.1.21-alpha.0
   resolution: "prismic-ts-codegen@npm:0.1.21-alpha.0"
   dependencies:


### PR DESCRIPTION
<!-- Please use a Conventional Commit in your PR title -->
<!-- https://conventionalcommits.org -->
<!-- e.g. "feat: support new field type" -->

**Resolves**: [DT-2191](https://linear.app/prismic/issue/DT-2191/aadev-i-can-see-a-difference-between-group-and-nested-group-code)

This PR depends on PR #1383.

### Description

<!-- Describe your changes in detail. -->
<!-- Why is this change required? -->
<!-- What problem does it solve? -->

This PR improves the way code snippet hints are constructed for groups and nested groups. It adds context to `SnippetReadHookData` to provide more info to the plugin kits when rendering snippet hints. In this case, it adds a `subItemHintBase` property to the context to distinguish sub-items of groups & nested groups. This allows slice machine to fully control the hint base. 

### Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- Don't hesitate to ask for help! -->

- [ ] If my changes require tests, I added them.
- [ ] If my changes affect backward compatibility, it has been discussed.
- [ ] If my changes require an update to the CONTRIBUTING.md guide, I updated it.

### Preview

<!-- If your changes are visual, screenshots or videos are welcome! -->

Here, you can see that the group uses the sub-item hint base "item" and the nested group uses "subItem":

<img width="869" alt="Screenshot 2024-06-17 at 14 54 31" src="https://github.com/prismicio/slice-machine/assets/9385378/8f0cafb7-42bb-4208-8c54-2ff2eab3db42">


### How to QA [^1]

<!-- When relevant, describe how to QA your changes. -->

<!-- Your favorite emoji is welcome to close your PR! -->

<!-- A note for reviewers: -->

[^1]:
	Please use these labels when submitting a review:
	:question: #ask:&ensp;Ask a question.
	:bulb: #idea:&ensp;Suggest an idea.
	:warning: #issue:&ensp;Strongly suggest a change.
	:tada: #nice:&ensp;Share a compliment.