### PR TITLE
fix: correctly generate types for groups in slices

### DIFF
--- a/packages/adapter-next/package.json
+++ b/packages/adapter-next/package.json
@@ -76,8 +76,7 @@
 		"lz-string": "1.5.0",
 		"monocle-ts": "^2.3.13",
 		"newtype-ts": "^0.3.5",
-		"pascal-case": "^3.1.2",
-		"prismic-ts-codegen": "^0.1.17"
+		"pascal-case": "^3.1.2"
 	},
 	"devDependencies": {
 		"@prismicio/mock": "0.2.0",
@@ -96,6 +95,7 @@
 		"next": "14.1.3",
 		"prettier": "3.0.3",
 		"prettier-plugin-jsdoc": "1.1.1",
+		"prismic-ts-codegen": "^0.1.20",
 		"react": "18.2.0",
 		"rollup-plugin-preserve-directives": "0.2.0",
 		"size-limit": "8.2.4",

--- a/packages/adapter-nuxt/package.json
+++ b/packages/adapter-nuxt/package.json
@@ -69,8 +69,7 @@
 		"magicast": "^0.3.4",
 		"monocle-ts": "^2.3.13",
 		"newtype-ts": "^0.3.5",
-		"pascal-case": "^3.1.2",
-		"prismic-ts-codegen": "^0.1.17"
+		"pascal-case": "^3.1.2"
 	},
 	"devDependencies": {
 		"@prismicio/mock": "0.2.0",
@@ -87,6 +86,7 @@
 		"nuxt": "3.3.3",
 		"prettier": "3.0.3",
 		"prettier-plugin-jsdoc": "1.1.1",
+		"prismic-ts-codegen": "^0.1.20",
 		"size-limit": "8.2.4",
 		"ts-morph": "17.0.1",
 		"typescript": "4.9.5",

--- a/packages/adapter-nuxt2/package.json
+++ b/packages/adapter-nuxt2/package.json
@@ -69,8 +69,7 @@
 		"magicast": "^0.3.4",
 		"monocle-ts": "^2.3.13",
 		"newtype-ts": "^0.3.5",
-		"pascal-case": "^3.1.2",
-		"prismic-ts-codegen": "^0.1.17"
+		"pascal-case": "^3.1.2"
 	},
 	"devDependencies": {
 		"@prismicio/mock": "0.2.0",
@@ -86,6 +85,7 @@
 		"nuxt": "2.16.3",
 		"prettier": "3.0.3",
 		"prettier-plugin-jsdoc": "1.1.1",
+		"prismic-ts-codegen": "^0.1.20",
 		"size-limit": "8.2.4",
 		"ts-morph": "17.0.1",
 		"typescript": "4.9.5",

--- a/packages/adapter-sveltekit/package.json
+++ b/packages/adapter-sveltekit/package.json
@@ -72,8 +72,7 @@
 		"monocle-ts": "^2.3.13",
 		"newtype-ts": "^0.3.5",
 		"pascal-case": "^3.1.2",
-		"prettier-plugin-svelte": "^3.0.3",
-		"prismic-ts-codegen": "^0.1.17"
+		"prettier-plugin-svelte": "^3.0.3"
 	},
 	"devDependencies": {
 		"@prismicio/mock": "0.2.0",
@@ -94,6 +93,7 @@
 		"eslint-plugin-tsdoc": "0.2.17",
 		"prettier": "3.0.3",
 		"prettier-plugin-jsdoc": "1.1.1",
+		"prismic-ts-codegen": "^0.1.20",
 		"size-limit": "8.2.4",
 		"svelte": "4.2.0",
 		"typescript": "4.9.5",

--- a/packages/plugin-kit/package.json
+++ b/packages/plugin-kit/package.json
@@ -72,7 +72,7 @@
 		"io-ts-reporters": "^2.0.1",
 		"p-limit": "^4.0.0",
 		"prettier": "^3.0.3",
-		"prismic-ts-codegen": "^0.1.19"
+		"prismic-ts-codegen": "^0.1.20"
 	},
 	"devDependencies": {
 		"@prismicio/mock": "0.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8194,7 +8194,7 @@ __metadata:
     pascal-case: ^3.1.2
     prettier: 3.0.3
     prettier-plugin-jsdoc: 1.1.1
-    prismic-ts-codegen: ^0.1.17
+    prismic-ts-codegen: ^0.1.20
     react: 18.2.0
     rollup-plugin-preserve-directives: 0.2.0
     size-limit: 8.2.4
@@ -8236,7 +8236,7 @@ __metadata:
     pascal-case: ^3.1.2
     prettier: 3.0.3
     prettier-plugin-jsdoc: 1.1.1
-    prismic-ts-codegen: ^0.1.17
+    prismic-ts-codegen: ^0.1.20
     size-limit: 8.2.4
     ts-morph: 17.0.1
     typescript: 4.9.5
@@ -8278,7 +8278,7 @@ __metadata:
     pascal-case: ^3.1.2
     prettier: 3.0.3
     prettier-plugin-jsdoc: 1.1.1
-    prismic-ts-codegen: ^0.1.17
+    prismic-ts-codegen: ^0.1.20
     size-limit: 8.2.4
     ts-morph: 17.0.1
     typescript: 4.9.5
@@ -8324,7 +8324,7 @@ __metadata:
     prettier: 3.0.3
     prettier-plugin-jsdoc: 1.1.1
     prettier-plugin-svelte: ^3.0.3
-    prismic-ts-codegen: ^0.1.17
+    prismic-ts-codegen: ^0.1.20
     size-limit: 8.2.4
     svelte: 4.2.0
     typescript: 4.9.5
@@ -8503,7 +8503,7 @@ __metadata:
     p-limit: ^4.0.0
     prettier: ^3.0.3
     prettier-plugin-jsdoc: 1.1.1
-    prismic-ts-codegen: ^0.1.19
+    prismic-ts-codegen: ^0.1.20
     size-limit: 8.2.4
     typescript: 4.9.5
     vite: 4.3.9
@@ -27179,9 +27179,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prismic-ts-codegen@npm:^0.1.17":
-  version: 0.1.17
-  resolution: "prismic-ts-codegen@npm:0.1.17"
+"prismic-ts-codegen@npm:^0.1.20":
+  version: 0.1.20
+  resolution: "prismic-ts-codegen@npm:0.1.20"
   dependencies:
     "@prismicio/custom-types-client": ^1.1.0
     common-tags: ^1.8.2
@@ -27202,34 +27202,7 @@ __metadata:
       optional: true
   bin:
     prismic-ts-codegen: bin/prismic-ts-codegen.js
-  checksum: 0dac0d18086facb475ee14d2851adbe1bf4c3ac05cf93bd20aae80bcdf9efbd6f455a1cd88c5aa8cb10bce07b03fc0dd270838d6f8c9682fa81c02840a124a1b
-  languageName: node
-  linkType: hard
-
-"prismic-ts-codegen@npm:^0.1.19":
-  version: 0.1.19
-  resolution: "prismic-ts-codegen@npm:0.1.19"
-  dependencies:
-    "@prismicio/custom-types-client": ^1.1.0
-    common-tags: ^1.8.2
-    fast-glob: ^3.2.12
-    jiti: ^1.18.2
-    joi: ^17.9.2
-    meow: ^12.0.1
-    node-fetch: ^3.3.1
-    pascal-case: ^3.1.2
-    quick-lru: ^6.1.1
-  peerDependencies:
-    "@prismicio/client": ^6.6 || ^7
-    "@prismicio/types": ^0.2.8
-  peerDependenciesMeta:
-    "@prismicio/client":
-      optional: true
-    "@prismicio/types":
-      optional: true
-  bin:
-    prismic-ts-codegen: bin/prismic-ts-codegen.js
-  checksum: 18fdb161d276170786cf2a0300250f32a372810cb5fa8d2810e8c894249e162a8d918a4d0b61ba19196eab9e09c022b4a2a06fe33c0dd669c93f4b1cc12c19c8
+  checksum: 575ddabb75ce31c047d32aed882c5bbef8d59a8390b5ea1721871f27e1b66ebe5a3de22db95ea40a0b31f5d6cc6e870a05789bb8bf54d8543d1c2c3e035e599b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!-- Please use a Conventional Commit in your PR title -->
<!-- https://conventionalcommits.org -->
<!-- e.g. "feat: support new field type" -->

**Resolves**: #1387

### Description

<!-- Describe your changes in detail. -->
<!-- Why is this change required? -->
<!-- What problem does it solve? -->

This PR fixes a bug where TypeScript types for groups in slices were not generated correctly. A groups interface would not be generated when it was added as a slice's primary field.

The bug happens because `prismic-ts-codegen`, the underlying library used to generate the types, was not updated to a version that supports groups in slices.

`prismic-ts-codegen` was updated in all adapters and `@slicemachine/plugin-kit`. `prismic-ts-codegen` was also moved to a dev dependency in all adapters because it is only used in tests.

### Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- Don't hesitate to ask for help! -->

- [ ] If my changes require tests, I added them.
- [x] If my changes affect backward compatibility, it has been discussed.
- [ ] If my changes require an update to the CONTRIBUTING.md guide, I updated it.

### Preview

<!-- If your changes are visual, screenshots or videos are welcome! -->

N/A

### How to QA [^1]

<!-- When relevant, describe how to QA your changes. -->

TODO

<!-- Your favorite emoji is welcome to close your PR! -->

<!-- A note for reviewers: -->

[^1]:
	Please use these labels when submitting a review:
	:question: #ask:&ensp;Ask a question.
	:bulb: #idea:&ensp;Suggest an idea.
	:warning: #issue:&ensp;Strongly suggest a change.
	:tada: #nice:&ensp;Share a compliment.
