### PR TITLE
feat(adapter-next): support `secret` in `/slice-simulator` route

### DIFF
--- a/packages/adapter-next/src/hooks/project-init.ts
+++ b/packages/adapter-next/src/hooks/project-init.ts
@@ -282,6 +282,7 @@ const createSliceSimulatorPage = async ({
 					getSlices,
 				} from "@slicemachine/adapter-next/simulator";
 				import { SliceZone } from "@prismicio/react";
+				import { redirect } from "next/navigation";
 
 				import { components } from "../../slices";
 
@@ -311,6 +312,7 @@ const createSliceSimulatorPage = async ({
 					getSlices,
 				} from "@slicemachine/adapter-next/simulator";
 				import { SliceZone } from "@prismicio/react";
+				import { redirect } from "next/navigation";
 
 				import { components } from "../../slices";
 

--- a/packages/adapter-next/src/simulator/types.ts
+++ b/packages/adapter-next/src/simulator/types.ts
@@ -7,5 +7,6 @@
 export type SliceSimulatorParams = {
 	searchParams: {
 		state?: string;
+		secret?: string;
 	};
 };

--- a/packages/adapter-next/test/plugin-project-init.test.ts
+++ b/packages/adapter-next/test/plugin-project-init.test.ts
@@ -891,6 +891,7 @@ describe("Slice Simulator route", () => {
 				  getSlices,
 				} from \\"@slicemachine/adapter-next/simulator\\";
 				import { SliceZone } from \\"@prismicio/react\\";
+				import { redirect } from \\"next/navigation\\";
 
 				import { components } from \\"../../slices\\";
 
@@ -963,6 +964,7 @@ describe("Slice Simulator route", () => {
 				  getSlices,
 				} from \\"@slicemachine/adapter-next/simulator\\";
 				import { SliceZone } from \\"@prismicio/react\\";
+				import { redirect } from \\"next/navigation\\";
 
 				import { components } from \\"../../slices\\";
 
@@ -1067,6 +1069,7 @@ describe("Slice Simulator route", () => {
 				  getSlices,
 				} from \\"@slicemachine/adapter-next/simulator\\";
 				import { SliceZone } from \\"@prismicio/react\\";
+				import { redirect } from \\"next/navigation\\";
 
 				import { components } from \\"../../slices\\";
 

--- a/packages/adapter-next/test/plugin-project-init.test.ts
+++ b/packages/adapter-next/test/plugin-project-init.test.ts
@@ -21,6 +21,50 @@ test("installs dependencies", async (ctx) => {
 	});
 });
 
+test("creates all Slice library index files", async (ctx) => {
+	await fs.writeFile(
+		path.join(ctx.project.root, "slicemachine.config.json"),
+		JSON.stringify({
+			...ctx.project.config,
+			libraries: ["./foo", "./bar"],
+		}),
+	);
+
+	await ctx.pluginRunner.callHook("project:init", {
+		log: vi.fn(),
+		installDependencies: vi.fn(),
+	});
+
+	expect(await fs.readdir(path.join(ctx.project.root, "foo"))).includes(
+		"index.js",
+	);
+	expect(await fs.readdir(path.join(ctx.project.root, "bar"))).includes(
+		"index.js",
+	);
+});
+
+test("doesn't throw if no Slice libraries are configured", async (ctx) => {
+	ctx.project.config.libraries = undefined;
+	const pluginRunner = createSliceMachinePluginRunner({
+		project: ctx.project,
+		nativePlugins: {
+			[ctx.project.config.adapter.resolve]: adapter,
+		},
+	});
+	await pluginRunner.init();
+
+	await expect(
+		ctx.pluginRunner.callHook("project:init", {
+			log: vi.fn(),
+			installDependencies: vi.fn(),
+		}),
+	).resolves.toStrictEqual(
+		expect.objectContaining({
+			errors: [],
+		}),
+	);
+});
+
 describe("modify slicemachine.config.json", () => {
 	test("adds default localSliceSimulatorURL", async (ctx) => {
 		const log = vi.fn();

--- a/packages/adapter-next/test/plugin-project-init.test.ts
+++ b/packages/adapter-next/test/plugin-project-init.test.ts
@@ -851,6 +851,13 @@ describe("Slice Simulator route", () => {
 				import { components } from \\"../../slices\\";
 
 				export default function SliceSimulatorPage({ searchParams }) {
+				  if (
+				    process.env.SLICE_SIMULATOR_SECRET &&
+				    searchParams.secret !== process.env.SLICE_SIMULATOR_SECRET
+				  ) {
+				    redirect(\\"/\\");
+				  }
+
 				  const slices = getSlices(searchParams.state);
 
 				  return (
@@ -916,6 +923,13 @@ describe("Slice Simulator route", () => {
 				import { components } from \\"../../slices\\";
 
 				export default function SliceSimulatorPage({ searchParams }) {
+				  if (
+				    process.env.SLICE_SIMULATOR_SECRET &&
+				    searchParams.secret !== process.env.SLICE_SIMULATOR_SECRET
+				  ) {
+				    redirect(\\"/\\");
+				  }
+
 				  const slices = getSlices(searchParams.state);
 
 				  return (
@@ -1015,6 +1029,13 @@ describe("Slice Simulator route", () => {
 				export default function SliceSimulatorPage({
 				  searchParams,
 				}: SliceSimulatorParams) {
+				  if (
+				    process.env.SLICE_SIMULATOR_SECRET &&
+				    searchParams.secret !== process.env.SLICE_SIMULATOR_SECRET
+				  ) {
+				    redirect(\\"/\\");
+				  }
+
 				  const slices = getSlices(searchParams.state);
 
 				  return (
@@ -1055,6 +1076,17 @@ describe("Slice Simulator route", () => {
 				      sliceZone={(props) => <SliceZone {...props} components={components} />}
 				    />
 				  );
+				}
+
+				export function getServerSideProps(context) {
+				  if (
+				    process.env.SLICE_SIMULATOR_SECRET &&
+				    context.query.secret !== process.env.SLICE_SIMULATOR_SECRET
+				  ) {
+				    return { redirect: { destination: \\"/\\", permanent: false } };
+				  }
+
+				  return { props: {} };
 				}
 				"
 			`);
@@ -1112,6 +1144,17 @@ describe("Slice Simulator route", () => {
 				      sliceZone={(props) => <SliceZone {...props} components={components} />}
 				    />
 				  );
+				}
+
+				export function getServerSideProps(context) {
+				  if (
+				    process.env.SLICE_SIMULATOR_SECRET &&
+				    context.query.secret !== process.env.SLICE_SIMULATOR_SECRET
+				  ) {
+				    return { redirect: { destination: \\"/\\", permanent: false } };
+				  }
+
+				  return { props: {} };
 				}
 				"
 			`);
@@ -1192,7 +1235,8 @@ describe("Slice Simulator route", () => {
 			);
 
 			expect(contents).toMatchInlineSnapshot(`
-				"import { SliceSimulator } from \\"@slicemachine/adapter-next/simulator\\";
+				"import { GetServerSidePropsContext } from \\"next\\";
+				import { SliceSimulator } from \\"@slicemachine/adapter-next/simulator\\";
 				import { SliceZone } from \\"@prismicio/react\\";
 
 				import { components } from \\"../slices\\";
@@ -1203,6 +1247,17 @@ describe("Slice Simulator route", () => {
 				      sliceZone={(props) => <SliceZone {...props} components={components} />}
 				    />
 				  );
+				}
+
+				export function getServerSideProps(context: GetServerSidePropsContext) {
+				  if (
+				    process.env.SLICE_SIMULATOR_SECRET &&
+				    context.query.secret !== process.env.SLICE_SIMULATOR_SECRET
+				  ) {
+				    return { redirect: { destination: \\"/\\", permanent: false } };
+				  }
+
+				  return { props: {} };
 				}
 				"
 			`);

--- a/packages/adapter-sveltekit/src/hooks/project-init.ts
+++ b/packages/adapter-sveltekit/src/hooks/project-init.ts
@@ -391,7 +391,7 @@ const upsertSliceLibraryIndexFiles = async (
 ) => {
 	// We must use the `getProject()` helper to get the latest version of
 	// the project config. The config may have been modified in
-	// `modifySliceMachineConfig()` and will not be relfected in
+	// `modifySliceMachineConfig()` and will not be reflected in
 	// `context.project`.
 	// TODO: Automatically update the plugin runner's in-memory `project`
 	// object when `updateSliceMachineConfig()` is called.


### PR DESCRIPTION
<!-- Please use a Conventional Commit in your PR title -->
<!-- https://conventionalcommits.org -->
<!-- e.g. "feat: support new field type" -->

**Resolves**: N/A

### Description

<!-- Describe your changes in detail. -->
<!-- Why is this change required? -->
<!-- What problem does it solve? -->

This PR adds support for a more secure `/slice-simulator` route in Next.js websites. Both the App Router and Pages Router are supported.

This PR includes the following updates:

- Adds a `secret` property to the public `SliceSimulatorParams` type.
- Adds server-side runtime checking for the `SLICE_SIMULATOR_SECRET` environment variable.
- Upserts slice library index files on `project:init`. Without this change, `/slice-simulator` throws an error on fresh projects after running `@slicemachine/init`.

See this draft documentation for details:

> ## Secure your simulator
>
> We recommend securing your app’s `/slice-simulator` route when deploying to production. You can require a secret to access the simulator route.
>
> 1. Add a `SLICE_SIMULATOR_SECRET` [environment variable](https://nextjs.org/docs/app/building-your-application/configuring/environment-variables). The value should be unique and unguessable.
> 2. Rebuild and deploy your app.
> 3. Once deployed, update the [live preview URL](https://prismic.io/docs/page-builder#enable-live-previews) in the Prismic Page Builder to include `?secret=<your-secret>`.
>
>    Example: `https://example.com/slice-simulator?secret=abc123`
>
> Apps bootstrapped using a Prismic starter include support for the `SLICE_SIMULATOR_SECRET` environment variable.
>
> If your app’s simulator route was created manually, update the route to check the secret on the server:
>
> ```tsx
> // app/slice-simulator/page.tsx
>
> import { SliceSimulatorParams } from "@slicemachine/adapter-next/simulator";
> import { redirect } from "next/navigation";
>
> export default function SliceSimulatorPage({
>   searchParams,
> }: SliceSimulatorParams & { searchParams: { secret?: string } }) {
>   if (
>     process.env.SLICE_SIMULATOR_SECRET &&
>     searchParams.secret !== process.env.SLICE_SIMULATOR_SECRET
>   ) {
>     redirect("/");
>   }
>
>   // ...
> }
> ```
>
> ```tsx
> // pages/slice-simulator.tsx
>
> import { GetServerSidePropsContext } from "next";
>
> // ...
>
> export function getServerSideProps(context: GetServerSidePropsContext) {
>   if (
>     process.env.SLICE_SIMULATOR_SECRET &&
>     context.query.secret !== process.env.SLICE_SIMULATOR_SECRET
>   ) {
>     return { redirect: { destination: "/", permanent: false } };
>   }
>
>   return { props: {} };
> }
> ```
>
> Now, the `/slice-simulator` route verifies the secret before rendering. If the secret is incorrect, the request is redirected to `/`.

### Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- Don't hesitate to ask for help! -->

- [x] If my changes require tests, I added them.
- [ ] If my changes affect backward compatibility, it has been discussed.
- [ ] If my changes require an update to the CONTRIBUTING.md guide, I updated it.

### Preview

See the above documentation and updated test snapshots.

### How to QA [^1]

<!-- When relevant, describe how to QA your changes. -->

1. Bootstrap a new Next.js app:

   ```
   npx create-next-app@latest nextjs-slice-simulator-secret
   cd nextjs-slice-simulator-secret
   npx @slicemachine/init@alpha.aa-nextjs-slice-simulator-secret
   npm run dev
   ```

2. Verify <http://localhost:3000/slice-simulator> loads.

3. Stop the server and add a `SLICE_SIMULATOR_SECRET` environment variable:

   ```sh
   echo "SLICE_SIMULATOR_SECRET=foo" > .env.local
   ```

4. Start the server and verify the secret works:

   1. Verify <http://localhost:3000/slice-simulator> redirects to `/`
   2. Verify <http://localhost:3000/slice-simulator?secret=foo> loads.

5. Verify the `src/app/slice-simulator/page.tsx` file looks correct and contains no TypeScript errors.

<!-- Your favorite emoji is welcome to close your PR! -->

<!-- A note for reviewers: -->

[^1]:
    Please use these labels when submitting a review:
    :question: #ask:&ensp;Ask a question.
    :bulb: #idea:&ensp;Suggest an idea.
    :warning: #issue:&ensp;Strongly suggest a change.
    :tada: #nice:&ensp;Share a compliment.
