### PR TITLE
feat(init): display more prominent login cta message

### DIFF
--- a/packages/init/src/SliceMachineInitProcess.ts
+++ b/packages/init/src/SliceMachineInitProcess.ts
@@ -575,12 +575,12 @@ ${
 
 					if (!isLoggedIn) {
 						parentTask.title = this.getLoggingInTitle(
-							`${chalk.cyan("Press any key to open the browser to login...")}`,
+							chalk.cyan("Press any key to open the browser to login..."),
 						);
 						await this.pressKeyToLogin();
 						await this.waitingForLogin(({ url }) => {
 							parentTask.title = this.getLoggingInTitle(
-								`${chalk.cyan("Opening browser, waiting for you to login...")}`,
+								chalk.cyan("Opening browser, waiting for you to login..."),
 								chalk.yellow(
 									"If your browser did not open automatically, please use the url below:",
 								),
@@ -639,11 +639,10 @@ ${
 		) => void,
 	): Promise<void> {
 		const sessionInfo = await this.manager.user.getLoginSessionInfo();
-		const { port, url } = sessionInfo;
 		await this.manager.user.nodeLoginSession({
-			port,
+			port: sessionInfo.port,
 			onListenCallback() {
-				open(url);
+				open(sessionInfo.url);
 				onListenCallback?.(sessionInfo);
 			},
 		});

--- a/packages/init/src/SliceMachineInitProcess.ts
+++ b/packages/init/src/SliceMachineInitProcess.ts
@@ -548,22 +548,35 @@ Continue with next steps in Slice Machine.
 		}
 	}
 
+	protected getLoggingInTitle(description?: string): string {
+		return `
+███████████████████████████████████████████████████████████████████████
+
+* * Logging in to Prismic...\n${description ? `* * ${description}` : ""}
+
+███████████████████████████████████████████████████████████████████████
+`;
+	}
+
 	protected loginAndFetchUserData(): Promise<void> {
 		return listrRun([
 			{
-				title: "Logging in to Prismic...",
+				title: this.getLoggingInTitle(),
 				task: async (_, parentTask) => {
-					parentTask.output = "Validating session...";
+					parentTask.title = this.getLoggingInTitle("Validating session...");
 					const isLoggedIn = await this.manager.user.checkIsLoggedIn();
 
 					if (!isLoggedIn) {
-						parentTask.output = "Press any key to open the browser to login...";
+						parentTask.title = this.getLoggingInTitle(
+							`${chalk.cyan("Press any key to open the browser to login...")}`,
+						);
 						await this.pressKeyToLogin();
-						parentTask.output = "Browser opened, waiting for you to login...";
+						parentTask.title = this.getLoggingInTitle(
+							`${chalk.cyan("Browser opened, waiting for you to login...")}`,
+						);
 						await this.waitingForLogin();
 					}
 
-					parentTask.output = "";
 					parentTask.title = `Logged in`;
 
 					return listr(

--- a/packages/init/src/SliceMachineInitProcess.ts
+++ b/packages/init/src/SliceMachineInitProcess.ts
@@ -552,10 +552,11 @@ Continue with next steps in Slice Machine.
 		subtitle?: string,
 		...extraLines: string[]
 	): string {
-		return `
+		return `Logging in to Prismic...
+		
 ███████████████████████████████████████████████████████████████████████████
 
-* * Logging in to Prismic...\n${subtitle ? `* * ${subtitle}` : ""}
+${subtitle ? `* * ${subtitle}` : ""}
 ${
 	extraLines.length
 		? `\n${extraLines.map((line) => `   ${line}`).join("\n")}\n`

--- a/packages/init/src/SliceMachineInitProcess.ts
+++ b/packages/init/src/SliceMachineInitProcess.ts
@@ -548,20 +548,13 @@ Continue with next steps in Slice Machine.
 		}
 	}
 
-	protected getLoggingInTitle(
-		subtitle?: string,
-		...extraLines: string[]
-	): string {
+	protected getLoggingInTitle(subtitle?: string, ...extra: string[]): string {
 		return `Logging in to Prismic...
 		
 ███████████████████████████████████████████████████████████████████████████
 
 ${subtitle ? `* * ${subtitle}` : ""}
-${
-	extraLines.length
-		? `\n${extraLines.map((line) => `   ${line}`).join("\n")}\n`
-		: ""
-}
+${extra.length ? `\n${extra.map((line) => `   ${line}`).join("\n")}\n` : ""}
 ███████████████████████████████████████████████████████████████████████████
 `;
 	}


### PR DESCRIPTION
**Resolves**: DT-1926

### Description

> In the init, we have received several feedbacks showing that the login CTA is not clear. Users don't really read their terminal and don't understand that they have to click and leave the terminal to login. Some just freeze and just think it's loading forever.

### Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- Don't hesitate to ask for help! -->

- [ ] If my changes require tests, I added them.
- [ ] If my changes affect backward compatibility, it has been discussed.
- [ ] If my changes require an update to the CONTRIBUTING.md guide, I updated it.

### Preview
![Screenshot 2024-07-09 at 16 40 30](https://github.com/prismicio/slice-machine/assets/7235666/429dccb8-338c-4682-86a6-37a86c82c1e9)

![Screenshot 2024-07-09 at 16 40 50](https://github.com/prismicio/slice-machine/assets/7235666/301a51da-4b8b-407b-9ebe-3da12e44ed10)


### How to QA [^1]

```bash
# build the script on packages/init
npm run dev

# if you already have a prismic session, logout by removing or backing up your config file
rm -rf ~/.prismic

# spin up a new playground to run the updated init script
yarn play --new
```
<!-- When relevant, describe how to QA your changes. -->

<!-- Your favorite emoji is welcome to close your PR! -->

<!-- A note for reviewers: -->

[^1]:
	Please use these labels when submitting a review:
	:question: #ask:&ensp;Ask a question.
	:bulb: #idea:&ensp;Suggest an idea.
	:warning: #issue:&ensp;Strongly suggest a change.
	:tada: #nice:&ensp;Share a compliment.