### PR TITLE
feat(onboarding): use previous guide content on new onboarding ui

### DIFF
--- a/packages/slice-machine/src/features/onboarding/OnboardingProgressStepper.tsx
+++ b/packages/slice-machine/src/features/onboarding/OnboardingProgressStepper.tsx
@@ -58,7 +58,7 @@ export const OnboardingProgressStepper = () => {
                     name={isCompleted ? "checkBox" : "checkBoxOutlinedBlank"}
                   />
                 }
-                description={step.title}
+                description={step.description}
               >
                 {step.title}
               </DropdownMenuItem>

--- a/packages/slice-machine/src/features/onboarding/OnboardingStepDialog/OnboardingStepDialogContent.tsx
+++ b/packages/slice-machine/src/features/onboarding/OnboardingStepDialog/OnboardingStepDialogContent.tsx
@@ -18,7 +18,7 @@ export const OnboardingStepDialogContent = ({
   const {
     content: Content,
     videoUrl,
-    title,
+    title = step.title,
   } = getOnboardingStepsContent({ repositoryUrl })[step.id];
 
   return (

--- a/packages/slice-machine/src/features/onboarding/content.tsx
+++ b/packages/slice-machine/src/features/onboarding/content.tsx
@@ -8,9 +8,9 @@ import type {
 
 export const onboardingSteps: OnboardingStep[] = [
   {
-    id: "createPage",
-    title: "Create Your Page",
-    description: "Setup a new page.",
+    id: "addSlice",
+    title: "Add Slices",
+    description: "Add slices to your page type.",
   },
   {
     id: "codePage",
@@ -18,19 +18,19 @@ export const onboardingSteps: OnboardingStep[] = [
     description: "Build your page's structure",
   },
   {
-    id: "addSlice",
-    title: "Add a Slice",
-    description: "Insert reusable sections.",
-  },
-  {
     id: "pushModels",
-    title: "Push Your Models",
-    description: "Deploy your models.",
+    title: "Push Your Page",
+    description: "Push to your Page Builder.",
   },
   {
-    id: "writeContent",
-    title: "Write Content",
-    description: "Add engaging content.",
+    id: "createContent",
+    title: "Create content",
+    description: "Create engaging content.",
+  },
+  {
+    id: "renderPage",
+    title: "Render your page",
+    description: "Render your page on localhost.",
   },
 ];
 
@@ -44,18 +44,11 @@ export const getOnboardingStepsContent = ({
   OnboardingStepType,
   OnboardingStepContentDefinition
 > => ({
-  createPage: {
+  addSlice: {
     videoUrl:
       "https://res.cloudinary.com/dmtf1daqp/video/upload/v1700213517/IN-APP-GUIDE-SM/ADD_SLICE.mp4",
     content: () => (
-      <Text>
-        Commodo irure ipsum exercitation consequat enim velit amet commodo.
-        Excepteur proident Lorem sunt enim amet tempor qui Lorem non non Lorem.
-        Ex sint elit ea. Proident veniam dolor cupidatat amet aute consectetur.
-        Non ad consectetur irure adipisicing aliquip. Ipsum nulla velit mollit
-        magna aliqua eu veniam. Commodo elit labore veniam nulla dolor aliqua
-        esse proident pariatur nostrud.
-      </Text>
+      <Text>Use slice templates and add them to your page type.</Text>
     ),
   },
   codePage: {
@@ -63,45 +56,25 @@ export const getOnboardingStepsContent = ({
       "https://res.cloudinary.com/dmtf1daqp/video/upload/v1700213517/IN-APP-GUIDE-SM/CODE_SNIP.mp4",
     content: () => (
       <Text>
-        Nulla consequat occaecat ut ut ex culpa veniam sunt nisi nisi. Velit
-        excepteur excepteur do anim incididunt in cillum ullamco occaecat minim
-        reprehenderit eu enim. Nulla irure est fugiat aliqua elit excepteur
-        labore ipsum occaecat eu minim duis non sit. Ea eu irure dolore duis
-        labore ad. Quis sunt eu commodo sit nisi ullamco qui aliqua nostrud
-        labore nostrud ut nostrud nostrud.
-      </Text>
-    ),
-  },
-  addSlice: {
-    videoUrl:
-      "https://res.cloudinary.com/dmtf1daqp/video/upload/v1700213517/IN-APP-GUIDE-SM/PUSH.mp4",
-    content: () => (
-      <Text>
-        Minim anim velit laboris cupidatat cupidatat culpa labore sunt eiusmod.
-        Consequat culpa mollit enim dolore aliquip ex voluptate ex eiusmod
-        incididunt eu. Cillum magna cillum magna consectetur. Id aliquip
-        excepteur adipisicing officia excepteur et pariatur aliquip aliquip
-        laborum.
+        If you don't already have a page component, copy-paste the page snippets
+        provided in your page type to create one.
       </Text>
     ),
   },
   pushModels: {
     videoUrl:
-      "https://res.cloudinary.com/dmtf1daqp/video/upload/v1700213517/IN-APP-GUIDE-SM/PREVIEW.mp4",
+      "https://res.cloudinary.com/dmtf1daqp/video/upload/v1700213517/IN-APP-GUIDE-SM/PUSH.mp4",
     content: () => (
       <Text>
-        Ipsum aliqua do consequat eiusmod id. Reprehenderit consectetur sit
-        officia consequat velit non officia aliquip laboris incididunt cillum
-        proident incididunt. Ad quis laborum tempor dolor duis ea cillum aliqua
-        occaecat. Sunt reprehenderit fugiat et ullamco proident pariatur
-        deserunt minim. Irure enim nulla et ad ut id anim elit. Voluptate culpa
-        esse qui et reprehenderit aute est.
+        You have just created some models, but you can't use them yet. First,
+        you must push them to the Page Builder. The Page Builder is where you
+        create content. Go head — push your models.
       </Text>
     ),
   },
-  writeContent: {
+  createContent: {
     videoUrl:
-      "https://res.cloudinary.com/dmtf1daqp/video/upload/v1700213517/IN-APP-GUIDE-SM/WRITE.mp4",
+      "https://res.cloudinary.com/dmtf1daqp/video/upload/v1700213517/IN-APP-GUIDE-SM/PREVIEW.mp4",
     content: () => (
       <Text>
         Open your{" "}
@@ -109,6 +82,17 @@ export const getOnboardingStepsContent = ({
           Page Builder
         </Text>
         , create a page, add slices, save, and publish. Then, come back here.
+      </Text>
+    ),
+  },
+  renderPage: {
+    videoUrl:
+      "https://res.cloudinary.com/dmtf1daqp/video/upload/v1700213517/IN-APP-GUIDE-SM/WRITE.mp4",
+    content: () => (
+      <Text>
+        To render the page, run your project in your terminal and visit the page
+        on localhost (e.g.{" "}
+        <Text component="code">localhost:3000/example-page</Text>).
       </Text>
     ),
   },

--- a/packages/slice-machine/src/features/onboarding/types.ts
+++ b/packages/slice-machine/src/features/onboarding/types.ts
@@ -1,11 +1,11 @@
 import { z } from "zod";
 
 export const onboardingStepStatusesSchema = z.object({
-  createPage: z.boolean(),
-  codePage: z.boolean(),
   addSlice: z.boolean(),
-  writeContent: z.boolean(),
+  codePage: z.boolean(),
   pushModels: z.boolean(),
+  createContent: z.boolean(),
+  renderPage: z.boolean(),
 });
 
 export type OnboardingStepStatuses = z.infer<


### PR DESCRIPTION
**Resolves**: DT-2218

### Description

Use the existing content in the new onboarding UI.

### Checklist

- [ ] If my changes require tests, I added them.
- [ ] If my changes affect backward compatibility, it has been discussed.
- [ ] If my changes require an update to the CONTRIBUTING.md guide, I updated it.

### Preview

https://github.com/user-attachments/assets/61f3d77e-de6b-4cc0-895c-f37aa95cd061

### How to QA [^1]

<!-- When relevant, describe how to QA your changes. -->

<!-- Your favorite emoji is welcome to close your PR! -->

<!-- A note for reviewers: -->

[^1]:
	Please use these labels when submitting a review:
	:question: #ask:&ensp;Ask a question.
	:bulb: #idea:&ensp;Suggest an idea.
	:warning: #issue:&ensp;Strongly suggest a change.
	:tada: #nice:&ensp;Share a compliment.