### PR TITLE
fix: add missing key

### DIFF
--- a/packages/slice-machine/src/features/builder/AddFieldDropdown.tsx
+++ b/packages/slice-machine/src/features/builder/AddFieldDropdown.tsx
@@ -55,7 +55,11 @@ export function AddFieldDropdown(props: AddFieldDropdownProps) {
       <DropdownMenuContent align="end" maxHeight={400} collisionPadding={8}>
         <DropdownMenuLabel>Single fields</DropdownMenuLabel>
         {singleFieldsToRender.map((field) => (
-          <AddFieldDropdownItem field={field} onSelectField={onSelectField} />
+          <AddFieldDropdownItem
+            key={field.name}
+            field={field}
+            onSelectField={onSelectField}
+          />
         ))}
 
         {groupFieldToRender && (


### PR DESCRIPTION
Added missing key prop in AddFieldDropdown

<!-- Please use a Conventional Commit in your PR title -->
<!-- https://conventionalcommits.org -->
<!-- e.g. "feat: support new field type" -->

**Resolves**: <!-- GitHub or Linear issue (e.g. #123, DT-123) -->

### Description

<!-- Describe your changes in detail. -->
<!-- Why is this change required? -->
<!-- What problem does it solve? -->

### Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- Don't hesitate to ask for help! -->

- [ ] If my changes require tests, I added them.
- [ ] If my changes affect backward compatibility, it has been discussed.
- [ ] If my changes require an update to the CONTRIBUTING.md guide, I updated it.

### Preview

<!-- If your changes are visual, screenshots or videos are welcome! -->

### How to QA [^1]

<!-- When relevant, describe how to QA your changes. -->

<!-- Your favorite emoji is welcome to close your PR! -->

<!-- A note for reviewers: -->

[^1]:
	Please use these labels when submitting a review:
	:question: #ask:&ensp;Ask a question.
	:bulb: #idea:&ensp;Suggest an idea.
	:warning: #issue:&ensp;Strongly suggest a change.
	:tada: #nice:&ensp;Share a compliment.