### PR TITLE
fix(adapter-next): improve usability of snippets

### DIFF
--- a/packages/adapter-next/src/hooks/snippet-read.ts
+++ b/packages/adapter-next/src/hooks/snippet-read.ts
@@ -85,16 +85,13 @@ export const snippetRead: SnippetReadHook<PluginOptions> = async (
 		}
 
 		case "Group": {
-			const code = await format(
-				stripIndent`
-					<>
-						{${dotPath(fieldPath)}.map((${itemName}) => {
-							// Render the ${itemName}
-						})}
-					</>
-				`,
-				helpers,
-			);
+			// We cannot use `format` since this snippet contains invalid syntax.
+			// Please ensure this snippet is manually formatted correctly.
+			const code = stripIndent`
+				{${dotPath(fieldPath)}.map((${itemName}) => (
+				  // Render the ${itemName}
+				))}
+			`;
 
 			return {
 				label,

--- a/packages/adapter-next/src/hooks/snippet-read.ts
+++ b/packages/adapter-next/src/hooks/snippet-read.ts
@@ -77,8 +77,8 @@ export const snippetRead: SnippetReadHook<PluginOptions> = async (
 				language: "tsx",
 				code: await format(
 					stripIndent`
-							<PrismicNextImage field={${dotPath(fieldPath)}} />
-						`,
+						<PrismicNextImage field={${dotPath(fieldPath)}} />
+					`,
 					helpers,
 				),
 			};
@@ -119,12 +119,11 @@ export const snippetRead: SnippetReadHook<PluginOptions> = async (
 		}
 
 		case "GeoPoint": {
-			const code = await format(
-				stripIndent`
-					<>{${dotPath(fieldPath, "latitude")}}, {${dotPath(fieldPath, "longitude")}}</>
-				`,
-				helpers,
-			);
+			// We cannot use `format` since this snippet contains invalid syntax.
+			// Please ensure this snippet is manually formatted correctly.
+			const code = stripIndent`
+				{${dotPath(fieldPath, "latitude")}}, {${dotPath(fieldPath, "longitude")}}
+			`;
 
 			return {
 				label,
@@ -152,12 +151,11 @@ export const snippetRead: SnippetReadHook<PluginOptions> = async (
 			return {
 				label,
 				language: "tsx",
-				code: await format(
-					stripIndent`
-						<>{${dotPath(fieldPath)}}</>
-					`,
-					helpers,
-				),
+				// We cannot use `format` since this snippet contains invalid syntax.
+				// Please ensure this snippet is manually formatted correctly.
+				code: stripIndent`
+					{${dotPath(fieldPath)}}
+				`,
 			};
 		}
 	}

--- a/packages/adapter-next/test/plugin-snippet-read.test.ts
+++ b/packages/adapter-next/test/plugin-snippet-read.test.ts
@@ -90,16 +90,16 @@ const testSnippet = (
 	});
 };
 
-testSnippet("boolean", `<>{${model.id}.data.boolean}</>`);
+testSnippet("boolean", `{${model.id}.data.boolean}`, { format: false });
 
-testSnippet("color", `<>{${model.id}.data.color}</>`);
+testSnippet("color", `{${model.id}.data.color}`, { format: false });
 
 testSnippet(
 	"contentRelationship",
 	`<PrismicNextLink field={${model.id}.data.contentRelationship}>Link</PrismicNextLink>`,
 );
 
-testSnippet("date", `<>{${model.id}.data.date}</>`);
+testSnippet("date", `{${model.id}.data.date}`, { format: false });
 
 testSnippet(
 	"embed",
@@ -108,7 +108,8 @@ testSnippet(
 
 testSnippet(
 	"geoPoint",
-	`<>{${model.id}.data.geoPoint.latitude}, {${model.id}.data.geoPoint.longitude}</>`,
+	`{${model.id}.data.geoPoint.latitude}, {${model.id}.data.geoPoint.longitude}`,
+	{ format: false },
 );
 
 testSnippet(
@@ -121,9 +122,11 @@ testSnippet(
 
 testSnippet("image", `<PrismicNextImage field={${model.id}.data.image} />`);
 
-testSnippet("integrationFields", `<>{${model.id}.data.integrationFields}</>`);
+testSnippet("integrationFields", `{${model.id}.data.integrationFields}`, {
+	format: false,
+});
 
-testSnippet("keyText", `<>{${model.id}.data.keyText}</>`);
+testSnippet("keyText", `{${model.id}.data.keyText}`, { format: false });
 
 testSnippet(
 	"link",
@@ -135,7 +138,7 @@ testSnippet(
 	`<PrismicNextLink field={${model.id}.data.linkToMedia}>Link</PrismicNextLink>`,
 );
 
-testSnippet("number", `<>{${model.id}.data.number}</>`);
+testSnippet("number", `{${model.id}.data.number}`, { format: false });
 
 testSnippet("richText", [
 	{
@@ -150,14 +153,14 @@ testSnippet("richText", [
 	},
 ]);
 
-testSnippet("select", `<>{${model.id}.data.select}</>`);
+testSnippet("select", `{${model.id}.data.select}`, { format: false });
 
 testSnippet(
 	"sliceZone",
 	`<SliceZone slices={${model.id}.data.sliceZone} components={components} />`,
 );
 
-testSnippet("timestamp", `<>{${model.id}.data.timestamp}</>`);
+testSnippet("timestamp", `{${model.id}.data.timestamp}`, { format: false });
 
 testSnippet("title", [
 	{
@@ -172,4 +175,4 @@ testSnippet("title", [
 	},
 ]);
 
-testSnippet("uid", `<>{${model.id}.data.uid}</>`);
+testSnippet("uid", `{${model.id}.data.uid}`, { format: false });


### PR DESCRIPTION
<!-- Please use a Conventional Commit in your PR title -->
<!-- https://conventionalcommits.org -->
<!-- e.g. "feat: support new field type" -->

**Resolves**: A request by @a-trost

### Description

<!-- Describe your changes in detail. -->
<!-- Why is this change required? -->
<!-- What problem does it solve? -->

This PR updates `@slicemachine/adapter-next`'s snippets. The updated snippets better reflect how developers render and use the data.

#### Group snippet

The previous snippet included a fragment (`<></>`) and did not use an implicit return (`() => ()`), requiring users to modify the snippet before using it. It was written that way for Prettier compatibility, but a snippet that works immediately is better than one that requires editing by a user.

> **Old**:
> 
> ```tsx
> <>
>   {slice.primary.my_group.map((item) => {
>     // Render the item
>   })}
> </>
> ```
> 
> **New**:
> 
> ```tsx
> {slice.primary.my_group.map((item) => (
>   // Render the item
> ))}
> ```

#### Other snippets

The wrapping `<></>` fragments were removed. They were originally added to support Prettier formatting, but the snippets are simple enough to not need automatic formatting.

> **Old**:
> 
> ```tsx
> <>{slice.primary.my_key_text}</>
> ```
> 
> **New**:
> 
> ```tsx
> {slice.primary.my_key_text}
> ```

### Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- Don't hesitate to ask for help! -->

- [x] If my changes require tests, I added them.
- [ ] If my changes affect backward compatibility, it has been discussed.
- [ ] If my changes require an update to the CONTRIBUTING.md guide, I updated it.

### Preview

<img width="636" alt="image" src="https://github.com/user-attachments/assets/9e538f98-224c-4e80-8007-7555943376d8">

### How to QA [^1]

1. Start a new playground with `yarn dev` + `yarn play --new`.
2. In Slice Machine, add a group to an existing custom type.
3. View the code snippet.

<!-- Your favorite emoji is welcome to close your PR! -->
🐤

<!-- A note for reviewers: -->

[^1]:
    Please use these labels when submitting a review:
    :question: #ask:&ensp;Ask a question.
    :bulb: #idea:&ensp;Suggest an idea.
    :warning: #issue:&ensp;Strongly suggest a change.
    :tada: #nice:&ensp;Share a compliment.

