### PR TITLE
fix(onboarding): hide onboarding guide when update is available

### DIFF
--- a/packages/slice-machine/src/features/onboarding/OnboardingGuide/OnboardingGuide.tsx
+++ b/packages/slice-machine/src/features/onboarding/OnboardingGuide/OnboardingGuide.tsx
@@ -14,6 +14,7 @@ import {
   useOnboardingContext,
 } from "@/features/onboarding/OnboardingProvider";
 import { useOnboardingExperiment } from "@/features/onboarding/useOnboardingExperiment";
+import { useUpdateAvailable } from "@/hooks/useUpdateAvailable";
 
 import styles from "./OnboardingGuide.module.css";
 
@@ -83,8 +84,12 @@ const OnboardingGuideContent = () => {
 
 export const OnboardingGuide = () => {
   const { eligible } = useOnboardingExperiment();
+  const { sliceMachineUpdateAvailable, adapterUpdateAvailable } =
+    useUpdateAvailable();
 
-  if (!eligible) return null;
+  if (!eligible || sliceMachineUpdateAvailable || adapterUpdateAvailable) {
+    return null;
+  }
 
   return <OnboardingGuideContent />;
 };

--- a/packages/slice-machine/src/legacy/components/Navigation/index.tsx
+++ b/packages/slice-machine/src/legacy/components/Navigation/index.tsx
@@ -124,7 +124,11 @@ const Navigation: FC = () => {
       </ErrorBoundary>
 
       <SideNavList position="bottom">
-        <OnboardingGuide />
+        <ErrorBoundary>
+          <Suspense>
+            <OnboardingGuide />
+          </Suspense>
+        </ErrorBoundary>
         {masterSliceLibrary !== undefined && (
           <SideNavListItem>
             <MasterSliceLibraryPreviewModal


### PR DESCRIPTION
**Resolves**: DT-2244

### Description

Avoid things like:
[![image](https://github.com/user-attachments/assets/2a6ae32d-cef2-4ef0-aba4-f0d3a52f1a9d)](https://uploads.linear.app/3df96788-1027-40da-bc50-e264033d039e/3fc0d4d9-9234-485a-9266-5ae0ce86be1a/9e9877fd-9d22-44a2-9346-93be5a045ac6)

### Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- Don't hesitate to ask for help! -->

- [ ] If my changes require tests, I added them.
- [ ] If my changes affect backward compatibility, it has been discussed.
- [ ] If my changes require an update to the CONTRIBUTING.md guide, I updated it.

### How to QA [^1]

<!-- When relevant, describe how to QA your changes. -->

<!-- Your favorite emoji is welcome to close your PR! -->

<!-- A note for reviewers: -->

[^1]:
	Please use these labels when submitting a review:
	:question: #ask:&ensp;Ask a question.
	:bulb: #idea:&ensp;Suggest an idea.
	:warning: #issue:&ensp;Strongly suggest a change.
	:tada: #nice:&ensp;Share a compliment.