### PR TITLE
[DT-2245] feat: display static and slice zone right away

### DIFF
--- a/packages/slice-machine/src/legacy/components/Forms/CreateCustomTypeModal/CreateCustomTypeModal.tsx
+++ b/packages/slice-machine/src/legacy/components/Forms/CreateCustomTypeModal/CreateCustomTypeModal.tsx
@@ -81,12 +81,6 @@ export const CreateCustomTypeModal: React.FC<CreateCustomTypeModalProps> = ({
 
         await router.push({
           pathname: customTypesConfig.getBuilderPagePathname(id),
-          query:
-            newCustomType.format === "page"
-              ? {
-                  newPageType: true,
-                }
-              : undefined,
         });
 
         syncChanges();

--- a/packages/slice-machine/src/legacy/lib/builders/CustomTypeBuilder/SliceZone/index.tsx
+++ b/packages/slice-machine/src/legacy/lib/builders/CustomTypeBuilder/SliceZone/index.tsx
@@ -10,7 +10,6 @@ import {
   Text,
 } from "@prismicio/editor-ui";
 import { SharedSlice } from "@prismicio/types-internal/lib/customtypes";
-import { useRouter } from "next/router";
 import { useEffect, useMemo, useState } from "react";
 import { useSelector } from "react-redux";
 import { toast } from "react-toastify";
@@ -111,7 +110,6 @@ const SliceZone: React.FC<SliceZoneProps> = ({
   sliceZone,
   tabId,
 }) => {
-  const { query, replace, pathname } = useRouter();
   const availableSlicesTemplates = useSlicesTemplates();
   const [isSlicesTemplatesModalOpen, setIsSlicesTemplatesModalOpen] =
     useState(false);
@@ -177,16 +175,6 @@ const SliceZone: React.FC<SliceZoneProps> = ({
       customTypeId: customType.id,
       customTypeFormat: customType.format,
     });
-  };
-
-  const redirectToEditMode = () => {
-    if (query.newPageType === "true") {
-      void replace(
-        { pathname, query: { pageTypeId: query.pageTypeId } },
-        undefined,
-        { shallow: true },
-      );
-    }
   };
 
   const closeUpdateSliceZoneModal = () => {
@@ -306,7 +294,6 @@ const SliceZone: React.FC<SliceZoneProps> = ({
             });
             setCustomType(CustomTypes.fromSM(newCustomType));
             closeUpdateSliceZoneModal();
-            redirectToEditMode();
             toast.success("Slice(s) added to slice zone");
           }}
           close={closeUpdateSliceZoneModal}
@@ -325,7 +312,6 @@ const SliceZone: React.FC<SliceZoneProps> = ({
             });
             setCustomType(CustomTypes.fromSM(newCustomType));
             closeSlicesTemplatesModal();
-            redirectToEditMode();
             toast.success(
               <ToastMessageWithPath
                 message="Slice template(s) added to slice zone and created at: "
@@ -357,7 +343,6 @@ const SliceZone: React.FC<SliceZoneProps> = ({
             });
             setCustomType(CustomTypes.fromSM(newCustomType));
             closeCreateSliceModal();
-            redirectToEditMode();
             toast.success(
               <ToastMessageWithPath
                 message="New slice added to slice zone and created at: "

--- a/packages/slice-machine/src/legacy/lib/builders/CustomTypeBuilder/SliceZone/index.tsx
+++ b/packages/slice-machine/src/legacy/lib/builders/CustomTypeBuilder/SliceZone/index.tsx
@@ -203,74 +203,73 @@ const SliceZone: React.FC<SliceZoneProps> = ({
 
   return (
     <>
-      {query.newPageType === undefined ? (
-        <ListHeader
-          actions={
-            sliceZone ? (
-              <DropdownMenu>
-                <DropdownMenuTrigger>
-                  <Button color="grey" startIcon="add">
-                    Add slices
-                  </Button>
-                </DropdownMenuTrigger>
+      <ListHeader
+        actions={
+          sliceZone ? (
+            <DropdownMenu>
+              <DropdownMenuTrigger>
+                <Button color="grey" startIcon="add">
+                  Add slices
+                </Button>
+              </DropdownMenuTrigger>
 
-                <DropdownMenuContent align="end">
+              <DropdownMenuContent align="end">
+                <DropdownMenuItem
+                  startIcon={<Icon name="add" size="large" />}
+                  onSelect={openCreateSliceModal}
+                  description="Start from scratch."
+                >
+                  Create new
+                </DropdownMenuItem>
+
+                {availableSlicesTemplates.length > 0 ? (
                   <DropdownMenuItem
-                    startIcon={<Icon name="add" size="large" />}
-                    onSelect={openCreateSliceModal}
-                    description="Start from scratch."
+                    onSelect={openSlicesTemplatesModal}
+                    startIcon={<Icon name="contentCopy" size="large" />}
+                    description="Select from premade examples."
+                    endAdornment={
+                      <Text color="inherit" component="kbd">
+                        <Badge color="purple" title="New" />
+                      </Text>
+                    }
                   >
-                    Create new
+                    Use template
                   </DropdownMenuItem>
+                ) : undefined}
 
-                  {availableSlicesTemplates.length > 0 ? (
-                    <DropdownMenuItem
-                      onSelect={openSlicesTemplatesModal}
-                      startIcon={<Icon name="contentCopy" size="large" />}
-                      description="Select from premade examples."
-                      endAdornment={
-                        <Text color="inherit" component="kbd">
-                          <Badge color="purple" title="New" />
-                        </Text>
-                      }
-                    >
-                      Use template
-                    </DropdownMenuItem>
-                  ) : undefined}
+                {availableSlicesToAdd.length > 0 ? (
+                  <DropdownMenuItem
+                    onSelect={openUpdateSliceZoneModal}
+                    startIcon={<Icon name="folder" size="large" />}
+                    description="Select from your own slices."
+                  >
+                    Select existing
+                  </DropdownMenuItem>
+                ) : undefined}
+              </DropdownMenuContent>
+            </DropdownMenu>
+          ) : undefined
+        }
+        toggle={
+          customType.format !== "page" || tabId !== "Main" ? (
+            <Switch
+              checked={!!sliceZone}
+              onCheckedChange={(checked) => {
+                if (checked) {
+                  onCreateSliceZone();
+                } else {
+                  setIsDeleteSliceZoneModalOpen(true);
+                }
+              }}
+              size="small"
+              data-testid="slice-zone-switch"
+            />
+          ) : undefined
+        }
+      >
+        Slice Zone
+      </ListHeader>
 
-                  {availableSlicesToAdd.length > 0 ? (
-                    <DropdownMenuItem
-                      onSelect={openUpdateSliceZoneModal}
-                      startIcon={<Icon name="folder" size="large" />}
-                      description="Select from your own slices."
-                    >
-                      Select existing
-                    </DropdownMenuItem>
-                  ) : undefined}
-                </DropdownMenuContent>
-              </DropdownMenu>
-            ) : undefined
-          }
-          toggle={
-            customType.format !== "page" || tabId !== "Main" ? (
-              <Switch
-                checked={!!sliceZone}
-                onCheckedChange={(checked) => {
-                  if (checked) {
-                    onCreateSliceZone();
-                  } else {
-                    setIsDeleteSliceZoneModalOpen(true);
-                  }
-                }}
-                size="small"
-                data-testid="slice-zone-switch"
-              />
-            ) : undefined
-          }
-        >
-          Slice Zone
-        </ListHeader>
-      ) : undefined}
       {sliceZone ? (
         slicesInSliceZone.length > 0 ? (
           <BaseStyles>

--- a/packages/slice-machine/src/legacy/lib/builders/CustomTypeBuilder/TabZone/index.tsx
+++ b/packages/slice-machine/src/legacy/lib/builders/CustomTypeBuilder/TabZone/index.tsx
@@ -4,7 +4,6 @@ import {
   NestableWidget,
   UID,
 } from "@prismicio/types-internal/lib/customtypes";
-import { useRouter } from "next/router";
 import { FC, Suspense } from "react";
 import type { DropResult } from "react-beautiful-dnd";
 import { flushSync } from "react-dom";
@@ -77,7 +76,6 @@ const TabZone: FC<TabZoneProps> = ({ tabId }) => {
   const fields: TabFields =
     customTypeSM.tabs.find((tab) => tab.key === tabId)?.value ?? [];
 
-  const { query } = useRouter();
   const poolOfFields = customTypeSM.tabs.reduce<PoolOfFields>(
     (acc: PoolOfFields, curr: TabSM) => {
       return [...acc, ...curr.value];
@@ -231,38 +229,36 @@ const TabZone: FC<TabZoneProps> = ({ tabId }) => {
         }
       >
         <List border={false} style={{ flexGrow: 1 }}>
-          {query.newPageType === undefined ? (
-            <Zone
-              zoneType="customType"
-              zoneTypeFormat={customType.format ?? "custom"}
-              // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-              tabId={tabId}
-              title="Static Zone"
-              dataTip={""}
-              // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-              fields={fields}
-              // @ts-expect-error propsType and typescript are incompatible on this type, we can remove the error when migrating the Zone component
-              // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
-              poolOfFieldsToCheck={poolOfFields}
-              showHints={true}
-              EditModal={EditModal}
-              widgetsArray={widgetsArray}
-              onDeleteItem={onDeleteItem}
-              onSave={onSave}
-              onSaveNewField={onSaveNewField}
-              onDragEnd={onDragEnd}
-              renderHintBase={({ item }) =>
-                // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-member-access
-                `data${transformKeyAccessor(item.key)}`
-              }
-              renderFieldAccessor={(key) =>
-                // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-argument
-                `data${transformKeyAccessor(key)}`
-              }
-              testId="static-zone-content"
-              isRepeatableCustomType={customType.repeatable}
-            />
-          ) : undefined}
+          <Zone
+            zoneType="customType"
+            zoneTypeFormat={customType.format ?? "custom"}
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+            tabId={tabId}
+            title="Static Zone"
+            dataTip={""}
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+            fields={fields}
+            // @ts-expect-error propsType and typescript are incompatible on this type, we can remove the error when migrating the Zone component
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
+            poolOfFieldsToCheck={poolOfFields}
+            showHints={true}
+            EditModal={EditModal}
+            widgetsArray={widgetsArray}
+            onDeleteItem={onDeleteItem}
+            onSave={onSave}
+            onSaveNewField={onSaveNewField}
+            onDragEnd={onDragEnd}
+            renderHintBase={({ item }) =>
+              // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-member-access
+              `data${transformKeyAccessor(item.key)}`
+            }
+            renderFieldAccessor={(key) =>
+              // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-argument
+              `data${transformKeyAccessor(key)}`
+            }
+            testId="static-zone-content"
+            isRepeatableCustomType={customType.repeatable}
+          />
 
           <SliceZone
             customType={customTypeSM}

--- a/packages/slice-machine/src/legacy/lib/builders/CustomTypeBuilder/index.tsx
+++ b/packages/slice-machine/src/legacy/lib/builders/CustomTypeBuilder/index.tsx
@@ -8,7 +8,6 @@ import {
   WindowTabsList,
   WindowTabsTrigger,
 } from "@prismicio/editor-ui";
-import { useRouter } from "next/router";
 import { useState } from "react";
 
 import {
@@ -37,7 +36,6 @@ export const CustomTypeBuilder = () => {
 
   const [dialog, setDialog] = useState<DialogState>();
 
-  const { query } = useRouter();
   const sliceZoneEmpty =
     customTypeSM.tabs.find((tab) => tab.key === tabValue)?.sliceZone?.value
       .length === 0;
@@ -46,59 +44,56 @@ export const CustomTypeBuilder = () => {
     <>
       <Window sx={sliceZoneEmpty ? { flexGrow: 1 } : undefined}>
         {customType.format === "page" ? <WindowFrame /> : undefined}
-        {query.newPageType === "true" ? (
-          <TabZone tabId={customTypeSM.tabs[0].key} />
-        ) : (
-          <WindowTabs onValueChange={setTabValue} value={tabValue}>
-            <WindowTabsList
-              onAddNewTab={() => {
-                setDialog({ type: "CREATE_CUSTOM_TYPE_TAB" });
-              }}
-            >
-              {customTypeSM.tabs.map((tab) => (
-                <WindowTabsTrigger
-                  key={tab.key}
-                  menu={
-                    <>
-                      <DropdownMenuItem
-                        onSelect={() => {
-                          setDialog({
-                            type: "UPDATE_CUSTOM_TYPE_TAB",
-                            tabKey: tab.key,
-                          });
-                        }}
-                        startIcon={<Icon name="edit" />}
-                      >
-                        Rename
-                      </DropdownMenuItem>
-                      <DropdownMenuItem
-                        color="tomato"
-                        disabled={customTypeSM.tabs.length <= 1}
-                        onSelect={() => {
-                          setDialog({
-                            type: "DELETE_CUSTOM_TYPE_TAB",
-                            tabKey: tab.key,
-                          });
-                        }}
-                        startIcon={<Icon name="delete" />}
-                      >
-                        Remove
-                      </DropdownMenuItem>
-                    </>
-                  }
-                  value={tab.key}
-                >
-                  {tab.key}
-                </WindowTabsTrigger>
-              ))}
-            </WindowTabsList>
+
+        <WindowTabs onValueChange={setTabValue} value={tabValue}>
+          <WindowTabsList
+            onAddNewTab={() => {
+              setDialog({ type: "CREATE_CUSTOM_TYPE_TAB" });
+            }}
+          >
             {customTypeSM.tabs.map((tab) => (
-              <WindowTabsContent key={tab.key} value={tab.key}>
-                <TabZone tabId={tab.key} />
-              </WindowTabsContent>
+              <WindowTabsTrigger
+                key={tab.key}
+                menu={
+                  <>
+                    <DropdownMenuItem
+                      onSelect={() => {
+                        setDialog({
+                          type: "UPDATE_CUSTOM_TYPE_TAB",
+                          tabKey: tab.key,
+                        });
+                      }}
+                      startIcon={<Icon name="edit" />}
+                    >
+                      Rename
+                    </DropdownMenuItem>
+                    <DropdownMenuItem
+                      color="tomato"
+                      disabled={customTypeSM.tabs.length <= 1}
+                      onSelect={() => {
+                        setDialog({
+                          type: "DELETE_CUSTOM_TYPE_TAB",
+                          tabKey: tab.key,
+                        });
+                      }}
+                      startIcon={<Icon name="delete" />}
+                    >
+                      Remove
+                    </DropdownMenuItem>
+                  </>
+                }
+                value={tab.key}
+              >
+                {tab.key}
+              </WindowTabsTrigger>
             ))}
-          </WindowTabs>
-        )}
+          </WindowTabsList>
+          {customTypeSM.tabs.map((tab) => (
+            <WindowTabsContent key={tab.key} value={tab.key}>
+              <TabZone tabId={tab.key} />
+            </WindowTabsContent>
+          ))}
+        </WindowTabs>
       </Window>
       {dialog?.type === "CREATE_CUSTOM_TYPE_TAB" ? (
         <CreateModal


### PR DESCRIPTION
<!-- Please use a Conventional Commit in your PR title -->
<!-- https://conventionalcommits.org -->
<!-- e.g. "feat: support new field type" -->

**Resolves**: [DT-2245](https://linear.app/prismic/issue/DT-2245/replace-the-initial-empty-page-type-screen)

### Description

<!-- Describe your changes in detail. -->
<!-- Why is this change required? -->
<!-- What problem does it solve? -->
Simplify the onboarding by removing the difference in page type builder page that occurs on adding new page.
This is not completed feature! In next steps placeholder for empty Static Zone will be removed.

### Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- Don't hesitate to ask for help! -->

- [ ] If my changes require tests, I added them.
- [ ] If my changes affect backward compatibility, it has been discussed.
- [ ] If my changes require an update to the CONTRIBUTING.md guide, I updated it.

### Preview
**BEFORE**
<img width="1078" alt="new-page-before" src="https://github.com/user-attachments/assets/b5ad57eb-7b8f-4f16-822c-a894ec218f9e">
**AFTER**
<img width="1078" alt="new-page-after" src="https://github.com/user-attachments/assets/fe65cc2b-5ce5-41ce-aa21-b77b4ff9813d">

<!-- If your changes are visual, screenshots or videos are welcome! -->

### How to QA [^1]

<!-- When relevant, describe how to QA your changes. -->

<!-- Your favorite emoji is welcome to close your PR! -->

<!-- A note for reviewers: -->

[^1]:
	Please use these labels when submitting a review:
	:question: #ask:&ensp;Ask a question.
	:bulb: #idea:&ensp;Suggest an idea.
	:warning: #issue:&ensp;Strongly suggest a change.
	:tada: #nice:&ensp;Share a compliment.