### PR TITLE
[DT-2277] feat: handle users out of the experiment scope

### DIFF
--- a/packages/slice-machine/src/hooks/usePromptToCreateContentExperiment.ts
+++ b/packages/slice-machine/src/hooks/usePromptToCreateContentExperiment.ts
@@ -5,14 +5,9 @@ type UsePromptToCreateContentExperimentReturnType = { eligible: boolean };
 export function usePromptToCreateContentExperiment(): UsePromptToCreateContentExperimentReturnType {
   const variant = useExperimentVariant("slicemachine-prompt-to-create-content");
 
-  // serve the experimental version to user with Telemetry deactivated
+  // we serve the previous version only to users in the control group
+  // users in variant on, users out of experiment scope, and users with telemetry deactivated will see the new version
   return {
-    eligible:
-      // serve the experimental version to user with Telemetry deactivated
-      variant === undefined ||
-      // serve the experimental version to user out of experiment scope
-      variant?.value === "off" ||
-      // serve the experimental version in the experiment test group with variant "on"
-      variant?.value === "on",
+    eligible: variant?.value !== "control",
   };
 }

--- a/packages/slice-machine/src/hooks/usePromptToCreateContentExperiment.ts
+++ b/packages/slice-machine/src/hooks/usePromptToCreateContentExperiment.ts
@@ -6,5 +6,13 @@ export function usePromptToCreateContentExperiment(): UsePromptToCreateContentEx
   const variant = useExperimentVariant("slicemachine-prompt-to-create-content");
 
   // serve the experimental version to user with Telemetry deactivated
-  return { eligible: variant === undefined || variant?.value === "on" };
+  return {
+    eligible:
+      // serve the experimental version to user with Telemetry deactivated
+      variant === undefined ||
+      // serve the experimental version to user out of experiment scope
+      variant?.value === "off" ||
+      // serve the experimental version in the experiment test group with variant "on"
+      variant?.value === "on",
+  };
 }

--- a/packages/slice-machine/src/hooks/usePromptToCreateContentExperiment.ts
+++ b/packages/slice-machine/src/hooks/usePromptToCreateContentExperiment.ts
@@ -5,8 +5,12 @@ type UsePromptToCreateContentExperimentReturnType = { eligible: boolean };
 export function usePromptToCreateContentExperiment(): UsePromptToCreateContentExperimentReturnType {
   const variant = useExperimentVariant("slicemachine-prompt-to-create-content");
 
-  // we serve the previous version only to users in the control group
-  // users in variant on, users out of experiment scope, and users with telemetry deactivated will see the new version
+  // we serve the previous version only to users in the "control" group
+  // users in:
+  // - variant "on"
+  // - out of experiment scope,
+  // - with telemetry deactivated
+  // will see the new version
   return {
     eligible: variant?.value !== "control",
   };


### PR DESCRIPTION
<!-- Please use a Conventional Commit in your PR title -->
<!-- https://conventionalcommits.org -->
<!-- e.g. "feat: support new field type" -->

**Resolves**: [DT-2277](https://linear.app/prismic/issue/DT-2277/add-success-toast-when-push-ready)

### Description
The experiment target only specific group of users.
For those who are not in scope of the experiment, we want to show the new version.

<!-- Describe your changes in detail. -->
<!-- Why is this change required? -->
<!-- What problem does it solve? -->

### Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- Don't hesitate to ask for help! -->

- [ ] If my changes require tests, I added them.
- [ ] If my changes affect backward compatibility, it has been discussed.
- [ ] If my changes require an update to the CONTRIBUTING.md guide, I updated it.

### Preview

<!-- If your changes are visual, screenshots or videos are welcome! -->

### How to QA [^1]

<!-- When relevant, describe how to QA your changes. -->

<!-- Your favorite emoji is welcome to close your PR! -->

<!-- A note for reviewers: -->

[^1]:
	Please use these labels when submitting a review:
	:question: #ask:&ensp;Ask a question.
	:bulb: #idea:&ensp;Suggest an idea.
	:warning: #issue:&ensp;Strongly suggest a change.
	:tada: #nice:&ensp;Share a compliment.