### PR TITLE
fix(adapter-next): don't purge user cache on simulator update

### DIFF
--- a/packages/adapter-next/src/simulator/react-server/SliceSimulator.tsx
+++ b/packages/adapter-next/src/simulator/react-server/SliceSimulator.tsx
@@ -13,8 +13,8 @@ import {
 import { compressToEncodedURIComponent } from "lz-string";
 
 import { SliceSimulatorWrapper } from "../SliceSimulatorWrapper";
-import { revalidatePath } from "./actions";
 import { getSlices } from "./getSlices";
+import { useRouter } from "next/navigation";
 
 const STATE_PARAMS_KEY = "state";
 
@@ -42,7 +42,6 @@ const throttle =
 			}
 		};
 	};
-const throttledRevalidatePath = throttle(revalidatePath, 300);
 
 const simulatorManager = new SimulatorManager();
 
@@ -58,6 +57,12 @@ export const SliceSimulator = ({
 	className,
 }: SliceSimulatorProps): JSX.Element => {
 	const [message, setMessage] = React.useState(() => getDefaultMessage());
+	const router = useRouter();
+
+	const throttledRefreshPage = React.useCallback(
+		() => throttle(() => router.refresh(), 300),
+		[router],
+	);
 
 	const state =
 		typeof window !== "undefined"
@@ -76,11 +81,7 @@ export const SliceSimulator = ({
 				);
 				window.history.pushState(null, "", url);
 
-				// A 0 ms timeout is needed to prevent a bug
-				// where the path is revalidated before the URL
-				// is updated with the new state.
-				const path = window.location.pathname;
-				setTimeout(() => throttledRevalidatePath(path), 0);
+				throttledRefreshPage();
 			},
 			"simulator-slices",
 		);

--- a/packages/adapter-next/src/simulator/react-server/actions.ts
+++ b/packages/adapter-next/src/simulator/react-server/actions.ts
@@ -1,7 +1,0 @@
-"use server";
-
-import { revalidatePath as baseRevalidatePath } from "next/cache";
-
-export async function revalidatePath(path: string): Promise<void> {
-	baseRevalidatePath(path);
-}


### PR DESCRIPTION
### Description

Previously when using the Next.js adapter and the Server Component `<SliceSimulator />`, 'simulator-slices' updates from the simulator would call [revalidatePath](https://nextjs.org/docs/app/api-reference/functions/revalidatePath) from Next.js in order to re-render the `<SliceSimulator />` component with the updated search params. A 'simulator-slices' update occurs every time a user makes a change in the simulator, for example a keystroke or slice field change.

This is a problem when slices contain data fetches. Next.js has a [Data Cache](https://nextjs.org/docs/app/building-your-application/caching#data-cache), which allows a user to specify a cache time on `fetch` requests, or use api's like [unstable_cache](https://nextjs.org/docs/app/api-reference/functions/unstable_cache) to cache the result of an operation. `revalidatePath` purges the Next.js Data Cache for that path, which means that if a slice is fetching data from an external source, that fetch will skip the Data Cache and hit origin.

This is problematic if the fetch or operation is expensive. Users could have wrapped expensive operations inside `unstable_cache`, or specified a cache time using [revalidate](https://nextjs.org/docs/app/api-reference/functions/fetch#optionsnextrevalidate), and those values would not be respected because of the `revalidatePath` call. Although this call is throttled to a maximum of 1 every 300 milliseconds, this could very quickly add up to a significant number. These calls are not made in user code either, they are made within the slice simulator, so this could result in a lot of unexpected and unwanted calls to origin for users.

We came across this issue when building a Google Reviews slice for one of our clients. The API call to fetch reviews is [quite expensive](https://developers.google.com/maps/documentation/places/web-service/usage-and-billing), and so we had wrapped the api call inside a `unstable_cache` to limit the number of calls to x per week. We of course weren't aware that editors adding this slice to pages in Prismic were inadvertently making calls to the API.

This commit fixes this by replacing `revalidatePath` with [router.refresh](https://nextjs.org/docs/app/building-your-application/caching#routerrefresh). Since the simulator state is in search params, and therefore not in Data Cache, there is no need to purge the cache. We just need to re-run the Server Component, which `router.refresh` does.

### Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- Don't hesitate to ask for help! -->

- [ ] If my changes require tests, I added them.
- [ ] If my changes affect backward compatibility, it has been discussed.
- [ ] If my changes require an update to the CONTRIBUTING.md guide, I updated it.


### How to QA [^1]

<!-- When relevant, describe how to QA your changes. -->

<!-- Your favorite emoji is welcome to close your PR! -->

<!-- A note for reviewers: -->

[^1]:
	Please use these labels when submitting a review:
	:question: #ask:&ensp;Ask a question.
	:bulb: #idea:&ensp;Suggest an idea.
	:warning: #issue:&ensp;Strongly suggest a change.
	:tada: #nice:&ensp;Share a compliment.