### PR TITLE
fix(adapter-next): don't purge user cache on simulator update (#1439)

### DIFF
--- a/packages/adapter-next/src/simulator/react-server/actions.ts
+++ b/packages/adapter-next/src/simulator/react-server/actions.ts
@@ -1,7 +1,0 @@
-"use server";
-
-import { revalidatePath as baseRevalidatePath } from "next/cache";
-
-export async function revalidatePath(path: string): Promise<void> {
-	baseRevalidatePath(path);
-}


### PR DESCRIPTION
<!-- Please use a Conventional Commit in your PR title -->
<!-- https://conventionalcommits.org -->
<!-- e.g. "feat: support new field type" -->

**Resolves**: #1439

### Description

See #1439. This is a cloned PR serving only to publish an alpha version.

Credit: @rajansolanki

### Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- Don't hesitate to ask for help! -->

- [ ] If my changes require tests, I added them.
- [x] If my changes affect backward compatibility, it has been discussed.
- [ ] If my changes require an update to the CONTRIBUTING.md guide, I updated it.

### Preview

N/A

### How to QA [^1]


1. Create and start a new playground.
   ```sh
   yarn play --new
   ```
2. Open Slice Machine at <http://localhost:9999>.
3. Open the simulator for the Rich Text slice.
4. Verify the simulator functions correctly on initial load and subsequent content changes.

<!-- A note for reviewers: -->

[^1]:
	Please use these labels when submitting a review:
	:question: #ask:&ensp;Ask a question.
	:bulb: #idea:&ensp;Suggest an idea.
	:warning: #issue:&ensp;Strongly suggest a change.
	:tada: #nice:&ensp;Share a compliment.