### PR TITLE
feat: Track allow text in links

### DIFF
--- a/packages/manager/src/managers/telemetry/types.ts
+++ b/packages/manager/src/managers/telemetry/types.ts
@@ -199,6 +199,7 @@ type FieldAddedSegmentEvent = SegmentEvent<
 		type: FieldType;
 		isInAGroup: boolean;
 		contentType: "page type" | "custom type" | "slice";
+		allowText?: boolean;
 	}
 >;
 

--- a/packages/slice-machine/src/legacy/lib/builders/CustomTypeBuilder/TabZone/index.tsx
+++ b/packages/slice-machine/src/legacy/lib/builders/CustomTypeBuilder/TabZone/index.tsx
@@ -145,6 +145,9 @@ const TabZone: FC<TabZoneProps> = ({ tabId }) => {
       type: newField.type,
       isInAGroup: false,
       contentType: getContentTypeForTracking(window.location.pathname),
+      ...(newField.type === "Link" && {
+        allowText: newField.config?.allowText,
+      }),
     });
   };
 

--- a/packages/slice-machine/src/legacy/lib/builders/SliceBuilder/FieldZones/index.tsx
+++ b/packages/slice-machine/src/legacy/lib/builders/SliceBuilder/FieldZones/index.tsx
@@ -166,6 +166,9 @@ const FieldZones: FC = () => {
       type: newField.type,
       isInAGroup: false,
       contentType: getContentTypeForTracking(window.location.pathname),
+      ...(newField.type === "Link" && {
+        allowText: newField.config?.allowText,
+      }),
     });
   };
 

--- a/packages/slice-machine/src/legacy/lib/models/common/widgets/Group/ListItem/index.jsx
+++ b/packages/slice-machine/src/legacy/lib/models/common/widgets/Group/ListItem/index.jsx
@@ -76,6 +76,9 @@ export const CustomListItem = ({
       type: newField.type,
       isInAGroup: true,
       contentType: getContentTypeForTracking(window.location.pathname),
+      ...(newField.type === "Link" && {
+        allowText: newField.config?.allowText,
+      }),
     });
   };
 


### PR DESCRIPTION
<!-- Please use a Conventional Commit in your PR title -->
<!-- https://conventionalcommits.org -->
<!-- e.g. "feat: support new field type" -->

**Resolves**: <!-- GitHub or Linear issue (e.g. #123, DT-123) -->
https://linear.app/prismic/issue/DT-2355/aapm-i-can-track-the-link-text-property

### Description

<!-- Describe your changes in detail. -->
<!-- Why is this change required? -->
<!-- What problem does it solve? -->
When adding a link field, track whether the user selected allowText.

### Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- Don't hesitate to ask for help! -->

- [ ] If my changes require tests, I added them.
- [ ] If my changes affect backward compatibility, it has been discussed.
- [ ] If my changes require an update to the CONTRIBUTING.md guide, I updated it.

### Preview

<!-- If your changes are visual, screenshots or videos are welcome! -->

### How to QA [^1]

<!-- When relevant, describe how to QA your changes. -->

<!-- Your favorite emoji is welcome to close your PR! -->

<!-- A note for reviewers: -->

[^1]:
	Please use these labels when submitting a review:
	:question: #ask:&ensp;Ask a question.
	:bulb: #idea:&ensp;Suggest an idea.
	:warning: #issue:&ensp;Strongly suggest a change.
	:tada: #nice:&ensp;Share a compliment.