### PR TITLE
[DT-2335] Introduce local package linking script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,12 @@
 !.yarn/sdks
 !.yarn/versions
 
+# Yalc
+.yalc
+yalc.lock
+packages/**/.yalc
+packages/**/yalc.lock
+
 # OS Specific
 .DS_Store
 .DS_Store?

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -129,6 +129,21 @@ gh pr create
 # When ready, PRs should be merged using the "Squash and merge" option.
 ```
 
+## 🏗️ Local development with editor (slice-machine-ui)
+
+In order to be able to develop faster locally, without having to publish new `editor-ui/fields/support` npm packages, you can use yalc (a local package repository). Here how to do it:
+
+#### 1. Check `editor/CONTRIBUTING.md` "Local package publishing" section
+#### 2. Link editor packages to yalc
+```shell
+yarn yalc:editor-packages link
+```
+
+#### _(after developing)_ Unlink to use the installed npm packages
+```shell
+yarn yalc:editor-packages clean
+```
+
 ## :rocket: Publish
 
 > [!CAUTION]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -131,21 +131,23 @@ gh pr create
 
 ## 🏗️ Local development with editor (slice-machine-ui)
 
-In order to be able to develop faster locally, without having to publish new `editor-ui/fields/support` npm packages, you can use yalc (a local package repository). Here how to do it:
+To accelerate local development without the need to publish new `editor-*` npm packages, you can use [`yalc`](https://github.com/wclr/yalc), a local package repository.
 
-#### 1. Check `editor/CONTRIBUTING.md` "Local package publishing" section
+### How to setup:
 
-#### 2. Link editor packages to yalc
+1️. Check [**`editor/CONTRIBUTING.md` Publish locally**](https://github.com/prismicio/editor/blob/main/CONTRIBUTING.md#%EF%B8%8F-publish-locally) section
 
-```shell
-yarn yalc:editor-packages link
-```
+2️. Link `editor-*` packages to `yalc`
 
-#### _(after developing)_ Unlink to use the installed npm packages
+   ```shell
+   yarn yalc:editor-packages link
+   ```
 
-```shell
-yarn yalc:editor-packages clean
-```
+_(after developing)_ Unlink `yalc` packages to continue using the installed npm ones.
+
+  ```shell
+  yarn yalc:editor-packages unlink
+  ```
 
 ## :rocket: Publish
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -134,12 +134,15 @@ gh pr create
 In order to be able to develop faster locally, without having to publish new `editor-ui/fields/support` npm packages, you can use yalc (a local package repository). Here how to do it:
 
 #### 1. Check `editor/CONTRIBUTING.md` "Local package publishing" section
+
 #### 2. Link editor packages to yalc
+
 ```shell
 yarn yalc:editor-packages link
 ```
 
 #### _(after developing)_ Unlink to use the installed npm packages
+
 ```shell
 yarn yalc:editor-packages clean
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -139,15 +139,15 @@ To accelerate local development without the need to publish new `editor-*` npm p
 
 2️. Link `editor-*` packages to `yalc`
 
-   ```shell
-   yarn yalc:editor-packages link
-   ```
+```shell
+yarn yalc:editor-packages link
+```
 
 _(after developing)_ Unlink `yalc` packages to continue using the installed npm ones.
 
-  ```shell
-  yarn yalc:editor-packages unlink
-  ```
+```shell
+yarn yalc:editor-packages unlink
+```
 
 ## :rocket: Publish
 

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "test": "yarn workspaces foreach --parallel --topological-dev --verbose run test",
     "publish": "tsx scripts/publish.ts",
     "play": "tsx scripts/play.ts",
-    "yalc:slice-machine": "tsx scripts/yalc-sm.ts"
+    "yalc:editor-packages": "tsx scripts/yalc-sm.ts"
   },
   "dependenciesMeta": {
     "@sentry/cli": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "prettier:check": "prettier --check .",
     "test": "yarn workspaces foreach --parallel --topological-dev --verbose run test",
     "publish": "tsx scripts/publish.ts",
-    "play": "tsx scripts/play.ts"
+    "play": "tsx scripts/play.ts",
+    "yalc:slice-machine": "tsx scripts/yalc-sm.ts"
   },
   "dependenciesMeta": {
     "@sentry/cli": {

--- a/scripts/utils/commandUtils.ts
+++ b/scripts/utils/commandUtils.ts
@@ -1,6 +1,9 @@
 import chalk from "chalk";
 import {
+  ExecaSyncReturnValue,
+  SyncOptions,
   execa,
+  execaSync,
   type ExecaChildProcess,
   type Options as ExecaOptions,
   type ExecaReturnValue,
@@ -47,6 +50,29 @@ export async function exec(
     console.log(chalk.blue(escapeCommand(file, args)));
   } else {
     return await execa(file, args, execaOptions);
+  }
+}
+
+export function execSync(
+  file: string,
+  args?: string[],
+  options?: SyncOptions & { dryRun: true },
+): void;
+export function execSync(
+  file: string,
+  args?: string[],
+  options?: SyncOptions & { dryRun?: boolean },
+): ExecaSyncReturnValue | void;
+export function execSync(
+  file: string,
+  args?: string[],
+  options: SyncOptions & { dryRun?: boolean } = {},
+): ExecaSyncReturnValue | void {
+  const { dryRun, ...execaOptions } = options;
+  if (dryRun === true) {
+    console.log(chalk.blue(escapeCommand(file, args)));
+  } else {
+    return execaSync(file, args, execaOptions);
   }
 }
 

--- a/scripts/yalc-sm.ts
+++ b/scripts/yalc-sm.ts
@@ -27,14 +27,14 @@ function getYalcPrismicPackages() {
   return readdirSync(prismicPkgsDir).map((name) => `@prismicio/${name}`);
 }
 
-async function linkPackages(packages: string[]) {
+function linkPackages(packages: string[]) {
   const prismicPkgs = getYalcPrismicPackages();
   if (prismicPkgs.length === 0) {
     fail(`No packages to link, ${seeMoreInfoMessage}`);
   }
 
   let someFailed = false;
-  for await (const name of packages) {
+  for (const name of packages) {
     if (prismicPkgs.includes(name)) {
       execaSync("yalc", ["link", name, "--dev"], { cwd: smWorkspaceLocation });
       console.log(`${greenBright("✔")} Linked ${bold(green(name))}`);

--- a/scripts/yalc-sm.ts
+++ b/scripts/yalc-sm.ts
@@ -1,6 +1,6 @@
 import { existsSync, readdirSync } from "node:fs";
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { join, basename } from "node:path";
 
 import { green, greenBright, red, bold } from "chalk";
 import { execaSync } from "execa";
@@ -48,7 +48,25 @@ function unlinkPackages(packages: string[]) {
   }
 }
 
-const [command] = process.argv.slice(2);
+function printHelp() {
+  console.log(`Slice machine yalc helper script
+
+USAGE
+  $ ${basename(process.argv[1])} <COMMAND>
+
+COMMANDS
+  link          Link slice-machine editor packages to yalc
+  clean         Unlink slice-machine editor packages from yalc
+
+  --help, -h    Display help`)
+}
+
+const [command, ...options] = process.argv.slice(2);
+if (options.includes("--help") || options.includes("-h")) {
+  printHelp();
+  process.exit(0);
+}
+
 switch (command) {
   case "link": {
     void linkPackages(packages);
@@ -59,6 +77,7 @@ switch (command) {
     break;
   }
   default: {
-    fail("Command not found");
+    printHelp();
+    process.exit(0);
   }
 }

--- a/scripts/yalc-sm.ts
+++ b/scripts/yalc-sm.ts
@@ -6,8 +6,8 @@ import { green, greenBright, red, bold, yellow } from "chalk";
 import { execaSync } from "execa";
 
 const cwd = process.cwd();
-
 const smWorkspaceLocation = join(cwd, "packages", "slice-machine");
+
 const packages = [
   "@prismicio/editor-ui",
   "@prismicio/editor-fields",
@@ -65,7 +65,7 @@ USAGE
 
 COMMANDS
   link          Link slice-machine editor packages to yalc
-  clean         Unlink slice-machine editor packages from yalc
+  unlink        Unlink slice-machine editor packages from yalc
 
   --help, -h    Display help`);
 }
@@ -81,7 +81,7 @@ switch (command) {
     void linkPackages(packages);
     break;
   }
-  case "clean": {
+  case "unlink": {
     void unlinkPackages(packages);
     break;
   }

--- a/scripts/yalc-sm.ts
+++ b/scripts/yalc-sm.ts
@@ -61,12 +61,13 @@ function printHelp() {
   console.log(`Slice machine Yalc helper script
 
 USAGE
-  $ ${basename(process.argv[1])} <COMMAND>
+  $ ${basename(process.argv[1])} <COMMAND> [OPTIONS...]
 
 COMMANDS
   link          Link slice-machine editor packages to yalc
   unlink        Unlink slice-machine editor packages from yalc
 
+OPTIONS
   --help, -h    Display help`);
 }
 

--- a/scripts/yalc-sm.ts
+++ b/scripts/yalc-sm.ts
@@ -1,0 +1,64 @@
+import { existsSync, readdirSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+import { green, greenBright, red, bold } from "chalk";
+import { execaSync } from "execa";
+
+const cwd = process.cwd();
+
+const smWorkspaceLocation = join(cwd, "packages", "slice-machine");
+const packages = [
+  "@prismicio/editor-ui",
+  "@prismicio/editor-fields",
+  "@prismicio/editor-support",
+];
+
+function fail(message: string) {
+  console.error(red(message));
+  process.exit(1);
+}
+
+function getYalcPrismicPackages() {
+  const prismicPkgsDir = join(homedir(), ".yalc", "packages", "@prismicio");
+  if (!existsSync(prismicPkgsDir)) return [];
+  return readdirSync(prismicPkgsDir).map((name) => `@prismicio/${name}`);
+}
+
+async function linkPackages(packages: string[]) {
+  const prismicPkgs = getYalcPrismicPackages();
+  if (prismicPkgs.length === 0) {
+    fail("No packaged to link");
+  }
+
+  for await (const name of packages) {
+    if (prismicPkgs.includes(name)) {
+      execaSync("yalc", ["link", name, "--dev"], { cwd: smWorkspaceLocation });
+      console.log(`${greenBright("✔")} Linked ${bold(green(name))}`);
+    } else {
+      console.log(`${red('✘')} Package ${bold(name)} not found in yalc`);
+    }
+  }
+}
+
+function unlinkPackages(packages: string[]) {
+  for (const pkg of packages) {
+    execaSync("yalc", ["remove", pkg], { cwd: smWorkspaceLocation });
+    console.log(`${greenBright("✘")} Unlinked ${bold(green(pkg))}`);
+  }
+}
+
+const [command] = process.argv.slice(2);
+switch (command) {
+  case "link": {
+    void linkPackages(packages);
+    break;
+  }
+  case "clean": {
+    void unlinkPackages(packages);
+    break;
+  }
+  default: {
+    fail("Command not found");
+  }
+}

--- a/scripts/yalc-sm.ts
+++ b/scripts/yalc-sm.ts
@@ -1,9 +1,8 @@
 import { existsSync, readdirSync } from "node:fs";
 import { homedir } from "node:os";
 import { join, basename } from "node:path";
-
 import { green, greenBright, red, bold, yellow } from "chalk";
-import { execaSync } from "execa";
+import { execSync } from "./utils/commandUtils";
 
 const cwd = process.cwd();
 const smWorkspaceLocation = join(cwd, "packages", "slice-machine");
@@ -36,7 +35,7 @@ function linkPackages(packages: string[]) {
   let someFailed = false;
   for (const name of packages) {
     if (prismicPkgs.includes(name)) {
-      execaSync("yalc", ["link", name, "--dev"], { cwd: smWorkspaceLocation });
+      execSync("yalc", ["link", name, "--dev"], { cwd: smWorkspaceLocation });
       console.log(`${greenBright("✔")} Linked ${bold(green(name))}`);
     } else {
       someFailed = true;
@@ -52,7 +51,7 @@ function linkPackages(packages: string[]) {
 
 function unlinkPackages(packages: string[]) {
   for (const pkg of packages) {
-    execaSync("yalc", ["remove", pkg], { cwd: smWorkspaceLocation });
+    execSync("yalc", ["remove", pkg], { cwd: smWorkspaceLocation });
     console.log(`${greenBright("✘")} Unlinked ${bold(green(pkg))}`);
   }
 }

--- a/scripts/yalc-sm.ts
+++ b/scripts/yalc-sm.ts
@@ -58,7 +58,7 @@ function unlinkPackages(packages: string[]) {
 }
 
 function printHelp() {
-  console.log(`Slice machine yalc helper script
+  console.log(`Slice machine Yalc helper script
 
 USAGE
   $ ${basename(process.argv[1])} <COMMAND>

--- a/scripts/yalc-sm.ts
+++ b/scripts/yalc-sm.ts
@@ -2,7 +2,7 @@ import { existsSync, readdirSync } from "node:fs";
 import { homedir } from "node:os";
 import { join, basename } from "node:path";
 
-import { green, greenBright, red, bold } from "chalk";
+import { green, greenBright, red, bold, yellow } from "chalk";
 import { execaSync } from "execa";
 
 const cwd = process.cwd();
@@ -13,6 +13,8 @@ const packages = [
   "@prismicio/editor-fields",
   "@prismicio/editor-support",
 ];
+const seeMoreInfoMessage =
+  "see CONTRIBUTING.md section on Local development with editor for more information.";
 
 function fail(message: string) {
   console.error(red(message));
@@ -28,16 +30,23 @@ function getYalcPrismicPackages() {
 async function linkPackages(packages: string[]) {
   const prismicPkgs = getYalcPrismicPackages();
   if (prismicPkgs.length === 0) {
-    fail("No packaged to link");
+    fail(`No packages to link, ${seeMoreInfoMessage}`);
   }
 
+  let someFailed = false;
   for await (const name of packages) {
     if (prismicPkgs.includes(name)) {
       execaSync("yalc", ["link", name, "--dev"], { cwd: smWorkspaceLocation });
       console.log(`${greenBright("✔")} Linked ${bold(green(name))}`);
     } else {
-      console.log(`${red('✘')} Package ${bold(name)} not found in yalc`);
+      someFailed = true;
+      console.log(`${red("✘")} Package ${bold(name)} not found in yalc`);
     }
+  }
+  if (someFailed) {
+    console.error(
+      yellow(`\nSome packages were not found in yalc, ${seeMoreInfoMessage}`),
+    );
   }
 }
 
@@ -58,7 +67,7 @@ COMMANDS
   link          Link slice-machine editor packages to yalc
   clean         Unlink slice-machine editor packages from yalc
 
-  --help, -h    Display help`)
+  --help, -h    Display help`);
 }
 
 const [command, ...options] = process.argv.slice(2);


### PR DESCRIPTION
**Resolves**: DT-2335

### Description

The current package development process required the publishing of a public alpha (of editor packages) on npm and installing it here. In an effort of improving this flow, this PR creates a script to link/unlick the packages locally, using yalc, so that they can be tested before publishing publicly.

Package publishing PR: https://github.com/prismicio/editor/pull/1322

### Preview

https://github.com/user-attachments/assets/0a7cf2c1-a864-4800-9396-0c1f4f30345f

### How to QA [^1]

<!-- When relevant, describe how to QA your changes. -->

<!-- Your favorite emoji is welcome to close your PR! -->

<!-- A note for reviewers: -->

[^1]:
	Please use these labels when submitting a review:
	:question: #ask:&ensp;Ask a question.
	:bulb: #idea:&ensp;Suggest an idea.
	:warning: #issue:&ensp;Strongly suggest a change.
	:tada: #nice:&ensp;Share a compliment.