### PR TITLE
fix: add field modal does not close on the first close-button click

### DIFF
--- a/packages/slice-machine/src/legacy/components/Card/index.tsx
+++ b/packages/slice-machine/src/legacy/components/Card/index.tsx
@@ -3,8 +3,13 @@ import { Card as ThemeCard, ThemeUIStyleObject } from "theme-ui";
 
 import { CardBox, CardBoxProps } from "./CardBox";
 
+// passing Header as a function caused a bug in EditModal
+// where the function was re-defined after each state update
+// which led to a bug where context was lost and a modal button was not working as expected
+// TODO: tech debt issue DT-2384
+
 interface CardProps extends Omit<CardBoxProps, "withRadius"> {
-  Header?: React.FC<{ radius: string }> | null;
+  Header?: React.FC<{ radius: string }> | JSX.Element | null;
   SubHeader?: React.FC<{ radius: string }> | null;
   Body?: React.FC | null;
   Footer?: React.FC | JSX.Element | null;
@@ -36,7 +41,13 @@ const Card: React.FC<CardProps> = ({
     }}
     {...rest}
   >
-    {Header ? <Header radius={radius} /> : null}
+    {Header ? (
+      typeof Header === "object" ? (
+        Header
+      ) : (
+        <Header radius={radius} />
+      )
+    ) : null}
     {SubHeader ? <SubHeader radius={radius} /> : null}
     <CardBox bg={bg} background={background} sx={bodySx} withRadius={!Footer}>
       {Body ? <Body /> : null}

--- a/packages/slice-machine/src/legacy/components/Card/index.tsx
+++ b/packages/slice-machine/src/legacy/components/Card/index.tsx
@@ -3,11 +3,6 @@ import { Card as ThemeCard, ThemeUIStyleObject } from "theme-ui";
 
 import { CardBox, CardBoxProps } from "./CardBox";
 
-// passing Header as a function caused a bug in EditModal
-// where the function was re-defined after each state update
-// which led to a bug where context was lost and a modal button was not working as expected
-// TODO: tech debt issue DT-2384
-
 interface CardProps extends Omit<CardBoxProps, "withRadius"> {
   Header?: React.FC<{ radius: string }> | JSX.Element | null;
   SubHeader?: React.FC<{ radius: string }> | null;

--- a/packages/slice-machine/src/legacy/lib/builders/common/EditModal/index.jsx
+++ b/packages/slice-machine/src/legacy/lib/builders/common/EditModal/index.jsx
@@ -209,7 +209,7 @@ const EditModal = ({ close, data, fields, onSave, zoneType }) => {
               borderFooter
               footerSx={{ position: "sticky", bottom: 0, p: 0 }}
               tabs={tabs}
-              Header={({ radius }) => (
+              Header={
                 <Flex
                   sx={{
                     position: "sticky",
@@ -219,10 +219,11 @@ const EditModal = ({ close, data, fields, onSave, zoneType }) => {
                     bg: "headSection",
                     alignItems: "center",
                     justifyContent: "space-between",
-                    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-assignment
-                    borderTopLeftRadius: radius,
-                    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-                    borderTopRightRadius: radius,
+                    // radius value should match default value in Card component
+                    // hard-coded value is a temporary
+                    // TODO: tech debt issue DT-2384
+                    borderTopLeftRadius: "6px",
+                    borderTopRightRadius: "6px",
                   }}
                 >
                   <ItemHeader
@@ -237,7 +238,7 @@ const EditModal = ({ close, data, fields, onSave, zoneType }) => {
                     type="button"
                   />
                 </Flex>
-              )}
+              }
               Footer={
                 <Flex
                   sx={{


### PR DESCRIPTION
<!-- Please use a Conventional Commit in your PR title -->
<!-- https://conventionalcommits.org -->
<!-- e.g. "feat: support new field type" -->

**Resolves**: [DT-2345](https://linear.app/prismic/issue/DT-2345/add-field-modal-dont-close-one-the-first-click)

### Description
When adding a new field in a a page or custom type in `slice-machine` the edit modal won't close on the first X button click.

The root cause is passing a Header to the Card as a function which gets re-defined after each state update.
This PR is a temporary solution to remove the bug: in order to remove Header as a function radius (that should be passed down to the Header) value was hard-coded.

Tech Debt ticket was created to remove the root issue: [DT-2384](https://linear.app/prismic/issue/DT-2384/tech-debt-aadev-i-can-use-card-component-in-a-predictable-way).

<!-- Describe your changes in detail. -->
<!-- Why is this change required? -->
<!-- What problem does it solve? -->

### Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- Don't hesitate to ask for help! -->

- [ ] If my changes require tests, I added them.
- [ ] If my changes affect backward compatibility, it has been discussed.
- [ ] If my changes require an update to the CONTRIBUTING.md guide, I updated it.

### Preview

BEFORE

https://github.com/user-attachments/assets/d9e3e0d1-aeb9-428e-85c0-6fffc24f97a3

AFTER

https://github.com/user-attachments/assets/843c8f9a-29dc-4e77-bf97-637eec21b7da


<!-- If your changes are visual, screenshots or videos are welcome! -->

### How to QA [^1]

<!-- When relevant, describe how to QA your changes. -->

<!-- Your favorite emoji is welcome to close your PR! -->

<!-- A note for reviewers: -->

[^1]:
	Please use these labels when submitting a review:
	:question: #ask:&ensp;Ask a question.
	:bulb: #idea:&ensp;Suggest an idea.
	:warning: #issue:&ensp;Strongly suggest a change.
	:tada: #nice:&ensp;Share a compliment.