### PR TITLE
[DT-2384] fix: pass radius to card header via react context

### DIFF
--- a/packages/slice-machine/src/legacy/components/AuthInstructions/index.jsx
+++ b/packages/slice-machine/src/legacy/components/AuthInstructions/index.jsx
@@ -1,6 +1,6 @@
 import { Flex, Heading, Text } from "theme-ui";
 
-import Card from "../Card";
+import { Card, useCardRadius } from "../Card";
 
 const AuthInstructions = () => (
   <Card
@@ -8,23 +8,7 @@ const AuthInstructions = () => (
     bg="gray"
     bodySx={{ p: 3 }}
     sx={{ maxWidth: "480px", m: 3 }}
-    Header={({ radius }) => (
-      <Flex
-        sx={{
-          p: 3,
-          pl: 4,
-          bg: "headSection",
-          alignItems: "center",
-          justifyContent: "space-between",
-          borderTopLeftRadius: radius,
-          borderTopRightRadius: radius,
-          // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-          borderBottom: (t) => `1px solid ${t.colors?.borders}`,
-        }}
-      >
-        <Heading as="h3">Log in to Prismic</Heading>
-      </Flex>
-    )}
+    Header={<CardHeader />}
   >
     <Text as="p">
       In order to access your builder, you will need to be connected to Prismic.
@@ -46,4 +30,24 @@ const AuthInstructions = () => (
   </Card>
 );
 
+function CardHeader() {
+  const radius = useCardRadius();
+  return (
+    <Flex
+      sx={{
+        p: 3,
+        pl: 4,
+        bg: "headSection",
+        alignItems: "center",
+        justifyContent: "space-between",
+        borderTopLeftRadius: radius,
+        borderTopRightRadius: radius,
+        // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
+        borderBottom: (t) => `1px solid ${t.colors?.borders}`,
+      }}
+    >
+      <Heading as="h3">Log in to Prismic</Heading>
+    </Flex>
+  );
+}
 export default AuthInstructions;

--- a/packages/slice-machine/src/legacy/components/Card/Default.jsx
+++ b/packages/slice-machine/src/legacy/components/Card/Default.jsx
@@ -1,6 +1,6 @@
 import { Box, Close, Flex } from "theme-ui";
 
-import Card from "./";
+import { Card, useCardRadius } from "./";
 
 const DefaultCard = ({
   children,
@@ -8,35 +8,21 @@ const DefaultCard = ({
   HeaderContent,
   close,
   sx = {},
-  headerSx = {},
 }) => (
   <Card
     borderFooter
     footerSx={{ p: 0 }}
     bodySx={{ pt: 2, pb: 4, px: 4 }}
     sx={{ border: "none", ...sx }}
-    Header={({ radius }) => (
-      <Flex
-        sx={{
-          p: 3,
-          pl: 4,
-          bg: "headSection",
-          alignItems: "center",
-          justifyContent: "space-between",
-          borderTopLeftRadius: radius,
-          borderTopRightRadius: radius,
-          // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-          borderBottom: (t) => `1px solid ${t.colors?.borders}`,
-          ...headerSx,
-        }}
-      >
+    Header={
+      <CardHeader>
         {HeaderContent}
         {
           // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions, @typescript-eslint/no-unsafe-assignment
           close ? <Close onClick={close} type="button" /> : null
         }
-      </Flex>
-    )}
+      </CardHeader>
+    }
     Footer={
       // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
       FooterContent ? (
@@ -51,4 +37,24 @@ const DefaultCard = ({
   </Card>
 );
 
+function CardHeader({ children }) {
+  const radius = useCardRadius();
+  return (
+    <Flex
+      sx={{
+        p: 3,
+        pl: 4,
+        bg: "headSection",
+        alignItems: "center",
+        justifyContent: "space-between",
+        borderTopLeftRadius: radius,
+        borderTopRightRadius: radius,
+        // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
+        borderBottom: (t) => `1px solid ${t.colors?.borders}`,
+      }}
+    >
+      {children}
+    </Flex>
+  );
+}
 export default DefaultCard;

--- a/packages/slice-machine/src/legacy/components/Card/WithTabs/index.jsx
+++ b/packages/slice-machine/src/legacy/components/Card/WithTabs/index.jsx
@@ -2,7 +2,7 @@ import { Children, memo, useState } from "react";
 import { TabPanel, Tabs } from "react-tabs";
 import { Box } from "theme-ui";
 
-import Card from "../";
+import { Card } from "../";
 import { CustomTab as Tab, CustomTabList as TabList } from "./components";
 
 const WithTabs = ({

--- a/packages/slice-machine/src/legacy/components/Card/index.tsx
+++ b/packages/slice-machine/src/legacy/components/Card/index.tsx
@@ -1,11 +1,14 @@
-import React from "react";
+import React, { createContext, useContext } from "react";
 import { Card as ThemeCard, ThemeUIStyleObject } from "theme-ui";
 
 import { CardBox, CardBoxProps } from "./CardBox";
 
+const CardRadiusContext = createContext<string>("6px");
+
+export const useCardRadius = () => useContext(CardRadiusContext);
 interface CardProps extends Omit<CardBoxProps, "withRadius"> {
-  Header?: React.FC<{ radius: string }> | JSX.Element | null;
-  SubHeader?: React.FC<{ radius: string }> | null;
+  Header?: JSX.Element | null;
+  SubHeader?: JSX.Element | null;
   Body?: React.FC | null;
   Footer?: React.FC | JSX.Element | null;
   borderFooter?: boolean;
@@ -13,7 +16,7 @@ interface CardProps extends Omit<CardBoxProps, "withRadius"> {
   footerSx?: ThemeUIStyleObject;
 }
 
-const Card: React.FC<CardProps> = ({
+export const Card: React.FC<CardProps> = ({
   Header = null,
   SubHeader = null,
   Body = null,
@@ -28,47 +31,41 @@ const Card: React.FC<CardProps> = ({
   children,
   ...rest
 }) => (
-  <ThemeCard
-    sx={{
-      border: (t) => `1px solid ${String(t.colors?.borders)}`,
-      borderRadius: radius,
-      ...sx,
-    }}
-    {...rest}
-  >
-    {Header ? (
-      typeof Header === "object" ? (
-        Header
-      ) : (
-        <Header radius={radius} />
-      )
-    ) : null}
-    {SubHeader ? <SubHeader radius={radius} /> : null}
-    <CardBox bg={bg} background={background} sx={bodySx} withRadius={!Footer}>
-      {Body ? <Body /> : null}
-      {/* eslint-disable-next-line @typescript-eslint/strict-boolean-expressions */}
-      {children ? children : null}
-    </CardBox>
-    {Footer ? (
-      <CardBox
-        bg={bg}
-        background={background}
-        sx={{
-          ...(borderFooter
-            ? {
-                borderTop: ({ colors }) =>
-                  `1px solid ${String(colors?.borders)}`,
-              }
-            : null),
-          ...footerSx,
-        }}
-        radius={radius}
-        withRadius
-      >
-        {typeof Footer === "object" ? Footer : <Footer />}
+  <CardRadiusContext.Provider value={radius}>
+    <ThemeCard
+      sx={{
+        border: (t) => `1px solid ${String(t.colors?.borders)}`,
+        borderRadius: radius,
+        ...sx,
+      }}
+      {...rest}
+    >
+      {Header ? Header : null}
+      {SubHeader ? SubHeader : null}
+      <CardBox bg={bg} background={background} sx={bodySx} withRadius={!Footer}>
+        {Body ? <Body /> : null}
+        {/* eslint-disable-next-line @typescript-eslint/strict-boolean-expressions */}
+        {children ? children : null}
       </CardBox>
-    ) : null}
-  </ThemeCard>
+      {Footer ? (
+        <CardBox
+          bg={bg}
+          background={background}
+          sx={{
+            ...(borderFooter
+              ? {
+                  borderTop: ({ colors }) =>
+                    `1px solid ${String(colors?.borders)}`,
+                }
+              : null),
+            ...footerSx,
+          }}
+          radius={radius}
+          withRadius
+        >
+          {typeof Footer === "object" ? Footer : <Footer />}
+        </CardBox>
+      ) : null}
+    </ThemeCard>
+  </CardRadiusContext.Provider>
 );
-
-export default Card;

--- a/packages/slice-machine/src/legacy/components/ConfigErrors/index.jsx
+++ b/packages/slice-machine/src/legacy/components/ConfigErrors/index.jsx
@@ -1,30 +1,10 @@
 import { Box, Flex, Heading, Text } from "theme-ui";
 
-import Card from "@/legacy/components/Card";
+import { Card, useCardRadius } from "@/legacy/components/Card";
 import Li from "@/legacy/components/Li";
 
 const ConfigErrors = ({ errors }) => (
-  <Card
-    bg="background"
-    bodySx={{ p: 3 }}
-    Header={({ radius }) => (
-      <Flex
-        sx={{
-          p: 3,
-          alignItems: "center",
-          justifyContent: "space-between",
-          borderTopLeftRadius: radius,
-          borderTopRightRadius: radius,
-          // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-          borderBottom: (t) => `1px solid ${t.colors?.borders}`,
-        }}
-      >
-        <Heading as="h3">
-          Your slicemachine.config.json file contains errors
-        </Heading>
-      </Flex>
-    )}
-  >
+  <Card bg="background" bodySx={{ p: 3 }} Header={<CardHeader />}>
     {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
       Object.entries(errors).map(([key, value]) => (
@@ -64,5 +44,26 @@ const ConfigErrors = ({ errors }) => (
     }
   </Card>
 );
+
+function CardHeader() {
+  const radius = useCardRadius();
+  return (
+    <Flex
+      sx={{
+        p: 3,
+        alignItems: "center",
+        justifyContent: "space-between",
+        borderTopLeftRadius: radius,
+        borderTopRightRadius: radius,
+        // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
+        borderBottom: (t) => `1px solid ${t.colors?.borders}`,
+      }}
+    >
+      <Heading as="h3">
+        Your slicemachine.config.json file contains errors
+      </Heading>
+    </Flex>
+  );
+}
 
 export default ConfigErrors;

--- a/packages/slice-machine/src/legacy/components/DeleteCTModal/index.tsx
+++ b/packages/slice-machine/src/legacy/components/DeleteCTModal/index.tsx
@@ -7,7 +7,7 @@ import { Close, Flex, Heading, Text, useThemeUI } from "theme-ui";
 import { deleteCustomType } from "@/features/customTypes/actions/deleteCustomType";
 import { CUSTOM_TYPES_MESSAGES } from "@/features/customTypes/customTypesMessages";
 import { Button } from "@/legacy/components/Button";
-import Card from "@/legacy/components/Card";
+import { Card } from "@/legacy/components/Card";
 import SliceMachineModal from "@/legacy/components/SliceMachineModal";
 import useSliceMachineActions from "@/modules/useSliceMachineActions";
 
@@ -64,7 +64,7 @@ export const DeleteCustomTypeModal: React.FunctionComponent<
         }}
         sx={{ border: "none", overflow: "hidden" }}
         borderFooter
-        Header={() => (
+        Header={
           <Flex
             sx={{
               position: "sticky",
@@ -88,7 +88,7 @@ export const DeleteCustomTypeModal: React.FunctionComponent<
             </Flex>
             <Close type="button" onClick={() => onClose()} />
           </Flex>
-        )}
+        }
         Footer={() => (
           <Flex
             sx={{

--- a/packages/slice-machine/src/legacy/components/DeleteSliceModal/index.tsx
+++ b/packages/slice-machine/src/legacy/components/DeleteSliceModal/index.tsx
@@ -5,7 +5,7 @@ import { Close, Flex, Heading, Paragraph, Text, useThemeUI } from "theme-ui";
 import { deleteSlice } from "@/features/slices/actions/deleteSlice";
 import { useAutoSync } from "@/features/sync/AutoSyncProvider";
 import { Button } from "@/legacy/components/Button";
-import Card from "@/legacy/components/Card";
+import { Card } from "@/legacy/components/Card";
 import SliceMachineModal from "@/legacy/components/SliceMachineModal";
 import useSliceMachineActions from "@/modules/useSliceMachineActions";
 
@@ -68,7 +68,7 @@ export const DeleteSliceModal: React.FunctionComponent<
         }}
         sx={{ border: "none" }}
         borderFooter
-        Header={() => (
+        Header={
           <Flex
             sx={{
               position: "sticky",
@@ -92,7 +92,7 @@ export const DeleteSliceModal: React.FunctionComponent<
             </Flex>
             <Close type="button" onClick={onClose} />
           </Flex>
-        )}
+        }
         Footer={() => (
           <Flex
             sx={{

--- a/packages/slice-machine/src/legacy/components/ModalFormCard/index.tsx
+++ b/packages/slice-machine/src/legacy/components/ModalFormCard/index.tsx
@@ -17,7 +17,7 @@ import { Button as ThemeButton, Close, Flex, Heading } from "theme-ui";
 import { Button } from "@/legacy/components/Button";
 import SliceMachineModal from "@/legacy/components/SliceMachineModal";
 
-import Card from "../Card";
+import { Card, useCardRadius } from "../Card";
 
 type ModalCardProps<T extends FormikValues> = {
   children: (props: {
@@ -120,27 +120,12 @@ function ModalCard<Values extends FormikValues>({
                 bodySx={{ px: 4, py: 4 }}
                 sx={{ border: "none" }}
                 {...cardProps}
-                Header={({ radius }: { radius: string | number }) => (
-                  <Flex
-                    sx={{
-                      position: "sticky",
-                      top: 0,
-                      zIndex: 1,
-                      p: "16px",
-                      pl: 4,
-                      bg: "headSection",
-                      alignItems: "center",
-                      justifyContent: "space-between",
-                      borderTopLeftRadius: radius,
-                      borderTopRightRadius: radius,
-                      // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-                      borderBottom: (t) => `1px solid ${t.colors?.borders}`,
-                    }}
-                  >
+                Header={
+                  <CardHeader>
                     <Heading sx={{ fontSize: "20px" }}>{title}</Heading>
                     <Close type="button" onClick={close} />
-                  </Flex>
-                )}
+                  </CardHeader>
+                }
                 Footer={
                   !omitFooter ? (
                     <Flex
@@ -197,6 +182,30 @@ function ModalCard<Values extends FormikValues>({
         }}
       </Formik>
     </SliceMachineModal>
+  );
+}
+
+function CardHeader({ children }: { children: ReactNode }) {
+  const radius = useCardRadius();
+  return (
+    <Flex
+      sx={{
+        position: "sticky",
+        top: 0,
+        zIndex: 1,
+        p: "16px",
+        pl: 4,
+        bg: "headSection",
+        alignItems: "center",
+        justifyContent: "space-between",
+        borderTopLeftRadius: radius,
+        borderTopRightRadius: radius,
+        // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
+        borderBottom: (t) => `1px solid ${t.colors?.borders}`,
+      }}
+    >
+      {children}
+    </Flex>
   );
 }
 

--- a/packages/slice-machine/src/legacy/components/ScreenshotChangesModal/index.tsx
+++ b/packages/slice-machine/src/legacy/components/ScreenshotChangesModal/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { ReactNode, useEffect, useState } from "react";
 import { AiOutlinePicture } from "react-icons/ai";
 import { RiErrorWarningLine } from "react-icons/ri";
 import { useSelector } from "react-redux";
@@ -6,7 +6,7 @@ import { Box, Close, Flex, Heading, Text } from "theme-ui";
 
 import { Kbd } from "@/components/Kbd";
 import { FigmaIcon } from "@/icons/FigmaIcon";
-import Card from "@/legacy/components/Card";
+import { Card, useCardRadius } from "@/legacy/components/Card";
 import SliceMachineModal from "@/legacy/components/SliceMachineModal";
 import { ComponentUI } from "@/legacy/lib/models/common/ComponentUI";
 import { isModalOpen } from "@/modules/modal";
@@ -207,25 +207,12 @@ const ScreenshotChangesModal = ({
         radius={"0px"}
         bodySx={{ p: 0, bg: "#FFF", position: "relative" }}
         sx={{ border: "none" }}
-        Header={({ radius }: { radius: string | number }) => (
-          <Flex
-            sx={{
-              position: "sticky",
-              top: 0,
-              zIndex: 1,
-              background: "gray",
-              p: "16px",
-              alignItems: "center",
-              justifyContent: "space-between",
-              borderTopLeftRadius: radius,
-              borderTopRightRadius: radius,
-              borderBottom: (t) => `1px solid ${String(t.colors?.borders)}`,
-            }}
-          >
+        Header={
+          <CardHeader>
             <Heading sx={{ fontSize: "20px" }}>Slice screenshots</Heading>
             <Close type="button" onClick={() => closeModals()} />
-          </Flex>
-        )}
+          </CardHeader>
+        }
         Footer={null}
       >
         <Box
@@ -284,5 +271,27 @@ const ScreenshotChangesModal = ({
     </SliceMachineModal>
   );
 };
+
+function CardHeader({ children }: { children: ReactNode }) {
+  const radius = useCardRadius();
+  return (
+    <Flex
+      sx={{
+        position: "sticky",
+        top: 0,
+        zIndex: 1,
+        background: "gray",
+        p: "16px",
+        alignItems: "center",
+        justifyContent: "space-between",
+        borderTopLeftRadius: radius,
+        borderTopRightRadius: radius,
+        borderBottom: (t) => `1px solid ${String(t.colors?.borders)}`,
+      }}
+    >
+      {children}
+    </Flex>
+  );
+}
 
 export default ScreenshotChangesModal;

--- a/packages/slice-machine/src/legacy/components/ScreenshotPreviewModal/index.tsx
+++ b/packages/slice-machine/src/legacy/components/ScreenshotPreviewModal/index.tsx
@@ -1,7 +1,7 @@
 import { useSelector } from "react-redux";
 import { Button, Close, Flex, Heading } from "theme-ui";
 
-import Card from "@/legacy/components/Card";
+import { Card } from "@/legacy/components/Card";
 import { ScreenshotPreview } from "@/legacy/components/ScreenshotPreview";
 import SliceMachineModal from "@/legacy/components/SliceMachineModal";
 import { isModalOpen } from "@/modules/modal";
@@ -53,7 +53,7 @@ const ScreenshotPreviewModal: React.FunctionComponent<ScreenshotModalProps> = ({
           p: 0,
         }}
         sx={{ border: "none" }}
-        Header={() => (
+        Header={
           <Flex
             sx={{
               position: "sticky",
@@ -70,7 +70,7 @@ const ScreenshotPreviewModal: React.FunctionComponent<ScreenshotModalProps> = ({
             </Heading>
             <Close type="button" onClick={() => closeModals()} />
           </Flex>
-        )}
+        }
         Footer={() => (
           <Flex
             style={{

--- a/packages/slice-machine/src/legacy/components/SliceMachineDrawer/index.tsx
+++ b/packages/slice-machine/src/legacy/components/SliceMachineDrawer/index.tsx
@@ -2,7 +2,7 @@ import Drawer from "rc-drawer";
 import React from "react";
 import { Close, Flex, Heading } from "theme-ui";
 
-import Card from "@/legacy/components/Card";
+import { Card } from "@/legacy/components/Card";
 
 export const SliceMachineDrawerUI: React.FunctionComponent<{
   isOpen: boolean;
@@ -39,7 +39,7 @@ export const SliceMachineDrawerUI: React.FunctionComponent<{
           border: "none",
         }}
         borderFooter
-        Header={() => (
+        Header={
           <Flex
             sx={{
               p: "16px",
@@ -55,7 +55,7 @@ export const SliceMachineDrawerUI: React.FunctionComponent<{
             </Flex>
             <Close type="button" onClick={() => onClose()} />
           </Flex>
-        )}
+        }
         Footer={() => (
           <Flex
             sx={{

--- a/packages/slice-machine/src/legacy/components/Warnings/index.jsx
+++ b/packages/slice-machine/src/legacy/components/Warnings/index.jsx
@@ -1,12 +1,11 @@
 import { Flex, Heading, Text } from "theme-ui";
 
-import Card from "../Card";
+import { Card, useCardRadius } from "../Card";
 
-export const ClientError = ({ errorType }) => (
-  <Card
-    bg="background"
-    bodySx={{ p: 3 }}
-    Header={({ radius }) => (
+export const ClientError = ({ errorType }) => {
+  function CardHeader() {
+    const radius = useCardRadius();
+    return (
       <Flex
         sx={{
           p: 3,
@@ -20,30 +19,33 @@ export const ClientError = ({ errorType }) => (
       >
         <Heading as="h3">Unable to fetch remote slices</Heading>
       </Flex>
-    )}
-  >
-    <Text as="p" mt={1}>
-      This error probably means that you are not connected to Prismic or that
-      your `prismic-auth` token is outdated.
-    </Text>
-    <Text as="p">
-      To generate a new token, type `prismic login` in your CLI. This message
-      you should disappear instantly.
-    </Text>
-    <Text as="p" mt={4}>
-      If the problem persists, check that your `slicemachine.config.json` file
-      points to the right API endpoint.
-      <br />
-      Full error: {errorType}
-    </Text>
-  </Card>
-);
+    );
+  }
 
-export const NotConnected = () => (
-  <Card
-    bg="background"
-    bodySx={{ p: 3 }}
-    Header={({ radius }) => (
+  return (
+    <Card bg="background" bodySx={{ p: 3 }} Header={CardHeader}>
+      <Text as="p" mt={1}>
+        This error probably means that you are not connected to Prismic or that
+        your `prismic-auth` token is outdated.
+      </Text>
+      <Text as="p">
+        To generate a new token, type `prismic login` in your CLI. This message
+        you should disappear instantly.
+      </Text>
+      <Text as="p" mt={4}>
+        If the problem persists, check that your `slicemachine.config.json` file
+        points to the right API endpoint.
+        <br />
+        Full error: {errorType}
+      </Text>
+    </Card>
+  );
+};
+
+export const NotConnected = () => {
+  function CardHeader() {
+    const radius = useCardRadius();
+    return (
       <Flex
         sx={{
           p: 3,
@@ -58,20 +60,23 @@ export const NotConnected = () => (
       >
         <Heading as="h3">You're not logged in</Heading>
       </Flex>
-    )}
-  >
-    <Text as="p">
-      In order to push your slices to your Shared Slices bucket, you will need
-      to be connected to Prismic. If you haven't already created a project,
-      please <b>run the setup command</b> first:
-      <Text variant="pre">prismic sm --setup</Text>
-      <Text mt={1}>
-        👆 This needs to be done inside a valid Next/Nuxt project.
+    );
+  }
+  return (
+    <Card bg="background" bodySx={{ p: 3 }} Header={CardHeader}>
+      <Text as="p">
+        In order to push your slices to your Shared Slices bucket, you will need
+        to be connected to Prismic. If you haven't already created a project,
+        please <b>run the setup command</b> first:
+        <Text variant="pre">prismic sm --setup</Text>
+        <Text mt={1}>
+          👆 This needs to be done inside a valid Next/Nuxt project.
+        </Text>
+        <Text mt={3}>
+          <b>Otherwise, simply run:</b>
+        </Text>
+        <Text mt={1}>prismic login</Text>
       </Text>
-      <Text mt={3}>
-        <b>Otherwise, simply run:</b>
-      </Text>
-      <Text mt={1}>prismic login</Text>
-    </Text>
-  </Card>
-);
+    </Card>
+  );
+};

--- a/packages/slice-machine/src/legacy/lib/builders/CustomTypeBuilder/SliceZone/DeleteSliceZoneModal.tsx
+++ b/packages/slice-machine/src/legacy/lib/builders/CustomTypeBuilder/SliceZone/DeleteSliceZoneModal.tsx
@@ -2,7 +2,7 @@ import { FC } from "react";
 import { Close, Flex, Heading, Paragraph } from "theme-ui";
 
 import { Button } from "@/legacy/components/Button";
-import Card from "@/legacy/components/Card";
+import { Card } from "@/legacy/components/Card";
 import SliceMachineModal from "@/legacy/components/SliceMachineModal";
 
 type DeleteSliceZoneModalProps = {
@@ -40,7 +40,7 @@ export const DeleteSliceZoneModal: FC<DeleteSliceZoneModalProps> = ({
         }}
         sx={{ border: "none", overflow: "hidden" }}
         borderFooter
-        Header={() => (
+        Header={
           <Flex
             sx={{
               position: "sticky",
@@ -57,7 +57,7 @@ export const DeleteSliceZoneModal: FC<DeleteSliceZoneModalProps> = ({
             </Heading>
             <Close type="button" onClick={closeDeleteSliceZoneModal} />
           </Flex>
-        )}
+        }
         Footer={() => (
           <Flex
             sx={{

--- a/packages/slice-machine/src/legacy/lib/builders/common/EditModal/index.jsx
+++ b/packages/slice-machine/src/legacy/lib/builders/common/EditModal/index.jsx
@@ -2,6 +2,7 @@ import Modal from "react-modal";
 import { Box, Button, Close, Flex, useThemeUI } from "theme-ui";
 import * as yup from "yup";
 
+import { useCardRadius } from "@/legacy/components/Card";
 import Card from "@/legacy/components/Card/WithTabs";
 import { Col, Flex as FlexGrid } from "@/legacy/components/Flex";
 import ItemHeader from "@/legacy/components/ItemHeader";
@@ -210,22 +211,7 @@ const EditModal = ({ close, data, fields, onSave, zoneType }) => {
               footerSx={{ position: "sticky", bottom: 0, p: 0 }}
               tabs={tabs}
               Header={
-                <Flex
-                  sx={{
-                    position: "sticky",
-                    zIndex: 1,
-                    top: 0,
-                    p: 3,
-                    bg: "headSection",
-                    alignItems: "center",
-                    justifyContent: "space-between",
-                    // radius value should match default value in Card component
-                    // hard-coded value is a temporary
-                    // TODO: tech debt issue DT-2384
-                    borderTopLeftRadius: "6px",
-                    borderTopRightRadius: "6px",
-                  }}
-                >
+                <CardHeader>
                   <ItemHeader
                     theme={theme}
                     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/strict-boolean-expressions
@@ -237,7 +223,7 @@ const EditModal = ({ close, data, fields, onSave, zoneType }) => {
                     onClick={close}
                     type="button"
                   />
-                </Flex>
+                </CardHeader>
               }
               Footer={
                 <Flex
@@ -285,5 +271,26 @@ const EditModal = ({ close, data, fields, onSave, zoneType }) => {
     </SliceMachineModal>
   );
 };
+
+function CardHeader({ children }) {
+  const radius = useCardRadius();
+  return (
+    <Flex
+      sx={{
+        position: "sticky",
+        zIndex: 1,
+        top: 0,
+        p: 3,
+        bg: "headSection",
+        alignItems: "center",
+        justifyContent: "space-between",
+        borderTopLeftRadius: radius,
+        borderTopRightRadius: radius,
+      }}
+    >
+      {children}
+    </Flex>
+  );
+}
 
 export default EditModal;


### PR DESCRIPTION
<!-- Please use a Conventional Commit in your PR title -->
<!-- https://conventionalcommits.org -->
<!-- e.g. "feat: support new field type" -->

**Resolves**: [DT-2384](https://linear.app/prismic/issue/DT-2384/tech-debt-aadev-i-can-use-card-component-in-a-predictable-way)

### Description

Continuation and fix for temporary solution in this [PR](https://github.com/prismicio/slice-machine/pull/1465).

In order to prevent passing inline Header component to the Card, radius of the Header is now passed down via react context.

<!-- Describe your changes in detail. -->
<!-- Why is this change required? -->
<!-- What problem does it solve? -->

### Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- Don't hesitate to ask for help! -->

- [ ] If my changes require tests, I added them.
- [ ] If my changes affect backward compatibility, it has been discussed.
- [ ] If my changes require an update to the CONTRIBUTING.md guide, I updated it.

### Preview

<!-- If your changes are visual, screenshots or videos are welcome! -->

### How to QA [^1]

<!-- When relevant, describe how to QA your changes. -->

<!-- Your favorite emoji is welcome to close your PR! -->

<!-- A note for reviewers: -->

[^1]:
	Please use these labels when submitting a review:
	:question: #ask:&ensp;Ask a question.
	:bulb: #idea:&ensp;Suggest an idea.
	:warning: #issue:&ensp;Strongly suggest a change.
	:tada: #nice:&ensp;Share a compliment.