### PR TITLE
fix(adapter-next): async access to `params` and `searchParams` in Next.js 15

### DIFF
--- a/packages/adapter-next/src/hooks/documentation-read.ts
+++ b/packages/adapter-next/src/hooks/documentation-read.ts
@@ -41,10 +41,10 @@ export const documentationRead: DocumentationReadHook<PluginOptions> = async (
 
 					type Params = { uid: string };
 
-					export default async function Page({ params }: { params: Params }) {
+					export default async function Page({ params }: { params: Promise<Params> }) {
 						const client = createClient();
 						const page = await client
-							.getByUID("${model.id}", params.uid)
+							.getByUID("${model.id}", (await params).uid)
 							.catch(() => notFound());
 
 						return <SliceZone slices={page.data.slices} components={components} />;
@@ -53,11 +53,11 @@ export const documentationRead: DocumentationReadHook<PluginOptions> = async (
 					export async function generateMetadata({
 						params,
 					}: {
-						params: Params;
+						params: Promise<Params>;
 					}): Promise<Metadata> {
 						const client = createClient();
 						const page = await client
-							.getByUID("${model.id}", params.uid)
+							.getByUID("${model.id}", (await params).uid)
 							.catch(() => notFound());
 
 						return {
@@ -207,7 +207,7 @@ export const documentationRead: DocumentationReadHook<PluginOptions> = async (
 					export default async function Page({ params }) {
 						const client = createClient();
 						const page = await client
-							.getByUID("${model.id}", params.uid)
+							.getByUID("${model.id}", (await params).uid)
 							.catch(() => notFound());
 
 						return <SliceZone slices={page.data.slices} components={components} />;
@@ -216,7 +216,7 @@ export const documentationRead: DocumentationReadHook<PluginOptions> = async (
 					export async function generateMetadata({ params }) {
 						const client = createClient();
 						const page = await client
-							.getByUID("${model.id}", params.uid)
+							.getByUID("${model.id}", (await params).uid)
 							.catch(() => notFound());
 
 						return {

--- a/packages/adapter-next/src/hooks/documentation-read.ts
+++ b/packages/adapter-next/src/hooks/documentation-read.ts
@@ -42,9 +42,10 @@ export const documentationRead: DocumentationReadHook<PluginOptions> = async (
 					type Params = { uid: string };
 
 					export default async function Page({ params }: { params: Promise<Params> }) {
+						const { uid } = await params
 						const client = createClient();
 						const page = await client
-							.getByUID("${model.id}", (await params).uid)
+							.getByUID("${model.id}", uid)
 							.catch(() => notFound());
 
 						return <SliceZone slices={page.data.slices} components={components} />;
@@ -55,9 +56,10 @@ export const documentationRead: DocumentationReadHook<PluginOptions> = async (
 					}: {
 						params: Promise<Params>;
 					}): Promise<Metadata> {
+						const { uid } = await params
 						const client = createClient();
 						const page = await client
-							.getByUID("${model.id}", (await params).uid)
+							.getByUID("${model.id}", uid)
 							.catch(() => notFound());
 
 						return {
@@ -205,18 +207,20 @@ export const documentationRead: DocumentationReadHook<PluginOptions> = async (
 
 
 					export default async function Page({ params }) {
+						const { uid } = await params
 						const client = createClient();
 						const page = await client
-							.getByUID("${model.id}", (await params).uid)
+							.getByUID("${model.id}", uid)
 							.catch(() => notFound());
 
 						return <SliceZone slices={page.data.slices} components={components} />;
 					}
 
 					export async function generateMetadata({ params }) {
+						const { uid } = await params
 						const client = createClient();
 						const page = await client
-							.getByUID("${model.id}", (await params).uid)
+							.getByUID("${model.id}", uid)
 							.catch(() => notFound());
 
 						return {

--- a/packages/adapter-next/src/hooks/project-init.ts
+++ b/packages/adapter-next/src/hooks/project-init.ts
@@ -287,7 +287,8 @@ const createSliceSimulatorPage = async ({
 				export default async function SliceSimulatorPage({
 					searchParams,
 				}: SliceSimulatorParams) {
-					const slices = getSlices((await searchParams).state);
+					const { state } = await searchParams
+					const slices = getSlices(state);
 
 					return (
 						<SliceSimulator>
@@ -307,7 +308,8 @@ const createSliceSimulatorPage = async ({
 				import { components } from "../../slices";
 
 				export default async function SliceSimulatorPage({ searchParams }) {
-					const slices = getSlices((await searchParams).state);
+					const { state } = await searchParams
+					const slices = getSlices(state);
 
 					return (
 						<SliceSimulator>

--- a/packages/adapter-next/src/hooks/project-init.ts
+++ b/packages/adapter-next/src/hooks/project-init.ts
@@ -284,10 +284,10 @@ const createSliceSimulatorPage = async ({
 
 				import { components } from "../../slices";
 
-				export default function SliceSimulatorPage({
+				export default async function SliceSimulatorPage({
 					searchParams,
 				}: SliceSimulatorParams) {
-					const slices = getSlices(searchParams.state);
+					const slices = getSlices((await searchParams).state);
 
 					return (
 						<SliceSimulator>
@@ -306,8 +306,8 @@ const createSliceSimulatorPage = async ({
 
 				import { components } from "../../slices";
 
-				export default function SliceSimulatorPage({ searchParams }) {
-					const slices = getSlices(searchParams.state);
+				export default async function SliceSimulatorPage({ searchParams }) {
+					const slices = getSlices((await searchParams).state);
 
 					return (
 						<SliceSimulator>

--- a/packages/adapter-next/src/simulator/types.ts
+++ b/packages/adapter-next/src/simulator/types.ts
@@ -5,7 +5,7 @@
  * Server Component.
  */
 export type SliceSimulatorParams = {
-	searchParams: {
+	searchParams: Promise<{
 		state?: string;
-	};
+	}>;
 };

--- a/packages/adapter-next/test/__snapshots__/plugin-documentation-read.test.ts.snap
+++ b/packages/adapter-next/test/__snapshots__/plugin-documentation-read.test.ts.snap
@@ -18,7 +18,7 @@ import { components } from \\"@/slices\\";
 export default async function Page({ params }) {
   const client = createClient();
   const page = await client
-    .getByUID(\\"foo_bar\\", params.uid)
+    .getByUID(\\"foo_bar\\", (await params).uid)
     .catch(() => notFound());
 
   return <SliceZone slices={page.data.slices} components={components} />;
@@ -27,7 +27,7 @@ export default async function Page({ params }) {
 export async function generateMetadata({ params }) {
   const client = createClient();
   const page = await client
-    .getByUID(\\"foo_bar\\", params.uid)
+    .getByUID(\\"foo_bar\\", (await params).uid)
     .catch(() => notFound());
 
   return {
@@ -69,10 +69,10 @@ import { components } from \\"@/slices\\";
 
 type Params = { uid: string };
 
-export default async function Page({ params }: { params: Params }) {
+export default async function Page({ params }: { params: Promise<Params> }) {
   const client = createClient();
   const page = await client
-    .getByUID(\\"foo_bar\\", params.uid)
+    .getByUID(\\"foo_bar\\", (await params).uid)
     .catch(() => notFound());
 
   return <SliceZone slices={page.data.slices} components={components} />;
@@ -81,11 +81,11 @@ export default async function Page({ params }: { params: Params }) {
 export async function generateMetadata({
   params,
 }: {
-  params: Params;
+  params: Promise<Params>;
 }): Promise<Metadata> {
   const client = createClient();
   const page = await client
-    .getByUID(\\"foo_bar\\", params.uid)
+    .getByUID(\\"foo_bar\\", (await params).uid)
     .catch(() => notFound());
 
   return {

--- a/packages/adapter-next/test/__snapshots__/plugin-documentation-read.test.ts.snap
+++ b/packages/adapter-next/test/__snapshots__/plugin-documentation-read.test.ts.snap
@@ -16,19 +16,17 @@ import { createClient } from \\"@/prismicio\\";
 import { components } from \\"@/slices\\";
 
 export default async function Page({ params }) {
+  const { uid } = await params;
   const client = createClient();
-  const page = await client
-    .getByUID(\\"foo_bar\\", (await params).uid)
-    .catch(() => notFound());
+  const page = await client.getByUID(\\"foo_bar\\", uid).catch(() => notFound());
 
   return <SliceZone slices={page.data.slices} components={components} />;
 }
 
 export async function generateMetadata({ params }) {
+  const { uid } = await params;
   const client = createClient();
-  const page = await client
-    .getByUID(\\"foo_bar\\", (await params).uid)
-    .catch(() => notFound());
+  const page = await client.getByUID(\\"foo_bar\\", uid).catch(() => notFound());
 
   return {
     title: page.data.meta_title,
@@ -70,10 +68,9 @@ import { components } from \\"@/slices\\";
 type Params = { uid: string };
 
 export default async function Page({ params }: { params: Promise<Params> }) {
+  const { uid } = await params;
   const client = createClient();
-  const page = await client
-    .getByUID(\\"foo_bar\\", (await params).uid)
-    .catch(() => notFound());
+  const page = await client.getByUID(\\"foo_bar\\", uid).catch(() => notFound());
 
   return <SliceZone slices={page.data.slices} components={components} />;
 }
@@ -83,10 +80,9 @@ export async function generateMetadata({
 }: {
   params: Promise<Params>;
 }): Promise<Metadata> {
+  const { uid } = await params;
   const client = createClient();
-  const page = await client
-    .getByUID(\\"foo_bar\\", (await params).uid)
-    .catch(() => notFound());
+  const page = await client.getByUID(\\"foo_bar\\", uid).catch(() => notFound());
 
   return {
     title: page.data.meta_title,

--- a/packages/adapter-next/test/plugin-project-init.test.ts
+++ b/packages/adapter-next/test/plugin-project-init.test.ts
@@ -850,8 +850,8 @@ describe("Slice Simulator route", () => {
 
 				import { components } from \\"../../slices\\";
 
-				export default function SliceSimulatorPage({ searchParams }) {
-				  const slices = getSlices(searchParams.state);
+				export default async function SliceSimulatorPage({ searchParams }) {
+				  const slices = getSlices((await searchParams).state);
 
 				  return (
 				    <SliceSimulator>
@@ -915,8 +915,8 @@ describe("Slice Simulator route", () => {
 
 				import { components } from \\"../../slices\\";
 
-				export default function SliceSimulatorPage({ searchParams }) {
-				  const slices = getSlices(searchParams.state);
+				export default async function SliceSimulatorPage({ searchParams }) {
+				  const slices = getSlices((await searchParams).state);
 
 				  return (
 				    <SliceSimulator>
@@ -1012,10 +1012,10 @@ describe("Slice Simulator route", () => {
 
 				import { components } from \\"../../slices\\";
 
-				export default function SliceSimulatorPage({
+				export default async function SliceSimulatorPage({
 				  searchParams,
 				}: SliceSimulatorParams) {
-				  const slices = getSlices(searchParams.state);
+				  const slices = getSlices((await searchParams).state);
 
 				  return (
 				    <SliceSimulator>

--- a/packages/adapter-next/test/plugin-project-init.test.ts
+++ b/packages/adapter-next/test/plugin-project-init.test.ts
@@ -851,7 +851,8 @@ describe("Slice Simulator route", () => {
 				import { components } from \\"../../slices\\";
 
 				export default async function SliceSimulatorPage({ searchParams }) {
-				  const slices = getSlices((await searchParams).state);
+				  const { state } = await searchParams;
+				  const slices = getSlices(state);
 
 				  return (
 				    <SliceSimulator>
@@ -916,7 +917,8 @@ describe("Slice Simulator route", () => {
 				import { components } from \\"../../slices\\";
 
 				export default async function SliceSimulatorPage({ searchParams }) {
-				  const slices = getSlices((await searchParams).state);
+				  const { state } = await searchParams;
+				  const slices = getSlices(state);
 
 				  return (
 				    <SliceSimulator>
@@ -1015,7 +1017,8 @@ describe("Slice Simulator route", () => {
 				export default async function SliceSimulatorPage({
 				  searchParams,
 				}: SliceSimulatorParams) {
-				  const slices = getSlices((await searchParams).state);
+				  const { state } = await searchParams;
+				  const slices = getSlices(state);
 
 				  return (
 				    <SliceSimulator>


### PR DESCRIPTION
<!-- Please use a Conventional Commit in your PR title -->
<!-- https://conventionalcommits.org -->
<!-- e.g. "feat: support new field type" -->

**Resolves**: https://community.prismic.io/t/nextjs-15-and-draftmode/17855

### Description

This PR updates `@slicemachine/adapter-next` to support async access to a page's `params` and `searchParams` props. The props are now wrapped in a `Promise` [as of Next.js 15](https://nextjs.org/blog/next-15#async-request-apis-breaking-change).

This change works in Next.js 13-15 with the App Router. The `Promise` wrappers are technically incorrect in Next.js 13 and 14, but it shouldn't break projects.

Projects using the App Router should be updating to the latest Next.js version as regular maintenance, reducing the effect of a slightly incorrect type.

### Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- Don't hesitate to ask for help! -->

- [x] If my changes require tests, I added them.
- [x] If my changes affect backward compatibility, it has been discussed.
- [ ] If my changes require an update to the CONTRIBUTING.md guide, I updated it.

### Preview

<!-- If your changes are visual, screenshots or videos are welcome! -->

N/A

### How to QA [^1]

1. Set up:

   ```sh
   npx create-next-app@latest
   cd my-app
   npx @slicemachine/init@alpha.aa-nextjs-15
   ```

1. Add a slice.

1. Add a page and its code.

1. Confirm slice simulator works in the repo (testing the changes to `searchParams`).

1. Confirm pages render correctly (testing changes to `params`).

1. Confirm page previews work (testing previews don't break any of the above).

<!-- Your favorite emoji is welcome to close your PR! -->

<!-- A note for reviewers: -->

[^1]:
    Please use these labels when submitting a review:
    :question: #ask:&ensp;Ask a question.
    :bulb: #idea:&ensp;Suggest an idea.
    :warning: #issue:&ensp;Strongly suggest a change.
    :tada: #nice:&ensp;Share a compliment.
