### PR TITLE
[DT-2939] fix: reordering fields on repeatable pages

### DIFF
--- a/packages/slice-machine/src/domain/__tests__/customType.test.ts
+++ b/packages/slice-machine/src/domain/__tests__/customType.test.ts
@@ -582,6 +582,73 @@ describe("CustomTypeModel test suite", () => {
     );
   });
 
+  it("reorderField should exclude UID field from reordering on repeatable page type", () => {
+    expect(
+      JSON.stringify(
+        CustomTypeModel.reorderField({
+          customType: {
+            ...mockCustomType,
+            format: "page",
+            json: {
+              mainSection: {
+                uid: {
+                  config: {
+                    label: "MainSectionField",
+                  },
+                  type: "UID",
+                },
+                booleanField: {
+                  config: {
+                    label: "BooleanField",
+                  },
+                  type: "Boolean",
+                },
+                textField: {
+                  config: {
+                    label: "TextField",
+                  },
+                  type: "Text",
+                },
+              },
+              anotherSection,
+            },
+          },
+          sectionId: "mainSection",
+          sourceIndex: 0,
+          destinationIndex: 1,
+        }),
+      ),
+    ).toEqual(
+      JSON.stringify({
+        ...mockCustomType,
+        format: "page",
+        json: {
+          mainSection: {
+            uid: {
+              config: {
+                label: "MainSectionField",
+              },
+              type: "UID",
+            },
+            textField: {
+              config: {
+                label: "TextField",
+              },
+              type: "Text",
+            },
+            booleanField: {
+              config: {
+                label: "BooleanField",
+              },
+              type: "Boolean",
+            },
+          },
+          anotherSection,
+        },
+      }),
+    );
+  });
+
   it("addUIDField should return the given custom type with the uid field (with default placeholder) added to the first section", () => {
     expect(
       CustomTypeModel.addUIDField("UID label", {

--- a/packages/slice-machine/src/domain/customType.ts
+++ b/packages/slice-machine/src/domain/customType.ts
@@ -430,8 +430,21 @@ export function reorderField(args: ReorderFieldArgs): CustomType {
     ),
   );
 
+  // On repetable pages UID field shouldn't be reordered
+  const isRepeatablePage =
+    customType.format === "page" && customType.repeatable;
+
+  // Remove UID field from the fields to be reordered
+  const sectionFieldsWithoutUid = Object.fromEntries(
+    Object.entries(sectionFields).filter(([_, value]) => value.type !== "UID"),
+  );
+
+  const fieldsToReorder = isRepeatablePage
+    ? sectionFieldsWithoutUid
+    : sectionFields;
+
   const updatedSection = reorderFields({
-    fields: sectionFields,
+    fields: fieldsToReorder,
     sourceIndex,
     destinationIndex,
   });
@@ -442,10 +455,20 @@ export function reorderField(args: ReorderFieldArgs): CustomType {
     updatedSection[sliceZoneKey] = sliceZoneField;
   }
 
+  // Put the UID field back at the begginnig of the reordered fields
+  const updatedSectionEntries = Object.entries(updatedSection);
+  const uidFieldEntry = Object.entries(sectionFields).find(
+    ([_, field]) => field.type === "UID",
+  );
+  if (uidFieldEntry) {
+    updatedSectionEntries.unshift(uidFieldEntry);
+  }
+  const updatedSectionWithUid = Object.fromEntries(updatedSectionEntries);
+
   const newCustomType = updateSection({
     customType,
     sectionId,
-    updatedSection,
+    updatedSection: isRepeatablePage ? updatedSectionWithUid : updatedSection,
   });
 
   return newCustomType;
@@ -537,8 +560,8 @@ export function reorderFields<T>(args: ReorderFieldsArgs<T>) {
   const fieldEntries = Object.entries(fields);
   const [removedEntry] = fieldEntries.splice(sourceIndex, 1);
   fieldEntries.splice(destinationIndex, 0, removedEntry);
-  const reorderedFields = Object.fromEntries(fieldEntries);
 
+  const reorderedFields = Object.fromEntries(fieldEntries);
   return reorderedFields;
 }
 

--- a/packages/slice-machine/src/domain/customType.ts
+++ b/packages/slice-machine/src/domain/customType.ts
@@ -430,7 +430,7 @@ export function reorderField(args: ReorderFieldArgs): CustomType {
     ),
   );
 
-  // On repetable pages UID field shouldn't be reordered
+  // On repeatable pages UID field shouldn't be reordered
   const isRepeatablePage =
     customType.format === "page" && customType.repeatable;
 
@@ -455,7 +455,7 @@ export function reorderField(args: ReorderFieldArgs): CustomType {
     updatedSection[sliceZoneKey] = sliceZoneField;
   }
 
-  // Put the UID field back at the begginnig of the reordered fields
+  // Put the UID field back at the beginning of the reordered fields
   const updatedSectionEntries = Object.entries(updatedSection);
   const uidFieldEntry = Object.entries(sectionFields).find(
     ([_, field]) => field.type === "UID",
@@ -562,6 +562,7 @@ export function reorderFields<T>(args: ReorderFieldsArgs<T>) {
   fieldEntries.splice(destinationIndex, 0, removedEntry);
 
   const reorderedFields = Object.fromEntries(fieldEntries);
+
   return reorderedFields;
 }
 

--- a/packages/slice-machine/src/legacy/lib/builders/CustomTypeBuilder/TabZone/index.tsx
+++ b/packages/slice-machine/src/legacy/lib/builders/CustomTypeBuilder/TabZone/index.tsx
@@ -79,18 +79,16 @@ const TabZone: FC<TabZoneProps> = ({ tabId }) => {
   const { customType, setCustomType } = useCustomTypeState();
   const customTypeSM = CustomTypes.toSM(customType);
 
-  const isRepeatablePage =
-    customTypeSM.format === "page" && customTypeSM.repeatable;
-
   const sliceZone = customTypeSM.tabs.find((tab) => tab.key === tabId)
     ?.sliceZone;
 
   const allFields: TabFields =
     customTypeSM.tabs.find((tab) => tab.key === tabId)?.value ?? [];
   // the uid field is moved to the top of the editor on repeatable pages
-  const fields = isRepeatablePage
-    ? allFields.filter((field) => field.key !== "uid")
-    : allFields;
+  const fields =
+    customTypeSM.format === "page" && customTypeSM.repeatable
+      ? allFields.filter((field) => field.key !== "uid")
+      : allFields;
 
   const poolOfFields = customTypeSM.tabs.reduce<PoolOfFields>(
     (acc: PoolOfFields, curr: TabSM) => {
@@ -155,18 +153,6 @@ const TabZone: FC<TabZoneProps> = ({ tabId }) => {
     });
   };
 
-  /**
-   * Adjusts the index of the field to be reordered
-   * taking into account the uid field that is moved
-   * to the top of the editor on repeatable pages
-   */
-  const adjustIndex = (index: number) => {
-    if (!isRepeatablePage) return index;
-    const uidIndex = allFields.findIndex((field) => field.key === "uid");
-    if (uidIndex === -1) return index;
-    return index >= uidIndex ? index + 1 : index;
-  };
-
   const onDragEnd = (result: DropResult) => {
     if (ensureDnDDestination(result)) {
       return;
@@ -179,8 +165,8 @@ const TabZone: FC<TabZoneProps> = ({ tabId }) => {
 
     const newCustomType = reorderField({
       customType,
-      sourceIndex: adjustIndex(source.index),
-      destinationIndex: adjustIndex(destination.index),
+      sourceIndex: source.index,
+      destinationIndex: destination.index,
       sectionId: tabId,
     });
 


### PR DESCRIPTION
<!-- Please use a Conventional Commit in your PR title -->
<!-- https://conventionalcommits.org -->
<!-- e.g. "feat: support new field type" -->

**Resolves**: [DT-2939](https://linear.app/prismic/issue/DT-2393/bug-aauser-i-can-reorder-fields-in-slice-machine)

### Description

<!-- Describe your changes in detail. -->
<!-- Why is this change required? -->
<!-- What problem does it solve? -->

Users are encountering [issue](https://community.prismic.io/t/drag-drop-for-ordering-fields-is-broken-slicemachine/17848) when trying to drag'n'drop fields in repeatable page.

The root cause of the bug was UID field that was moved away from the list of the fields (and now is displayed at the top of the TypeBuilder), but is still present in the array of fields.

The fix was to omit UID field while reordering fields and keep it at the first position.

### Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- Don't hesitate to ask for help! -->

- [ ] If my changes require tests, I added them.
- [ ] If my changes affect backward compatibility, it has been discussed.
- [ ] If my changes require an update to the CONTRIBUTING.md guide, I updated it.

### Preview

<!-- If your changes are visual, screenshots or videos are welcome! -->

### How to QA [^1]

<!-- When relevant, describe how to QA your changes. -->

<!-- Your favorite emoji is welcome to close your PR! -->

<!-- A note for reviewers: -->

[^1]:
	Please use these labels when submitting a review:
	:question: #ask:&ensp;Ask a question.
	:bulb: #idea:&ensp;Suggest an idea.
	:warning: #issue:&ensp;Strongly suggest a change.
	:tada: #nice:&ensp;Share a compliment.