### PR TITLE
Refetch field snippet when field config changes

### DIFF
--- a/packages/slice-machine/src/legacy/lib/builders/common/Zone/Card/components/Hints/index.tsx
+++ b/packages/slice-machine/src/legacy/lib/builders/common/Zone/Card/components/Hints/index.tsx
@@ -20,7 +20,7 @@ const Hint: React.FC<HintProps> = ({
 }) => {
   const fieldPathString = renderHintBase({ item });
 
-  const snippetCacheKey = [fieldPathString];
+  const snippetCacheKey = [item.value.type];
   if (item.value.type === "Link") {
     if (item.value.config?.allowText ?? false)
       snippetCacheKey.push("allowText");

--- a/packages/slice-machine/src/legacy/lib/builders/common/Zone/Card/components/Hints/index.tsx
+++ b/packages/slice-machine/src/legacy/lib/builders/common/Zone/Card/components/Hints/index.tsx
@@ -20,7 +20,7 @@ const Hint: React.FC<HintProps> = ({
 }) => {
   const fieldPathString = renderHintBase({ item });
 
-  const snippetCacheKey = [item.value.type];
+  const snippetCacheKey: string[] = [item.value.type];
   if (item.value.type === "Link") {
     if (item.value.config?.allowText ?? false)
       snippetCacheKey.push("allowText");

--- a/packages/slice-machine/src/legacy/lib/builders/common/Zone/Card/components/Hints/index.tsx
+++ b/packages/slice-machine/src/legacy/lib/builders/common/Zone/Card/components/Hints/index.tsx
@@ -20,7 +20,7 @@ const Hint: React.FC<HintProps> = ({
 }) => {
   const fieldPathString = renderHintBase({ item });
 
-  const snippetCacheKey: string[] = [item.value.type];
+  const snippetCacheKey = [fieldPathString];
   if (item.value.type === "Link") {
     if (item.value.config?.allowText ?? false)
       snippetCacheKey.push("allowText");

--- a/packages/slice-machine/src/legacy/lib/builders/common/Zone/Card/components/Hints/index.tsx
+++ b/packages/slice-machine/src/legacy/lib/builders/common/Zone/Card/components/Hints/index.tsx
@@ -24,7 +24,6 @@ const Hint: React.FC<HintProps> = ({
   if (item.value.type === "Link") {
     if (item.value.config?.allowText ?? false)
       snippetCacheKey.push("allowText");
-    if (item.value.config?.repeat ?? false) snippetCacheKey.push("repeat");
   }
 
   // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment

--- a/packages/slice-machine/src/legacy/lib/builders/common/Zone/Card/components/Hints/index.tsx
+++ b/packages/slice-machine/src/legacy/lib/builders/common/Zone/Card/components/Hints/index.tsx
@@ -20,9 +20,15 @@ const Hint: React.FC<HintProps> = ({
 }) => {
   const fieldPathString = renderHintBase({ item });
 
-  // TODO: Call `swr`'s global `mutate` function when something changes to clear the cache.
+  const snippetCacheKey = [fieldPathString];
+  if (item.value.type === "Link") {
+    if (item.value.config?.allowText ?? false)
+      snippetCacheKey.push("allowText");
+    if (item.value.config?.repeat ?? false) snippetCacheKey.push("repeat");
+  }
+
   // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-  const { data, error } = useSWR(fieldPathString, async () => {
+  const { data, error } = useSWR(snippetCacheKey.join("$"), async () => {
     return await managerClient.snippets.readSnippets({
       fieldPath: fieldPathString.split("."),
       model: item.value,


### PR DESCRIPTION
<!-- Please use a Conventional Commit in your PR title -->
<!-- https://conventionalcommits.org -->
<!-- e.g. "feat: support new field type" -->

**Resolves**: <!-- GitHub or Linear issue (e.g. #123, DT-123) -->
https://linear.app/prismic/issue/DT-2433/aauser-when-i-edit-a-link-field-i-can-see-the-code-snippet-change

### Description

<!-- Describe your changes in detail. -->
<!-- Why is this change required? -->
<!-- What problem does it solve? -->
Use a dynamic key based on the config of some fields to make useSWR refetch the field snippet to show. More as comments in the PR.

### Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- Don't hesitate to ask for help! -->

- [ ] If my changes require tests, I added them.
- [ ] If my changes affect backward compatibility, it has been discussed.
- [ ] If my changes require an update to the CONTRIBUTING.md guide, I updated it.

### Preview

<!-- If your changes are visual, screenshots or videos are welcome! -->

### How to QA [^1]

<!-- When relevant, describe how to QA your changes. -->

<!-- Your favorite emoji is welcome to close your PR! -->

<!-- A note for reviewers: -->

[^1]:
	Please use these labels when submitting a review:
	:question: #ask:&ensp;Ask a question.
	:bulb: #idea:&ensp;Suggest an idea.
	:warning: #issue:&ensp;Strongly suggest a change.
	:tada: #nice:&ensp;Share a compliment.