### PR TITLE
feat: set up default master locale

### DIFF
--- a/packages/init/src/SliceMachineInitProcess.ts
+++ b/packages/init/src/SliceMachineInitProcess.ts
@@ -184,6 +184,9 @@ export class SliceMachineInitProcess {
 			}
 			if (!this.context.repository.exists) {
 				await this.createNewRepository();
+				if (!this.options.starter) {
+					await this.setDefaultMasterLocale();
+				}
 			}
 
 			await this.syncDataWithPrismic();
@@ -960,6 +963,20 @@ ${chalk.cyan("?")} Your Prismic repository name`.replace("\n", ""),
 					task.title = `Created new repository ${chalk.cyan(
 						this.context.repository.domain,
 					)}`;
+				},
+			},
+		]);
+	}
+
+	protected setDefaultMasterLocale(): Promise<void> {
+		return listrRun([
+			{
+				title: `Setting default master language...`,
+				task: async (_, task) => {
+					await this.manager.prismicRepository.setDefaultMasterLocale();
+					task.title = `Default master language set to ${chalk.cyan(
+						"en-US",
+					)} 🇺🇸. You can change it anytime in your project settings.`;
 				},
 			},
 		]);

--- a/packages/init/src/SliceMachineInitProcess.ts
+++ b/packages/init/src/SliceMachineInitProcess.ts
@@ -971,10 +971,21 @@ ${chalk.cyan("?")} Your Prismic repository name`.replace("\n", ""),
 			{
 				title: `Setting main content language...`,
 				task: async (_, task) => {
-					await this.manager.prismicRepository.setDefaultMasterLocale();
-					task.title = `Main content language set to ${chalk.cyan(
-						"English - United States",
-					)} 🇺🇸. You can change it anytime in your project settings.`;
+					const documentsRead = await this.readDocuments();
+
+					if (
+						documentsRead !== undefined &&
+						documentsRead.documents.length > 0
+					) {
+						// if there are documents to push,
+						// we assume it's a starter which has a master locale already set
+						task.title = `Setting main content language skipped`;
+					} else {
+						await this.manager.prismicRepository.setDefaultMasterLocale();
+						task.title = `Main content language set to ${chalk.cyan(
+							"English - United States",
+						)} 🇺🇸. You can change it anytime in your project settings.`;
+					}
 				},
 			},
 		]);

--- a/packages/init/src/SliceMachineInitProcess.ts
+++ b/packages/init/src/SliceMachineInitProcess.ts
@@ -983,6 +983,20 @@ ${chalk.cyan("?")} Your Prismic repository name`.replace("\n", ""),
 					task.title = `Main content language set to ${chalk.cyan(
 						"English - United States",
 					)} 🇺🇸. You can change it anytime in your project settings.`;
+
+					try {
+						const { value: onboardingExperimentVariant } =
+							(await this.manager.telemetry.getExperimentVariant(
+								"shared-onboarding",
+							)) ?? {};
+						if (onboardingExperimentVariant === "with-shared-onboarding") {
+							this.manager.prismicRepository.completeOnboardingStep(
+								"chooseLocale",
+							);
+						}
+					} catch (error) {
+						await this.trackError(error);
+					}
 				},
 			},
 		]);

--- a/packages/init/src/SliceMachineInitProcess.ts
+++ b/packages/init/src/SliceMachineInitProcess.ts
@@ -184,9 +184,7 @@ export class SliceMachineInitProcess {
 			}
 			if (!this.context.repository.exists) {
 				await this.createNewRepository();
-				if (!this.options.starter) {
-					await this.setDefaultMasterLocale();
-				}
+				await this.setDefaultMasterLocale();
 			}
 
 			await this.syncDataWithPrismic();

--- a/packages/init/src/SliceMachineInitProcess.ts
+++ b/packages/init/src/SliceMachineInitProcess.ts
@@ -969,11 +969,11 @@ ${chalk.cyan("?")} Your Prismic repository name`.replace("\n", ""),
 	protected setDefaultMasterLocale(): Promise<void> {
 		return listrRun([
 			{
-				title: `Setting default master language...`,
+				title: `Setting main content language...`,
 				task: async (_, task) => {
 					await this.manager.prismicRepository.setDefaultMasterLocale();
-					task.title = `Default master language set to ${chalk.cyan(
-						"en-US",
+					task.title = `Main content language set to ${chalk.cyan(
+						"English - United States",
 					)} 🇺🇸. You can change it anytime in your project settings.`;
 				},
 			},

--- a/packages/init/src/SliceMachineInitProcess.ts
+++ b/packages/init/src/SliceMachineInitProcess.ts
@@ -966,26 +966,23 @@ ${chalk.cyan("?")} Your Prismic repository name`.replace("\n", ""),
 		]);
 	}
 
-	protected setDefaultMasterLocale(): Promise<void> {
+	protected async setDefaultMasterLocale(): Promise<void> {
+		const documentsRead = await this.readDocuments();
+
+		if (documentsRead !== undefined && documentsRead.documents.length > 0) {
+			// if there are documents to push,
+			// we assume it's a starter which has a master locale already set
+			return;
+		}
+
 		return listrRun([
 			{
 				title: `Setting main content language...`,
 				task: async (_, task) => {
-					const documentsRead = await this.readDocuments();
-
-					if (
-						documentsRead !== undefined &&
-						documentsRead.documents.length > 0
-					) {
-						// if there are documents to push,
-						// we assume it's a starter which has a master locale already set
-						task.title = `Setting main content language skipped`;
-					} else {
-						await this.manager.prismicRepository.setDefaultMasterLocale();
-						task.title = `Main content language set to ${chalk.cyan(
-							"English - United States",
-						)} 🇺🇸. You can change it anytime in your project settings.`;
-					}
+					await this.manager.prismicRepository.setDefaultMasterLocale();
+					task.title = `Main content language set to ${chalk.cyan(
+						"English - United States",
+					)} 🇺🇸. You can change it anytime in your project settings.`;
 				},
 			},
 		]);


### PR DESCRIPTION
<!-- Please use a Conventional Commit in your PR title -->
<!-- https://conventionalcommits.org -->
<!-- e.g. "feat: support new field type" -->

**Resolves**: [DT-2482](https://linear.app/prismic/issue/DT-2482/set-default-master-language-when-creating-new-repo-via-cli)

### Description

When a user creates a repository through the terminal (without starter), it should set a default master lang (en-us) for the repository.

<!-- Describe your changes in detail. -->
<!-- Why is this change required? -->
<!-- What problem does it solve? -->

### Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- Don't hesitate to ask for help! -->

- [ ] A comprehensive Linear ticket, providing sufficient context and details to facilitate the review of the PR, is linked to the PR.
- [ ] If my changes require tests, I added them.
- [ ] If my changes affect backward compatibility, it has been discussed.
- [ ] If my changes require an update to the CONTRIBUTING.md guide, I updated it.

### Preview

<!-- If your changes are visual, screenshots or videos are welcome! -->

### How to QA [^1]

<!-- When relevant, describe how to QA your changes. -->

<!-- Your favorite emoji is welcome to close your PR! -->

<!-- A note for reviewers: -->

[^1]:
	Please use these labels when submitting a review:
	:question: #ask:&ensp;Ask a question.
	:bulb: #idea:&ensp;Suggest an idea.
	:warning: #issue:&ensp;Strongly suggest a change.
	:tada: #nice:&ensp;Share a compliment.
