### PR TITLE
feat: track groups pushed

### DIFF
--- a/packages/manager/src/managers/telemetry/types.ts
+++ b/packages/manager/src/managers/telemetry/types.ts
@@ -24,6 +24,7 @@ export const SegmentEventType = {
 	legacySlice_converted: "legacy-slice:converted",
 	screenshotTaken: "screenshot-taken",
 	changes_pushed: "changes:pushed",
+	changes_groupPushed: "changes:group-pushed",
 	changes_limitReach: "changes:limit-reach",
 	editor_widgetUsed: "editor:widget-used",
 	open_page_snippet: "page-type:open-snippet",
@@ -71,6 +72,7 @@ export const HumanSegmentEventType = {
 		"SliceMachine Legacy Slice Converted",
 	[SegmentEventType.screenshotTaken]: "SliceMachine Screenshot Taken",
 	[SegmentEventType.changes_pushed]: "SliceMachine Changes Pushed",
+	[SegmentEventType.changes_groupPushed]: "SliceMachine Group Field Pushed",
 	[SegmentEventType.changes_limitReach]: "SliceMachine Changes Limit Reach",
 	[SegmentEventType.editor_widgetUsed]: "SliceMachine Editor Widget Used",
 	[SegmentEventType.open_page_snippet]:
@@ -294,6 +296,16 @@ type ChangesPushedSegmentEvent = SegmentEvent<
 	}
 >;
 
+type ChangesGroupPushedSegmentEvent = SegmentEvent<
+	typeof SegmentEventType.changes_groupPushed,
+	{
+		isInStaticZone: boolean;
+		isInSlice: boolean;
+	} & {
+		[key in FieldType]?: number;
+	}
+>;
+
 type ChangesLimitReachSegmentEvent = SegmentEvent<
 	typeof SegmentEventType.changes_limitReach,
 	{ limitType: PushChangesLimitType }
@@ -410,6 +422,7 @@ export type SegmentEvents =
 	| LegacySliceConvertedSegmentEvent
 	| ScreenshotTakenSegmentEvent
 	| ChangesPushedSegmentEvent
+	| ChangesGroupPushedSegmentEvent
 	| ChangesLimitReachSegmentEvent
 	| EditorWidgetUsedSegmentEvent
 	| OpenPageSnippetSegmentEvent


### PR DESCRIPTION
<!-- Please use a Conventional Commit in your PR title -->
<!-- https://conventionalcommits.org -->
<!-- e.g. "feat: support new field type" -->

**Resolves**: [DT-2439](https://linear.app/prismic/issue/DT-2439/aapm-i-can-track-when-a-user-pushed-a-group)

### Description

In order to gain more knowledge about the usage of the groups there is tracking added to get the data of the groups in new custom types or slices.

<!-- Describe your changes in detail. -->
<!-- Why is this change required? -->
<!-- What problem does it solve? -->

### Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- Don't hesitate to ask for help! -->

- [ ] A comprehensive Linear ticket, providing sufficient context and details to facilitate the review of the PR, is linked to the PR.
- [ ] If my changes require tests, I added them.
- [ ] If my changes affect backward compatibility, it has been discussed.
- [ ] If my changes require an update to the CONTRIBUTING.md guide, I updated it.

### Preview

<!-- If your changes are visual, screenshots or videos are welcome! -->

### How to QA [^1]

<!-- When relevant, describe how to QA your changes. -->

<!-- Your favorite emoji is welcome to close your PR! -->

<!-- A note for reviewers: -->

[^1]:
	Please use these labels when submitting a review:
	:question: #ask:&ensp;Ask a question.
	:bulb: #idea:&ensp;Suggest an idea.
	:warning: #issue:&ensp;Strongly suggest a change.
	:tada: #nice:&ensp;Share a compliment.
