### PR TITLE
feat: repeatable link badge

### DIFF
--- a/packages/slice-machine/src/legacy/components/ListItem/Header.tsx
+++ b/packages/slice-machine/src/legacy/components/ListItem/Header.tsx
@@ -27,6 +27,7 @@ const ItemHeader: React.FC<ItemHeaderProps> = ({
         padding: "4px",
         border: "2px solid",
         borderColor: theme.colors?.primary as CSS.Property.Color,
+        flexShrink: 0,
       }}
     />
     <TextWithTooltip
@@ -42,6 +43,8 @@ const ItemHeader: React.FC<ItemHeaderProps> = ({
         fontSize: "14px",
         ml: 1,
         color: "textClear",
+        overflow: "hidden",
+        textOverflow: "ellipsis",
       }}
       data-testid="field-id"
     >

--- a/packages/slice-machine/src/legacy/components/ListItem/index.tsx
+++ b/packages/slice-machine/src/legacy/components/ListItem/index.tsx
@@ -61,6 +61,11 @@ function ListItem<F extends TabField, S extends AnyObjectSchema>({
     value: { config, type },
   } = item;
 
+  const shouldDisplayRepeatableBadge = Boolean(
+    type === "Link" && config?.repeat,
+  ); // for the moment we don't display the badge for repeatable groups
+  // type === "Link" && config && "repeat" in config && Boolean(config.repeat);
+
   return (
     <Fragment>
       <Draggable draggableId={draggableId} index={index}>
@@ -112,16 +117,14 @@ function ListItem<F extends TabField, S extends AnyObjectSchema>({
                       WidgetIcon={widget.Meta.icon}
                     />
                     <Flex sx={{ flex: "0 0 auto" }}>
-                      {config &&
-                        "repeat" in config &&
-                        Boolean(config.repeat) && (
-                          <Badge
-                            title="Repeatable"
-                            color="purple"
-                            size="medium"
-                            sx={{ alignSelf: "center", marginInline: 16 }}
-                          />
-                        )}
+                      {shouldDisplayRepeatableBadge && (
+                        <Badge
+                          title="Repeatable"
+                          color="purple"
+                          size="medium"
+                          sx={{ alignSelf: "center", marginInline: 16 }}
+                        />
+                      )}
                       {CustomEditElements ? CustomEditElements : null}
                       {CustomEditElement ? (
                         CustomEditElement

--- a/packages/slice-machine/src/legacy/components/ListItem/index.tsx
+++ b/packages/slice-machine/src/legacy/components/ListItem/index.tsx
@@ -1,3 +1,4 @@
+import { Badge } from "@prismicio/editor-ui";
 import { Menu, MenuButton, MenuItem, MenuList } from "@reach/menu-button";
 import React, { Fragment } from "react";
 import { Draggable } from "react-beautiful-dnd";
@@ -110,7 +111,17 @@ function ListItem<F extends TabField, S extends AnyObjectSchema>({
                       }
                       WidgetIcon={widget.Meta.icon}
                     />
-                    <Flex>
+                    <Flex sx={{ flex: "0 0 auto" }}>
+                      {config &&
+                        "repeat" in config &&
+                        Boolean(config.repeat) && (
+                          <Badge
+                            title="Repeatable"
+                            color="purple"
+                            size="medium"
+                            sx={{ alignSelf: "center", marginInline: 16 }}
+                          />
+                        )}
                       {CustomEditElements ? CustomEditElements : null}
                       {CustomEditElement ? (
                         CustomEditElement
@@ -119,7 +130,11 @@ function ListItem<F extends TabField, S extends AnyObjectSchema>({
                           size={22}
                           Icon={AiOutlineEdit}
                           label="Edit field"
-                          sx={{ cursor: "pointer", color: theme.colors?.icons }}
+                          sx={{
+                            cursor: "pointer",
+                            color: theme.colors?.icons,
+                            flexShrink: 0,
+                          }}
                           onClick={() =>
                             enterEditMode(
                               [key, item.value],

--- a/packages/slice-machine/src/legacy/components/ListItem/index.tsx
+++ b/packages/slice-machine/src/legacy/components/ListItem/index.tsx
@@ -64,7 +64,6 @@ function ListItem<F extends TabField, S extends AnyObjectSchema>({
   const shouldDisplayRepeatableBadge = Boolean(
     type === "Link" && config?.repeat,
   ); // for the moment we don't display the badge for repeatable groups
-  // type === "Link" && config && "repeat" in config && Boolean(config.repeat);
 
   return (
     <Fragment>


### PR DESCRIPTION
<!-- Please use a Conventional Commit in your PR title -->
<!-- https://conventionalcommits.org -->
<!-- e.g. "feat: support new field type" -->

**Resolves**: [DT-2489](https://linear.app/prismic/issue/DT-2489/aauser-i-can-see-on-the-list-of-fields-in-sm-if-a-link-field-is-set-to)

### Description

Added a badge that gives a clear indication that field is repeatable (without need to open the edit modal).
<img width="817" alt="repeatable-link-badge" src="https://github.com/user-attachments/assets/34d25fee-b8ac-41f5-814c-6da7e62424cc">

Also fixed issue with buttons and icons in Field List Items shrinking or overflowing when Field label is very long which got even more noticeable with additional element of badge.
See screenshot before fix:
<img width="645" alt="buttons-overflowing" src="https://github.com/user-attachments/assets/132051a7-5040-4d4d-aad1-d7ed0dc8e687">

<!-- Describe your changes in detail. -->
<!-- Why is this change required? -->
<!-- What problem does it solve? -->

### Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- Don't hesitate to ask for help! -->

- [ ] A comprehensive Linear ticket, providing sufficient context and details to facilitate the review of the PR, is linked to the PR.
- [ ] If my changes require tests, I added them.
- [ ] If my changes affect backward compatibility, it has been discussed.
- [ ] If my changes require an update to the CONTRIBUTING.md guide, I updated it.

### Preview

<!-- If your changes are visual, screenshots or videos are welcome! -->



### How to QA [^1]

<!-- When relevant, describe how to QA your changes. -->

<!-- Your favorite emoji is welcome to close your PR! -->

<!-- A note for reviewers: -->

[^1]:
	Please use these labels when submitting a review:
	:question: #ask:&ensp;Ask a question.
	:bulb: #idea:&ensp;Suggest an idea.
	:warning: #issue:&ensp;Strongly suggest a change.
	:tada: #nice:&ensp;Share a compliment.
