### PR TITLE
[DT-2489]: repeatable badge for all fields

### DIFF
--- a/packages/slice-machine/src/legacy/components/ListItem/index.tsx
+++ b/packages/slice-machine/src/legacy/components/ListItem/index.tsx
@@ -62,8 +62,8 @@ function ListItem<F extends TabField, S extends AnyObjectSchema>({
   } = item;
 
   const shouldDisplayRepeatableBadge = Boolean(
-    type === "Link" && config?.repeat,
-  ); // for the moment we don't display the badge for repeatable groups
+    config && "repeat" in config && config.repeat,
+  );
 
   return (
     <Fragment>

--- a/packages/slice-machine/src/legacy/components/ListItem/index.tsx
+++ b/packages/slice-machine/src/legacy/components/ListItem/index.tsx
@@ -62,7 +62,7 @@ function ListItem<F extends TabField, S extends AnyObjectSchema>({
   } = item;
 
   const shouldDisplayRepeatableBadge = Boolean(
-    config && "repeat" in config && config.repeat,
+    (type === "Link" || type === "Group") && config?.repeat,
   );
 
   return (


### PR DESCRIPTION
<!-- Please use a Conventional Commit in your PR title -->
<!-- https://conventionalcommits.org -->
<!-- e.g. "feat: support new field type" -->

**Resolves**: [DT-2489](https://linear.app/prismic/issue/DT-2489/aauser-i-can-see-on-the-list-of-fields-in-sm-if-a-link-field-is-set-to)

### Description
Update to display `Repeatable` on each repeatable field (currently available for group and link field)

<!-- Describe your changes in detail. -->
<!-- Why is this change required? -->
<!-- What problem does it solve? -->

### Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- Don't hesitate to ask for help! -->

- [ ] A comprehensive Linear ticket, providing sufficient context and details to facilitate the review of the PR, is linked to the PR.
- [ ] If my changes require tests, I added them.
- [ ] If my changes affect backward compatibility, it has been discussed.
- [ ] If my changes require an update to the CONTRIBUTING.md guide, I updated it.

### Preview

<!-- If your changes are visual, screenshots or videos are welcome! -->

### How to QA [^1]

<!-- When relevant, describe how to QA your changes. -->

<!-- Your favorite emoji is welcome to close your PR! -->

<!-- A note for reviewers: -->

[^1]:
	Please use these labels when submitting a review:
	:question: #ask:&ensp;Ask a question.
	:bulb: #idea:&ensp;Suggest an idea.
	:warning: #issue:&ensp;Strongly suggest a change.
	:tada: #nice:&ensp;Share a compliment.
