### PR TITLE
feat(onboarding): mark sm onboarding steps as done on init

### DIFF
--- a/packages/init/src/SliceMachineInitProcess.ts
+++ b/packages/init/src/SliceMachineInitProcess.ts
@@ -911,6 +911,7 @@ ${chalk.cyan("?")} Your Prismic repository name`.replace("\n", ""),
 			await this.trackError(error);
 		}
 	}
+
 	protected createNewRepository(): Promise<void> {
 		assertExists(
 			this.context.repository,

--- a/packages/init/src/SliceMachineInitProcess.ts
+++ b/packages/init/src/SliceMachineInitProcess.ts
@@ -190,6 +190,7 @@ export class SliceMachineInitProcess {
 			await this.syncDataWithPrismic();
 			await this.initializeProject();
 			await this.initializePlugins();
+			await this.completeOnboardingSteps();
 		} catch (error) {
 			await this.trackError(error);
 
@@ -893,14 +894,18 @@ ${chalk.cyan("?")} Your Prismic repository name`.replace("\n", ""),
 		};
 	}
 
-	protected async completeOnboardingSteps(...steps: string[]): Promise<void> {
+	protected async completeOnboardingSteps(): Promise<void> {
 		try {
 			const { value: onboardingExperimentVariant } =
 				(await this.manager.telemetry.getExperimentVariant(
 					"shared-onboarding",
 				)) ?? {};
 			if (onboardingExperimentVariant === "with-shared-onboarding") {
-				this.manager.prismicRepository.completeOnboardingStep(...steps);
+				this.manager.prismicRepository.completeOnboardingStep(
+					"chooseLocale",
+					"createProject",
+					"setupSliceMachine",
+				);
 			}
 		} catch (error) {
 			await this.trackError(error);
@@ -933,11 +938,6 @@ ${chalk.cyan("?")} Your Prismic repository name`.replace("\n", ""),
 							framework: this.context.framework.wroomTelemetryID,
 							starterId: this.context.starterId,
 						});
-
-						await this.completeOnboardingSteps(
-							"createProject",
-							"setupSliceMachine",
-						);
 					} catch (error) {
 						// When we have an error here, it's most probably because the user has a stale SESSION cookie
 
@@ -973,11 +973,7 @@ ${chalk.cyan("?")} Your Prismic repository name`.replace("\n", ""),
 		const documentsRead = await this.readDocuments();
 
 		if (documentsRead !== undefined && documentsRead.documents.length > 0) {
-			// if there are documents to push, we assume it's a starter which
-			// has a master locale already set, and we only ensure the onboarding
-			// step is completed.
-			await this.completeOnboardingSteps("chooseLocale");
-
+			// if there are documents to push, we assume it's a starter which has a master locale already set
 			return;
 		}
 
@@ -989,8 +985,6 @@ ${chalk.cyan("?")} Your Prismic repository name`.replace("\n", ""),
 					task.title = `Main content language set to ${chalk.cyan(
 						"English - United States",
 					)} 🇺🇸. You can change it anytime in your project settings.`;
-
-					await this.completeOnboardingSteps("chooseLocale");
 				},
 			},
 		]);

--- a/packages/init/test/SliceMachineInitProcess-run.test.ts
+++ b/packages/init/test/SliceMachineInitProcess-run.test.ts
@@ -17,6 +17,7 @@ import { loginUser } from "./__testutils__/loginUser";
 import { watchStd } from "./__testutils__/watchStd";
 import { spyManager, SpyManagerReturnType } from "./__testutils__/spyManager";
 import { prompt } from "prompts";
+import { mockAmplitudeAPI } from "./__testutils__/mockAmplitudeAPI";
 
 const existingRepo = "existing-repo";
 const prepareEnvironment = async (
@@ -162,6 +163,9 @@ const prepareEnvironment = async (
 			documents,
 		},
 	});
+
+	// Mock Amplitude
+	mockAmplitudeAPI(ctx);
 
 	// Mock execa
 	const spiedManager = spyManager(initProcess);

--- a/packages/init/test/__testutils__/mockAmplitudeAPI.ts
+++ b/packages/init/test/__testutils__/mockAmplitudeAPI.ts
@@ -1,0 +1,35 @@
+import { TestContext } from "vitest";
+import { rest } from "msw";
+
+type MockAmplitudeAPIConfig = {
+	experiment: string;
+	variant: string;
+};
+
+type MockAmplitudeAPIReturnType = {
+	value: string;
+};
+
+export const mockAmplitudeAPI = (
+	ctx: TestContext,
+	config?: MockAmplitudeAPIConfig,
+): MockAmplitudeAPIReturnType => {
+	const value = config?.variant ?? "off";
+
+	ctx.msw.use(
+		rest.get(
+			"https://api.lab.amplitude.com/sdk/v2/vardata",
+			(_req, res, ctx) => {
+				return res(
+					ctx.json({
+						value,
+					}),
+				);
+			},
+		),
+	);
+
+	return {
+		value,
+	};
+};


### PR DESCRIPTION
<!-- Please use a Conventional Commit in your PR title -->
<!-- https://conventionalcommits.org -->
<!-- e.g. "feat: support new field type" -->

**Resolves**: [DT-2441](https://linear.app/prismic/issue/DT-2441/aauser-when-i-create-a-new-repository-with-the-shared-onboarding-i-see)

### Description

When slice-machine is initialised first 4 steps of onboarding guide should be completed. 
Currently that is not the case when creating repo in dashboard and going directly to cli, or when we're not in the scope of shared-onboarding experiment in the editor.

This PR ads last step in the init process, which completes all the steps related to SM init.

<!-- Describe your changes in detail. -->
<!-- Why is this change required? -->
<!-- What problem does it solve? -->

### Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- Don't hesitate to ask for help! -->

- [ ] A comprehensive Linear ticket, providing sufficient context and details to facilitate the review of the PR, is linked to the PR.
- [ ] If my changes require tests, I added them.
- [ ] If my changes affect backward compatibility, it has been discussed.
- [ ] If my changes require an update to the CONTRIBUTING.md guide, I updated it.

### Preview

<!-- If your changes are visual, screenshots or videos are welcome! -->

### How to QA [^1]

<!-- When relevant, describe how to QA your changes. -->

<!-- Your favorite emoji is welcome to close your PR! -->

<!-- A note for reviewers: -->

[^1]:
	Please use these labels when submitting a review:
	:question: #ask:&ensp;Ask a question.
	:bulb: #idea:&ensp;Suggest an idea.
	:warning: #issue:&ensp;Strongly suggest a change.
	:tada: #nice:&ensp;Share a compliment.
