### PR TITLE
feat: prevent creating slices and custom types with reserved name

### DIFF
--- a/packages/slice-machine/src/legacy/components/Forms/CreateCustomTypeModal/CreateCustomTypeModal.tsx
+++ b/packages/slice-machine/src/legacy/components/Forms/CreateCustomTypeModal/CreateCustomTypeModal.tsx
@@ -173,6 +173,10 @@ export const CreateCustomTypeModal: React.FC<CreateCustomTypeModalProps> = ({
           errors.id = "ID cannot be empty.";
         }
 
+        if (["update", "insert"].includes(id.toLowerCase())) {
+          errors.id = `Id "${id}" is reserved for Slice Machine use.`;
+        }
+
         // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
         if (!errors.id && id && !API_ID_REGEX.exec(id)) {
           errors.id = "Invalid id: No special characters allowed.";

--- a/packages/slice-machine/src/legacy/components/Forms/CreateCustomTypeModal/CreateCustomTypeModal.tsx
+++ b/packages/slice-machine/src/legacy/components/Forms/CreateCustomTypeModal/CreateCustomTypeModal.tsx
@@ -165,6 +165,10 @@ export const CreateCustomTypeModal: React.FC<CreateCustomTypeModalProps> = ({
           })} name is already taken.`;
         }
 
+        if (["update", "insert"].includes(label.toLowerCase())) {
+          errors.label = `Name "${label}" is reserved for Slice Machine use.`;
+        }
+
         if (!id || !id.length) {
           errors.id = "ID cannot be empty.";
         }

--- a/packages/slice-machine/src/legacy/components/Forms/RenameCustomTypeModal/RenameCustomTypeModal.tsx
+++ b/packages/slice-machine/src/legacy/components/Forms/RenameCustomTypeModal/RenameCustomTypeModal.tsx
@@ -103,6 +103,10 @@ export const RenameCustomTypeModal: React.FC<RenameCustomTypeModalProps> = ({
           })} name is already taken.`;
         }
 
+        if (["update", "insert"].includes(newName.toLowerCase())) {
+          errors.customTypeName = `Name "${newName}" is reserved for Slice Machine use.`;
+        }
+
         return Object.keys(errors).length > 0 ? errors : undefined;
       }}
     >

--- a/packages/slice-machine/src/legacy/components/Forms/formsValidator.ts
+++ b/packages/slice-machine/src/legacy/components/Forms/formsValidator.ts
@@ -21,21 +21,21 @@ export function validateSliceModalValues(
   if (!sliceName) {
     return { sliceName: "Cannot be empty" };
   }
+  if (RESERVED_SLICE_NAME.includes(sliceName.toLowerCase())) {
+    return {
+      sliceName: `Name "${sliceName}" is reserved for Slice Machine use.`,
+    };
+  }
   if (!API_ID_REGEX.exec(sliceName)) {
-    return { sliceName: "No special characters allowed" };
+    return { sliceName: "No special characters allowed." };
   }
   const cased = startCase(camelCase(sliceName)).replace(/\s/gm, "");
   if (cased !== sliceName.trim()) {
-    return { sliceName: "Value has to be PascalCased" };
+    return { sliceName: "Value has to be PascalCased." };
   }
   // See: #599
   if (sliceName.match(/^\d/)) {
-    return { sliceName: "Value cannot start with a number" };
-  }
-  if (RESERVED_SLICE_NAME.includes(sliceName)) {
-    return {
-      sliceName: `${sliceName} is reserved for Slice Machine use`,
-    };
+    return { sliceName: "Value cannot start with a number." };
   }
 
   const localNames = localLibs.flatMap((lib) =>

--- a/packages/slice-machine/src/legacy/lib/consts.ts
+++ b/packages/slice-machine/src/legacy/lib/consts.ts
@@ -1,5 +1,5 @@
 // A list of slice names that are reserved for internal uses.
-export const RESERVED_SLICE_NAME = ["components"];
+export const RESERVED_SLICE_NAME = ["components", "update", "insert"];
 
 export const acceptedImagesTypes = ["png", "jpg", "jpeg"];
 

--- a/playwright/tests/customTypes/customTypesTable.spec.ts
+++ b/playwright/tests/customTypes/customTypesTable.spec.ts
@@ -63,6 +63,27 @@ test("I cannot create a custom type with a name or id already used", async ({
   ).toBeDisabled();
 });
 
+test("I cannot create a custom type with a name update or insert", async ({
+  customTypesTablePage,
+}) => {
+  await customTypesTablePage.goto();
+  await customTypesTablePage.openCreateDialog();
+
+  await expect(customTypesTablePage.createTypeDialog.title).toBeVisible();
+  await customTypesTablePage.createTypeDialog.nameInput.fill(
+    "update",
+  );
+  await expect(
+    customTypesTablePage.createTypeDialog.submitButton,
+  ).toBeDisabled();
+  await customTypesTablePage.createTypeDialog.nameInput.fill(
+    "insert",
+  );
+  await expect(
+    customTypesTablePage.createTypeDialog.submitButton,
+  ).toBeDisabled();
+});
+
 test("I can rename a custom type", async ({
   reusableCustomType,
   customTypesTablePage,

--- a/playwright/tests/customTypes/customTypesTable.spec.ts
+++ b/playwright/tests/customTypes/customTypesTable.spec.ts
@@ -70,15 +70,11 @@ test("I cannot create a custom type with a name update or insert", async ({
   await customTypesTablePage.openCreateDialog();
 
   await expect(customTypesTablePage.createTypeDialog.title).toBeVisible();
-  await customTypesTablePage.createTypeDialog.nameInput.fill(
-    "update",
-  );
+  await customTypesTablePage.createTypeDialog.nameInput.fill("update");
   await expect(
     customTypesTablePage.createTypeDialog.submitButton,
   ).toBeDisabled();
-  await customTypesTablePage.createTypeDialog.nameInput.fill(
-    "insert",
-  );
+  await customTypesTablePage.createTypeDialog.nameInput.fill("insert");
   await expect(
     customTypesTablePage.createTypeDialog.submitButton,
   ).toBeDisabled();

--- a/playwright/tests/pageTypes/pageTypesTable.spec.ts
+++ b/playwright/tests/pageTypes/pageTypesTable.spec.ts
@@ -89,6 +89,23 @@ test("I cannot create a page type with a name or id already used", async ({
   await expect(pageTypesTablePage.createTypeDialog.submitButton).toBeDisabled();
 });
 
+test("I cannot create a page type with a name update or insert", async ({
+  pageTypesTablePage,
+}) => {
+  await pageTypesTablePage.goto();
+  await pageTypesTablePage.openCreateDialog();
+
+  await expect(pageTypesTablePage.createTypeDialog.title).toBeVisible();
+  await pageTypesTablePage.createTypeDialog.nameInput.fill(
+    "update",
+  );
+  await expect(pageTypesTablePage.createTypeDialog.submitButton).toBeDisabled();
+  await pageTypesTablePage.createTypeDialog.nameInput.fill(
+    "insert",
+  );
+  await expect(pageTypesTablePage.createTypeDialog.submitButton).toBeDisabled();
+});
+
 test("I can rename a page type", async ({
   pageTypesTablePage,
   reusablePageType,

--- a/playwright/tests/pageTypes/pageTypesTable.spec.ts
+++ b/playwright/tests/pageTypes/pageTypesTable.spec.ts
@@ -96,13 +96,9 @@ test("I cannot create a page type with a name update or insert", async ({
   await pageTypesTablePage.openCreateDialog();
 
   await expect(pageTypesTablePage.createTypeDialog.title).toBeVisible();
-  await pageTypesTablePage.createTypeDialog.nameInput.fill(
-    "update",
-  );
+  await pageTypesTablePage.createTypeDialog.nameInput.fill("update");
   await expect(pageTypesTablePage.createTypeDialog.submitButton).toBeDisabled();
-  await pageTypesTablePage.createTypeDialog.nameInput.fill(
-    "insert",
-  );
+  await pageTypesTablePage.createTypeDialog.nameInput.fill("insert");
   await expect(pageTypesTablePage.createTypeDialog.submitButton).toBeDisabled();
 });
 

--- a/playwright/tests/slices/slicesList.spec.ts
+++ b/playwright/tests/slices/slicesList.spec.ts
@@ -147,6 +147,23 @@ test("I cannot rename a slice with a name starting with a number", async ({
   await expect(slicesListPage.renameSliceDialog.submitButton).toBeDisabled();
 });
 
+test("I cannot create a slice with a restricted name ", async ({
+  slicesListPage,
+}) => {
+  await slicesListPage.goto();
+  await slicesListPage.openCreateDialog();
+
+  const { nameInput, submitButton } = slicesListPage.createSliceDialog;
+
+  await nameInput.fill("components");
+  await expect(submitButton).toBeDisabled();
+  await nameInput.fill("update");
+  await expect(submitButton).toBeDisabled();
+  await nameInput.fill("insert");
+  await expect(submitButton).toBeDisabled();
+
+});
+
 test("I cannot create two slices with the same name", async ({
   sliceBuilderPage,
   slicesListPage,

--- a/playwright/tests/slices/slicesList.spec.ts
+++ b/playwright/tests/slices/slicesList.spec.ts
@@ -161,7 +161,6 @@ test("I cannot create a slice with a restricted name ", async ({
   await expect(submitButton).toBeDisabled();
   await nameInput.fill("insert");
   await expect(submitButton).toBeDisabled();
-
 });
 
 test("I cannot create two slices with the same name", async ({


### PR DESCRIPTION
<!-- Please use a Conventional Commit in your PR title -->
<!-- https://conventionalcommits.org -->
<!-- e.g. "feat: support new field type" -->

**Resolves**: [DT-2239](https://linear.app/prismic/issue/DT-2239/bug-aauser-i-cant-create-a-slice-or-a-ct-called-update-or-insert-as)

### Description

Added validation to prevent creating or renaming slices and custom types with reserved endpoints name : update, insert.
 
<!-- Describe your changes in detail. -->
<!-- Why is this change required? -->
<!-- What problem does it solve? -->

### Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- Don't hesitate to ask for help! -->

- [ ] A comprehensive Linear ticket, providing sufficient context and details to facilitate the review of the PR, is linked to the PR.
- [ ] If my changes require tests, I added them.
- [ ] If my changes affect backward compatibility, it has been discussed.
- [ ] If my changes require an update to the CONTRIBUTING.md guide, I updated it.

### Preview
![Zrzut ekranu 2024-12-13 o 16 00 36](https://github.com/user-attachments/assets/6662c97f-1fd6-43e4-ac1b-7a0ed9cc89f4)

<!-- If your changes are visual, screenshots or videos are welcome! -->

### How to QA [^1]

<!-- When relevant, describe how to QA your changes. -->

<!-- Your favorite emoji is welcome to close your PR! -->

<!-- A note for reviewers: -->

[^1]:
	Please use these labels when submitting a review:
	:question: #ask:&ensp;Ask a question.
	:bulb: #idea:&ensp;Suggest an idea.
	:warning: #issue:&ensp;Strongly suggest a change.
	:tada: #nice:&ensp;Share a compliment.
