### PR TITLE
fix: skip flaky test

### DIFF
--- a/playwright/tests/common/autoSync.spec.ts
+++ b/playwright/tests/common/autoSync.spec.ts
@@ -3,7 +3,10 @@ import { expect } from "@playwright/test";
 import { test } from "../../fixtures";
 import { environments } from "../../mocks";
 
-test("I can see the auto-sync succeed when making a change", async ({
+// TODO: Fix if we release auto-sync (without feature flag)
+// Test skipped as the feature is not currently maintained, and the test is randomly failing
+// https://linear.app/prismic/issue/DT-2526/aadev-i-dont-want-to-have-flaky-test
+test.skip("I can see the auto-sync succeed when making a change", async ({
   pageTypesBuilderPage,
   reusablePageType,
   procedures,


### PR DESCRIPTION
<!-- Please use a Conventional Commit in your PR title -->
<!-- https://conventionalcommits.org -->
<!-- e.g. "feat: support new field type" -->

**Resolves**: [DT-2526](https://linear.app/prismic/issue/DT-2526/aadev-i-dont-want-to-have-flaky-test)

### Description

`autoSync` e2e test is notoriously failing which blocks the CI.
It can be skipped since the feature is not currently supported.

<!-- Describe your changes in detail. -->
<!-- Why is this change required? -->
<!-- What problem does it solve? -->

### Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- Don't hesitate to ask for help! -->

- [ ] A comprehensive Linear ticket, providing sufficient context and details to facilitate the review of the PR, is linked to the PR.
- [ ] If my changes require tests, I added them.
- [ ] If my changes affect backward compatibility, it has been discussed.
- [ ] If my changes require an update to the CONTRIBUTING.md guide, I updated it.

### Preview

<!-- If your changes are visual, screenshots or videos are welcome! -->

### How to QA [^1]

<!-- When relevant, describe how to QA your changes. -->

<!-- Your favorite emoji is welcome to close your PR! -->

<!-- A note for reviewers: -->

[^1]:
	Please use these labels when submitting a review:
	:question: #ask:&ensp;Ask a question.
	:bulb: #idea:&ensp;Suggest an idea.
	:warning: #issue:&ensp;Strongly suggest a change.
	:tada: #nice:&ensp;Share a compliment.
