### PR TITLE
Fix delete link variant bug

### DIFF
--- a/packages/slice-machine/src/legacy/lib/models/common/widgets/Link/components.tsx
+++ b/packages/slice-machine/src/legacy/lib/models/common/widgets/Link/components.tsx
@@ -187,6 +187,7 @@ export function Variants({
               </Box>
               {deleteButtonShown && (
                 <IconButton
+                  type="button"
                   icon="delete"
                   onClick={() =>
                     onVariantsChange(


### PR DESCRIPTION
<!-- Please use a Conventional Commit in your PR title -->
<!-- https://conventionalcommits.org -->
<!-- e.g. "feat: support new field type" -->

**Resolves**: <!-- GitHub or Linear issue (e.g. #123, DT-123) -->

### Description
Before, once you had 4+ link variants in the link modal, clicking one of the delete variant buttons would submit the form and potentially close the modal, rather than just stay there. Now it works as expected.

<!-- Describe your changes in detail. -->
<!-- Why is this change required? -->
<!-- What problem does it solve? -->

### Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- Don't hesitate to ask for help! -->

- [ ] A comprehensive Linear ticket, providing sufficient context and details to facilitate the review of the PR, is linked to the PR.
- [ ] If my changes require tests, I added them.
- [ ] If my changes affect backward compatibility, it has been discussed.
- [ ] If my changes require an update to the CONTRIBUTING.md guide, I updated it.

### Preview

<!-- If your changes are visual, screenshots or videos are welcome! -->

### How to QA [^1]

<!-- When relevant, describe how to QA your changes. -->

<!-- Your favorite emoji is welcome to close your PR! -->

<!-- A note for reviewers: -->

[^1]:
	Please use these labels when submitting a review:
	:question: #ask:&ensp;Ask a question.
	:bulb: #idea:&ensp;Suggest an idea.
	:warning: #issue:&ensp;Strongly suggest a change.
	:tada: #nice:&ensp;Share a compliment.
