### PR TITLE
feat(adapter-*): update page snippets with meta image

### DIFF
--- a/packages/adapter-next/src/hooks/documentation-read.ts
+++ b/packages/adapter-next/src/hooks/documentation-read.ts
@@ -34,7 +34,7 @@ export const documentationRead: DocumentationReadHook<PluginOptions> = async (
 				appFileContent = stripIndent`
 					import { Metadata } from "next";
 					import { notFound } from "next/navigation";
-					import { asImageSrc } from "@prismicio/client";
+					import { isFilled, asImageSrc } from "@prismicio/client";
 					import { SliceZone } from "@prismicio/react";
 
 					import { createClient } from "@/prismicio";
@@ -67,9 +67,9 @@ export const documentationRead: DocumentationReadHook<PluginOptions> = async (
 							title: page.data.meta_title,
 							description: page.data.meta_description,
 							openGraph: {
-								title: page.data.meta_title,
-								description: page.data.meta_description,
-								images: [asImageSrc(page.data.meta_image)],
+								title: isFilled.keyText(page.data.meta_title) ? page.data.meta_title : undefined,
+								description: isFilled.keyText(page.data.meta_description) ? page.data.meta_description : undefined,
+								images: isFilled.image(page.data.meta_image) ? [asImageSrc(page.data.meta_image)] : undefined,
 							},
 						};
 					}
@@ -148,7 +148,7 @@ export const documentationRead: DocumentationReadHook<PluginOptions> = async (
 			} else {
 				appFileContent = stripIndent`
 					import { Metadata } from "next";
-					import { asImageSrc } from "@prismicio/client";
+					import { isFilled, asImageSrc } from "@prismicio/client";
 					import { SliceZone } from "@prismicio/react";
 
 					import { createClient } from "@/prismicio";
@@ -169,9 +169,9 @@ export const documentationRead: DocumentationReadHook<PluginOptions> = async (
 							title: page.data.meta_title,
 							description: page.data.meta_description,
 							openGraph: {
-								title: page.data.meta_title,
-								description: page.data.meta_description,
-								images: [asImageSrc(page.data.meta_image)],
+								title: isFilled.keyText(page.data.meta_title) ? page.data.meta_title : undefined,
+								description: isFilled.keyText(page.data.meta_description) ? page.data.meta_description : undefined,
+								images: isFilled.image(page.data.meta_image) ? [asImageSrc(page.data.meta_image)] : undefined,
 							},
 						};
 					}
@@ -226,7 +226,7 @@ export const documentationRead: DocumentationReadHook<PluginOptions> = async (
 			if (model.repeatable) {
 				appFileContent = stripIndent`
 					import { notFound } from "next/navigation";
-					import { asImageSrc } from "@prismicio/client";
+					import { isFilled, asImageSrc } from "@prismicio/client";
 					import { SliceZone } from "@prismicio/react";
 
 					import { createClient } from "@/prismicio";
@@ -254,9 +254,9 @@ export const documentationRead: DocumentationReadHook<PluginOptions> = async (
 							title: page.data.meta_title,
 							description: page.data.meta_description,
 							openGraph: {
-								title: page.data.meta_title,
-								description: page.data.meta_description,
-								images: [asImageSrc(page.data.meta_image)],
+								title: isFilled.keyText(page.data.meta_title) ? page.data.meta_title : undefined,
+								description: isFilled.keyText(page.data.meta_description) ? page.data.meta_description : undefined,
+								images: isFilled.image(page.data.meta_image) ? [asImageSrc(page.data.meta_image)] : undefined,
 							},
 						};
 					}
@@ -329,7 +329,7 @@ export const documentationRead: DocumentationReadHook<PluginOptions> = async (
 				`;
 			} else {
 				appFileContent = stripIndent`
-					import { asImageSrc } from "@prismicio/client";
+					import { isFilled, asImageSrc } from "@prismicio/client";
 					import { SliceZone } from "@prismicio/react";
 
 					import { createClient } from "@/prismicio";
@@ -350,9 +350,9 @@ export const documentationRead: DocumentationReadHook<PluginOptions> = async (
 							title: page.data.meta_title,
 							description: page.data.meta_description,
 							openGraph: {
-								title: page.data.meta_title,
-								description: page.data.meta_description,
-								images: [asImageSrc(page.data.meta_image)],
+								title: isFilled.keyText(page.data.meta_title) ? page.data.meta_title : undefined,
+								description: isFilled.keyText(page.data.meta_description) ? page.data.meta_description : undefined,
+								images: isFilled.image(page.data.meta_image) ? [asImageSrc(page.data.meta_image)] : undefined,
 							},
 						};
 					}

--- a/packages/adapter-next/src/hooks/documentation-read.ts
+++ b/packages/adapter-next/src/hooks/documentation-read.ts
@@ -34,6 +34,7 @@ export const documentationRead: DocumentationReadHook<PluginOptions> = async (
 				appFileContent = stripIndent`
 					import { Metadata } from "next";
 					import { notFound } from "next/navigation";
+					import { asImageSrc } from "@prismicio/client";
 					import { SliceZone } from "@prismicio/react";
 
 					import { createClient } from "@/prismicio";
@@ -65,6 +66,11 @@ export const documentationRead: DocumentationReadHook<PluginOptions> = async (
 						return {
 							title: page.data.meta_title,
 							description: page.data.meta_description,
+							openGraph: {
+								title: page.data.meta_title,
+								description: page.data.meta_description,
+								images: [asImageSrc(page.data.meta_image)],
+							},
 						};
 					}
 
@@ -80,7 +86,7 @@ export const documentationRead: DocumentationReadHook<PluginOptions> = async (
 				pagesFileContent = stripIndent`
 					import { GetStaticPropsContext, InferGetStaticPropsType } from "next";
 					import Head from "next/head";
-					import { isFilled, asLink } from "@prismicio/client";
+					import { isFilled, asLink, asImageSrc } from "@prismicio/client";
 					import { SliceZone } from "@prismicio/react";
 
 					import { components } from "@/slices";
@@ -95,8 +101,15 @@ export const documentationRead: DocumentationReadHook<PluginOptions> = async (
 							<>
 								<Head>
 									<title>{page.data.meta_title}</title>
+									<meta property="og:title" content={page.data.meta_title} />
 									{isFilled.keyText(page.data.meta_description) ? (
-										<meta name="description" content={page.data.meta_description} />
+										<>
+											<meta name="description" content={page.data.meta_description} />
+											<meta property="og:description" content={page.data.meta_description} />
+										</>
+									) : null}
+									{isFilled.image(page.data.meta_image) ? (
+										<meta property="og:image" content={asImageSrc(page.data.meta_image)} />
 									) : null}
 								</Head>
 								<SliceZone slices={page.data.slices} components={components} />
@@ -135,6 +148,7 @@ export const documentationRead: DocumentationReadHook<PluginOptions> = async (
 			} else {
 				appFileContent = stripIndent`
 					import { Metadata } from "next";
+					import { asImageSrc } from "@prismicio/client";
 					import { SliceZone } from "@prismicio/react";
 
 					import { createClient } from "@/prismicio";
@@ -154,13 +168,18 @@ export const documentationRead: DocumentationReadHook<PluginOptions> = async (
 						return {
 							title: page.data.meta_title,
 							description: page.data.meta_description,
+							openGraph: {
+								title: page.data.meta_title,
+								description: page.data.meta_description,
+								images: [asImageSrc(page.data.meta_image)],
+							},
 						};
 					}
 				`;
 				pagesFileContent = stripIndent`
 					import { GetStaticPropsContext, InferGetStaticPropsType } from "next";
 					import Head from "next/head";
-					import { isFilled } from "@prismicio/client";
+					import { isFilled, asImageSrc } from "@prismicio/client";
 					import { SliceZone } from "@prismicio/react";
 
 					import { components } from "@/slices";
@@ -173,8 +192,15 @@ export const documentationRead: DocumentationReadHook<PluginOptions> = async (
 							<>
 								<Head>
 									<title>{page.data.meta_title}</title>
+									<meta property="og:title" content={page.data.meta_title} />
 									{isFilled.keyText(page.data.meta_description) ? (
-										<meta name="description" content={page.data.meta_description} />
+										<>
+											<meta name="description" content={page.data.meta_description} />
+											<meta property="og:description" content={page.data.meta_description} />
+										</>
+									) : null}
+									{isFilled.image(page.data.meta_image) ? (
+										<meta property="og:image" content={asImageSrc(page.data.meta_image)} />
 									) : null}
 								</Head>
 								<SliceZone slices={page.data.slices} components={components} />
@@ -200,6 +226,7 @@ export const documentationRead: DocumentationReadHook<PluginOptions> = async (
 			if (model.repeatable) {
 				appFileContent = stripIndent`
 					import { notFound } from "next/navigation";
+					import { asImageSrc } from "@prismicio/client";
 					import { SliceZone } from "@prismicio/react";
 
 					import { createClient } from "@/prismicio";
@@ -226,6 +253,11 @@ export const documentationRead: DocumentationReadHook<PluginOptions> = async (
 						return {
 							title: page.data.meta_title,
 							description: page.data.meta_description,
+							openGraph: {
+								title: page.data.meta_title,
+								description: page.data.meta_description,
+								images: [asImageSrc(page.data.meta_image)],
+							},
 						};
 					}
 
@@ -240,7 +272,7 @@ export const documentationRead: DocumentationReadHook<PluginOptions> = async (
 				`;
 				pagesFileContent = stripIndent`
 					import Head from "next/head";
-					import { isFilled, asLink } from "@prismicio/client";
+					import { isFilled, asLink, asImageSrc } from "@prismicio/client";
 					import { SliceZone } from "@prismicio/react";
 
 					import { components } from "@/slices";
@@ -251,8 +283,15 @@ export const documentationRead: DocumentationReadHook<PluginOptions> = async (
 							<>
 								<Head>
 									<title>{page.data.meta_title}</title>
+									<meta property="og:title" content={page.data.meta_title} />
 									{isFilled.keyText(page.data.meta_description) ? (
-										<meta name="description" content={page.data.meta_description} />
+										<>
+											<meta name="description" content={page.data.meta_description} />
+											<meta property="og:description" content={page.data.meta_description} />
+										</>
+									) : null}
+									{isFilled.image(page.data.meta_image) ? (
+										<meta property="og:image" content={asImageSrc(page.data.meta_image)} />
 									) : null}
 								</Head>
 								<SliceZone slices={page.data.slices} components={components} />
@@ -290,6 +329,7 @@ export const documentationRead: DocumentationReadHook<PluginOptions> = async (
 				`;
 			} else {
 				appFileContent = stripIndent`
+					import { asImageSrc } from "@prismicio/client";
 					import { SliceZone } from "@prismicio/react";
 
 					import { createClient } from "@/prismicio";
@@ -309,12 +349,17 @@ export const documentationRead: DocumentationReadHook<PluginOptions> = async (
 						return {
 							title: page.data.meta_title,
 							description: page.data.meta_description,
+							openGraph: {
+								title: page.data.meta_title,
+								description: page.data.meta_description,
+								images: [asImageSrc(page.data.meta_image)],
+							},
 						};
 					}
 				`;
 				pagesFileContent = stripIndent`
 					import Head from "next/head";
-					import { isFilled } from "@prismicio/client";
+					import { isFilled, asImageSrc } from "@prismicio/client";
 					import { SliceZone } from "@prismicio/react";
 
 					import { components } from "@/slices";
@@ -325,8 +370,15 @@ export const documentationRead: DocumentationReadHook<PluginOptions> = async (
 							<>
 								<Head>
 									<title>{page.data.meta_title}</title>
+									<meta property="og:title" content={page.data.meta_title} />
 									{isFilled.keyText(page.data.meta_description) ? (
-										<meta name="description" content={page.data.meta_description} />
+										<>
+											<meta name="description" content={page.data.meta_description} />
+											<meta property="og:description" content={page.data.meta_description} />
+										</>
+									) : null}
+									{isFilled.image(page.data.meta_image) ? (
+										<meta property="og:image" content={asImageSrc(page.data.meta_image)} />
 									) : null}
 								</Head>
 								<SliceZone slices={page.data.slices} components={components} />

--- a/packages/adapter-next/test/__snapshots__/plugin-documentation-read.test.ts.snap
+++ b/packages/adapter-next/test/__snapshots__/plugin-documentation-read.test.ts.snap
@@ -10,7 +10,7 @@ Paste in this code:
 
 ~~~js [app/[uid]/page.js]
 import { notFound } from \\"next/navigation\\";
-import { asImageSrc } from \\"@prismicio/client\\";
+import { isFilled, asImageSrc } from \\"@prismicio/client\\";
 import { SliceZone } from \\"@prismicio/react\\";
 
 import { createClient } from \\"@/prismicio\\";
@@ -33,9 +33,15 @@ export async function generateMetadata({ params }) {
     title: page.data.meta_title,
     description: page.data.meta_description,
     openGraph: {
-      title: page.data.meta_title,
-      description: page.data.meta_description,
-      images: [asImageSrc(page.data.meta_image)],
+      title: isFilled.keyText(page.data.meta_title)
+        ? page.data.meta_title
+        : undefined,
+      description: isFilled.keyText(page.data.meta_description)
+        ? page.data.meta_description
+        : undefined,
+      images: isFilled.image(page.data.meta_image)
+        ? [asImageSrc(page.data.meta_image)]
+        : undefined,
     },
   };
 }
@@ -66,7 +72,7 @@ Paste in this code:
 ~~~tsx [app/[uid]/page.tsx]
 import { Metadata } from \\"next\\";
 import { notFound } from \\"next/navigation\\";
-import { asImageSrc } from \\"@prismicio/client\\";
+import { isFilled, asImageSrc } from \\"@prismicio/client\\";
 import { SliceZone } from \\"@prismicio/react\\";
 
 import { createClient } from \\"@/prismicio\\";
@@ -95,9 +101,15 @@ export async function generateMetadata({
     title: page.data.meta_title,
     description: page.data.meta_description,
     openGraph: {
-      title: page.data.meta_title,
-      description: page.data.meta_description,
-      images: [asImageSrc(page.data.meta_image)],
+      title: isFilled.keyText(page.data.meta_title)
+        ? page.data.meta_title
+        : undefined,
+      description: isFilled.keyText(page.data.meta_description)
+        ? page.data.meta_description
+        : undefined,
+      images: isFilled.image(page.data.meta_image)
+        ? [asImageSrc(page.data.meta_image)]
+        : undefined,
     },
   };
 }

--- a/packages/adapter-next/test/__snapshots__/plugin-documentation-read.test.ts.snap
+++ b/packages/adapter-next/test/__snapshots__/plugin-documentation-read.test.ts.snap
@@ -10,6 +10,7 @@ Paste in this code:
 
 ~~~js [app/[uid]/page.js]
 import { notFound } from \\"next/navigation\\";
+import { asImageSrc } from \\"@prismicio/client\\";
 import { SliceZone } from \\"@prismicio/react\\";
 
 import { createClient } from \\"@/prismicio\\";
@@ -31,6 +32,11 @@ export async function generateMetadata({ params }) {
   return {
     title: page.data.meta_title,
     description: page.data.meta_description,
+    openGraph: {
+      title: page.data.meta_title,
+      description: page.data.meta_description,
+      images: [asImageSrc(page.data.meta_image)],
+    },
   };
 }
 
@@ -60,6 +66,7 @@ Paste in this code:
 ~~~tsx [app/[uid]/page.tsx]
 import { Metadata } from \\"next\\";
 import { notFound } from \\"next/navigation\\";
+import { asImageSrc } from \\"@prismicio/client\\";
 import { SliceZone } from \\"@prismicio/react\\";
 
 import { createClient } from \\"@/prismicio\\";
@@ -87,6 +94,11 @@ export async function generateMetadata({
   return {
     title: page.data.meta_title,
     description: page.data.meta_description,
+    openGraph: {
+      title: page.data.meta_title,
+      description: page.data.meta_description,
+      images: [asImageSrc(page.data.meta_image)],
+    },
   };
 }
 
@@ -113,7 +125,7 @@ Add a new route by creating a \`pages/[uid].js\` file. (If the route should be n
 
 ~~~js [pages/[uid].js]
 import Head from \\"next/head\\";
-import { isFilled, asLink } from \\"@prismicio/client\\";
+import { isFilled, asLink, asImageSrc } from \\"@prismicio/client\\";
 import { SliceZone } from \\"@prismicio/react\\";
 
 import { components } from \\"@/slices\\";
@@ -124,8 +136,21 @@ export default function Page({ page }) {
     <>
       <Head>
         <title>{page.data.meta_title}</title>
+        <meta property=\\"og:title\\" content={page.data.meta_title} />
         {isFilled.keyText(page.data.meta_description) ? (
-          <meta name=\\"description\\" content={page.data.meta_description} />
+          <>
+            <meta name=\\"description\\" content={page.data.meta_description} />
+            <meta
+              property=\\"og:description\\"
+              content={page.data.meta_description}
+            />
+          </>
+        ) : null}
+        {isFilled.image(page.data.meta_image) ? (
+          <meta
+            property=\\"og:image\\"
+            content={asImageSrc(page.data.meta_image)}
+          />
         ) : null}
       </Head>
       <SliceZone slices={page.data.slices} components={components} />
@@ -173,7 +198,7 @@ Add a new route by creating a \`pages/[uid].tsx\` file. (If the route should be 
 ~~~tsx [pages/[uid].tsx]
 import { GetStaticPropsContext, InferGetStaticPropsType } from \\"next\\";
 import Head from \\"next/head\\";
-import { isFilled, asLink } from \\"@prismicio/client\\";
+import { isFilled, asLink, asImageSrc } from \\"@prismicio/client\\";
 import { SliceZone } from \\"@prismicio/react\\";
 
 import { components } from \\"@/slices\\";
@@ -188,8 +213,21 @@ export default function Page({
     <>
       <Head>
         <title>{page.data.meta_title}</title>
+        <meta property=\\"og:title\\" content={page.data.meta_title} />
         {isFilled.keyText(page.data.meta_description) ? (
-          <meta name=\\"description\\" content={page.data.meta_description} />
+          <>
+            <meta name=\\"description\\" content={page.data.meta_description} />
+            <meta
+              property=\\"og:description\\"
+              content={page.data.meta_description}
+            />
+          </>
+        ) : null}
+        {isFilled.image(page.data.meta_image) ? (
+          <meta
+            property=\\"og:image\\"
+            content={asImageSrc(page.data.meta_image)}
+          />
         ) : null}
       </Head>
       <SliceZone slices={page.data.slices} components={components} />

--- a/packages/adapter-nuxt/src/hooks/documentation-read.ts
+++ b/packages/adapter-nuxt/src/hooks/documentation-read.ts
@@ -39,12 +39,13 @@ export const documentationRead: DocumentationReadHook<PluginOptions> = async (
 					})
 				);
 
-				useHead({
+				useSeoMeta({
 					title: page.value?.data.meta_title,
-					meta: [{
-						name: "description",
-						content: page.value?.data.meta_description,
-					}],
+					ogTitle: page.value?.data.meta_title,
+					description: page.value?.data.meta_description,
+					ogDescription: page.value?.data.meta_description,
+					ogImage: computed(() => prismic.asImageSrc(page.value?.data.meta_image)),
+					twitterCard: "summary_large_image",
 				});
 				</script>
 
@@ -59,20 +60,21 @@ export const documentationRead: DocumentationReadHook<PluginOptions> = async (
 		} else {
 			fileContent = stripIndent`
 				<script ${scriptAttributes.join(" ")}>
-					import { components } from "~/slices";
+				import { components } from "~/slices";
 
-					const prismic = usePrismic();
-					const { data: page } = useAsyncData("[${model.id}]", () =>
-						prismic.client.getSingle("${model.id}")
-					);
+				const prismic = usePrismic();
+				const { data: page } = useAsyncData("[${model.id}]", () =>
+					prismic.client.getSingle("${model.id}")
+				);
 
-					useHead({
-						title: page.value?.data.meta_title,
-						meta: [{
-							name: "description",
-							content: page.value?.data.meta_description,
-						}],
-					});
+				useSeoMeta({
+					title: page.value?.data.meta_title,
+					ogTitle: page.value?.data.meta_title,
+					description: page.value?.data.meta_description,
+					ogDescription: page.value?.data.meta_description,
+					ogImage: computed(() => prismic.asImageSrc(page.value?.data.meta_image)),
+					twitterCard: "summary_large_image",
+				});
 				</script>
 
 				<template>

--- a/packages/adapter-nuxt/src/hooks/documentation-read.ts
+++ b/packages/adapter-nuxt/src/hooks/documentation-read.ts
@@ -45,7 +45,6 @@ export const documentationRead: DocumentationReadHook<PluginOptions> = async (
 					description: page.value?.data.meta_description,
 					ogDescription: page.value?.data.meta_description,
 					ogImage: computed(() => prismic.asImageSrc(page.value?.data.meta_image)),
-					twitterCard: "summary_large_image",
 				});
 				</script>
 
@@ -73,7 +72,6 @@ export const documentationRead: DocumentationReadHook<PluginOptions> = async (
 					description: page.value?.data.meta_description,
 					ogDescription: page.value?.data.meta_description,
 					ogImage: computed(() => prismic.asImageSrc(page.value?.data.meta_image)),
-					twitterCard: "summary_large_image",
 				});
 				</script>
 

--- a/packages/adapter-nuxt/src/hooks/slice-create.ts
+++ b/packages/adapter-nuxt/src/hooks/slice-create.ts
@@ -41,7 +41,7 @@ const createComponentFile = async ({
 	} else if (isTypeScriptProject) {
 		contents = stripIndent`
 			<script setup lang="ts">
-			import { type Content } from "@prismicio/client";
+			import type { Content } from "@prismicio/client";
 
 			// The array passed to \`getSliceComponentProps\` is purely optional.
 			// Consider it as a visual hint for you when templating your slice.

--- a/packages/adapter-sveltekit/src/hooks/project-init.ts
+++ b/packages/adapter-sveltekit/src/hooks/project-init.ts
@@ -336,14 +336,14 @@ const createRootLayoutFile = async ({
 		</script>
 
 		<svelte:head>
-			<title>{$page.data.page?.data.meta_title}</title>
-			<meta property="og:title" content={$page.data.page?.data.meta_title} />
-			{#if isFilled.keyText($page.data.page?.data.meta_description)}
-				<meta name="description" content={$page.data.page.data.meta_description} />
-				<meta property="og:description" content={$page.data.page.data.meta_description} />
+			<title>{page.data.page?.data.meta_title}</title>
+			<meta property="og:title" content={page.data.page?.data.meta_title} />
+			{#if isFilled.keyText(page.data.page?.data.meta_description)}
+				<meta name="description" content={page.data.page.data.meta_description} />
+				<meta property="og:description" content={page.data.page.data.meta_description} />
 			{/if}
-			{#if isFilled.image($page.data.page?.data.meta_image)}
-				<meta property="og:image" content={asImageSrc($page.data.page.data.meta_image)} />
+			{#if isFilled.image(page.data.page?.data.meta_image)}
+				<meta property="og:image" content={asImageSrc(page.data.page.data.meta_image)} />
 			{/if}
 		</svelte:head>
 		<slot />

--- a/packages/adapter-sveltekit/src/hooks/project-init.ts
+++ b/packages/adapter-sveltekit/src/hooks/project-init.ts
@@ -336,14 +336,14 @@ const createRootLayoutFile = async ({
 		</script>
 
 		<svelte:head>
-			<title>{$page?.data.title}</title>
-			<meta property="og:title" content={$page?.data.title} />
-			{#if isFilled.keyText($page?.data.meta_description)}
-				<meta name="description" content={$page.data.meta_description} />
-				<meta property="og:description" content={$page.data.meta_description} />
+			<title>{$page.data.page?.meta_title}</title>
+			<meta property="og:title" content={$page.data.page?.meta_title} />
+			{#if isFilled.keyText($page.data.page?.meta_description)}
+				<meta name="description" content={$page.data.page.meta_description} />
+				<meta property="og:description" content={$page.data.page.meta_description} />
 			{/if}
-			{#if isFilled.image($page?.data.meta_image)}
-				<meta property="og:image" content={asImageSrc($page.data.meta_image)} />
+			{#if isFilled.image($page.data.page?.meta_image)}
+				<meta property="og:image" content={asImageSrc($page.data.page.meta_image)} />
 			{/if}
 		</svelte:head>
 		<slot />

--- a/packages/adapter-sveltekit/src/hooks/project-init.ts
+++ b/packages/adapter-sveltekit/src/hooks/project-init.ts
@@ -331,7 +331,7 @@ const createRootLayoutFile = async ({
 		<script>
 			import { isFilled, asImageSrc } from '@prismicio/client';
 			import { PrismicPreview } from '@prismicio/svelte/kit';
-			import { page } from '$app/stores';
+			import { page } from '$app/state';
 			import { repositoryName } from '$lib/prismicio';
 		</script>
 

--- a/packages/adapter-sveltekit/src/hooks/project-init.ts
+++ b/packages/adapter-sveltekit/src/hooks/project-init.ts
@@ -329,10 +329,23 @@ const createRootLayoutFile = async ({
 
 	const contents = source`
 		<script>
+			import { isFilled, asImageSrc } from '@prismicio/client';
 			import { PrismicPreview } from '@prismicio/svelte/kit';
+			import { page } from '$app/stores';
 			import { repositoryName } from '$lib/prismicio';
 		</script>
 
+		<svelte:head>
+			<title>{$page?.data.title}</title>
+			<meta property="og:title" content={$page?.data.title} />
+			{#if isFilled.keyText($page?.data.meta_description)}
+				<meta name="description" content={$page.data.meta_description} />
+				<meta property="og:description" content={$page.data.meta_description} />
+			{/if}
+			{#if isFilled.image($page?.data.meta_image)}
+				<meta property="og:image" content={asImageSrc($page.data.meta_image)} />
+			{/if}
+		</svelte:head>
 		<slot />
 		<PrismicPreview {repositoryName} />
 	`;

--- a/packages/adapter-sveltekit/src/hooks/project-init.ts
+++ b/packages/adapter-sveltekit/src/hooks/project-init.ts
@@ -336,14 +336,14 @@ const createRootLayoutFile = async ({
 		</script>
 
 		<svelte:head>
-			<title>{$page.data.page?.meta_title}</title>
-			<meta property="og:title" content={$page.data.page?.meta_title} />
-			{#if isFilled.keyText($page.data.page?.meta_description)}
-				<meta name="description" content={$page.data.page.meta_description} />
-				<meta property="og:description" content={$page.data.page.meta_description} />
+			<title>{$page.data.page?.data.meta_title}</title>
+			<meta property="og:title" content={$page.data.page?.data.meta_title} />
+			{#if isFilled.keyText($page.data.page?.data.meta_description)}
+				<meta name="description" content={$page.data.page.data.meta_description} />
+				<meta property="og:description" content={$page.data.page.data.meta_description} />
 			{/if}
-			{#if isFilled.image($page.data.page?.meta_image)}
-				<meta property="og:image" content={asImageSrc($page.data.page.meta_image)} />
+			{#if isFilled.image($page.data.page?.data.meta_image)}
+				<meta property="og:image" content={asImageSrc($page.data.page.data.meta_image)} />
 			{/if}
 		</svelte:head>
 		<slot />

--- a/packages/adapter-sveltekit/test/plugin-project-init.test.ts
+++ b/packages/adapter-sveltekit/test/plugin-project-init.test.ts
@@ -1045,19 +1045,19 @@ describe("root layout file", () => {
 			</script>
 
 			<svelte:head>
-			  <title>{$page.data.page?.meta_title}</title>
-			  <meta property=\\"og:title\\" content={$page.data.page?.meta_title} />
-			  {#if isFilled.keyText($page.data.page?.meta_description)}
-			    <meta name=\\"description\\" content={$page.data.page.meta_description} />
+			  <title>{$page.data.page?.data.meta_title}</title>
+			  <meta property=\\"og:title\\" content={$page.data.page?.data.meta_title} />
+			  {#if isFilled.keyText($page.data.page?.data.meta_description)}
+			    <meta name=\\"description\\" content={$page.data.page.data.meta_description} />
 			    <meta
 			      property=\\"og:description\\"
-			      content={$page.data.page.meta_description}
+			      content={$page.data.page.data.meta_description}
 			    />
 			  {/if}
-			  {#if isFilled.image($page.data.page?.meta_image)}
+			  {#if isFilled.image($page.data.page?.data.meta_image)}
 			    <meta
 			      property=\\"og:image\\"
-			      content={asImageSrc($page.data.page.meta_image)}
+			      content={asImageSrc($page.data.page.data.meta_image)}
 			    />
 			  {/if}
 			</svelte:head>

--- a/packages/adapter-sveltekit/test/plugin-project-init.test.ts
+++ b/packages/adapter-sveltekit/test/plugin-project-init.test.ts
@@ -1040,7 +1040,7 @@ describe("root layout file", () => {
 			"<script>
 			  import { isFilled, asImageSrc } from \\"@prismicio/client\\";
 			  import { PrismicPreview } from \\"@prismicio/svelte/kit\\";
-			  import { page } from \\"$app/stores\\";
+			  import { page } from \\"$app/state\\";
 			  import { repositoryName } from \\"$lib/prismicio\\";
 			</script>
 

--- a/packages/adapter-sveltekit/test/plugin-project-init.test.ts
+++ b/packages/adapter-sveltekit/test/plugin-project-init.test.ts
@@ -1045,14 +1045,20 @@ describe("root layout file", () => {
 			</script>
 
 			<svelte:head>
-			  <title>{$page?.data.title}</title>
-			  <meta property=\\"og:title\\" content={$page?.data.title} />
-			  {#if isFilled.keyText($page?.data.meta_description)}
-			    <meta name=\\"description\\" content={$page.data.meta_description} />
-			    <meta property=\\"og:description\\" content={$page.data.meta_description} />
+			  <title>{$page.data.page?.meta_title}</title>
+			  <meta property=\\"og:title\\" content={$page.data.page?.meta_title} />
+			  {#if isFilled.keyText($page.data.page?.meta_description)}
+			    <meta name=\\"description\\" content={$page.data.page.meta_description} />
+			    <meta
+			      property=\\"og:description\\"
+			      content={$page.data.page.meta_description}
+			    />
 			  {/if}
-			  {#if isFilled.image($page?.data.meta_image)}
-			    <meta property=\\"og:image\\" content={asImageSrc($page.data.meta_image)} />
+			  {#if isFilled.image($page.data.page?.meta_image)}
+			    <meta
+			      property=\\"og:image\\"
+			      content={asImageSrc($page.data.page.meta_image)}
+			    />
 			  {/if}
 			</svelte:head>
 			<slot />

--- a/packages/adapter-sveltekit/test/plugin-project-init.test.ts
+++ b/packages/adapter-sveltekit/test/plugin-project-init.test.ts
@@ -1045,19 +1045,19 @@ describe("root layout file", () => {
 			</script>
 
 			<svelte:head>
-			  <title>{$page.data.page?.data.meta_title}</title>
-			  <meta property=\\"og:title\\" content={$page.data.page?.data.meta_title} />
-			  {#if isFilled.keyText($page.data.page?.data.meta_description)}
-			    <meta name=\\"description\\" content={$page.data.page.data.meta_description} />
+			  <title>{page.data.page?.data.meta_title}</title>
+			  <meta property=\\"og:title\\" content={page.data.page?.data.meta_title} />
+			  {#if isFilled.keyText(page.data.page?.data.meta_description)}
+			    <meta name=\\"description\\" content={page.data.page.data.meta_description} />
 			    <meta
 			      property=\\"og:description\\"
-			      content={$page.data.page.data.meta_description}
+			      content={page.data.page.data.meta_description}
 			    />
 			  {/if}
-			  {#if isFilled.image($page.data.page?.data.meta_image)}
+			  {#if isFilled.image(page.data.page?.data.meta_image)}
 			    <meta
 			      property=\\"og:image\\"
-			      content={asImageSrc($page.data.page.data.meta_image)}
+			      content={asImageSrc(page.data.page.data.meta_image)}
 			    />
 			  {/if}
 			</svelte:head>

--- a/packages/adapter-sveltekit/test/plugin-project-init.test.ts
+++ b/packages/adapter-sveltekit/test/plugin-project-init.test.ts
@@ -1038,10 +1038,23 @@ describe("root layout file", () => {
 
 		expect(contents).toMatchInlineSnapshot(`
 			"<script>
+			  import { isFilled, asImageSrc } from \\"@prismicio/client\\";
 			  import { PrismicPreview } from \\"@prismicio/svelte/kit\\";
+			  import { page } from \\"$app/stores\\";
 			  import { repositoryName } from \\"$lib/prismicio\\";
 			</script>
 
+			<svelte:head>
+			  <title>{$page?.data.title}</title>
+			  <meta property=\\"og:title\\" content={$page?.data.title} />
+			  {#if isFilled.keyText($page?.data.meta_description)}
+			    <meta name=\\"description\\" content={$page.data.meta_description} />
+			    <meta property=\\"og:description\\" content={$page.data.meta_description} />
+			  {/if}
+			  {#if isFilled.image($page?.data.meta_image)}
+			    <meta property=\\"og:image\\" content={asImageSrc($page.data.meta_image)} />
+			  {/if}
+			</svelte:head>
 			<slot />
 			<PrismicPreview {repositoryName} />
 			"


### PR DESCRIPTION
<!-- Please use a Conventional Commit in your PR title -->
<!-- https://conventionalcommits.org -->
<!-- e.g. "feat: support new field type" -->

**Resolves**: https://github.com/nuxt-modules/prismic/issues/222

### Description

This pull request updates Nuxt pages snippets to use the modern equivalent of `useHead`: `useSeoMeta`, also taking into account meta image.
<!-- Describe your changes in detail. -->
<!-- Why is this change required? -->
<!-- What problem does it solve? -->

### Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- Don't hesitate to ask for help! -->

- [ ] A comprehensive Linear ticket, providing sufficient context and details to facilitate the review of the PR, is linked to the PR.
- [x] If my changes require tests, I added them.
- [x] If my changes affect backward compatibility, it has been discussed.
- [x] If my changes require an update to the CONTRIBUTING.md guide, I updated it.

### Preview

<!-- If your changes are visual, screenshots or videos are welcome! -->
N/A

### How to QA [^1]

<!-- When relevant, describe how to QA your changes. -->
Try the new page snippet with:

```bash
yarn play --new --framework nuxt
```
<!-- Your favorite emoji is welcome to close your PR! -->

<!-- A note for reviewers: -->

[^1]:
	Please use these labels when submitting a review:
	:question: #ask:&ensp;Ask a question.
	:bulb: #idea:&ensp;Suggest an idea.
	:warning: #issue:&ensp;Strongly suggest a change.
	:tada: #nice:&ensp;Share a compliment.
