### PR TITLE
[DT-2597] feat: remove hard cap on link field variants

### DIFF
--- a/packages/slice-machine/src/legacy/lib/models/common/widgets/Link/components.tsx
+++ b/packages/slice-machine/src/legacy/lib/models/common/widgets/Link/components.tsx
@@ -121,9 +121,7 @@ export function Variants({
 
   const switchLabel = enabled ? "Enabled" : "Disabled";
 
-  const optionsTitle = `Options (${variants?.length ?? 0}/5)`;
-
-  const addButtonShown = (variants?.length ?? 0) < 5;
+  const optionsTitle = `Options (${variants?.length ?? 0})`;
 
   const deleteButtonShown = (variants?.length ?? 0) > 2;
 
@@ -202,20 +200,18 @@ export function Variants({
               )}
             </Box>
           ))}
-          {addButtonShown && (
-            <Box>
-              <Button
-                invisible
-                startIcon="add"
-                onClick={() => {
-                  focusableInputIndex.current = variants?.length;
-                  onVariantsChange([...(variants ?? []), ""]);
-                }}
-              >
-                Add option
-              </Button>
-            </Box>
-          )}
+          <Box>
+            <Button
+              invisible
+              startIcon="add"
+              onClick={() => {
+                focusableInputIndex.current = variants?.length;
+                onVariantsChange([...(variants ?? []), ""]);
+              }}
+            >
+              Add option
+            </Button>
+          </Box>
         </Box>
       )}
       <Box backgroundColor="white" flexDirection="column" padding={12}>


### PR DESCRIPTION
**Resolves**: DT-2597

### Description

Remove the maximum of 5 variants per link in `LinkField`.

### Preview

![Screenshot 2025-01-27 at 10 58 23](https://github.com/user-attachments/assets/a9263a28-1c5f-40b7-8601-bc5e476d6bb1)

### How to QA [^1]

<!-- When relevant, describe how to QA your changes. -->

<!-- Your favorite emoji is welcome to close your PR! -->

<!-- A note for reviewers: -->

[^1]:
	Please use these labels when submitting a review:
	:question: #ask:&ensp;Ask a question.
	:bulb: #idea:&ensp;Suggest an idea.
	:warning: #issue:&ensp;Strongly suggest a change.
	:tada: #nice:&ensp;Share a compliment.
