### PR TITLE
fix(adapter-nuxt): add removed wrappers

### DIFF
--- a/packages/adapter-nuxt/public/AlternateGrid/javascript.vue
+++ b/packages/adapter-nuxt/public/AlternateGrid/javascript.vue
@@ -40,11 +40,13 @@ defineProps(getSliceComponentProps(["slice", "index", "slices", "context"]));
 						v-if="isFilled.richText(slice.primary.title)"
 						:field="slice.primary.title"
 						class="es-alternate-grid__primary-content__intro__headline"
+						wrapper="div"
 					/>
 					<PrismicRichText
 						v-if="isFilled.richText(slice.primary.description)"
 						:field="slice.primary.description"
 						class="es-alternate-grid__primary-content__intro__description"
+						wrapper="div"
 					/>
 				</div>
 				<div
@@ -60,11 +62,13 @@ defineProps(getSliceComponentProps(["slice", "index", "slices", "context"]));
 							v-if="isFilled.richText(item.title)"
 							:field="item.title"
 							class="es-alternate-grid__item__heading"
+							wrapper="div"
 						/>
 						<PrismicRichText
 							v-if="isFilled.richText(item.description)"
 							:field="item.description"
 							class="es-alternate-grid__item__description"
+							wrapper="div"
 						/>
 					</div>
 				</div>

--- a/packages/adapter-nuxt/public/AlternateGrid/typescript.vue
+++ b/packages/adapter-nuxt/public/AlternateGrid/typescript.vue
@@ -47,11 +47,13 @@ defineProps(
 						v-if="isFilled.richText(slice.primary.title)"
 						:field="slice.primary.title"
 						class="es-alternate-grid__primary-content__intro__headline"
+						wrapper="div"
 					/>
 					<PrismicRichText
 						v-if="isFilled.richText(slice.primary.description)"
 						:field="slice.primary.description"
 						class="es-alternate-grid__primary-content__intro__description"
+						wrapper="div"
 					/>
 				</div>
 				<div
@@ -67,11 +69,13 @@ defineProps(
 							v-if="isFilled.richText(item.title)"
 							:field="item.title"
 							class="es-alternate-grid__item__heading"
+							wrapper="div"
 						/>
 						<PrismicRichText
 							v-if="isFilled.richText(item.description)"
 							:field="item.description"
 							class="es-alternate-grid__item__description"
+							wrapper="div"
 						/>
 					</div>
 				</div>


### PR DESCRIPTION
<!-- Please use a Conventional Commit in your PR title -->
<!-- https://conventionalcommits.org -->
<!-- e.g. "feat: support new field type" -->

**Resolves**: https://github.com/nuxt-modules/prismic/issues/231

### Description

With @prismicio/vue v5, default wrappers were removed from `<PrismicRichText>` components: https://prismic.io/docs/technical-reference/prismicio-vue/v5#wrap-prismicrichtext-output

This creates an issue with an existing slice templates, this PR therefore adds them back using the `wrapper` prop :)

<!-- Describe your changes in detail. -->
<!-- Why is this change required? -->
<!-- What problem does it solve? -->

### Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- Don't hesitate to ask for help! -->

- [x] If my changes require tests, I added them.
- [x] If my changes affect backward compatibility, it has been discussed.
- [x] If my changes require an update to the CONTRIBUTING.md guide, I updated it.

### Preview

N/A

### How to QA [^1]

1. Create a Nuxt project with Slice Machine
2. Create a slice from the alternative grid template
3. No Vue warning should be emitted after bootstrapping it

[^1]:
	Please use these labels when submitting a review:
	:question: #ask:&ensp;Ask a question.
	:bulb: #idea:&ensp;Suggest an idea.
	:warning: #issue:&ensp;Strongly suggest a change.
	:tada: #nice:&ensp;Share a compliment.
