### PR TITLE
test: add test for table field

### DIFF
--- a/playwright/README.md
+++ b/playwright/README.md
@@ -310,11 +310,12 @@ To run tests with an experiment, enable the experiment in the test directly:
 
 ```ts
 test("does something when the experiment is on", async ({ procedures }) => {
-  procedures.mock("getExperimentVariant", ({ data }) => {
-    if (data === "example-experiment-name") {
-      return { value: "on" };
-    }
-  });
+  procedures.mock(
+    "telemetry.getExperimentVariant",
+    ({ args }) =>
+      args[0] === "example-experiment-name" ? { value: "on" } : undefined,
+    { execute: false },
+  );
 });
 ```
 

--- a/playwright/pages/components/AddFieldDropdown.ts
+++ b/playwright/pages/components/AddFieldDropdown.ts
@@ -15,7 +15,8 @@ export type FieldTypeLabel =
   | "Geopoint"
   | "Color"
   | "Key Text"
-  | "Repeatable Group";
+  | "Repeatable Group"
+  | "Table";
 
 export class AddFieldDropdown {
   readonly page: Page;

--- a/playwright/tests/fields/table.spec.ts
+++ b/playwright/tests/fields/table.spec.ts
@@ -4,8 +4,16 @@ import { test } from "../../fixtures";
 
 test("I can create a table field", async ({
   customTypesBuilderPage,
+  procedures,
   singleCustomType,
 }) => {
+  procedures.mock(
+    "telemetry.getExperimentVariant",
+    ({ args }) =>
+      args[0] === "slicemachine-table-field" ? { value: "on" } : undefined,
+    { execute: false },
+  );
+
   await customTypesBuilderPage.goto(singleCustomType.name);
   await customTypesBuilderPage.addStaticField({
     type: "Table",

--- a/playwright/tests/fields/table.spec.ts
+++ b/playwright/tests/fields/table.spec.ts
@@ -1,0 +1,20 @@
+import { expect } from "@playwright/test";
+
+import { test } from "../../fixtures";
+
+test("I can create a table field", async ({
+  customTypesBuilderPage,
+  singleCustomType,
+}) => {
+  await customTypesBuilderPage.goto(singleCustomType.name);
+  await customTypesBuilderPage.addStaticField({
+    type: "Table",
+    name: "My Table",
+    expectedId: "my_table",
+  });
+  await customTypesBuilderPage.getEditFieldButton("my_table").click();
+
+  await expect(
+    customTypesBuilderPage.editFieldDialog.getFieldByLabel("Label"),
+  ).toHaveValue("My Table");
+});


### PR DESCRIPTION
**Resolves**: [DT-2596](https://linear.app/prismic/issue/DT-2596/add-tests-for-sm-ui)

### Description

This PR adds an e2e test for adding a table field to a custom type.

### Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- Don't hesitate to ask for help! -->

- [x] A comprehensive Linear ticket, providing sufficient context and details to facilitate the review of the PR, is linked to the PR.
- [x] If my changes require tests, I added them.
- [ ] If my changes affect backward compatibility, it has been discussed.
- [ ] If my changes require an update to the CONTRIBUTING.md guide, I updated it.

### Preview

N/A

### How to QA [^1]

<!-- When relevant, describe how to QA your changes. -->

<!-- Your favorite emoji is welcome to close your PR! -->

<!-- A note for reviewers: -->

[^1]:
	Please use these labels when submitting a review:
	:question: #ask:&ensp;Ask a question.
	:bulb: #idea:&ensp;Suggest an idea.
	:warning: #issue:&ensp;Strongly suggest a change.
	:tada: #nice:&ensp;Share a compliment.
