### PR TITLE
fix(adapter-next): support `@prismicio/next` v2

### DIFF
--- a/packages/adapter-next/src/hooks/documentation-read.ts
+++ b/packages/adapter-next/src/hooks/documentation-read.ts
@@ -154,7 +154,7 @@ export const documentationRead: DocumentationReadHook<PluginOptions> = async (
 						const page = await client.getSingle("${model.id}").catch(() => notFound());
 
 						return {
-							title: page.data.title,
+							title: page.data.meta_title,
 							description: page.data.meta_description,
 							openGraph: {
 								images: [{ url: asImageSrc(page.data.meta_image) ?? "" }],
@@ -301,7 +301,7 @@ export const documentationRead: DocumentationReadHook<PluginOptions> = async (
 						const page = await client.getSingle("${model.id}").catch(() => notFound());
 
 						return {
-							title: page.data.title,
+							title: page.data.meta_title,
 							description: page.data.meta_description,
 							openGraph: {
 								images: [{ url: asImageSrc(page.data.meta_image) ?? "" }],

--- a/packages/adapter-next/src/hooks/documentation-read.ts
+++ b/packages/adapter-next/src/hooks/documentation-read.ts
@@ -201,7 +201,6 @@ export const documentationRead: DocumentationReadHook<PluginOptions> = async (
 		} else {
 			if (model.repeatable) {
 				appFileContent = source`
-					import { Metadata } from "next";
 					import { notFound } from "next/navigation";
 					import { asImageSrc } from "@prismicio/client";
 					import { SliceZone } from "@prismicio/react";
@@ -334,7 +333,7 @@ export const documentationRead: DocumentationReadHook<PluginOptions> = async (
 						);
 					}
 
-					export async function getStaticProps({ previewData }: GetStaticPropsContext) {
+					export async function getStaticProps({ previewData }) {
 						const client = createClient({ previewData });
 						const page = await client.getSingle("${model.id}");
 

--- a/packages/adapter-next/src/hooks/project-init.ts
+++ b/packages/adapter-next/src/hooks/project-init.ts
@@ -192,7 +192,7 @@ const createPrismicIOFile = async ({
 			 * The project's Prismic repository name.
 			 */
 			export const repositoryName =
-				process.env.${PRISMIC_ENVIRONMENT_ENVIRONMENT_VARIABLE_NAME} || config.repositoryName;
+				process.env.${PRISMIC_ENVIRONMENT_ENVIRONMENT_VARIABLE_NAME} || sm.repositoryName;
 
 			/**
 			 * A list of Route Resolver objects that define how a document's \`url\` field is resolved.
@@ -200,7 +200,7 @@ const createPrismicIOFile = async ({
 			 * {@link https://prismic.io/docs/route-resolver#route-resolver}
 			 */
 			// TODO: Update the routes array to match your project's route structure.
-			const routes: Routes[] = [
+			const routes: Route[] = [
 				// Examples:
 				// { type: "homepage", path: "/" },
 				// { type: "page", path: "/:uid" },
@@ -216,7 +216,7 @@ const createPrismicIOFile = async ({
 			 * The project's Prismic repository name.
 			 */
 			export const repositoryName =
-				process.env.${PRISMIC_ENVIRONMENT_ENVIRONMENT_VARIABLE_NAME} || config.repositoryName;
+				process.env.${PRISMIC_ENVIRONMENT_ENVIRONMENT_VARIABLE_NAME} || sm.repositoryName;
 
 			/**
 			 * A list of Route Resolver objects that define how a document's \`url\` field is resolved.
@@ -404,7 +404,7 @@ const createPreviewRoute = async ({
 				export default async function handler(req: NextApiRequest, res: NextApiResponse) {
 					const client = createClient({ req });
 
-					await setPreviewData({ req, res });
+					setPreviewData({ req, res });
 
 					return await redirectToPreviewURL({ req, res, client });
 				};
@@ -418,7 +418,7 @@ const createPreviewRoute = async ({
 				export default async function handler(req, res) {
 					const client = createClient({ req });
 
-					await setPreviewData({ req, res });
+					setPreviewData({ req, res });
 
 					return await redirectToPreviewURL({ req, res, client });
 				};

--- a/packages/adapter-next/test/__snapshots__/plugin-documentation-read.test.ts.snap
+++ b/packages/adapter-next/test/__snapshots__/plugin-documentation-read.test.ts.snap
@@ -9,7 +9,6 @@ Add a new route by creating an \`app/[uid]/page.js\` file. (If the route should 
 Paste in this code:
 
 ~~~js [app/[uid]/page.js]
-import { Metadata } from \\"next\\";
 import { notFound } from \\"next/navigation\\";
 import { asImageSrc } from \\"@prismicio/client\\";
 import { SliceZone } from \\"@prismicio/react\\";

--- a/packages/adapter-next/test/__snapshots__/plugin-documentation-read.test.ts.snap
+++ b/packages/adapter-next/test/__snapshots__/plugin-documentation-read.test.ts.snap
@@ -9,50 +9,41 @@ Add a new route by creating an \`app/[uid]/page.js\` file. (If the route should 
 Paste in this code:
 
 ~~~js [app/[uid]/page.js]
+import { Metadata } from \\"next\\";
 import { notFound } from \\"next/navigation\\";
-import { isFilled, asImageSrc } from \\"@prismicio/client\\";
+import { asImageSrc } from \\"@prismicio/client\\";
 import { SliceZone } from \\"@prismicio/react\\";
 
 import { createClient } from \\"@/prismicio\\";
 import { components } from \\"@/slices\\";
 
 export default async function Page({ params }) {
-  const { uid } = await params;
-  const client = createClient();
-  const page = await client.getByUID(\\"foo_bar\\", uid).catch(() => notFound());
+	const { uid } = await params;
+	const client = createClient();
+	const page = await client.getByUID(\\"foo_bar\\", uid).catch(() => notFound());
 
-  return <SliceZone slices={page.data.slices} components={components} />;
+	return <SliceZone slices={page.data.slices} components={components} />;
 }
 
 export async function generateMetadata({ params }) {
-  const { uid } = await params;
-  const client = createClient();
-  const page = await client.getByUID(\\"foo_bar\\", uid).catch(() => notFound());
+	const { uid } = await params;
+	const client = createClient();
+	const page = await client.getByUID(\\"foo_bar\\", uid).catch(() => notFound());
 
-  return {
-    title: page.data.meta_title,
-    description: page.data.meta_description,
-    openGraph: {
-      title: isFilled.keyText(page.data.meta_title)
-        ? page.data.meta_title
-        : undefined,
-      description: isFilled.keyText(page.data.meta_description)
-        ? page.data.meta_description
-        : undefined,
-      images: isFilled.image(page.data.meta_image)
-        ? [asImageSrc(page.data.meta_image)]
-        : undefined,
-    },
-  };
+	return {
+		title: page.data.meta_title,
+		description: page.data.meta_description,
+		openGraph: {
+			images: [{ url: asImageSrc(page.data.meta_image) ?? \\"\\" }],
+		},
+	};
 }
 
 export async function generateStaticParams() {
-  const client = createClient();
-  const pages = await client.getAllByType(\\"foo_bar\\");
+	const client = createClient();
+	const pages = await client.getAllByType(\\"foo_bar\\");
 
-  return pages.map((page) => {
-    return { uid: page.uid };
-  });
+	return pages.map((page) => ({ uid: page.uid }));
 }
 ~~~
 
@@ -72,7 +63,7 @@ Paste in this code:
 ~~~tsx [app/[uid]/page.tsx]
 import { Metadata } from \\"next\\";
 import { notFound } from \\"next/navigation\\";
-import { isFilled, asImageSrc } from \\"@prismicio/client\\";
+import { asImageSrc } from \\"@prismicio/client\\";
 import { SliceZone } from \\"@prismicio/react\\";
 
 import { createClient } from \\"@/prismicio\\";
@@ -81,46 +72,79 @@ import { components } from \\"@/slices\\";
 type Params = { uid: string };
 
 export default async function Page({ params }: { params: Promise<Params> }) {
-  const { uid } = await params;
-  const client = createClient();
-  const page = await client.getByUID(\\"foo_bar\\", uid).catch(() => notFound());
+	const { uid } = await params;
+	const client = createClient();
+	const page = await client.getByUID(\\"foo_bar\\", uid).catch(() => notFound());
 
-  return <SliceZone slices={page.data.slices} components={components} />;
+	return <SliceZone slices={page.data.slices} components={components} />;
 }
 
 export async function generateMetadata({
-  params,
+	params,
 }: {
-  params: Promise<Params>;
+	params: Promise<Params>;
 }): Promise<Metadata> {
-  const { uid } = await params;
-  const client = createClient();
-  const page = await client.getByUID(\\"foo_bar\\", uid).catch(() => notFound());
+	const { uid } = await params;
+	const client = createClient();
+	const page = await client.getByUID(\\"foo_bar\\", uid).catch(() => notFound());
 
-  return {
-    title: page.data.meta_title,
-    description: page.data.meta_description,
-    openGraph: {
-      title: isFilled.keyText(page.data.meta_title)
-        ? page.data.meta_title
-        : undefined,
-      description: isFilled.keyText(page.data.meta_description)
-        ? page.data.meta_description
-        : undefined,
-      images: isFilled.image(page.data.meta_image)
-        ? [asImageSrc(page.data.meta_image)]
-        : undefined,
-    },
-  };
+	return {
+		title: page.data.meta_title,
+		description: page.data.meta_description,
+		openGraph: {
+			images: [{ url: asImageSrc(page.data.meta_image) ?? \\"\\" }],
+		},
+	};
 }
 
 export async function generateStaticParams() {
-  const client = createClient();
-  const pages = await client.getAllByType(\\"foo_bar\\");
+	const client = createClient();
+	const pages = await client.getAllByType(\\"foo_bar\\");
 
-  return pages.map((page) => {
-    return { uid: page.uid };
-  });
+	return pages.map((page) => ({ uid: page.uid }));
+}
+~~~
+
+Make sure all of your import paths are correct. See the [install guide](https://prismic.io/docs/setup-nextjs) for more information.",
+  "label": "App Router",
+}
+`;
+
+exports[`PageSnippet > App Router > supports the special single homepage type 1`] = `
+{
+  "content": "## Create your Homepage's page component
+
+Add a new route by creating an \`app/page.tsx\` file. (If the route should be nested in a child directory, you can create the file in a directory, like \`app/marketing/page.tsx\`.)
+
+Paste in this code:
+
+~~~tsx [app/page.tsx]
+import { type Metadata } from \\"next\\";
+import { notFound } from \\"next/navigation\\";
+import { asImageSrc } from \\"@prismicio/client\\";
+import { SliceZone } from \\"@prismicio/react\\";
+
+import { createClient } from \\"@/prismicio\\";
+import { components } from \\"@/slices\\";
+
+export default async function Page() {
+	const client = createClient();
+	const page = await client.getSingle(\\"homepage\\").catch(() => notFound());
+
+	return <SliceZone slices={page.data.slices} components={components} />;
+}
+
+export async function generateMetadata(): Promise<Metadata> {
+	const client = createClient();
+	const page = await client.getSingle(\\"homepage\\").catch(() => notFound());
+
+	return {
+		title: page.data.title,
+		description: page.data.meta_description,
+		openGraph: {
+			images: [{ url: asImageSrc(page.data.meta_image) ?? \\"\\" }],
+		},
+	};
 }
 ~~~
 
@@ -144,55 +168,40 @@ import { components } from \\"@/slices\\";
 import { createClient } from \\"@/prismicio\\";
 
 export default function Page({ page }) {
-  return (
-    <>
-      <Head>
-        <title>{page.data.meta_title}</title>
-        <meta property=\\"og:title\\" content={page.data.meta_title} />
-        {isFilled.keyText(page.data.meta_description) ? (
-          <>
-            <meta name=\\"description\\" content={page.data.meta_description} />
-            <meta
-              property=\\"og:description\\"
-              content={page.data.meta_description}
-            />
-          </>
-        ) : null}
-        {isFilled.image(page.data.meta_image) ? (
-          <meta
-            property=\\"og:image\\"
-            content={asImageSrc(page.data.meta_image)}
-          />
-        ) : null}
-      </Head>
-      <SliceZone slices={page.data.slices} components={components} />
-    </>
-  );
+	return (
+		<>
+			<Head>
+				<title>{page.data.meta_title}</title>
+				{isFilled.keyText(page.data.meta_description) ? (
+					<meta name=\\"description\\" content={page.data.meta_description} />
+				) : null}
+				{isFilled.image(page.data.meta_image) ? (
+					<meta
+						property=\\"og:image\\"
+						content={asImageSrc(page.data.meta_image)}
+					/>
+				) : null}
+			</Head>
+			<SliceZone slices={page.data.slices} components={components} />
+		</>
+	);
 }
 
 export async function getStaticProps({ params, previewData }) {
-  // The \`previewData\` parameter allows your app to preview
-  // drafts from the Page Builder.
-  const client = createClient({ previewData });
+	const client = createClient({ previewData });
+	const page = await client.getByUID(\\"foo_bar\\", params.uid);
 
-  const page = await client.getByUID(\\"foo_bar\\", params.uid);
-
-  return {
-    props: { page },
-  };
+	return { props: { page } };
 }
 
 export async function getStaticPaths() {
-  const client = createClient();
+	const client = createClient();
+	const pages = await client.getAllByType(\\"foo_bar\\");
 
-  const pages = await client.getAllByType(\\"foo_bar\\");
-
-  return {
-    paths: pages.map((page) => {
-      return asLink(page);
-    }),
-    fallback: false,
-  };
+	return {
+		paths: pages.map((page) => asLink(page)),
+		fallback: false,
+	};
 }
 ~~~
 
@@ -219,60 +228,95 @@ import { createClient } from \\"@/prismicio\\";
 type Params = { uid: string };
 
 export default function Page({
-  page,
+	page,
 }: InferGetStaticPropsType<typeof getStaticProps>) {
-  return (
-    <>
-      <Head>
-        <title>{page.data.meta_title}</title>
-        <meta property=\\"og:title\\" content={page.data.meta_title} />
-        {isFilled.keyText(page.data.meta_description) ? (
-          <>
-            <meta name=\\"description\\" content={page.data.meta_description} />
-            <meta
-              property=\\"og:description\\"
-              content={page.data.meta_description}
-            />
-          </>
-        ) : null}
-        {isFilled.image(page.data.meta_image) ? (
-          <meta
-            property=\\"og:image\\"
-            content={asImageSrc(page.data.meta_image)}
-          />
-        ) : null}
-      </Head>
-      <SliceZone slices={page.data.slices} components={components} />
-    </>
-  );
+	return (
+		<>
+			<Head>
+				<title>{page.data.meta_title}</title>
+				{isFilled.keyText(page.data.meta_description) ? (
+					<meta name=\\"description\\" content={page.data.meta_description} />
+				) : null}
+				{isFilled.image(page.data.meta_image) ? (
+					<meta
+						property=\\"og:image\\"
+						content={asImageSrc(page.data.meta_image)}
+					/>
+				) : null}
+			</Head>
+			<SliceZone slices={page.data.slices} components={components} />
+		</>
+	);
 }
 
 export async function getStaticProps({
-  params,
-  previewData,
+	params,
+	previewData,
 }: GetStaticPropsContext<Params>) {
-  // The \`previewData\` parameter allows your app to preview
-  // drafts from the Page Builder.
-  const client = createClient({ previewData });
+	const client = createClient({ previewData });
+	const page = await client.getByUID(\\"foo_bar\\", params!.uid);
 
-  const page = await client.getByUID(\\"foo_bar\\", params!.uid);
-
-  return {
-    props: { page },
-  };
+	return { props: { page } };
 }
 
 export async function getStaticPaths() {
-  const client = createClient();
+	const client = createClient();
+	const pages = await client.getAllByType(\\"foo_bar\\");
 
-  const pages = await client.getAllByType(\\"foo_bar\\");
+	return {
+		paths: pages.map((page) => asLink(page)),
+		fallback: false,
+	};
+}
+~~~
 
-  return {
-    paths: pages.map((page) => {
-      return asLink(page);
-    }),
-    fallback: false,
-  };
+Make sure all of your import paths are correct. See the [install guide](https://prismic.io/docs/setup-nextjs) for more information.",
+  "label": "Pages Router",
+}
+`;
+
+exports[`PageSnippet > Pages Router > supports the special single homepage type 1`] = `
+{
+  "content": "## Create your Homepage's page component
+
+Add a new route by creating a \`pages/index.tsx\` file. (If the route should be nested in a child directory, you can create the file in a directory, like \`pages/marketing/index.tsx\`.)
+
+~~~tsx [pages/index.tsx]
+import { GetStaticPropsContext, InferGetStaticPropsType } from \\"next\\";
+import Head from \\"next/head\\";
+import { isFilled, asImageSrc } from \\"@prismicio/client\\";
+import { SliceZone } from \\"@prismicio/react\\";
+
+import { components } from \\"@/slices\\";
+import { createClient } from \\"@/prismicio\\";
+
+export default function Page({
+	page,
+}: InferGetStaticPropsType<typeof getStaticProps>) {
+	return (
+		<>
+			<Head>
+				<title>{page.data.meta_title}</title>
+				{isFilled.keyText(page.data.meta_description) ? (
+					<meta name=\\"description\\" content={page.data.meta_description} />
+				) : null}
+				{isFilled.image(page.data.meta_image) ? (
+					<meta
+						property=\\"og:image\\"
+						content={asImageSrc(page.data.meta_image)}
+					/>
+				) : null}
+			</Head>
+			<SliceZone slices={page.data.slices} components={components} />
+		</>
+	);
+}
+
+export async function getStaticProps({ previewData }: GetStaticPropsContext) {
+	const client = createClient({ previewData });
+	const page = await client.getSingle(\\"homepage\\");
+
+	return { props: { page } };
 }
 ~~~
 

--- a/packages/adapter-next/test/__snapshots__/plugin-documentation-read.test.ts.snap
+++ b/packages/adapter-next/test/__snapshots__/plugin-documentation-read.test.ts.snap
@@ -139,7 +139,7 @@ export async function generateMetadata(): Promise<Metadata> {
 	const page = await client.getSingle(\\"homepage\\").catch(() => notFound());
 
 	return {
-		title: page.data.title,
+		title: page.data.meta_title,
 		description: page.data.meta_description,
 		openGraph: {
 			images: [{ url: asImageSrc(page.data.meta_image) ?? \\"\\" }],

--- a/packages/adapter-next/test/plugin-documentation-read.test.ts
+++ b/packages/adapter-next/test/plugin-documentation-read.test.ts
@@ -49,6 +49,29 @@ describe("PageSnippet", () => {
 
 			expect(item).toMatchSnapshot();
 		});
+
+		it("supports the special single homepage type", async (ctx) => {
+			await fs.writeFile(
+				path.join(ctx.project.root, "tsconfig.json"),
+				JSON.stringify({}),
+			);
+
+			const model = mock.model.customType({
+				id: "homepage",
+				repeatable: false,
+			});
+
+			const res = await ctx.pluginRunner.callHook("documentation:read", {
+				kind: "PageSnippet",
+				data: {
+					model,
+				},
+			});
+
+			const item = res.data.flat().find((item) => item.label === "App Router");
+
+			expect(item).toMatchSnapshot();
+		});
 	});
 
 	describe("Pages Router", () => {
@@ -73,6 +96,31 @@ describe("PageSnippet", () => {
 		});
 
 		it("return a snippet with JavaScript", async (ctx) => {
+			const res = await ctx.pluginRunner.callHook("documentation:read", {
+				kind: "PageSnippet",
+				data: {
+					model,
+				},
+			});
+
+			const item = res.data
+				.flat()
+				.find((item) => item.label === "Pages Router");
+
+			expect(item).toMatchSnapshot();
+		});
+
+		it("supports the special single homepage type", async (ctx) => {
+			await fs.writeFile(
+				path.join(ctx.project.root, "tsconfig.json"),
+				JSON.stringify({}),
+			);
+
+			const model = mock.model.customType({
+				id: "homepage",
+				repeatable: false,
+			});
+
 			const res = await ctx.pluginRunner.callHook("documentation:read", {
 				kind: "PageSnippet",
 				data: {

--- a/packages/adapter-next/test/plugin-project-init.test.ts
+++ b/packages/adapter-next/test/plugin-project-init.test.ts
@@ -302,7 +302,7 @@ describe("prismicio.js file", () => {
 				 * The project's Prismic repository name.
 				 */
 				export const repositoryName =
-				  process.env.NEXT_PUBLIC_PRISMIC_ENVIRONMENT || config.repositoryName;
+				  process.env.NEXT_PUBLIC_PRISMIC_ENVIRONMENT || sm.repositoryName;
 
 				/**
 				 * A list of Route Resolver objects that define how a document's \`url\` field is resolved.
@@ -367,7 +367,7 @@ describe("prismicio.js file", () => {
 				 * The project's Prismic repository name.
 				 */
 				export const repositoryName =
-				  process.env.NEXT_PUBLIC_PRISMIC_ENVIRONMENT || config.repositoryName;
+				  process.env.NEXT_PUBLIC_PRISMIC_ENVIRONMENT || sm.repositoryName;
 
 				/**
 				 * A list of Route Resolver objects that define how a document's \`url\` field is resolved.
@@ -436,7 +436,7 @@ describe("prismicio.js file", () => {
 				 * The project's Prismic repository name.
 				 */
 				export const repositoryName =
-				  process.env.NEXT_PUBLIC_PRISMIC_ENVIRONMENT || config.repositoryName;
+				  process.env.NEXT_PUBLIC_PRISMIC_ENVIRONMENT || sm.repositoryName;
 
 				/**
 				 * A list of Route Resolver objects that define how a document's \`url\` field is resolved.
@@ -444,7 +444,7 @@ describe("prismicio.js file", () => {
 				 * {@link https://prismic.io/docs/route-resolver#route-resolver}
 				 */
 				// TODO: Update the routes array to match your project's route structure.
-				const routes: Routes[] = [
+				const routes: Route[] = [
 				  // Examples:
 				  // { type: \\"homepage\\", path: \\"/\\" },
 				  // { type: \\"page\\", path: \\"/:uid\\" },
@@ -506,7 +506,7 @@ describe("prismicio.js file", () => {
 				 * The project's Prismic repository name.
 				 */
 				export const repositoryName =
-				  process.env.NEXT_PUBLIC_PRISMIC_ENVIRONMENT || config.repositoryName;
+				  process.env.NEXT_PUBLIC_PRISMIC_ENVIRONMENT || sm.repositoryName;
 
 				/**
 				 * A list of Route Resolver objects that define how a document's \`url\` field is resolved.
@@ -514,7 +514,7 @@ describe("prismicio.js file", () => {
 				 * {@link https://prismic.io/docs/route-resolver#route-resolver}
 				 */
 				// TODO: Update the routes array to match your project's route structure.
-				const routes: Routes[] = [
+				const routes: Route[] = [
 				  // Examples:
 				  // { type: \\"homepage\\", path: \\"/\\" },
 				  // { type: \\"page\\", path: \\"/:uid\\" },
@@ -569,7 +569,7 @@ describe("prismicio.js file", () => {
 				 * The project's Prismic repository name.
 				 */
 				export const repositoryName =
-				  process.env.NEXT_PUBLIC_PRISMIC_ENVIRONMENT || config.repositoryName;
+				  process.env.NEXT_PUBLIC_PRISMIC_ENVIRONMENT || sm.repositoryName;
 
 				/**
 				 * A list of Route Resolver objects that define how a document's \`url\` field is resolved.
@@ -630,7 +630,7 @@ describe("prismicio.js file", () => {
 				 * The project's Prismic repository name.
 				 */
 				export const repositoryName =
-				  process.env.NEXT_PUBLIC_PRISMIC_ENVIRONMENT || config.repositoryName;
+				  process.env.NEXT_PUBLIC_PRISMIC_ENVIRONMENT || sm.repositoryName;
 
 				/**
 				 * A list of Route Resolver objects that define how a document's \`url\` field is resolved.
@@ -701,7 +701,7 @@ describe("prismicio.js file", () => {
 				 * The project's Prismic repository name.
 				 */
 				export const repositoryName =
-				  process.env.NEXT_PUBLIC_PRISMIC_ENVIRONMENT || config.repositoryName;
+				  process.env.NEXT_PUBLIC_PRISMIC_ENVIRONMENT || sm.repositoryName;
 
 				/**
 				 * A list of Route Resolver objects that define how a document's \`url\` field is resolved.
@@ -709,7 +709,7 @@ describe("prismicio.js file", () => {
 				 * {@link https://prismic.io/docs/route-resolver#route-resolver}
 				 */
 				// TODO: Update the routes array to match your project's route structure.
-				const routes: Routes[] = [
+				const routes: Route[] = [
 				  // Examples:
 				  // { type: \\"homepage\\", path: \\"/\\" },
 				  // { type: \\"page\\", path: \\"/:uid\\" },
@@ -773,7 +773,7 @@ describe("prismicio.js file", () => {
 				 * The project's Prismic repository name.
 				 */
 				export const repositoryName =
-				  process.env.NEXT_PUBLIC_PRISMIC_ENVIRONMENT || config.repositoryName;
+				  process.env.NEXT_PUBLIC_PRISMIC_ENVIRONMENT || sm.repositoryName;
 
 				/**
 				 * A list of Route Resolver objects that define how a document's \`url\` field is resolved.
@@ -781,7 +781,7 @@ describe("prismicio.js file", () => {
 				 * {@link https://prismic.io/docs/route-resolver#route-resolver}
 				 */
 				// TODO: Update the routes array to match your project's route structure.
-				const routes: Routes[] = [
+				const routes: Route[] = [
 				  // Examples:
 				  // { type: \\"homepage\\", path: \\"/\\" },
 				  // { type: \\"page\\", path: \\"/:uid\\" },
@@ -1329,7 +1329,7 @@ describe("/api/preview route", () => {
 				export default async function handler(req, res) {
 				  const client = createClient({ req });
 
-				  await setPreviewData({ req, res });
+				  setPreviewData({ req, res });
 
 				  return await redirectToPreviewURL({ req, res, client });
 				}
@@ -1363,7 +1363,7 @@ describe("/api/preview route", () => {
 				export default async function handler(req, res) {
 				  const client = createClient({ req });
 
-				  await setPreviewData({ req, res });
+				  setPreviewData({ req, res });
 
 				  return await redirectToPreviewURL({ req, res, client });
 				}
@@ -1402,7 +1402,7 @@ describe("/api/preview route", () => {
 				) {
 				  const client = createClient({ req });
 
-				  await setPreviewData({ req, res });
+				  setPreviewData({ req, res });
 
 				  return await redirectToPreviewURL({ req, res, client });
 				}


### PR DESCRIPTION
<!-- Please use a Conventional Commit in your PR title -->
<!-- https://conventionalcommits.org -->
<!-- e.g. "feat: support new field type" -->

**Resolves**: N/A

### Description

<!-- Describe your changes in detail. -->
<!-- Why is this change required? -->
<!-- What problem does it solve? -->

This PR updates `@slicemachine/adapter-next` to support `@prismicio/next` v2.

Files generated by the `project:init` hook and page snippets generated by the `documentation:read` hook needed to be updated.

This PR also includes the following small enhancements:

- Generate all slice library index files on `project:init`. Generating those files ensures importing `@/slices` does not throw in a new project. This behavior matches `@slicemachine/adapter-sveltekit`'s behavior.
- Update the page snippet to act as a homepage when a model is non-repeatable and its ID is `homepage`.

### Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- Don't hesitate to ask for help! -->

- [ ] A comprehensive Linear ticket, providing sufficient context and details to facilitate the review of the PR, is linked to the PR.
- [x] If my changes require tests, I added them.
- [ ] If my changes affect backward compatibility, it has been discussed.
- [ ] If my changes require an update to the CONTRIBUTING.md guide, I updated it.

### Preview

<!-- If your changes are visual, screenshots or videos are welcome! -->

```sh
npx create-next-app@latest
cd my-app
npx @slicemachine/init@alpha.aa-prismicio-next-v2
```

### How to QA [^1]

<!-- When relevant, describe how to QA your changes. -->

<!-- Your favorite emoji is welcome to close your PR! -->

<!-- A note for reviewers: -->

[^1]:
	Please use these labels when submitting a review:
	:question: #ask:&ensp;Ask a question.
	:bulb: #idea:&ensp;Suggest an idea.
	:warning: #issue:&ensp;Strongly suggest a change.
	:tada: #nice:&ensp;Share a compliment.
