### PR TITLE
[DT-2536] Retire old "Advanced Repository" feedback survey

### DIFF
--- a/packages/manager/src/managers/telemetry/types.ts
+++ b/packages/manager/src/managers/telemetry/types.ts
@@ -141,7 +141,7 @@ type ReviewSegmentEvent = SegmentEvent<
 	{
 		rating: number;
 		comment: string;
-		type: "onboarding" | "advanced repository";
+		type: "onboarding";
 	}
 >;
 

--- a/packages/slice-machine/src/legacy/components/ReviewModal/ReviewForm.tsx
+++ b/packages/slice-machine/src/legacy/components/ReviewModal/ReviewForm.tsx
@@ -19,7 +19,6 @@ import { isLoading } from "@/modules/loading";
 import { LoadingKeysEnum } from "@/modules/loading/types";
 import { isModalOpen } from "@/modules/modal";
 import { ModalKeysEnum } from "@/modules/modal/types";
-import { UserReviewType } from "@/modules/userContext/types";
 import useSliceMachineActions from "@/modules/useSliceMachineActions";
 import { SliceMachineStoreType } from "@/redux/type";
 
@@ -27,12 +26,9 @@ import { ReviewFormSelect } from "./ReviewFormSelect";
 
 Modal.setAppElement("#__next");
 
-type ReviewFormProps = {
-  reviewType: UserReviewType;
-};
+const reviewType = "onboarding";
 
-export const ReviewForm: FC<ReviewFormProps> = (props) => {
-  const { reviewType } = props;
+export const ReviewForm: FC = () => {
   const { isReviewLoading, isLoginModalOpen } = useSelector(
     (store: SliceMachineStoreType) => ({
       isReviewLoading: isLoading(store, LoadingKeysEnum.REVIEW),
@@ -48,10 +44,7 @@ export const ReviewForm: FC<ReviewFormProps> = (props) => {
       event: "review",
       rating,
       comment,
-      type:
-        reviewType === "advancedRepository"
-          ? "advanced repository"
-          : "onboarding",
+      type: reviewType,
     });
     sendAReview(reviewType);
     stopLoadingReview();

--- a/packages/slice-machine/src/legacy/components/ReviewModal/ReviewModal.tsx
+++ b/packages/slice-machine/src/legacy/components/ReviewModal/ReviewModal.tsx
@@ -42,28 +42,14 @@ export const ReviewModal: FC = () => {
     lastSyncChange && Date.now() - lastSyncChange >= 3600000,
   );
 
-  const isAdvancedRepository =
-    sliceCount >= 6 &&
-    customTypes.length >= 6 &&
-    hasSliceWithinCustomType &&
-    hasPushedAnHourAgo;
-
-  if (!userReview.advancedRepository && isAdvancedRepository) {
-    return <ReviewForm reviewType="advancedRepository" />;
-  }
-
   const isOnboardingDone =
     sliceCount >= 1 &&
     customTypes.length >= 1 &&
     hasSliceWithinCustomType &&
     hasPushedAnHourAgo;
 
-  if (
-    !userReview.onboarding &&
-    !userReview.advancedRepository &&
-    isOnboardingDone
-  ) {
-    return <ReviewForm reviewType="onboarding" />;
+  if (!userReview.onboarding && isOnboardingDone) {
+    return <ReviewForm />;
   }
 
   return null;

--- a/packages/slice-machine/src/modules/userContext/index.ts
+++ b/packages/slice-machine/src/modules/userContext/index.ts
@@ -17,7 +17,6 @@ import { refreshStateCreator } from "../environment";
 const initialState: UserContextStoreType = {
   userReview: {
     onboarding: false,
-    advancedRepository: false,
   },
   hasSeenSimulatorToolTip: false,
   hasSeenChangesToolTip: false,
@@ -59,7 +58,6 @@ type userContextActions = ActionType<
 export const getUserReview = (state: SliceMachineStoreType): UserReviewState =>
   state.userContext.userReview ?? {
     onboarding: state.userContext.hasSendAReview ?? false,
-    advancedRepository: false,
   };
 
 export const userHasSeenSimulatorToolTip = (

--- a/packages/slice-machine/src/modules/userContext/types.ts
+++ b/packages/slice-machine/src/modules/userContext/types.ts
@@ -15,7 +15,6 @@ export type UserContextStoreType = {
 
 export type UserReviewState = {
   onboarding: boolean;
-  advancedRepository: boolean;
 };
 
 export type UserReviewType = keyof UserReviewState;

--- a/packages/slice-machine/test/src/modules/userContext.test.ts
+++ b/packages/slice-machine/test/src/modules/userContext.test.ts
@@ -24,7 +24,6 @@ describe("[UserContext module]", () => {
       const initialState: UserContextStoreType = {
         userReview: {
           onboarding: false,
-          advancedRepository: false,
         },
       };
 
@@ -36,7 +35,6 @@ describe("[UserContext module]", () => {
         ...initialState,
         userReview: {
           onboarding: true,
-          advancedRepository: false,
         },
       };
 
@@ -48,7 +46,6 @@ describe("[UserContext module]", () => {
       const initialState: UserContextStoreType = {
         userReview: {
           onboarding: false,
-          advancedRepository: false,
         },
       };
 
@@ -60,7 +57,6 @@ describe("[UserContext module]", () => {
         ...initialState,
         userReview: {
           onboarding: true,
-          advancedRepository: false,
         },
       };
 

--- a/playwright/fixtures/index.ts
+++ b/playwright/fixtures/index.ts
@@ -217,7 +217,6 @@ export const test = baseTest.extend<Options & Fixtures>({
       ? {
           userReview: {
             onboarding: false,
-            advancedRepository: true,
           },
           hasSeenChangesToolTip: true,
           hasSeenSimulatorToolTip: true,
@@ -228,7 +227,6 @@ export const test = baseTest.extend<Options & Fixtures>({
       : {
           userReview: {
             onboarding: onboarded,
-            advancedRepository: false,
           },
           hasSeenChangesToolTip: false,
           hasSeenSimulatorToolTip: false,

--- a/playwright/tests/common/reviewForm.spec.ts
+++ b/playwright/tests/common/reviewForm.spec.ts
@@ -10,53 +10,6 @@ test.use({
   },
 });
 
-test("I can write a review after creating enough models", async ({
-  sliceMachinePage,
-  procedures,
-}) => {
-  const libraries = generateLibraries({ slicesCount: 6 });
-
-  // We mock a page type with a slice that is a requirement for the review dialog
-  procedures.mock(
-    "getState",
-    ({ data }) => ({
-      ...(data as Record<string, unknown>),
-      libraries,
-      customTypes: generateTypes({ typesCount: 1, libraries }),
-      remoteCustomTypes: [],
-      remoteSlices: [],
-      clientError: undefined,
-    }),
-    { times: 2 },
-  );
-
-  await sliceMachinePage.gotoDefaultPage();
-
-  // We close the first review for onboarding
-  await sliceMachinePage.reviewDialog.closeButton.click();
-
-  procedures.mock("getState", ({ data }) => ({
-    ...(data as Record<string, unknown>),
-    libraries,
-    customTypes: generateTypes({ typesCount: 6, libraries }),
-    remoteCustomTypes: [],
-    remoteSlices: [],
-    clientError: undefined,
-  }));
-
-  // We reload and mock with 6 types to trigger the advanced review dialog
-  await sliceMachinePage.page.reload();
-
-  await sliceMachinePage.reviewDialog.submitReview({
-    rating: 5,
-    message: "I love Slice Machine!",
-  });
-
-  // We verify that the review dialog is not displayed anymore
-  await sliceMachinePage.page.reload();
-  await expect(sliceMachinePage.reviewDialog.title).not.toBeVisible();
-});
-
 test("I can close the review dialog", async ({
   sliceMachinePage,
   procedures,


### PR DESCRIPTION
**Resolves**: DT-2536

### Description

Stop displaying the review form for `Advanced Repositories`.

### Preview

It will still be displayed for onboarding.

![Screenshot 2025-03-18 at 16 57 11](https://github.com/user-attachments/assets/faff3c53-9617-4206-b00d-513e8ade6d74)

### How to QA [^1]

<!-- When relevant, describe how to QA your changes. -->

<!-- Your favorite emoji is welcome to close your PR! -->

<!-- A note for reviewers: -->

[^1]:
	Please use these labels when submitting a review:
	:question: #ask:&ensp;Ask a question.
	:bulb: #idea:&ensp;Suggest an idea.
	:warning: #issue:&ensp;Strongly suggest a change.
	:tada: #nice:&ensp;Share a compliment.
