### PR TITLE
feat: add AI slice generation option and empty modal

### DIFF
--- a/packages/slice-machine/src/components/GenerateSliceWithAiModal/GenerateSliceWithAiModal.tsx
+++ b/packages/slice-machine/src/components/GenerateSliceWithAiModal/GenerateSliceWithAiModal.tsx
@@ -1,0 +1,29 @@
+import {
+  Box,
+  Dialog,
+  DialogActions,
+  DialogCancelButton,
+  DialogContent,
+  DialogHeader,
+} from "@prismicio/editor-ui";
+
+interface GenerateSliceWithAiModalProps {
+  onClose: () => void;
+}
+
+export function GenerateSliceWithAiModal(props: GenerateSliceWithAiModalProps) {
+  const { onClose } = props;
+
+  return (
+    <Dialog open onOpenChange={onClose}>
+      <DialogHeader title="Generate with AI" />
+      <DialogContent gap={0}>
+        <Box height="100%" />
+
+        <DialogActions>
+          <DialogCancelButton />
+        </DialogActions>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/packages/slice-machine/src/components/GenerateSliceWithAiModal/GenerateSliceWithAiModal.tsx
+++ b/packages/slice-machine/src/components/GenerateSliceWithAiModal/GenerateSliceWithAiModal.tsx
@@ -16,7 +16,12 @@ export function GenerateSliceWithAiModal(props: GenerateSliceWithAiModalProps) {
   const { open, onClose } = props;
 
   return (
-    <Dialog open={open} onOpenChange={onClose}>
+    <Dialog
+      open={open}
+      onOpenChange={(open) => {
+        if (!open) onClose();
+      }}
+    >
       <DialogHeader title="Generate with AI" />
       <DialogContent gap={0}>
         <Box height="100%" />

--- a/packages/slice-machine/src/components/GenerateSliceWithAiModal/GenerateSliceWithAiModal.tsx
+++ b/packages/slice-machine/src/components/GenerateSliceWithAiModal/GenerateSliceWithAiModal.tsx
@@ -8,14 +8,15 @@ import {
 } from "@prismicio/editor-ui";
 
 interface GenerateSliceWithAiModalProps {
+  open: boolean;
   onClose: () => void;
 }
 
 export function GenerateSliceWithAiModal(props: GenerateSliceWithAiModalProps) {
-  const { onClose } = props;
+  const { open, onClose } = props;
 
   return (
-    <Dialog open onOpenChange={onClose}>
+    <Dialog open={open} onOpenChange={onClose}>
       <DialogHeader title="Generate with AI" />
       <DialogContent gap={0}>
         <Box height="100%" />

--- a/packages/slice-machine/src/components/GenerateSliceWithAiModal/GenerateSliceWithAiModal.tsx
+++ b/packages/slice-machine/src/components/GenerateSliceWithAiModal/GenerateSliceWithAiModal.tsx
@@ -19,7 +19,6 @@ export function GenerateSliceWithAiModal(props: GenerateSliceWithAiModalProps) {
       <DialogHeader title="Generate with AI" />
       <DialogContent gap={0}>
         <Box height="100%" />
-
         <DialogActions>
           <DialogCancelButton />
         </DialogActions>

--- a/packages/slice-machine/src/components/GenerateSliceWithAiModal/index.tsx
+++ b/packages/slice-machine/src/components/GenerateSliceWithAiModal/index.tsx
@@ -1,0 +1,1 @@
+export { GenerateSliceWithAiModal } from "./GenerateSliceWithAiModal";

--- a/packages/slice-machine/src/features/builder/useAiSliceGenerationExperiment.ts
+++ b/packages/slice-machine/src/features/builder/useAiSliceGenerationExperiment.ts
@@ -1,0 +1,8 @@
+import { useExperimentVariant } from "@/hooks/useExperimentVariant";
+
+type useAiSliceGenerationExperimentReturnType = { eligible: boolean };
+
+export function useAiSliceGenerationExperiment(): useAiSliceGenerationExperimentReturnType {
+  const variant = useExperimentVariant("slicemachine-ai-slice-generation");
+  return { eligible: variant?.value === "on" };
+}

--- a/packages/slice-machine/src/features/customTypes/customTypesBuilder/SliceZoneBlankSlate.tsx
+++ b/packages/slice-machine/src/features/customTypes/customTypesBuilder/SliceZoneBlankSlate.tsx
@@ -1,4 +1,4 @@
-import { ActionList, ActionListItem, Badge, Box } from "@prismicio/editor-ui";
+import { ActionList, ActionListItem, Box } from "@prismicio/editor-ui";
 import { FC } from "react";
 
 import {
@@ -8,11 +8,13 @@ import {
   BlankSlateDescription,
   BlankSlateTitle,
 } from "@/components/BlankSlate";
+import { useAiSliceGenerationExperiment } from "@/features/builder/useAiSliceGenerationExperiment";
 import { SliceMachinePrinterIcon } from "@/icons/SliceMachinePrinterIcon";
 
 export type SliceZoneBlankSlateProps = {
   openUpdateSliceZoneModal: () => void;
   openCreateSliceModal: () => void;
+  openGenerateSliceWithAiModal: () => void;
   openSlicesTemplatesModal: () => void;
   projectHasAvailableSlices: boolean;
   isSlicesTemplatesSupported: boolean;
@@ -20,11 +22,14 @@ export type SliceZoneBlankSlateProps = {
 
 export const SliceZoneBlankSlate: FC<SliceZoneBlankSlateProps> = ({
   openCreateSliceModal,
+  openGenerateSliceWithAiModal,
   openUpdateSliceZoneModal,
   openSlicesTemplatesModal,
   projectHasAvailableSlices,
   isSlicesTemplatesSupported,
 }) => {
+  const aiSliceGenerationExperiment = useAiSliceGenerationExperiment();
+
   return (
     <Box
       flexGrow={1}
@@ -44,19 +49,27 @@ export const SliceZoneBlankSlate: FC<SliceZoneBlankSlateProps> = ({
           </BlankSlateDescription>
           <BlankSlateActions>
             <ActionList>
+              {aiSliceGenerationExperiment.eligible && (
+                <ActionListItem
+                  startIcon="autoFixHigh"
+                  onClick={openGenerateSliceWithAiModal}
+                  description="Let AI instantly create a Slice for you."
+                >
+                  Generate with AI
+                </ActionListItem>
+              )}
               <ActionListItem
                 startIcon="add"
                 onClick={openCreateSliceModal}
-                description="Start from scratch."
+                description="Build a custom Slice your way."
               >
-                Create new
+                Start from scratch
               </ActionListItem>
               {isSlicesTemplatesSupported ? (
                 <ActionListItem
                   startIcon="contentCopy"
                   onClick={openSlicesTemplatesModal}
                   description="Select from premade examples."
-                  endAdornment={<Badge color="purple" title="New" />}
                 >
                   Use template
                 </ActionListItem>

--- a/packages/slice-machine/src/legacy/lib/builders/CustomTypeBuilder/SliceZone/index.tsx
+++ b/packages/slice-machine/src/legacy/lib/builders/CustomTypeBuilder/SliceZone/index.tsx
@@ -16,7 +16,9 @@ import { toast } from "react-toastify";
 import { BaseStyles } from "theme-ui";
 
 import { telemetry } from "@/apiClient";
+import { GenerateSliceWithAiModal } from "@/components/GenerateSliceWithAiModal";
 import { ListHeader } from "@/components/List";
+import { useAiSliceGenerationExperiment } from "@/features/builder/useAiSliceGenerationExperiment";
 import { useCustomTypeState } from "@/features/customTypes/customTypesBuilder/CustomTypeProvider";
 import { SliceZoneBlankSlate } from "@/features/customTypes/customTypesBuilder/SliceZoneBlankSlate";
 import { useOnboarding } from "@/features/onboarding/useOnboarding";
@@ -111,12 +113,16 @@ const SliceZone: React.FC<SliceZoneProps> = ({
   sliceZone,
   tabId,
 }) => {
+  const aiSliceGenerationExperiment = useAiSliceGenerationExperiment();
+
   const availableSlicesTemplates = useSlicesTemplates();
   const [isSlicesTemplatesModalOpen, setIsSlicesTemplatesModalOpen] =
     useState(false);
   const [isUpdateSliceZoneModalOpen, setIsUpdateSliceZoneModalOpen] =
     useState(false);
   const [isCreateSliceModalOpen, setIsCreateSliceModalOpen] = useState(false);
+  const [isGenerateSliceWithAiModalOpen, setIsGenerateSliceWithAiModalOpen] =
+    useState(false);
   const { remoteSlices, libraries } = useSelector(
     (store: SliceMachineStoreType) => ({
       remoteSlices: getRemoteSlices(store),
@@ -169,6 +175,10 @@ const SliceZone: React.FC<SliceZoneProps> = ({
     setIsCreateSliceModalOpen(true);
   };
 
+  const openGenerateSliceWithAiModal = () => {
+    setIsGenerateSliceWithAiModalOpen(true);
+  };
+
   const openSlicesTemplatesModal = () => {
     setIsSlicesTemplatesModalOpen(true);
 
@@ -185,6 +195,10 @@ const SliceZone: React.FC<SliceZoneProps> = ({
 
   const closeCreateSliceModal = () => {
     setIsCreateSliceModalOpen(false);
+  };
+
+  const closeGenerateSliceWithAiModal = () => {
+    setIsGenerateSliceWithAiModalOpen(false);
   };
 
   const closeSlicesTemplatesModal = () => {
@@ -282,6 +296,7 @@ const SliceZone: React.FC<SliceZoneProps> = ({
           <SliceZoneBlankSlate
             openUpdateSliceZoneModal={openUpdateSliceZoneModal}
             openCreateSliceModal={openCreateSliceModal}
+            openGenerateSliceWithAiModal={openGenerateSliceWithAiModal}
             openSlicesTemplatesModal={openSlicesTemplatesModal}
             projectHasAvailableSlices={availableSlicesToAdd.length > 0}
             isSlicesTemplatesSupported={availableSlicesTemplates.length > 0}
@@ -366,6 +381,10 @@ const SliceZone: React.FC<SliceZoneProps> = ({
           onClose={closeCreateSliceModal}
         />
       )}
+      {aiSliceGenerationExperiment.eligible &&
+        isGenerateSliceWithAiModalOpen && (
+          <GenerateSliceWithAiModal onClose={closeGenerateSliceWithAiModal} />
+        )}
     </>
   );
 };

--- a/packages/slice-machine/src/legacy/lib/builders/CustomTypeBuilder/SliceZone/index.tsx
+++ b/packages/slice-machine/src/legacy/lib/builders/CustomTypeBuilder/SliceZone/index.tsx
@@ -389,9 +389,10 @@ const SliceZone: React.FC<SliceZoneProps> = ({
           onClose={closeCreateSliceModal}
         />
       )}
-      {isGenerateSliceWithAiModalOpen && (
-        <GenerateSliceWithAiModal onClose={closeGenerateSliceWithAiModal} />
-      )}
+      <GenerateSliceWithAiModal
+        open={isGenerateSliceWithAiModalOpen}
+        onClose={closeGenerateSliceWithAiModal}
+      />
     </>
   );
 };

--- a/packages/slice-machine/src/legacy/lib/builders/CustomTypeBuilder/SliceZone/index.tsx
+++ b/packages/slice-machine/src/legacy/lib/builders/CustomTypeBuilder/SliceZone/index.tsx
@@ -18,7 +18,6 @@ import { BaseStyles } from "theme-ui";
 import { telemetry } from "@/apiClient";
 import { GenerateSliceWithAiModal } from "@/components/GenerateSliceWithAiModal";
 import { ListHeader } from "@/components/List";
-import { useAiSliceGenerationExperiment } from "@/features/builder/useAiSliceGenerationExperiment";
 import { useCustomTypeState } from "@/features/customTypes/customTypesBuilder/CustomTypeProvider";
 import { SliceZoneBlankSlate } from "@/features/customTypes/customTypesBuilder/SliceZoneBlankSlate";
 import { useOnboarding } from "@/features/onboarding/useOnboarding";
@@ -113,8 +112,6 @@ const SliceZone: React.FC<SliceZoneProps> = ({
   sliceZone,
   tabId,
 }) => {
-  const aiSliceGenerationExperiment = useAiSliceGenerationExperiment();
-
   const availableSlicesTemplates = useSlicesTemplates();
   const [isSlicesTemplatesModalOpen, setIsSlicesTemplatesModalOpen] =
     useState(false);
@@ -381,10 +378,9 @@ const SliceZone: React.FC<SliceZoneProps> = ({
           onClose={closeCreateSliceModal}
         />
       )}
-      {aiSliceGenerationExperiment.eligible &&
-        isGenerateSliceWithAiModalOpen && (
-          <GenerateSliceWithAiModal onClose={closeGenerateSliceWithAiModal} />
-        )}
+      {isGenerateSliceWithAiModalOpen && (
+        <GenerateSliceWithAiModal onClose={closeGenerateSliceWithAiModal} />
+      )}
     </>
   );
 };

--- a/packages/slice-machine/src/legacy/lib/builders/CustomTypeBuilder/SliceZone/index.tsx
+++ b/packages/slice-machine/src/legacy/lib/builders/CustomTypeBuilder/SliceZone/index.tsx
@@ -18,6 +18,7 @@ import { BaseStyles } from "theme-ui";
 import { telemetry } from "@/apiClient";
 import { GenerateSliceWithAiModal } from "@/components/GenerateSliceWithAiModal";
 import { ListHeader } from "@/components/List";
+import { useAiSliceGenerationExperiment } from "@/features/builder/useAiSliceGenerationExperiment";
 import { useCustomTypeState } from "@/features/customTypes/customTypesBuilder/CustomTypeProvider";
 import { SliceZoneBlankSlate } from "@/features/customTypes/customTypesBuilder/SliceZoneBlankSlate";
 import { useOnboarding } from "@/features/onboarding/useOnboarding";
@@ -112,6 +113,7 @@ const SliceZone: React.FC<SliceZoneProps> = ({
   sliceZone,
   tabId,
 }) => {
+  const aiSliceGenerationExperiment = useAiSliceGenerationExperiment();
   const availableSlicesTemplates = useSlicesTemplates();
   const [isSlicesTemplatesModalOpen, setIsSlicesTemplatesModalOpen] =
     useState(false);
@@ -219,12 +221,21 @@ const SliceZone: React.FC<SliceZoneProps> = ({
               </DropdownMenuTrigger>
 
               <DropdownMenuContent align="end">
+                {aiSliceGenerationExperiment.eligible && (
+                  <DropdownMenuItem
+                    startIcon={<Icon name="autoFixHigh" size="large" />}
+                    onSelect={openGenerateSliceWithAiModal}
+                    description="Let AI instantly create a Slice for you."
+                  >
+                    Generate with AI
+                  </DropdownMenuItem>
+                )}
                 <DropdownMenuItem
                   startIcon={<Icon name="add" size="large" />}
                   onSelect={openCreateSliceModal}
-                  description="Start from scratch."
+                  description="Build a custom Slice your way."
                 >
-                  Create new
+                  Start from scratch
                 </DropdownMenuItem>
 
                 {availableSlicesTemplates.length > 0 ? (

--- a/playwright/pages/shared/TypeBuilderPage.ts
+++ b/playwright/pages/shared/TypeBuilderPage.ts
@@ -113,7 +113,7 @@ export class TypeBuilderPage extends BuilderPage {
         exact: true,
       });
     this.sliceZoneBlankSlateCreateNewAction =
-      this.sliceZoneBlankSlate.getByText("Create new", {
+      this.sliceZoneBlankSlate.getByText("Start from scratch", {
         exact: true,
       });
     this.sliceZoneAddDropdown = page.getByTestId("add-new-slice-dropdown");
@@ -125,7 +125,7 @@ export class TypeBuilderPage extends BuilderPage {
       .getByText("Select existing", { exact: true });
     this.sliceZoneAddDropdownCreateNewAction = page
       .getByRole("menu")
-      .getByText("Create new", { exact: true });
+      .getByText("Start from scratch", { exact: true });
     this.removeSliceButton = page.getByRole("button", {
       name: "Remove slice",
       exact: true,


### PR DESCRIPTION
**Resolves**: [DT-2606](https://linear.app/prismic/issue/DT-2606/%5Bm%5D-aadev-in-slice-machine-i-can-add-slices-screenshots-from-page-type)

### Description

Design: https://www.figma.com/design/RGAejB5IuJtUsplHMFxN9H/AI?node-id=95-6171&t=07Z8aeiuQcSxSUQa-0

- Adds the "slicemachine-ai-slice-generation" feature flag hook
- Adds the "Generate with AI" option to slice zone
- Adds a blank Generate with AI modal

### Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- Don't hesitate to ask for help! -->

- [ ] A comprehensive Linear ticket, providing sufficient context and details to facilitate the review of the PR, is linked to the PR.
- [ ] If my changes require tests, I added them.
- [ ] If my changes affect backward compatibility, it has been discussed.
- [ ] If my changes require an update to the CONTRIBUTING.md guide, I updated it.

### Preview

https://github.com/user-attachments/assets/e265e212-fc06-4007-88ab-14ee64fd3c71

### How to QA [^1]

<!-- When relevant, describe how to QA your changes. -->

<!-- Your favorite emoji is welcome to close your PR! -->

<!-- A note for reviewers: -->

[^1]:
	Please use these labels when submitting a review:
	:question: #ask:&ensp;Ask a question.
	:bulb: #idea:&ensp;Suggest an idea.
	:warning: #issue:&ensp;Strongly suggest a change.
	:tada: #nice:&ensp;Share a compliment.
