### PR TITLE
feat: remove table amplitude experiment

### DIFF
--- a/packages/slice-machine/src/features/builder/useTableFieldExperiment.ts
+++ b/packages/slice-machine/src/features/builder/useTableFieldExperiment.ts
@@ -1,8 +1,0 @@
-import { useExperimentVariant } from "@/hooks/useExperimentVariant";
-
-type UseTableFieldExperimentReturnType = { eligible: boolean };
-
-export function useTableFieldExperiment(): UseTableFieldExperimentReturnType {
-  const variant = useExperimentVariant("slicemachine-table-field");
-  return { eligible: variant?.value === "on" };
-}

--- a/packages/slice-machine/src/legacy/lib/builders/CustomTypeBuilder/TabZone/index.tsx
+++ b/packages/slice-machine/src/legacy/lib/builders/CustomTypeBuilder/TabZone/index.tsx
@@ -20,7 +20,6 @@ import {
   updateField,
 } from "@/domain/customType";
 import { ErrorBoundary } from "@/ErrorBoundary";
-import { useTableFieldExperiment } from "@/features/builder/useTableFieldExperiment";
 import { useCustomTypeState } from "@/features/customTypes/customTypesBuilder/CustomTypeProvider";
 import {
   CustomTypes,
@@ -78,11 +77,6 @@ type OnSaveFieldProps = {
 };
 
 const TabZone: FC<TabZoneProps> = ({ tabId }) => {
-  const tableFieldExperiment = useTableFieldExperiment();
-  const maybeFilteredWidgetsArray = tableFieldExperiment.eligible
-    ? widgetsArray
-    : widgetsArray.filter((widget) => widget.TYPE_NAME !== "Table");
-
   const { customType, setCustomType } = useCustomTypeState();
   const customTypeSM = CustomTypes.toSM(customType);
 
@@ -265,7 +259,7 @@ const TabZone: FC<TabZoneProps> = ({ tabId }) => {
             poolOfFieldsToCheck={poolOfFields}
             showHints={true}
             EditModal={EditModal}
-            widgetsArray={maybeFilteredWidgetsArray}
+            widgetsArray={widgetsArray}
             onDeleteItem={onDeleteItem}
             onSave={onCreateOrSave}
             onDragEnd={onDragEnd}

--- a/packages/slice-machine/src/legacy/lib/builders/SliceBuilder/FieldZones/index.tsx
+++ b/packages/slice-machine/src/legacy/lib/builders/SliceBuilder/FieldZones/index.tsx
@@ -24,7 +24,6 @@ import {
   reorderField,
   updateField,
 } from "@/domain/slice";
-import { useTableFieldExperiment } from "@/features/builder/useTableFieldExperiment";
 import { useSliceState } from "@/features/slices/sliceBuilder/SliceBuilderProvider";
 import EditModal from "@/legacy/lib/builders/common/EditModal";
 import Zone from "@/legacy/lib/builders/common/Zone";
@@ -79,15 +78,7 @@ const FieldZones: FC = () => {
     setIsDeleteRepeatableZoneDialogOpen,
   ] = useState(false);
 
-  const tableFieldExperiment = useTableFieldExperiment();
-  const maybeFilteredItemsWidgetsArray = tableFieldExperiment.eligible
-    ? itemsWidgetsArray
-    : itemsWidgetsArray.filter((widget) => widget.TYPE_NAME !== "Table");
-
-  const primaryWidgetsArray = [
-    Widgets.Group,
-    ...maybeFilteredItemsWidgetsArray,
-  ];
+  const primaryWidgetsArray = [Widgets.Group, ...itemsWidgetsArray];
 
   // We won't show the Repeatable Zone if no items are configured.
   const hasItems = Boolean(
@@ -254,7 +245,7 @@ const FieldZones: FC = () => {
           isRepeatable
           title="Repeatable Zone"
           dataTip={dataTipText2}
-          widgetsArray={maybeFilteredItemsWidgetsArray}
+          widgetsArray={itemsWidgetsArray}
           // eslint-disable-next-line @typescript-eslint/ban-ts-comment
           fields={variation.items}
           EditModal={EditModal}

--- a/packages/slice-machine/src/legacy/lib/models/common/widgets/Group/index.tsx
+++ b/packages/slice-machine/src/legacy/lib/models/common/widgets/Group/index.tsx
@@ -1,7 +1,6 @@
 import { type DroppableStateSnapshot } from "react-beautiful-dnd";
 
 import { useNestedGroupExperiment } from "@/features/builder/useNestedGroupExperiment";
-import { useTableFieldExperiment } from "@/features/builder/useTableFieldExperiment";
 import { type Item } from "@/legacy/components/ListItem";
 import { type TabField } from "@/legacy/lib/models/common/CustomType";
 import { type GroupSM } from "@/legacy/lib/models/common/Group";
@@ -56,12 +55,9 @@ const hintItemName = "item";
 
 const GroupListItem = (props: GroupListItemProps<GroupSM>): JSX.Element => {
   const nestedGroupExperiment = useNestedGroupExperiment();
-  const tableFieldExperiment = useTableFieldExperiment();
 
   const maybeFilteredWidgetsArray = widgetsArray.filter((widget) => {
     if (!nestedGroupExperiment.eligible && widget.CUSTOM_NAME === "NestedGroup")
-      return false;
-    if (!tableFieldExperiment.eligible && widget.TYPE_NAME === "Table")
       return false;
     return true;
   });

--- a/packages/slice-machine/src/legacy/lib/models/common/widgets/NestedGroup/index.tsx
+++ b/packages/slice-machine/src/legacy/lib/models/common/widgets/NestedGroup/index.tsx
@@ -1,4 +1,3 @@
-import { useTableFieldExperiment } from "@/features/builder/useTableFieldExperiment";
 import { type NestedGroupSM } from "@/legacy/lib/models/common/Group";
 import { type GroupListItemProps } from "@/legacy/lib/models/common/widgets/Group";
 import { createGroupWidget } from "@/legacy/lib/models/common/widgets/Group/createGroupWidget";
@@ -26,15 +25,10 @@ const widgetsArray = [
 const hintItemName = "subItem";
 
 const NestedGroupListItem = (props: GroupListItemProps<NestedGroupSM>) => {
-  const tableFieldExperiment = useTableFieldExperiment();
-  const maybeFilteredWidgetsArray = tableFieldExperiment.eligible
-    ? widgetsArray
-    : widgetsArray.filter((widget) => widget.TYPE_NAME !== "Table");
-
   return (
     <CustomListItem
       Widgets={Widgets}
-      widgetsArray={maybeFilteredWidgetsArray}
+      widgetsArray={widgetsArray}
       hintBase={hintItemName}
       {...props}
     />

--- a/playwright/tests/fields/table.spec.ts
+++ b/playwright/tests/fields/table.spec.ts
@@ -4,16 +4,8 @@ import { test } from "../../fixtures";
 
 test("I can create a table field", async ({
   customTypesBuilderPage,
-  procedures,
   singleCustomType,
 }) => {
-  procedures.mock(
-    "telemetry.getExperimentVariant",
-    ({ args }) =>
-      args[0] === "slicemachine-table-field" ? { value: "on" } : undefined,
-    { execute: false },
-  );
-
   await customTypesBuilderPage.goto(singleCustomType.name);
   await customTypesBuilderPage.addStaticField({
     type: "Table",


### PR DESCRIPTION
<!-- Please use a Conventional Commit in your PR title -->
<!-- https://conventionalcommits.org -->
<!-- e.g. "feat: support new field type" -->

**Resolves**: [DT-2637: \[S\] AAPrismicDev, I don't need Amplitude experiment to activate Table field](https://linear.app/prismic/issue/DT-2637/[s]-aaprismicdev-i-dont-need-amplitude-experiment-to-activate-table)

### Description

- Remove Amplitude experiment for Table as it's now open for all
This is required as we detected that the users that disabled telemetry or block amplitude request don't have access to our new feature.

<!-- Describe your changes in detail. -->
<!-- Why is this change required? -->
<!-- What problem does it solve? -->

### Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- Don't hesitate to ask for help! -->

- [ ] A comprehensive Linear ticket, providing sufficient context and details to facilitate the review of the PR, is linked to the PR.
- [ ] If my changes require tests, I added them.
- [ ] If my changes affect backward compatibility, it has been discussed.
- [ ] If my changes require an update to the CONTRIBUTING.md guide, I updated it.

### Preview

<!-- If your changes are visual, screenshots or videos are welcome! -->

### How to QA [^1]

<!-- When relevant, describe how to QA your changes. -->

<!-- Your favorite emoji is welcome to close your PR! -->

<!-- A note for reviewers: -->

[^1]:
	Please use these labels when submitting a review:
	:question: #ask:&ensp;Ask a question.
	:bulb: #idea:&ensp;Suggest an idea.
	:warning: #issue:&ensp;Strongly suggest a change.
	:tada: #nice:&ensp;Share a compliment.
