### PR TITLE
feat(image-to-slice): create slices on submit

### DIFF
--- a/packages/slice-machine/src/apiClient.ts
+++ b/packages/slice-machine/src/apiClient.ts
@@ -33,7 +33,7 @@ export const getState = async (): Promise<ServerState> => {
             ...component,
             model: Slices.toSM(component.model),
 
-            // Replace screnshot Blobs with URLs.
+            // Replace screenshot Blobs with URLs.
             screenshots: Object.fromEntries(
               Object.entries(component.screenshots).map(
                 ([variationID, screenshot]) => {

--- a/packages/slice-machine/src/features/customTypes/customTypesBuilder/GenerateSliceWithAiModal/SliceCard.tsx
+++ b/packages/slice-machine/src/features/customTypes/customTypesBuilder/GenerateSliceWithAiModal/SliceCard.tsx
@@ -30,7 +30,7 @@ export function SliceCard(props: SliceCardProps) {
       <CardFooter
         loading={loading}
         startIcon={getStartIcon(slice.status)}
-        title={slice.image.name}
+        title={slice.status === "success" ? slice.model.name : slice.image.name}
         subtitle={getSubtitle(slice.status)}
         error={error}
         action={

--- a/packages/slice-machine/src/features/customTypes/customTypesBuilder/SliceZoneBlankSlate.tsx
+++ b/packages/slice-machine/src/features/customTypes/customTypesBuilder/SliceZoneBlankSlate.tsx
@@ -59,9 +59,9 @@ export const SliceZoneBlankSlate: FC<SliceZoneBlankSlateProps> = ({
                 />
               )}
               onClick={openGenerateSliceWithAiModal}
-              description="Let AI instantly create a Slice for you."
+              description="Build a Slice based on your design image."
             >
-              Generate with AI
+              Generate from image
             </ActionListItem>
           )}
           <ActionListItem

--- a/packages/slice-machine/src/legacy/lib/builders/CustomTypeBuilder/SliceZone/index.tsx
+++ b/packages/slice-machine/src/legacy/lib/builders/CustomTypeBuilder/SliceZone/index.tsx
@@ -237,9 +237,9 @@ const SliceZone: React.FC<SliceZoneProps> = ({
                       />
                     )}
                     onSelect={openGenerateSliceWithAiModal}
-                    description="Let AI instantly create a Slice for you."
+                    description="Build a Slice based on your design image."
                   >
-                    Generate with AI
+                    Generate from image
                   </DropdownMenuItem>
                 )}
                 <DropdownMenuItem

--- a/packages/slice-machine/src/legacy/lib/builders/CustomTypeBuilder/SliceZone/index.tsx
+++ b/packages/slice-machine/src/legacy/lib/builders/CustomTypeBuilder/SliceZone/index.tsx
@@ -14,7 +14,7 @@ import { useSelector } from "react-redux";
 import { toast } from "react-toastify";
 import { BaseStyles } from "theme-ui";
 
-import { telemetry } from "@/apiClient";
+import { getState, telemetry } from "@/apiClient";
 import { ListHeader } from "@/components/List";
 import { useAiSliceGenerationExperiment } from "@/features/builder/useAiSliceGenerationExperiment";
 import { useCustomTypeState } from "@/features/customTypes/customTypesBuilder/CustomTypeProvider";
@@ -23,6 +23,7 @@ import { SliceZoneBlankSlate } from "@/features/customTypes/customTypesBuilder/S
 import { useOnboarding } from "@/features/onboarding/useOnboarding";
 import { addSlicesToSliceZone } from "@/features/slices/actions/addSlicesToSliceZone";
 import { useSlicesTemplates } from "@/features/slicesTemplates/useSlicesTemplates";
+import { useAutoSync } from "@/features/sync/AutoSyncProvider";
 import { CreateSliceModal } from "@/legacy/components/Forms/CreateSliceModal";
 import { ToastMessageWithPath } from "@/legacy/components/ToasterContainer";
 import type { ComponentUI } from "@/legacy/lib/models/common/ComponentUI";
@@ -38,6 +39,7 @@ import {
   getLibraries,
   getRemoteSlices,
 } from "@/modules/slices";
+import useSliceMachineActions from "@/modules/useSliceMachineActions";
 import type { SliceMachineStoreType } from "@/redux/type";
 
 import { DeleteSliceZoneModal } from "./DeleteSliceZoneModal";
@@ -130,6 +132,8 @@ const SliceZone: React.FC<SliceZoneProps> = ({
   );
   const { setCustomType } = useCustomTypeState();
   const { completeStep } = useOnboarding();
+  const { createSliceSuccess } = useSliceMachineActions();
+  const { syncChanges } = useAutoSync();
 
   const localLibraries: readonly LibraryUI[] = libraries.filter(
     (library) => library.isLocal,
@@ -429,6 +433,39 @@ const SliceZone: React.FC<SliceZoneProps> = ({
       )}
       <GenerateSliceWithAiModal
         open={isGenerateSliceWithAiModalOpen}
+        onSuccess={async (args: { slices: SharedSlice[]; library: string }) => {
+          const { slices, library } = args;
+
+          const serverState = await getState();
+          createSliceSuccess(serverState.libraries);
+
+          const newCustomType = addSlicesToSliceZone({
+            customType,
+            tabId,
+            slices,
+          });
+          setCustomType(CustomTypes.fromSM(newCustomType), () => {
+            toast.success(
+              <ToastMessageWithPath
+                message="Slice(s) added to slice zone and created at: "
+                path={library}
+              />,
+            );
+          });
+          void completeStep("createSlice");
+          syncChanges();
+
+          for (const slice of slices) {
+            void telemetry.track({
+              event: "slice:created",
+              id: slice.id,
+              name: slice.name,
+              library,
+            });
+          }
+
+          closeGenerateSliceWithAiModal();
+        }}
         onClose={closeGenerateSliceWithAiModal}
       />
     </>


### PR DESCRIPTION
**Resolves**: [DT-2606](https://linear.app/prismic/issue/DT-2606/%5Bm%5D-aadev-in-slice-machine-i-can-add-slices-screenshots-from-page-type)

### Description

This PR:
- Creates the inferred slices and adds them to the page type on submit
- Adds a 10 file limit to the file drop zone
- Removes the modal scrollbar padding
- Updates menu text

### Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- Don't hesitate to ask for help! -->

- [ ] A comprehensive Linear ticket, providing sufficient context and details to facilitate the review of the PR, is linked to the PR.
- [ ] If my changes require tests, I added them.
- [ ] If my changes affect backward compatibility, it has been discussed.
- [ ] If my changes require an update to the CONTRIBUTING.md guide, I updated it.

### Preview

<!-- If your changes are visual, screenshots or videos are welcome! -->

### How to QA [^1]

<!-- When relevant, describe how to QA your changes. -->

<!-- Your favorite emoji is welcome to close your PR! -->

<!-- A note for reviewers: -->

[^1]:
	Please use these labels when submitting a review:
	:question: #ask:&ensp;Ask a question.
	:bulb: #idea:&ensp;Suggest an idea.
	:warning: #issue:&ensp;Strongly suggest a change.
	:tada: #nice:&ensp;Share a compliment.
