### PR TITLE
fix(image-to-slice): add warning when exceeding upload limit

### DIFF
--- a/packages/slice-machine/src/features/customTypes/customTypesBuilder/GenerateSliceWithAiModal/GenerateSliceWithAiModal.tsx
+++ b/packages/slice-machine/src/features/customTypes/customTypesBuilder/GenerateSliceWithAiModal/GenerateSliceWithAiModal.tsx
@@ -24,6 +24,8 @@ import { managerClient } from "@/managerClient";
 
 import { Slice, SliceCard } from "./SliceCard";
 
+const IMAGE_UPLOAD_LIMIT = 10;
+
 interface GenerateSliceWithAiModalProps {
   open: boolean;
   onSuccess: (args: {
@@ -60,6 +62,13 @@ export function GenerateSliceWithAiModal(props: GenerateSliceWithAiModalProps) {
   };
 
   const onImagesSelected = (images: File[]) => {
+    if (images.length > IMAGE_UPLOAD_LIMIT) {
+      toast.error(
+        `You can only upload ${IMAGE_UPLOAD_LIMIT} images at a time.`,
+      );
+      return;
+    }
+
     setSlices(
       images.map((image) => ({
         status: "uploading",
@@ -184,7 +193,7 @@ export function GenerateSliceWithAiModal(props: GenerateSliceWithAiModalProps) {
             <FileDropZone
               onFilesSelected={onImagesSelected}
               assetType="image"
-              maxFiles={10}
+              maxFiles={IMAGE_UPLOAD_LIMIT}
               overlay={
                 <UploadBlankSlate
                   onFilesSelected={onImagesSelected}


### PR DESCRIPTION
**Resolves**: N/A

### Description

Fixes issue where it was possible to upload more than 10 images via the upload button. It now blocks the upload and provides a toast error.

### Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- Don't hesitate to ask for help! -->

- [ ] A comprehensive Linear ticket, providing sufficient context and details to facilitate the review of the PR, is linked to the PR.
- [ ] If my changes require tests, I added them.
- [ ] If my changes affect backward compatibility, it has been discussed.
- [ ] If my changes require an update to the CONTRIBUTING.md guide, I updated it.

### Preview

https://github.com/user-attachments/assets/fb2f620b-21c2-4632-8df2-cf2818d05dce

### How to QA [^1]

<!-- When relevant, describe how to QA your changes. -->

<!-- Your favorite emoji is welcome to close your PR! -->

<!-- A note for reviewers: -->

[^1]:
	Please use these labels when submitting a review:
	:question: #ask:&ensp;Ask a question.
	:bulb: #idea:&ensp;Suggest an idea.
	:warning: #issue:&ensp;Strongly suggest a change.
	:tada: #nice:&ensp;Share a compliment.
