### PR TITLE
feat(image-to-slice): display login modal if not logged in 

### DIFF
--- a/packages/slice-machine/src/features/customTypes/customTypesBuilder/GenerateSliceWithAiModal/GenerateSliceWithAiModal.tsx
+++ b/packages/slice-machine/src/features/customTypes/customTypesBuilder/GenerateSliceWithAiModal/GenerateSliceWithAiModal.tsx
@@ -163,9 +163,9 @@ export function GenerateSliceWithAiModal(props: GenerateSliceWithAiModalProps) {
     addSlices(newSlices)
       .then(async ({ slices, library }) => {
         if (currentId !== id.current) return;
-        setIsCreatingSlices(false);
         id.current = crypto.randomUUID();
         await onSuccess({ slices, library });
+        setIsCreatingSlices(false);
         setSlices([]);
       })
       .catch(() => {

--- a/packages/slice-machine/src/legacy/lib/builders/CustomTypeBuilder/SliceZone/index.tsx
+++ b/packages/slice-machine/src/legacy/lib/builders/CustomTypeBuilder/SliceZone/index.tsx
@@ -34,6 +34,7 @@ import {
 import type { SliceZoneSlice } from "@/legacy/lib/models/common/CustomType/sliceZone";
 import type { LibraryUI } from "@/legacy/lib/models/common/LibraryUI";
 import type { SlicesSM } from "@/legacy/lib/models/common/Slices";
+import { managerClient } from "@/managerClient";
 import {
   getFrontendSlices,
   getLibraries,
@@ -132,7 +133,7 @@ const SliceZone: React.FC<SliceZoneProps> = ({
   );
   const { setCustomType } = useCustomTypeState();
   const { completeStep } = useOnboarding();
-  const { createSliceSuccess } = useSliceMachineActions();
+  const { createSliceSuccess, openLoginModal } = useSliceMachineActions();
   const { syncChanges } = useAutoSync();
 
   const localLibraries: readonly LibraryUI[] = libraries.filter(
@@ -177,8 +178,14 @@ const SliceZone: React.FC<SliceZoneProps> = ({
     setIsCreateSliceModalOpen(true);
   };
 
-  const openGenerateSliceWithAiModal = () => {
-    setIsGenerateSliceWithAiModalOpen(true);
+  const openGenerateSliceWithAiModal = async () => {
+    const isLoggedIn = await managerClient.user.checkIsLoggedIn();
+
+    if (isLoggedIn) {
+      setIsGenerateSliceWithAiModalOpen(true);
+    } else {
+      openLoginModal();
+    }
   };
 
   const openSlicesTemplatesModal = () => {
@@ -236,7 +243,7 @@ const SliceZone: React.FC<SliceZoneProps> = ({
                         color="purple"
                       />
                     )}
-                    onSelect={openGenerateSliceWithAiModal}
+                    onSelect={() => void openGenerateSliceWithAiModal()}
                     description="Build a Slice based on your design image."
                   >
                     Generate from image
@@ -345,7 +352,9 @@ const SliceZone: React.FC<SliceZoneProps> = ({
             <SliceZoneBlankSlate
               openUpdateSliceZoneModal={openUpdateSliceZoneModal}
               openCreateSliceModal={openCreateSliceModal}
-              openGenerateSliceWithAiModal={openGenerateSliceWithAiModal}
+              openGenerateSliceWithAiModal={() =>
+                void openGenerateSliceWithAiModal()
+              }
               openSlicesTemplatesModal={openSlicesTemplatesModal}
               projectHasAvailableSlices={availableSlicesToAdd.length > 0}
               isSlicesTemplatesSupported={availableSlicesTemplates.length > 0}


### PR DESCRIPTION
**Resolves**: [DT-2646](https://linear.app/prismic/issue/DT-2646/aauser-i-see-an-explicit-error-message-when-not-logged-in)

### Description

This PR will display the login modal if the user isn't logged in and tries opening the Image to Slice modal.

It also includes a small fix that maintains the modal's "creating slices" state until the after the slices have been added to the file system and to the custom type.

### Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- Don't hesitate to ask for help! -->

- [ ] A comprehensive Linear ticket, providing sufficient context and details to facilitate the review of the PR, is linked to the PR.
- [ ] If my changes require tests, I added them.
- [ ] If my changes affect backward compatibility, it has been discussed.
- [ ] If my changes require an update to the CONTRIBUTING.md guide, I updated it.

### Preview

Login Modal:

https://github.com/user-attachments/assets/e5319450-15b0-4671-9315-4c787b827301


Create Slice state:

https://github.com/user-attachments/assets/1ad9c94a-686e-4d20-9c4a-96d34850f1f7


### How to QA [^1]

<!-- When relevant, describe how to QA your changes. -->

<!-- Your favorite emoji is welcome to close your PR! -->

<!-- A note for reviewers: -->

[^1]:
	Please use these labels when submitting a review:
	:question: #ask:&ensp;Ask a question.
	:bulb: #idea:&ensp;Suggest an idea.
	:warning: #issue:&ensp;Strongly suggest a change.
	:tada: #nice:&ensp;Share a compliment.
