### PR TITLE
fix: image thumbnail issue

### DIFF
--- a/packages/slice-machine/src/legacy/lib/models/common/widgets/Image/Form.tsx
+++ b/packages/slice-machine/src/legacy/lib/models/common/widgets/Image/Form.tsx
@@ -37,25 +37,21 @@ const FormFields = {
   },
   thumbnails: {
     validate: () =>
-      yup
-        .array()
-        .defined()
-        .of(
-          yup.object().test({
-            name: "Thumbnails",
-            message: "Must set name and width or height at minimum",
-            test: function (value) {
-              if (!value.name) {
-                return false;
-              }
-              const hasWidth = typeof value.width === "number" && value.width;
-              const hasHeight =
-                typeof value.height === "number" && value.height;
-              const hasWidthOrHeight = hasWidth || hasHeight;
-              return value.name && hasWidthOrHeight;
-            },
-          }),
-        ),
+      yup.array().of(
+        yup.object().test({
+          name: "Thumbnails",
+          message: "Must set name and width or height at minimum",
+          test: function (value) {
+            if (!value.name) {
+              return false;
+            }
+            const hasWidth = typeof value.width === "number" && value.width;
+            const hasHeight = typeof value.height === "number" && value.height;
+            const hasWidthOrHeight = hasWidth || hasHeight;
+            return value.name && hasWidthOrHeight;
+          },
+        }),
+      ),
   },
 };
 
@@ -100,7 +96,7 @@ type FieldValues = {
       width?: number;
       height?: number;
     };
-    thumbnails: Array<Thumbnail>;
+    thumbnails?: Array<Thumbnail>;
   };
 };
 
@@ -118,7 +114,7 @@ const Form: React.FC<FormProps> = (props) => {
   const [thumbI, setThumbI] = useState(0);
 
   const {
-    config: { thumbnails, constraint },
+    config: { thumbnails = [], constraint },
   } = formValues;
 
   useEffect(() => {


### PR DESCRIPTION
Resolves: [DT-2658](https://linear.app/prismic/issue/DT-2658/sm-fix-image-missing-thumbnails-issue)

### Description

This fixes an issue where the edit field modal would fail to load for an image field if the `thumbnails` property doesn't exist on the type model.

### Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- Don't hesitate to ask for help! -->

- [ ] A comprehensive Linear ticket, providing sufficient context and details to facilitate the review of the PR, is linked to the PR.
- [ ] If my changes require tests, I added them.
- [ ] If my changes affect backward compatibility, it has been discussed.
- [ ] If my changes require an update to the CONTRIBUTING.md guide, I updated it.

### Preview

N/A

### How to QA [^1]

<!-- When relevant, describe how to QA your changes. -->

<!-- Your favorite emoji is welcome to close your PR! -->

<!-- A note for reviewers: -->

[^1]:
	Please use these labels when submitting a review:
	:question: #ask:&ensp;Ask a question.
	:bulb: #idea:&ensp;Suggest an idea.
	:warning: #issue:&ensp;Strongly suggest a change.
	:tada: #nice:&ensp;Share a compliment.
