### PR TITLE
remove ai feedback when slice variation is gone

### DIFF
--- a/packages/manager/src/managers/telemetry/types.ts
+++ b/packages/manager/src/managers/telemetry/types.ts
@@ -279,7 +279,7 @@ type SliceCreatedSegmentEvent = SegmentEvent<
 		library: string;
 		location: "custom_type" | "page_type" | "slices";
 	} & (
-		| { mode: "ai" }
+		| { mode: "ai"; langSmithUrl?: string }
 		| { mode: "manual" }
 		| { mode: "template"; sliceTemplate: string }
 	)

--- a/packages/slice-machine/src/features/aiFeedback/index.tsx
+++ b/packages/slice-machine/src/features/aiFeedback/index.tsx
@@ -12,6 +12,7 @@ import { z } from "zod";
 
 import { telemetry } from "@/apiClient";
 import { usePersistedState } from "@/hooks/usePersistedState";
+import { getAiFeedbackKey } from "@/utils/localStorageKeys";
 
 export function addAiFeedback({
   type,
@@ -26,7 +27,7 @@ export function addAiFeedback({
   variationId: string;
   langSmithUrl?: string;
 }) {
-  const key = getKey({ type, library, sliceId, variationId });
+  const key = getAiFeedbackKey({ type, library, sliceId, variationId });
   const feedback = JSON.stringify({ langSmithUrl });
   localStorage.setItem(key, feedback);
 }
@@ -42,7 +43,7 @@ export function useAiFeedback({
   sliceId: string;
   variationId: string;
 }) {
-  const key = getKey({ type, library, sliceId, variationId });
+  const key = getAiFeedbackKey({ type, library, sliceId, variationId });
   const [value, setValue] = usePersistedState(key, undefined, {
     schema: z.object({
       langSmithUrl: z.string().url().optional(),
@@ -53,20 +54,6 @@ export function useAiFeedback({
     value,
     remove: () => setValue(undefined),
   };
-}
-
-function getKey({
-  type,
-  library,
-  sliceId,
-  variationId,
-}: {
-  type: "model";
-  library: string;
-  sliceId: string;
-  variationId: string;
-}) {
-  return ["ai-feedback", type, library, sliceId, variationId].join("#");
 }
 
 export function AiFeedback({

--- a/packages/slice-machine/src/features/aiFeedback/index.tsx
+++ b/packages/slice-machine/src/features/aiFeedback/index.tsx
@@ -32,6 +32,21 @@ export function addAiFeedback({
   localStorage.setItem(key, feedback);
 }
 
+export function removeAiFeedback({
+  type,
+  library,
+  sliceId,
+  variationId,
+}: {
+  type: "model";
+  library: string;
+  sliceId: string;
+  variationId: string;
+}) {
+  const key = getAiFeedbackKey({ type, library, sliceId, variationId });
+  localStorage.removeItem(key);
+}
+
 export function useAiFeedback({
   type,
   library,

--- a/packages/slice-machine/src/features/aiFeedback/index.tsx
+++ b/packages/slice-machine/src/features/aiFeedback/index.tsx
@@ -52,7 +52,7 @@ export function useAiFeedback({
   return {
     key,
     value,
-    remove: () => setValue(undefined),
+    done: () => setValue(undefined),
   };
 }
 
@@ -67,7 +67,7 @@ export function AiFeedback({
   sliceId: string;
   variationId: string;
 }) {
-  const { key, value, remove } = useAiFeedback({
+  const { key, value, done } = useAiFeedback({
     type,
     library,
     sliceId,
@@ -87,7 +87,7 @@ export function AiFeedback({
       feedback,
       langSmithUrl: value.langSmithUrl,
     });
-    remove();
+    done();
   };
 
   const toastShown = Boolean(toastKey);

--- a/packages/slice-machine/src/features/builder/AddStaticFieldDropdown.tsx
+++ b/packages/slice-machine/src/features/builder/AddStaticFieldDropdown.tsx
@@ -8,8 +8,7 @@ import {
 } from "@/features/builder/AddFieldDropdown";
 import { StaticFieldsInfoDialog } from "@/features/builder/StaticFieldsInfoDialog";
 import { usePersistedState } from "@/hooks/usePersistedState";
-
-const LOCAL_STORAGE_KEY = "slice-machine_staticFieldsInfoDialogDismissed";
+import { staticFieldsInfoDialogDismissedKey } from "@/utils/localStorageKeys";
 
 const AddFieldButton = forwardRef<
   HTMLButtonElement,
@@ -49,7 +48,7 @@ function PageTypeAddStaticFieldDropdown(props: AddFieldDropdownProps) {
   const [isFieldDropdownOpen, setFieldsDropdownOpen] = useState(false);
   const [isInfoDialogOpen, setInfoDialogOpen] = useState(false);
   const [isInfoDialogSeen, setInfoDialogSeen] = usePersistedState(
-    LOCAL_STORAGE_KEY,
+    staticFieldsInfoDialogDismissedKey,
     false,
   );
 

--- a/packages/slice-machine/src/features/slices/actions/deleteSlice.ts
+++ b/packages/slice-machine/src/features/slices/actions/deleteSlice.ts
@@ -1,16 +1,18 @@
 import { toast } from "react-toastify";
 
+import { removeAiFeedback } from "@/features/aiFeedback";
 import { managerClient } from "@/managerClient";
 
 type DeleteSliceArgs = {
   libraryID: string;
   sliceID: string;
   sliceName: string;
+  sliceVariationIds: string[];
   onSuccess: () => void;
 };
 
 export async function deleteSlice(args: DeleteSliceArgs) {
-  const { sliceName, sliceID, libraryID, onSuccess } = args;
+  const { sliceName, sliceID, libraryID, sliceVariationIds, onSuccess } = args;
 
   try {
     const { errors } = await managerClient.slices.deleteSlice({
@@ -21,6 +23,15 @@ export async function deleteSlice(args: DeleteSliceArgs) {
     if (errors.length > 0) {
       throw errors;
     }
+
+    sliceVariationIds.forEach((variationId) => {
+      removeAiFeedback({
+        type: "model",
+        library: libraryID,
+        sliceId: sliceID,
+        variationId,
+      });
+    });
 
     onSuccess();
 

--- a/packages/slice-machine/src/features/slices/sliceBuilder/actions/deleteVariation.ts
+++ b/packages/slice-machine/src/features/slices/sliceBuilder/actions/deleteVariation.ts
@@ -7,6 +7,7 @@ import {
   readSliceMocks,
   updateSlice,
 } from "@/apiClient";
+import { removeAiFeedback } from "@/features/aiFeedback";
 import { SLICES_CONFIG } from "@/features/slices/slicesConfig";
 import type { ComponentUI } from "@/legacy/lib/models/common/ComponentUI";
 import type { VariationSM } from "@/legacy/lib/models/common/Slice";
@@ -37,6 +38,14 @@ export async function deleteVariation(
     if (deleteSliceVariationErrors.length > 0) {
       throw deleteSliceVariationErrors;
     }
+
+    removeAiFeedback({
+      type: "model",
+      library: args.component.from,
+      sliceId: args.component.model.id,
+      variationId: args.variation.id,
+    });
+
     const { slice, errors: readSliceErrors } = await readSlice(
       args.component.from,
       args.component.model.id,

--- a/packages/slice-machine/src/legacy/components/DeleteSliceModal/index.tsx
+++ b/packages/slice-machine/src/legacy/components/DeleteSliceModal/index.tsx
@@ -14,12 +14,13 @@ type DeleteSliceModalProps = {
   libName: string;
   sliceId: string;
   sliceName: string;
+  variationIds: string[];
   onClose: () => void;
 };
 
 export const DeleteSliceModal: React.FunctionComponent<
   DeleteSliceModalProps
-> = ({ sliceId, sliceName, libName, isOpen, onClose }) => {
+> = ({ isOpen, libName, sliceId, sliceName, variationIds, onClose }) => {
   const [isDeleting, setIsDeleting] = useState(false);
   const { deleteSliceSuccess } = useSliceMachineActions();
   const { syncChanges } = useAutoSync();
@@ -29,9 +30,10 @@ export const DeleteSliceModal: React.FunctionComponent<
     setIsDeleting(true);
 
     await deleteSlice({
+      libraryID: libName,
       sliceID: sliceId,
       sliceName,
-      libraryID: libName,
+      sliceVariationIds: variationIds,
       onSuccess: () => {
         deleteSliceSuccess(sliceId, libName);
         syncChanges();

--- a/packages/slice-machine/src/legacy/components/DeleteSliceModal/index.tsx
+++ b/packages/slice-machine/src/legacy/components/DeleteSliceModal/index.tsx
@@ -14,13 +14,13 @@ type DeleteSliceModalProps = {
   libName: string;
   sliceId: string;
   sliceName: string;
-  variationIds: string[];
+  sliceVariationIds: string[];
   onClose: () => void;
 };
 
 export const DeleteSliceModal: React.FunctionComponent<
   DeleteSliceModalProps
-> = ({ isOpen, libName, sliceId, sliceName, variationIds, onClose }) => {
+> = ({ isOpen, libName, sliceId, sliceName, sliceVariationIds, onClose }) => {
   const [isDeleting, setIsDeleting] = useState(false);
   const { deleteSliceSuccess } = useSliceMachineActions();
   const { syncChanges } = useAutoSync();
@@ -33,7 +33,7 @@ export const DeleteSliceModal: React.FunctionComponent<
       libraryID: libName,
       sliceID: sliceId,
       sliceName,
-      sliceVariationIds: variationIds,
+      sliceVariationIds,
       onSuccess: () => {
         deleteSliceSuccess(sliceId, libName);
         syncChanges();

--- a/packages/slice-machine/src/legacy/lib/builders/CustomTypeBuilder/SliceZone/index.tsx
+++ b/packages/slice-machine/src/legacy/lib/builders/CustomTypeBuilder/SliceZone/index.tsx
@@ -473,6 +473,7 @@ const SliceZone: React.FC<SliceZoneProps> = ({
               library,
               location: `${customType.format}_type`,
               mode: "ai",
+              langSmithUrl,
             });
 
             addAiFeedback({

--- a/packages/slice-machine/src/pages/slices.tsx
+++ b/packages/slice-machine/src/pages/slices.tsx
@@ -259,7 +259,7 @@ const SlicesIndex: React.FunctionComponent = () => {
             libName={sliceForEdit?.from ?? ""}
             sliceId={sliceForEdit?.model.id ?? ""}
             sliceName={sliceForEdit?.model.name ?? ""}
-            variationIds={(sliceForEdit?.model.variations ?? []).map(
+            sliceVariationIds={(sliceForEdit?.model.variations ?? []).map(
               (variation) => variation.id,
             )}
             onClose={() => {

--- a/packages/slice-machine/src/pages/slices.tsx
+++ b/packages/slice-machine/src/pages/slices.tsx
@@ -259,6 +259,9 @@ const SlicesIndex: React.FunctionComponent = () => {
             libName={sliceForEdit?.from ?? ""}
             sliceId={sliceForEdit?.model.id ?? ""}
             sliceName={sliceForEdit?.model.name ?? ""}
+            variationIds={(sliceForEdit?.model.variations ?? []).map(
+              (variation) => variation.id,
+            )}
             onClose={() => {
               setIsDeleteSliceModalOpen(false);
             }}

--- a/packages/slice-machine/src/utils/localStorageKeys.ts
+++ b/packages/slice-machine/src/utils/localStorageKeys.ts
@@ -1,0 +1,27 @@
+/**
+ * Local storage keys used in the app (incomplete for now, so you still have to be careful when picking one).
+ * Do not remove old keys that become unused in newer versions.
+ * Always prefix keys with `slice-machine_` to avoid conflicts with other libraries and have them grouped together in the local storage.
+ */
+
+const withPrefix = (key: string) => `slice-machine_${key}`;
+
+export const staticFieldsInfoDialogDismissedKey = withPrefix(
+  "staticFieldsInfoDialogDismissed",
+);
+
+export function getAiFeedbackKey({
+  type,
+  library,
+  sliceId,
+  variationId,
+}: {
+  type: "model";
+  library: string;
+  sliceId: string;
+  variationId: string;
+}) {
+  return withPrefix(
+    ["ai-feedback", type, library, sliceId, variationId].join("#"),
+  );
+}


### PR DESCRIPTION
<!-- Please use a Conventional Commit in your PR title -->
<!-- https://conventionalcommits.org -->
<!-- e.g. "feat: support new field type" -->
To merge into https://github.com/prismicio/slice-machine/pull/1586.
Resolves: <!-- GitHub or Linear issue (e.g. #123, DT-123) -->
https://linear.app/prismic/issue/DT-2643/[m]-implement-ai-slice-feedback-flow-thumbs-updown

### Description

<!-- Describe your changes in detail. -->
<!-- Why is this change required? -->
<!-- What problem does it solve? -->
ensures ai feedback is removed when a slice variation is gone

it also refactors local storage keys and adds a property to the slice created event when it's via ai

### Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- Don't hesitate to ask for help! -->

- [ ] A comprehensive Linear ticket, providing sufficient context and details to facilitate the review of the PR, is linked to the PR.
- [ ] If my changes require tests, I added them.
- [ ] If my changes affect backward compatibility, it has been discussed.
- [ ] If my changes require an update to the CONTRIBUTING.md guide, I updated it.

### Preview

<!-- If your changes are visual, screenshots or videos are welcome! -->

### How to QA [^1]

<!-- When relevant, describe how to QA your changes. -->

<!-- Your favorite emoji is welcome to close your PR! -->

<!-- A note for reviewers: -->

[^1]:
	Please use these labels when submitting a review:
	:question: #ask:&ensp;Ask a question.
	:bulb: #idea:&ensp;Suggest an idea.
	:warning: #issue:&ensp;Strongly suggest a change.
	:tada: #nice:&ensp;Share a compliment.
