### PR TITLE
feat: add Sections experiment

### DIFF
--- a/packages/slice-machine/src/features/builder/useSectionsExperiment.ts
+++ b/packages/slice-machine/src/features/builder/useSectionsExperiment.ts
@@ -1,0 +1,29 @@
+// import { useExperimentVariant } from "@/hooks/useExperimentVariant";
+
+export type useSectionsExperimentReturnType = {
+  eligible: boolean;
+  singular: {
+    uppercase: string;
+    lowercase: string;
+  };
+  plural: {
+    uppercase: string;
+    lowercase: string;
+  };
+};
+
+export function useSectionsExperiment(): useSectionsExperimentReturnType {
+  // const variant = useExperimentVariant("slicemachine-sections");
+  // return variant?.value === "on"
+  return false
+    ? {
+        eligible: true,
+        singular: { uppercase: "Section", lowercase: "section" },
+        plural: { uppercase: "Sections", lowercase: "sections" },
+      }
+    : {
+        eligible: false,
+        singular: { uppercase: "Slice", lowercase: "slice" },
+        plural: { uppercase: "Slices", lowercase: "slices" },
+      };
+}

--- a/packages/slice-machine/src/features/builder/useSectionsExperiment.ts
+++ b/packages/slice-machine/src/features/builder/useSectionsExperiment.ts
@@ -1,6 +1,6 @@
 // import { useExperimentVariant } from "@/hooks/useExperimentVariant";
 
-export type useSectionsExperimentReturnType = {
+export type UseSectionsExperimentReturnType = {
   eligible: boolean;
   singular: {
     uppercase: string;
@@ -12,7 +12,7 @@ export type useSectionsExperimentReturnType = {
   };
 };
 
-export function useSectionsExperiment(): useSectionsExperimentReturnType {
+export function useSectionsExperiment(): UseSectionsExperimentReturnType {
   // const variant = useExperimentVariant("slicemachine-sections");
   // return variant?.value === "on"
   return false

--- a/packages/slice-machine/src/features/builder/useSectionsNamingExperiment.ts
+++ b/packages/slice-machine/src/features/builder/useSectionsNamingExperiment.ts
@@ -8,7 +8,7 @@ export type useSectionsNamingExperimentReturnType = {
 export function useSectionsNamingExperiment(): useSectionsNamingExperimentReturnType {
   // const variant = useExperimentVariant("slicemachine-sections");
   // return variant?.value === "on"
-  const eligible = true;
+  const eligible = false;
   return {
     eligible,
     value: eligible ? "section" : "slice",

--- a/packages/slice-machine/src/features/builder/useSectionsNamingExperiment.ts
+++ b/packages/slice-machine/src/features/builder/useSectionsNamingExperiment.ts
@@ -2,28 +2,15 @@
 
 export type useSectionsNamingExperimentReturnType = {
   eligible: boolean;
-  singular: {
-    uppercase: string;
-    lowercase: string;
-  };
-  plural: {
-    uppercase: string;
-    lowercase: string;
-  };
+  value: string;
 };
 
 export function useSectionsNamingExperiment(): useSectionsNamingExperimentReturnType {
   // const variant = useExperimentVariant("slicemachine-sections");
   // return variant?.value === "on"
-  return false
-    ? {
-        eligible: true,
-        singular: { uppercase: "Section", lowercase: "section" },
-        plural: { uppercase: "Sections", lowercase: "sections" },
-      }
-    : {
-        eligible: false,
-        singular: { uppercase: "Slice", lowercase: "slice" },
-        plural: { uppercase: "Slices", lowercase: "slices" },
-      };
+  const eligible = true;
+  return {
+    eligible,
+    value: eligible ? "section" : "slice",
+  };
 }

--- a/packages/slice-machine/src/features/builder/useSectionsNamingExperiment.ts
+++ b/packages/slice-machine/src/features/builder/useSectionsNamingExperiment.ts
@@ -1,11 +1,11 @@
 // import { useExperimentVariant } from "@/hooks/useExperimentVariant";
 
-export type useSectionsNamingExperimentReturnType = {
+export type UseSectionsNamingExperimentReturnType = {
   eligible: boolean;
   value: string;
 };
 
-export function useSectionsNamingExperiment(): useSectionsNamingExperimentReturnType {
+export function useSectionsNamingExperiment(): UseSectionsNamingExperimentReturnType {
   // const variant = useExperimentVariant("slicemachine-sections");
   // return variant?.value === "on"
   const eligible = false;

--- a/packages/slice-machine/src/features/builder/useSectionsNamingExperiment.ts
+++ b/packages/slice-machine/src/features/builder/useSectionsNamingExperiment.ts
@@ -1,6 +1,6 @@
 // import { useExperimentVariant } from "@/hooks/useExperimentVariant";
 
-export type UseSectionsExperimentReturnType = {
+export type useSectionsNamingExperimentReturnType = {
   eligible: boolean;
   singular: {
     uppercase: string;
@@ -12,7 +12,7 @@ export type UseSectionsExperimentReturnType = {
   };
 };
 
-export function useSectionsExperiment(): UseSectionsExperimentReturnType {
+export function useSectionsNamingExperiment(): useSectionsNamingExperimentReturnType {
   // const variant = useExperimentVariant("slicemachine-sections");
   // return variant?.value === "on"
   return false

--- a/packages/slice-machine/src/features/builder/useSectionsNamingExperiment.ts
+++ b/packages/slice-machine/src/features/builder/useSectionsNamingExperiment.ts
@@ -1,4 +1,4 @@
-// import { useExperimentVariant } from "@/hooks/useExperimentVariant";
+import { useExperimentVariant } from "@/hooks/useExperimentVariant";
 
 export type UseSectionsNamingExperimentReturnType = {
   eligible: boolean;
@@ -6,9 +6,8 @@ export type UseSectionsNamingExperimentReturnType = {
 };
 
 export function useSectionsNamingExperiment(): UseSectionsNamingExperimentReturnType {
-  // const variant = useExperimentVariant("slicemachine-sections");
-  // return variant?.value === "on"
-  const eligible = false;
+  const variant = useExperimentVariant("section_greater_than_slice");
+  const eligible = variant?.value === "treatment";
   return {
     eligible,
     value: eligible ? "section" : "slice",

--- a/packages/slice-machine/src/features/customTypes/customTypesBuilder/CreateSliceFromImageModal/CreateSliceFromImageModal.tsx
+++ b/packages/slice-machine/src/features/customTypes/customTypesBuilder/CreateSliceFromImageModal/CreateSliceFromImageModal.tsx
@@ -23,9 +23,9 @@ import { toast } from "react-toastify";
 import { getState, telemetry } from "@/apiClient";
 import { addAiFeedback } from "@/features/aiFeedback";
 import {
-  useSectionsExperiment,
-  UseSectionsExperimentReturnType,
-} from "@/features/builder/useSectionsExperiment";
+  useSectionsNamingExperiment,
+  useSectionsNamingExperimentReturnType,
+} from "@/features/builder/useSectionsNamingExperiment";
 import { useOnboarding } from "@/features/onboarding/useOnboarding";
 import { useAutoSync } from "@/features/sync/AutoSyncProvider";
 import { managerClient } from "@/managerClient";
@@ -57,7 +57,7 @@ export function CreateSliceFromImageModal(
   const { syncChanges } = useAutoSync();
   const { createSliceSuccess } = useSliceMachineActions();
   const { completeStep } = useOnboarding();
-  const sectionsExperiment = useSectionsExperiment();
+  const sectionsExperiment = useSectionsNamingExperiment();
   /**
    * Keeps track of the current instance id.
    * When the modal is closed, the id is reset.
@@ -297,7 +297,7 @@ function UploadBlankSlate(props: {
   droppingFiles?: boolean;
   onFilesSelected: (files: File[]) => void;
 }) {
-  const sectionsExperiment = useSectionsExperiment();
+  const sectionsExperiment = useSectionsNamingExperiment();
   const { droppingFiles = false, onFilesSelected } = props;
 
   return (
@@ -473,7 +473,7 @@ const getSubmitButtonLabel = ({
   sectionsExperiment,
 }: {
   location: "custom_type" | "page_type" | "slices";
-  sectionsExperiment: UseSectionsExperimentReturnType;
+  sectionsExperiment: useSectionsNamingExperimentReturnType;
 }) => {
   switch (location) {
     case "custom_type":

--- a/packages/slice-machine/src/features/customTypes/customTypesBuilder/CreateSliceFromImageModal/CreateSliceFromImageModal.tsx
+++ b/packages/slice-machine/src/features/customTypes/customTypesBuilder/CreateSliceFromImageModal/CreateSliceFromImageModal.tsx
@@ -24,7 +24,7 @@ import { getState, telemetry } from "@/apiClient";
 import { addAiFeedback } from "@/features/aiFeedback";
 import {
   useSectionsExperiment,
-  useSectionsExperimentReturnType,
+  UseSectionsExperimentReturnType,
 } from "@/features/builder/useSectionsExperiment";
 import { useOnboarding } from "@/features/onboarding/useOnboarding";
 import { useAutoSync } from "@/features/sync/AutoSyncProvider";
@@ -473,7 +473,7 @@ const getSubmitButtonLabel = ({
   sectionsExperiment,
 }: {
   location: "custom_type" | "page_type" | "slices";
-  sectionsExperiment: useSectionsExperimentReturnType;
+  sectionsExperiment: UseSectionsExperimentReturnType;
 }) => {
   switch (location) {
     case "custom_type":

--- a/packages/slice-machine/src/features/customTypes/customTypesBuilder/CreateSliceFromImageModal/CreateSliceFromImageModal.tsx
+++ b/packages/slice-machine/src/features/customTypes/customTypesBuilder/CreateSliceFromImageModal/CreateSliceFromImageModal.tsx
@@ -30,6 +30,7 @@ import { useOnboarding } from "@/features/onboarding/useOnboarding";
 import { useAutoSync } from "@/features/sync/AutoSyncProvider";
 import { managerClient } from "@/managerClient";
 import useSliceMachineActions from "@/modules/useSliceMachineActions";
+import { pluralize } from "@/utils/textConversion";
 
 import { Slice, SliceCard } from "./SliceCard";
 
@@ -57,7 +58,7 @@ export function CreateSliceFromImageModal(
   const { syncChanges } = useAutoSync();
   const { createSliceSuccess } = useSliceMachineActions();
   const { completeStep } = useOnboarding();
-  const sectionsExperiment = useSectionsNamingExperiment();
+  const sectionsNamingExperiment = useSectionsNamingExperiment();
   /**
    * Keeps track of the current instance id.
    * When the modal is closed, the id is reset.
@@ -243,8 +244,8 @@ export function CreateSliceFromImageModal(
       <DialogHeader title="Generate from image" />
       <DialogContent gap={0}>
         <DialogDescription hidden>
-          Upload images to generate {sectionsExperiment.plural.lowercase} with
-          AI
+          Upload images to generate {pluralize(sectionsNamingExperiment.value)}{" "}
+          with AI
         </DialogDescription>
         {slices.length === 0 ? (
           <Box padding={16} height="100%">
@@ -284,7 +285,7 @@ export function CreateSliceFromImageModal(
             loading={isCreatingSlices}
             onClick={onSubmit}
           >
-            {getSubmitButtonLabel({ location, sectionsExperiment })} (
+            {getSubmitButtonLabel({ location, sectionsNamingExperiment })} (
             {readySlices.length})
           </DialogActionButton>
         </DialogActions>
@@ -297,7 +298,7 @@ function UploadBlankSlate(props: {
   droppingFiles?: boolean;
   onFilesSelected: (files: File[]) => void;
 }) {
-  const sectionsExperiment = useSectionsNamingExperiment();
+  const sectionsNamingExperiment = useSectionsNamingExperiment();
   const { droppingFiles = false, onFilesSelected } = props;
 
   return (
@@ -319,8 +320,8 @@ function UploadBlankSlate(props: {
         />
         <BlankSlateTitle>Upload your design images.</BlankSlateTitle>
         <BlankSlateDescription>
-          Once uploaded, you can generate {sectionsExperiment.plural.lowercase}{" "}
-          automatically using AI.
+          Once uploaded, you can generate{" "}
+          {pluralize(sectionsNamingExperiment.value)} automatically using AI.
         </BlankSlateDescription>
         <BlankSlateActions>
           <FileUploadButton
@@ -470,10 +471,10 @@ async function addSlices(newSlices: NewSlice[]) {
 
 const getSubmitButtonLabel = ({
   location,
-  sectionsExperiment,
+  sectionsNamingExperiment,
 }: {
   location: "custom_type" | "page_type" | "slices";
-  sectionsExperiment: useSectionsNamingExperimentReturnType;
+  sectionsNamingExperiment: useSectionsNamingExperimentReturnType;
 }) => {
   switch (location) {
     case "custom_type":
@@ -481,6 +482,6 @@ const getSubmitButtonLabel = ({
     case "page_type":
       return "Add to page";
     case "slices":
-      return `Add to ${sectionsExperiment.plural.lowercase}`;
+      return `Add to ${pluralize(sectionsNamingExperiment.value)}`;
   }
 };

--- a/packages/slice-machine/src/features/customTypes/customTypesBuilder/CreateSliceFromImageModal/CreateSliceFromImageModal.tsx
+++ b/packages/slice-machine/src/features/customTypes/customTypesBuilder/CreateSliceFromImageModal/CreateSliceFromImageModal.tsx
@@ -24,7 +24,7 @@ import { getState, telemetry } from "@/apiClient";
 import { addAiFeedback } from "@/features/aiFeedback";
 import {
   useSectionsNamingExperiment,
-  useSectionsNamingExperimentReturnType,
+  UseSectionsNamingExperimentReturnType,
 } from "@/features/builder/useSectionsNamingExperiment";
 import { useOnboarding } from "@/features/onboarding/useOnboarding";
 import { useAutoSync } from "@/features/sync/AutoSyncProvider";
@@ -474,7 +474,7 @@ const getSubmitButtonLabel = ({
   sectionsNamingExperiment,
 }: {
   location: "custom_type" | "page_type" | "slices";
-  sectionsNamingExperiment: useSectionsNamingExperimentReturnType;
+  sectionsNamingExperiment: UseSectionsNamingExperimentReturnType;
 }) => {
   switch (location) {
     case "custom_type":

--- a/packages/slice-machine/src/features/customTypes/customTypesBuilder/CreateSliceFromImageModal/CreateSliceFromImageModal.tsx
+++ b/packages/slice-machine/src/features/customTypes/customTypesBuilder/CreateSliceFromImageModal/CreateSliceFromImageModal.tsx
@@ -22,6 +22,10 @@ import { toast } from "react-toastify";
 
 import { getState, telemetry } from "@/apiClient";
 import { addAiFeedback } from "@/features/aiFeedback";
+import {
+  useSectionsExperiment,
+  useSectionsExperimentReturnType,
+} from "@/features/builder/useSectionsExperiment";
 import { useOnboarding } from "@/features/onboarding/useOnboarding";
 import { useAutoSync } from "@/features/sync/AutoSyncProvider";
 import { managerClient } from "@/managerClient";
@@ -53,7 +57,7 @@ export function CreateSliceFromImageModal(
   const { syncChanges } = useAutoSync();
   const { createSliceSuccess } = useSliceMachineActions();
   const { completeStep } = useOnboarding();
-
+  const sectionsExperiment = useSectionsExperiment();
   /**
    * Keeps track of the current instance id.
    * When the modal is closed, the id is reset.
@@ -239,7 +243,8 @@ export function CreateSliceFromImageModal(
       <DialogHeader title="Generate from image" />
       <DialogContent gap={0}>
         <DialogDescription hidden>
-          Upload images to generate slices with AI
+          Upload images to generate {sectionsExperiment.plural.lowercase} with
+          AI
         </DialogDescription>
         {slices.length === 0 ? (
           <Box padding={16} height="100%">
@@ -279,7 +284,8 @@ export function CreateSliceFromImageModal(
             loading={isCreatingSlices}
             onClick={onSubmit}
           >
-            {getSubmitButtonLabel(location)} ({readySlices.length})
+            {getSubmitButtonLabel({ location, sectionsExperiment })} (
+            {readySlices.length})
           </DialogActionButton>
         </DialogActions>
       </DialogContent>
@@ -291,6 +297,7 @@ function UploadBlankSlate(props: {
   droppingFiles?: boolean;
   onFilesSelected: (files: File[]) => void;
 }) {
+  const sectionsExperiment = useSectionsExperiment();
   const { droppingFiles = false, onFilesSelected } = props;
 
   return (
@@ -312,7 +319,8 @@ function UploadBlankSlate(props: {
         />
         <BlankSlateTitle>Upload your design images.</BlankSlateTitle>
         <BlankSlateDescription>
-          Once uploaded, you can generate slices automatically using AI.
+          Once uploaded, you can generate {sectionsExperiment.plural.lowercase}{" "}
+          automatically using AI.
         </BlankSlateDescription>
         <BlankSlateActions>
           <FileUploadButton
@@ -460,15 +468,19 @@ async function addSlices(newSlices: NewSlice[]) {
   return { library, slices };
 }
 
-const getSubmitButtonLabel = (
-  location: "custom_type" | "page_type" | "slices",
-) => {
+const getSubmitButtonLabel = ({
+  location,
+  sectionsExperiment,
+}: {
+  location: "custom_type" | "page_type" | "slices";
+  sectionsExperiment: useSectionsExperimentReturnType;
+}) => {
   switch (location) {
     case "custom_type":
       return "Add to type";
     case "page_type":
       return "Add to page";
     case "slices":
-      return "Add to slices";
+      return `Add to ${sectionsExperiment.plural.lowercase}`;
   }
 };

--- a/packages/slice-machine/src/features/customTypes/customTypesBuilder/SliceZoneBlankSlate.tsx
+++ b/packages/slice-machine/src/features/customTypes/customTypesBuilder/SliceZoneBlankSlate.tsx
@@ -11,6 +11,7 @@ import { FC } from "react";
 
 import { useAiSliceGenerationExperiment } from "@/features/builder/useAiSliceGenerationExperiment";
 import { useSectionsNamingExperiment } from "@/features/builder/useSectionsNamingExperiment";
+import { capitalizeFirstLetter, pluralize } from "@/utils/textConversion";
 
 import { getSliceCreationOptions } from "./sliceCreationOptions";
 
@@ -32,10 +33,10 @@ export const SliceZoneBlankSlate: FC<SliceZoneBlankSlateProps> = ({
   isSlicesTemplatesSupported,
 }) => {
   const aiSliceGenerationExperiment = useAiSliceGenerationExperiment();
-  const sectionsExperiment = useSectionsNamingExperiment();
+  const sectionsNamingExperiment = useSectionsNamingExperiment();
   const sliceCreationOptions = getSliceCreationOptions({
     menuType: "ActionList",
-    sectionsExperiment,
+    sectionsNamingExperiment,
   });
 
   return (
@@ -47,13 +48,13 @@ export const SliceZoneBlankSlate: FC<SliceZoneBlankSlateProps> = ({
         size="large"
       />
       <BlankSlateTitle size="big">
-        Add {sectionsExperiment.plural.lowercase}
+        Add {pluralize(sectionsNamingExperiment.value)}
       </BlankSlateTitle>
       <BlankSlateDescription>
-        {sectionsExperiment.plural.uppercase} are website sections that you can
-        reuse on different pages with different content. Each on different pages
-        with different content. Each {sectionsExperiment.singular.lowercase} has
-        its own component in your code.
+        {pluralize(capitalizeFirstLetter(sectionsNamingExperiment.value))} are
+        website sections that you can reuse on different pages with different
+        content. Each on different pages with different content. Each{" "}
+        {sectionsNamingExperiment.value} has its own component in your code.
       </BlankSlateDescription>
       <BlankSlateActions>
         <ActionList>

--- a/packages/slice-machine/src/features/customTypes/customTypesBuilder/SliceZoneBlankSlate.tsx
+++ b/packages/slice-machine/src/features/customTypes/customTypesBuilder/SliceZoneBlankSlate.tsx
@@ -1,7 +1,6 @@
 import {
   ActionList,
   ActionListItem,
-  BackgroundIcon,
   BlankSlate,
   BlankSlateActions,
   BlankSlateDescription,
@@ -11,6 +10,9 @@ import {
 import { FC } from "react";
 
 import { useAiSliceGenerationExperiment } from "@/features/builder/useAiSliceGenerationExperiment";
+import { useSectionsExperiment } from "@/features/builder/useSectionsExperiment";
+
+import { getSliceCreationOptions } from "./sliceCreationOptions";
 
 export type SliceZoneBlankSlateProps = {
   openUpdateSliceZoneModal: () => void;
@@ -30,6 +32,11 @@ export const SliceZoneBlankSlate: FC<SliceZoneBlankSlateProps> = ({
   isSlicesTemplatesSupported,
 }) => {
   const aiSliceGenerationExperiment = useAiSliceGenerationExperiment();
+  const sectionsExperiment = useSectionsExperiment();
+  const sliceCreationOptions = getSliceCreationOptions({
+    menuType: "ActionList",
+    sectionsExperiment,
+  });
 
   return (
     <BlankSlate data-testid="slice-zone-blank-slate" sx={{ width: 648 }}>
@@ -39,81 +46,57 @@ export const SliceZoneBlankSlate: FC<SliceZoneBlankSlateProps> = ({
         name="add"
         size="large"
       />
-      <BlankSlateTitle size="big">Add slices</BlankSlateTitle>
+      <BlankSlateTitle size="big">
+        Add {sectionsExperiment.plural.lowercase}
+      </BlankSlateTitle>
       <BlankSlateDescription>
-        Slices are website sections that you can reuse on different pages with
-        different content. Each slice has its own component in your code.
+        {sectionsExperiment.plural.uppercase} are website sections that you can
+        reuse on different pages with different content. Each on different pages
+        with different content. Each {sectionsExperiment.singular.lowercase} has
+        its own component in your code.
       </BlankSlateDescription>
       <BlankSlateActions>
         <ActionList>
           {aiSliceGenerationExperiment.eligible && (
             <ActionListItem
-              renderStartIcon={() => (
-                <BackgroundIcon
-                  name="autoFixHigh"
-                  size="small"
-                  iconSize="medium"
-                  color="purple"
-                  variant="solid"
-                  radius={6}
-                />
-              )}
+              renderStartIcon={() =>
+                sliceCreationOptions.fromImage.BackgroundIcon
+              }
               onClick={openCreateSliceFromImageModal}
-              description="Build a Slice based on your design image."
+              description={sliceCreationOptions.fromImage.description}
             >
-              Generate from image
+              {sliceCreationOptions.fromImage.title}
             </ActionListItem>
           )}
           <ActionListItem
-            renderStartIcon={() => (
-              <BackgroundIcon
-                name="add"
-                size="small"
-                iconSize="medium"
-                color="white"
-                variant="solid"
-                radius={6}
-              />
-            )}
+            renderStartIcon={() =>
+              sliceCreationOptions.fromScratch.BackgroundIcon
+            }
             onClick={openCreateSliceModal}
-            description="Build a custom Slice your way."
+            description={sliceCreationOptions.fromScratch.description}
           >
-            Start from scratch
+            {sliceCreationOptions.fromScratch.title}
           </ActionListItem>
           {isSlicesTemplatesSupported && (
             <ActionListItem
-              renderStartIcon={() => (
-                <BackgroundIcon
-                  name="contentCopy"
-                  size="small"
-                  iconSize="medium"
-                  color="white"
-                  variant="solid"
-                  radius={6}
-                />
-              )}
+              renderStartIcon={() =>
+                sliceCreationOptions.fromTemplate.BackgroundIcon
+              }
               onClick={openSlicesTemplatesModal}
-              description="Choose from ready-made examples."
+              description={sliceCreationOptions.fromTemplate.description}
             >
-              Use a template
+              {sliceCreationOptions.fromTemplate.title}
             </ActionListItem>
           )}
           {projectHasAvailableSlices && (
             <ActionListItem
-              renderStartIcon={() => (
-                <BackgroundIcon
-                  name="folder"
-                  size="small"
-                  iconSize="medium"
-                  color="white"
-                  variant="solid"
-                  radius={6}
-                />
-              )}
+              renderStartIcon={() =>
+                sliceCreationOptions.fromExisting.BackgroundIcon
+              }
               onClick={openUpdateSliceZoneModal}
-              description="Select from your created Slices."
+              description={sliceCreationOptions.fromExisting.description}
             >
-              Reuse an existing Slice
+              {sliceCreationOptions.fromExisting.title}
             </ActionListItem>
           )}
         </ActionList>

--- a/packages/slice-machine/src/features/customTypes/customTypesBuilder/SliceZoneBlankSlate.tsx
+++ b/packages/slice-machine/src/features/customTypes/customTypesBuilder/SliceZoneBlankSlate.tsx
@@ -10,7 +10,7 @@ import {
 import { FC } from "react";
 
 import { useAiSliceGenerationExperiment } from "@/features/builder/useAiSliceGenerationExperiment";
-import { useSectionsExperiment } from "@/features/builder/useSectionsExperiment";
+import { useSectionsNamingExperiment } from "@/features/builder/useSectionsNamingExperiment";
 
 import { getSliceCreationOptions } from "./sliceCreationOptions";
 
@@ -32,7 +32,7 @@ export const SliceZoneBlankSlate: FC<SliceZoneBlankSlateProps> = ({
   isSlicesTemplatesSupported,
 }) => {
   const aiSliceGenerationExperiment = useAiSliceGenerationExperiment();
-  const sectionsExperiment = useSectionsExperiment();
+  const sectionsExperiment = useSectionsNamingExperiment();
   const sliceCreationOptions = getSliceCreationOptions({
     menuType: "ActionList",
     sectionsExperiment,

--- a/packages/slice-machine/src/features/customTypes/customTypesBuilder/sliceCreationOptions.tsx
+++ b/packages/slice-machine/src/features/customTypes/customTypesBuilder/sliceCreationOptions.tsx
@@ -1,10 +1,10 @@
 import { BackgroundIcon } from "@prismicio/editor-ui";
 
-import { UseSectionsExperimentReturnType } from "@/features/builder/useSectionsExperiment";
+import { useSectionsNamingExperimentReturnType } from "@/features/builder/useSectionsNamingExperiment";
 
 type SliceCreationOptionArgs = {
   menuType: "ActionList" | "Dropdown";
-  sectionsExperiment: UseSectionsExperimentReturnType;
+  sectionsExperiment: useSectionsNamingExperimentReturnType;
 };
 
 export const getSliceCreationOptions = (args: SliceCreationOptionArgs) => {

--- a/packages/slice-machine/src/features/customTypes/customTypesBuilder/sliceCreationOptions.tsx
+++ b/packages/slice-machine/src/features/customTypes/customTypesBuilder/sliceCreationOptions.tsx
@@ -1,11 +1,11 @@
 import { BackgroundIcon } from "@prismicio/editor-ui";
 
-import { useSectionsNamingExperimentReturnType } from "@/features/builder/useSectionsNamingExperiment";
+import { UseSectionsNamingExperimentReturnType } from "@/features/builder/useSectionsNamingExperiment";
 import { capitalizeFirstLetter, pluralize } from "@/utils/textConversion";
 
 type SliceCreationOptionArgs = {
   menuType: "ActionList" | "Dropdown";
-  sectionsNamingExperiment: useSectionsNamingExperimentReturnType;
+  sectionsNamingExperiment: UseSectionsNamingExperimentReturnType;
 };
 
 export const getSliceCreationOptions = (args: SliceCreationOptionArgs) => {

--- a/packages/slice-machine/src/features/customTypes/customTypesBuilder/sliceCreationOptions.tsx
+++ b/packages/slice-machine/src/features/customTypes/customTypesBuilder/sliceCreationOptions.tsx
@@ -1,7 +1,7 @@
 import { BackgroundIcon } from "@prismicio/editor-ui";
 
 import { UseSectionsNamingExperimentReturnType } from "@/features/builder/useSectionsNamingExperiment";
-import { capitalizeFirstLetter, pluralize } from "@/utils/textConversion";
+import { pluralize } from "@/utils/textConversion";
 
 type SliceCreationOptionArgs = {
   menuType: "ActionList" | "Dropdown";
@@ -24,9 +24,7 @@ export const getSliceCreationOptions = (args: SliceCreationOptionArgs) => {
         />
       ),
       title: "Generate from image",
-      description: `Build a ${capitalizeFirstLetter(
-        sectionsNamingExperiment.value,
-      )} based on your design image.`,
+      description: `Build a ${sectionsNamingExperiment.value} based on your design image.`,
     },
     fromScratch: {
       BackgroundIcon: (
@@ -40,9 +38,7 @@ export const getSliceCreationOptions = (args: SliceCreationOptionArgs) => {
         />
       ),
       title: "Start from scratch",
-      description: `Build a custom ${capitalizeFirstLetter(
-        sectionsNamingExperiment.value,
-      )} your way.`,
+      description: `Build a custom ${sectionsNamingExperiment.value} your way.`,
     },
     fromTemplate: {
       BackgroundIcon: (
@@ -69,11 +65,9 @@ export const getSliceCreationOptions = (args: SliceCreationOptionArgs) => {
           radius={6}
         />
       ),
-      title: `Reuse an existing ${capitalizeFirstLetter(
-        sectionsNamingExperiment.value,
-      )}`,
+      title: `Reuse an existing ${sectionsNamingExperiment.value}`,
       description: `Select from your created ${pluralize(
-        capitalizeFirstLetter(sectionsNamingExperiment.value),
+        sectionsNamingExperiment.value,
       )}`,
     },
   };

--- a/packages/slice-machine/src/features/customTypes/customTypesBuilder/sliceCreationOptions.tsx
+++ b/packages/slice-machine/src/features/customTypes/customTypesBuilder/sliceCreationOptions.tsx
@@ -1,10 +1,10 @@
 import { BackgroundIcon } from "@prismicio/editor-ui";
 
-import { useSectionsExperimentReturnType } from "@/features/builder/useSectionsExperiment";
+import { UseSectionsExperimentReturnType } from "@/features/builder/useSectionsExperiment";
 
 type SliceCreationOptionArgs = {
   menuType: "ActionList" | "Dropdown";
-  sectionsExperiment: useSectionsExperimentReturnType;
+  sectionsExperiment: UseSectionsExperimentReturnType;
 };
 
 export const getSliceCreationOptions = (args: SliceCreationOptionArgs) => {

--- a/packages/slice-machine/src/features/customTypes/customTypesBuilder/sliceCreationOptions.tsx
+++ b/packages/slice-machine/src/features/customTypes/customTypesBuilder/sliceCreationOptions.tsx
@@ -1,0 +1,71 @@
+import { BackgroundIcon } from "@prismicio/editor-ui";
+
+import { useSectionsExperimentReturnType } from "@/features/builder/useSectionsExperiment";
+
+type SliceCreationOptionArgs = {
+  menuType: "ActionList" | "Dropdown";
+  sectionsExperiment: useSectionsExperimentReturnType;
+};
+
+export const getSliceCreationOptions = (args: SliceCreationOptionArgs) => {
+  const { menuType, sectionsExperiment } = args;
+
+  return {
+    fromImage: {
+      BackgroundIcon: (
+        <BackgroundIcon
+          name="autoFixHigh"
+          size={menuType === "ActionList" ? "small" : "extraSmall"}
+          iconSize={menuType === "ActionList" ? "medium" : "small"}
+          color="purple"
+          variant="solid"
+          radius={6}
+        />
+      ),
+      title: "Generate from image",
+      description: `Build a ${sectionsExperiment.singular.uppercase} based on your design image.`,
+    },
+    fromScratch: {
+      BackgroundIcon: (
+        <BackgroundIcon
+          name="add"
+          size={menuType === "ActionList" ? "small" : "extraSmall"}
+          iconSize={menuType === "ActionList" ? "medium" : "small"}
+          color="white"
+          variant="solid"
+          radius={6}
+        />
+      ),
+      title: "Start from scratch",
+      description: `Build a custom ${sectionsExperiment.singular.uppercase} your way.`,
+    },
+    fromTemplate: {
+      BackgroundIcon: (
+        <BackgroundIcon
+          name="contentCopy"
+          size={menuType === "ActionList" ? "small" : "extraSmall"}
+          iconSize={menuType === "ActionList" ? "medium" : "small"}
+          color="white"
+          variant="solid"
+          radius={6}
+        />
+      ),
+      title: "Use a template",
+      description: "Choose from ready-made examples.",
+    },
+    fromExisting: {
+      BackgroundIcon: (
+        <BackgroundIcon
+          name="folder"
+          size={menuType === "ActionList" ? "small" : "extraSmall"}
+          iconSize={menuType === "ActionList" ? "medium" : "small"}
+          color="white"
+          variant="solid"
+          radius={6}
+        />
+      ),
+      title: `Reuse an existing ${sectionsExperiment.singular.uppercase}`,
+      description: `Select from your created ${sectionsExperiment.plural.uppercase}`,
+    },
+  };
+};

--- a/packages/slice-machine/src/features/customTypes/customTypesBuilder/sliceCreationOptions.tsx
+++ b/packages/slice-machine/src/features/customTypes/customTypesBuilder/sliceCreationOptions.tsx
@@ -1,14 +1,15 @@
 import { BackgroundIcon } from "@prismicio/editor-ui";
 
 import { useSectionsNamingExperimentReturnType } from "@/features/builder/useSectionsNamingExperiment";
+import { capitalizeFirstLetter, pluralize } from "@/utils/textConversion";
 
 type SliceCreationOptionArgs = {
   menuType: "ActionList" | "Dropdown";
-  sectionsExperiment: useSectionsNamingExperimentReturnType;
+  sectionsNamingExperiment: useSectionsNamingExperimentReturnType;
 };
 
 export const getSliceCreationOptions = (args: SliceCreationOptionArgs) => {
-  const { menuType, sectionsExperiment } = args;
+  const { menuType, sectionsNamingExperiment } = args;
 
   return {
     fromImage: {
@@ -23,7 +24,9 @@ export const getSliceCreationOptions = (args: SliceCreationOptionArgs) => {
         />
       ),
       title: "Generate from image",
-      description: `Build a ${sectionsExperiment.singular.uppercase} based on your design image.`,
+      description: `Build a ${capitalizeFirstLetter(
+        sectionsNamingExperiment.value,
+      )} based on your design image.`,
     },
     fromScratch: {
       BackgroundIcon: (
@@ -37,7 +40,9 @@ export const getSliceCreationOptions = (args: SliceCreationOptionArgs) => {
         />
       ),
       title: "Start from scratch",
-      description: `Build a custom ${sectionsExperiment.singular.uppercase} your way.`,
+      description: `Build a custom ${capitalizeFirstLetter(
+        sectionsNamingExperiment.value,
+      )} your way.`,
     },
     fromTemplate: {
       BackgroundIcon: (
@@ -64,8 +69,12 @@ export const getSliceCreationOptions = (args: SliceCreationOptionArgs) => {
           radius={6}
         />
       ),
-      title: `Reuse an existing ${sectionsExperiment.singular.uppercase}`,
-      description: `Select from your created ${sectionsExperiment.plural.uppercase}`,
+      title: `Reuse an existing ${capitalizeFirstLetter(
+        sectionsNamingExperiment.value,
+      )}`,
+      description: `Select from your created ${pluralize(
+        capitalizeFirstLetter(sectionsNamingExperiment.value),
+      )}`,
     },
   };
 };

--- a/packages/slice-machine/src/features/masterSliceLibrary/SliceLibraryPreviewModal.tsx
+++ b/packages/slice-machine/src/features/masterSliceLibrary/SliceLibraryPreviewModal.tsx
@@ -10,6 +10,7 @@ import {
 
 import { telemetry } from "@/apiClient";
 import { useMarketingContent } from "@/hooks/useMarketingContent";
+import { capitalizeFirstLetter, pluralize } from "@/utils/textConversion";
 
 import { useSectionsNamingExperiment } from "../builder/useSectionsNamingExperiment";
 
@@ -22,7 +23,7 @@ export const MasterSliceLibraryPreviewModal: React.FC<
   MasterSliceLibraryPreviewModalProps
 > = ({ isOpen, onClose }) => {
   const { masterSliceLibrary } = useMarketingContent();
-  const sectionsExperiment = useSectionsNamingExperiment();
+  const sectionsNamingExperiment = useSectionsNamingExperiment();
 
   if (!masterSliceLibrary) return null;
 
@@ -42,21 +43,24 @@ export const MasterSliceLibraryPreviewModal: React.FC<
       onOpenChange={(open) => !open && onClose()}
     >
       <DialogHeader
-        title={`Master ${sectionsExperiment.singular.uppercase} Library Generator (BETA)`}
+        title={`Master ${capitalizeFirstLetter(
+          sectionsNamingExperiment.value,
+        )} Library Generator (BETA)`}
       />
       <DialogContent>
         <Box flexDirection="column" padding={16} gap={16}>
           <Text variant="h2">
-            Create a Master {sectionsExperiment.singular.uppercase} Library
+            Create a Master{" "}
+            {capitalizeFirstLetter(sectionsNamingExperiment.value)} Library
           </Text>
           <Video src={previewVideoUrl} sizing="contain" autoPlay loop />
           <Text>
             This is an{" "}
             <a href={exampleLinkUrl} target="_blank">
-              example {sectionsExperiment.singular.lowercase} library
+              example {sectionsNamingExperiment.value} library
             </a>
             , which provides you with an overview of all your{" "}
-            {sectionsExperiment.plural.lowercase} in one place. Build it
+            {pluralize(sectionsNamingExperiment.value)} in one place. Build it
             yourself in a few steps.
           </Text>
           <Button size="large" onClick={onGetTheCodeButtonClick}>

--- a/packages/slice-machine/src/features/masterSliceLibrary/SliceLibraryPreviewModal.tsx
+++ b/packages/slice-machine/src/features/masterSliceLibrary/SliceLibraryPreviewModal.tsx
@@ -11,7 +11,7 @@ import {
 import { telemetry } from "@/apiClient";
 import { useMarketingContent } from "@/hooks/useMarketingContent";
 
-import { useSectionsExperiment } from "../builder/useSectionsExperiment";
+import { useSectionsNamingExperiment } from "../builder/useSectionsNamingExperiment";
 
 type MasterSliceLibraryPreviewModalProps = {
   isOpen: boolean;
@@ -22,7 +22,7 @@ export const MasterSliceLibraryPreviewModal: React.FC<
   MasterSliceLibraryPreviewModalProps
 > = ({ isOpen, onClose }) => {
   const { masterSliceLibrary } = useMarketingContent();
-  const sectionsExperiment = useSectionsExperiment();
+  const sectionsExperiment = useSectionsNamingExperiment();
 
   if (!masterSliceLibrary) return null;
 

--- a/packages/slice-machine/src/features/masterSliceLibrary/SliceLibraryPreviewModal.tsx
+++ b/packages/slice-machine/src/features/masterSliceLibrary/SliceLibraryPreviewModal.tsx
@@ -11,6 +11,8 @@ import {
 import { telemetry } from "@/apiClient";
 import { useMarketingContent } from "@/hooks/useMarketingContent";
 
+import { useSectionsExperiment } from "../builder/useSectionsExperiment";
+
 type MasterSliceLibraryPreviewModalProps = {
   isOpen: boolean;
   onClose: () => void;
@@ -20,6 +22,7 @@ export const MasterSliceLibraryPreviewModal: React.FC<
   MasterSliceLibraryPreviewModalProps
 > = ({ isOpen, onClose }) => {
   const { masterSliceLibrary } = useMarketingContent();
+  const sectionsExperiment = useSectionsExperiment();
 
   if (!masterSliceLibrary) return null;
 
@@ -38,18 +41,23 @@ export const MasterSliceLibraryPreviewModal: React.FC<
       open={isOpen}
       onOpenChange={(open) => !open && onClose()}
     >
-      <DialogHeader title="Master Slice Library Generator (BETA)" />
+      <DialogHeader
+        title={`Master ${sectionsExperiment.singular.uppercase} Library Generator (BETA)`}
+      />
       <DialogContent>
         <Box flexDirection="column" padding={16} gap={16}>
-          <Text variant="h2">Create a Master Slice Library</Text>
+          <Text variant="h2">
+            Create a Master {sectionsExperiment.singular.uppercase} Library
+          </Text>
           <Video src={previewVideoUrl} sizing="contain" autoPlay loop />
           <Text>
             This is an{" "}
             <a href={exampleLinkUrl} target="_blank">
-              example slice library
+              example {sectionsExperiment.singular.lowercase} library
             </a>
-            ,  which provides you with an overview of all your slices in one
-            place. Build it yourself in a few steps.
+            , which provides you with an overview of all your{" "}
+            {sectionsExperiment.plural.lowercase} in one place. Build it
+            yourself in a few steps.
           </Text>
           <Button size="large" onClick={onGetTheCodeButtonClick}>
             Get the code

--- a/packages/slice-machine/src/features/navigation/Navigation.tsx
+++ b/packages/slice-machine/src/features/navigation/Navigation.tsx
@@ -15,6 +15,7 @@ import { FolderIcon } from "@/icons/FolderIcon";
 import { LightningIcon } from "@/icons/Lightning";
 import { MasterSliceLibraryIcon } from "@/icons/MasterSliceLibraryIcon";
 import { SettingsIcon } from "@/icons/SettingsIcon";
+import { capitalizeFirstLetter, pluralize } from "@/utils/textConversion";
 
 import { ChangesItem } from "../../legacy/components/Navigation/ChangesItem";
 import { Environment } from "../../legacy/components/Navigation/Environment";
@@ -30,7 +31,7 @@ export function Navigation() {
   const [isSliceLibraryDialogOpen, setIsSliceLibraryDialogOpen] =
     useState(false);
   const { masterSliceLibrary } = useMarketingContent();
-  const sectionsExperiment = useSectionsNamingExperiment();
+  const sectionsNamingExperiment = useSectionsNamingExperiment();
 
   interface CustomTypeNavigationItemProps {
     type: "page" | "custom";
@@ -80,7 +81,9 @@ export function Navigation() {
           <CustomTypeNavigationItem type="custom" />
 
           <NavigationItem
-            title={sectionsExperiment.plural.uppercase}
+            title={pluralize(
+              capitalizeFirstLetter(sectionsNamingExperiment.value),
+            )}
             href="/slices"
             Icon={FolderIcon}
             active={router.asPath.startsWith("/slices")}
@@ -111,7 +114,9 @@ export function Navigation() {
                 }}
               />
               <NavigationItem
-                title={`Master ${sectionsExperiment.singular.uppercase} Library`}
+                title={`Master ${capitalizeFirstLetter(
+                  sectionsNamingExperiment.value,
+                )} Library`}
                 Icon={MasterSliceLibraryIcon}
                 onClick={() => {
                   void telemetry.track({

--- a/packages/slice-machine/src/features/navigation/Navigation.tsx
+++ b/packages/slice-machine/src/features/navigation/Navigation.tsx
@@ -18,7 +18,7 @@ import { SettingsIcon } from "@/icons/SettingsIcon";
 
 import { ChangesItem } from "../../legacy/components/Navigation/ChangesItem";
 import { Environment } from "../../legacy/components/Navigation/Environment";
-import { useSectionsExperiment } from "../builder/useSectionsExperiment";
+import { useSectionsNamingExperiment } from "../builder/useSectionsNamingExperiment";
 import { NavigationItem } from "./NavigationItem";
 import { SliceMachineVersion } from "./SliceMachineVersion";
 import { UpdateInfo } from "./UpdateInfo";
@@ -30,7 +30,7 @@ export function Navigation() {
   const [isSliceLibraryDialogOpen, setIsSliceLibraryDialogOpen] =
     useState(false);
   const { masterSliceLibrary } = useMarketingContent();
-  const sectionsExperiment = useSectionsExperiment();
+  const sectionsExperiment = useSectionsNamingExperiment();
 
   interface CustomTypeNavigationItemProps {
     type: "page" | "custom";

--- a/packages/slice-machine/src/features/navigation/Navigation.tsx
+++ b/packages/slice-machine/src/features/navigation/Navigation.tsx
@@ -18,6 +18,7 @@ import { SettingsIcon } from "@/icons/SettingsIcon";
 
 import { ChangesItem } from "../../legacy/components/Navigation/ChangesItem";
 import { Environment } from "../../legacy/components/Navigation/Environment";
+import { useSectionsExperiment } from "../builder/useSectionsExperiment";
 import { NavigationItem } from "./NavigationItem";
 import { SliceMachineVersion } from "./SliceMachineVersion";
 import { UpdateInfo } from "./UpdateInfo";
@@ -29,6 +30,7 @@ export function Navigation() {
   const [isSliceLibraryDialogOpen, setIsSliceLibraryDialogOpen] =
     useState(false);
   const { masterSliceLibrary } = useMarketingContent();
+  const sectionsExperiment = useSectionsExperiment();
 
   interface CustomTypeNavigationItemProps {
     type: "page" | "custom";
@@ -78,7 +80,7 @@ export function Navigation() {
           <CustomTypeNavigationItem type="custom" />
 
           <NavigationItem
-            title="Slices"
+            title={sectionsExperiment.plural.uppercase}
             href="/slices"
             Icon={FolderIcon}
             active={router.asPath.startsWith("/slices")}
@@ -109,7 +111,7 @@ export function Navigation() {
                 }}
               />
               <NavigationItem
-                title="Master Slice Library"
+                title={`Master ${sectionsExperiment.singular.uppercase} Library`}
                 Icon={MasterSliceLibraryIcon}
                 onClick={() => {
                   void telemetry.track({

--- a/packages/slice-machine/src/legacy/components/ChangesItems/ChangesItems.tsx
+++ b/packages/slice-machine/src/legacy/components/ChangesItems/ChangesItems.tsx
@@ -4,7 +4,7 @@ import { AiOutlineExclamationCircle } from "react-icons/ai";
 
 import { countMissingScreenshots } from "@/domain/slice";
 import { ErrorBoundary } from "@/ErrorBoundary";
-import { useSectionsExperiment } from "@/features/builder/useSectionsExperiment";
+import { useSectionsNamingExperiment } from "@/features/builder/useSectionsNamingExperiment";
 import { SharedSliceCard } from "@/features/slices/sliceCards/SharedSliceCard";
 import { ModelsStatuses } from "@/features/sync/getUnSyncChanges";
 import { useScreenshotChangesModal } from "@/hooks/useScreenshotChangesModal";
@@ -35,7 +35,7 @@ export const ChangesItems: React.FC<ChangesItemsProps> = ({
   isOnline,
 }) => {
   const { modalPayload, onOpenModal } = useScreenshotChangesModal();
-  const sectionsExperiment = useSectionsExperiment();
+  const sectionsExperiment = useSectionsNamingExperiment();
 
   const { sliceFilterFn, defaultVariationSelector } = modalPayload;
 

--- a/packages/slice-machine/src/legacy/components/ChangesItems/ChangesItems.tsx
+++ b/packages/slice-machine/src/legacy/components/ChangesItems/ChangesItems.tsx
@@ -16,6 +16,7 @@ import { ComponentUI } from "@/legacy/lib/models/common/ComponentUI";
 import { LocalOrRemoteCustomType } from "@/legacy/lib/models/common/ModelData";
 import { ModelStatus } from "@/legacy/lib/models/common/ModelStatus";
 import { AuthStatus } from "@/modules/userContext/types";
+import { capitalizeFirstLetter, pluralize } from "@/utils/textConversion";
 
 import { DevCollaborationExperiment } from "./DevCollaborationExperiment";
 
@@ -35,7 +36,7 @@ export const ChangesItems: React.FC<ChangesItemsProps> = ({
   isOnline,
 }) => {
   const { modalPayload, onOpenModal } = useScreenshotChangesModal();
-  const sectionsExperiment = useSectionsNamingExperiment();
+  const sectionsNamingExperiment = useSectionsNamingExperiment();
 
   const { sliceFilterFn, defaultVariationSelector } = modalPayload;
 
@@ -71,7 +72,9 @@ export const ChangesItems: React.FC<ChangesItemsProps> = ({
                 <ChangesSectionHeader>
                   <Box>
                     <Text variant="h5">
-                      {sectionsExperiment.plural.uppercase}
+                      {pluralize(
+                        capitalizeFirstLetter(sectionsNamingExperiment.value),
+                      )}
                     </Text>
                     <Text variant="h5" sx={{ marginLeft: 8 }}>
                       {unSyncedSlices.length}

--- a/packages/slice-machine/src/legacy/components/ChangesItems/ChangesItems.tsx
+++ b/packages/slice-machine/src/legacy/components/ChangesItems/ChangesItems.tsx
@@ -4,6 +4,7 @@ import { AiOutlineExclamationCircle } from "react-icons/ai";
 
 import { countMissingScreenshots } from "@/domain/slice";
 import { ErrorBoundary } from "@/ErrorBoundary";
+import { useSectionsExperiment } from "@/features/builder/useSectionsExperiment";
 import { SharedSliceCard } from "@/features/slices/sliceCards/SharedSliceCard";
 import { ModelsStatuses } from "@/features/sync/getUnSyncChanges";
 import { useScreenshotChangesModal } from "@/hooks/useScreenshotChangesModal";
@@ -34,6 +35,7 @@ export const ChangesItems: React.FC<ChangesItemsProps> = ({
   isOnline,
 }) => {
   const { modalPayload, onOpenModal } = useScreenshotChangesModal();
+  const sectionsExperiment = useSectionsExperiment();
 
   const { sliceFilterFn, defaultVariationSelector } = modalPayload;
 
@@ -68,7 +70,9 @@ export const ChangesItems: React.FC<ChangesItemsProps> = ({
               <Box padding={{ bottom: 8 }}>
                 <ChangesSectionHeader>
                   <Box>
-                    <Text variant="h5">Slices</Text>
+                    <Text variant="h5">
+                      {sectionsExperiment.plural.uppercase}
+                    </Text>
                     <Text variant="h5" sx={{ marginLeft: 8 }}>
                       {unSyncedSlices.length}
                     </Text>

--- a/packages/slice-machine/src/legacy/components/Forms/CreateSliceModal/CreateSliceModal.tsx
+++ b/packages/slice-machine/src/legacy/components/Forms/CreateSliceModal/CreateSliceModal.tsx
@@ -12,6 +12,7 @@ import ModalFormCard from "@/legacy/components/ModalFormCard";
 import { LibraryUI } from "@/legacy/lib/models/common/LibraryUI";
 import { SliceSM } from "@/legacy/lib/models/common/Slice";
 import useSliceMachineActions from "@/modules/useSliceMachineActions";
+import { capitalizeFirstLetter } from "@/utils/textConversion";
 
 import { InputBox } from "../components/InputBox";
 import { validateSliceModalValues } from "../formsValidator";
@@ -37,7 +38,7 @@ export const CreateSliceModal: FC<CreateSliceModalProps> = ({
   const [isCreatingSlice, setIsCreatingSlice] = useState(false);
   const { syncChanges } = useAutoSync();
   const { completeStep } = useOnboarding();
-  const sectionsExperiment = useSectionsNamingExperiment();
+  const sectionsNamingExperiment = useSectionsNamingExperiment();
 
   const onSubmit = async (values: FormValues) => {
     const sliceName = values.sliceName;
@@ -81,15 +82,19 @@ export const CreateSliceModal: FC<CreateSliceModalProps> = ({
         validateSliceModalValues(values, localLibraries, remoteSlices)
       }
       content={{
-        title: `Create a new ${sectionsExperiment.singular.lowercase}`,
+        title: `Create a new ${sectionsNamingExperiment.value}`,
       }}
     >
       {({ touched, values, setFieldValue, errors }) => (
         <Box>
           <InputBox
             name="sliceName"
-            label={`${sectionsExperiment.singular.uppercase} name`}
-            placeholder={`Pascalised ${sectionsExperiment.singular.uppercase} API ID (e.g. TextBlock)`}
+            label={`${capitalizeFirstLetter(
+              sectionsNamingExperiment.value,
+            )} name`}
+            placeholder={`Pascalised ${capitalizeFirstLetter(
+              sectionsNamingExperiment.value,
+            )} API ID (e.g. TextBlock)`}
             // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
             error={touched.sliceName ? errors.sliceName : undefined}
             testId="slice-name-input"

--- a/packages/slice-machine/src/legacy/components/Forms/CreateSliceModal/CreateSliceModal.tsx
+++ b/packages/slice-machine/src/legacy/components/Forms/CreateSliceModal/CreateSliceModal.tsx
@@ -92,9 +92,7 @@ export const CreateSliceModal: FC<CreateSliceModalProps> = ({
             label={`${capitalizeFirstLetter(
               sectionsNamingExperiment.value,
             )} name`}
-            placeholder={`Pascalised ${capitalizeFirstLetter(
-              sectionsNamingExperiment.value,
-            )} API ID (e.g. TextBlock)`}
+            placeholder={`Pascalised ${sectionsNamingExperiment.value} API ID (e.g. TextBlock)`}
             // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
             error={touched.sliceName ? errors.sliceName : undefined}
             testId="slice-name-input"

--- a/packages/slice-machine/src/legacy/components/Forms/CreateSliceModal/CreateSliceModal.tsx
+++ b/packages/slice-machine/src/legacy/components/Forms/CreateSliceModal/CreateSliceModal.tsx
@@ -4,7 +4,7 @@ import Select from "react-select";
 import { Box, Label } from "theme-ui";
 
 import { getState } from "@/apiClient";
-import { useSectionsExperiment } from "@/features/builder/useSectionsExperiment";
+import { useSectionsNamingExperiment } from "@/features/builder/useSectionsNamingExperiment";
 import { useOnboarding } from "@/features/onboarding/useOnboarding";
 import { createSlice } from "@/features/slices/actions/createSlice";
 import { useAutoSync } from "@/features/sync/AutoSyncProvider";
@@ -37,7 +37,7 @@ export const CreateSliceModal: FC<CreateSliceModalProps> = ({
   const [isCreatingSlice, setIsCreatingSlice] = useState(false);
   const { syncChanges } = useAutoSync();
   const { completeStep } = useOnboarding();
-  const sectionsExperiment = useSectionsExperiment();
+  const sectionsExperiment = useSectionsNamingExperiment();
 
   const onSubmit = async (values: FormValues) => {
     const sliceName = values.sliceName;

--- a/packages/slice-machine/src/legacy/components/Forms/CreateSliceModal/CreateSliceModal.tsx
+++ b/packages/slice-machine/src/legacy/components/Forms/CreateSliceModal/CreateSliceModal.tsx
@@ -4,6 +4,7 @@ import Select from "react-select";
 import { Box, Label } from "theme-ui";
 
 import { getState } from "@/apiClient";
+import { useSectionsExperiment } from "@/features/builder/useSectionsExperiment";
 import { useOnboarding } from "@/features/onboarding/useOnboarding";
 import { createSlice } from "@/features/slices/actions/createSlice";
 import { useAutoSync } from "@/features/sync/AutoSyncProvider";
@@ -36,6 +37,7 @@ export const CreateSliceModal: FC<CreateSliceModalProps> = ({
   const [isCreatingSlice, setIsCreatingSlice] = useState(false);
   const { syncChanges } = useAutoSync();
   const { completeStep } = useOnboarding();
+  const sectionsExperiment = useSectionsExperiment();
 
   const onSubmit = async (values: FormValues) => {
     const sliceName = values.sliceName;
@@ -79,15 +81,15 @@ export const CreateSliceModal: FC<CreateSliceModalProps> = ({
         validateSliceModalValues(values, localLibraries, remoteSlices)
       }
       content={{
-        title: "Create a new slice",
+        title: `Create a new ${sectionsExperiment.singular.lowercase}`,
       }}
     >
       {({ touched, values, setFieldValue, errors }) => (
         <Box>
           <InputBox
             name="sliceName"
-            label="Slice Name"
-            placeholder="Pascalised Slice API ID (e.g. TextBlock)"
+            label={`${sectionsExperiment.singular.uppercase} name`}
+            placeholder={`Pascalised ${sectionsExperiment.singular.uppercase} API ID (e.g. TextBlock)`}
             // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
             error={touched.sliceName ? errors.sliceName : undefined}
             testId="slice-name-input"

--- a/packages/slice-machine/src/legacy/components/Simulator/components/FailedConnect/index.tsx
+++ b/packages/slice-machine/src/legacy/components/Simulator/components/FailedConnect/index.tsx
@@ -1,66 +1,71 @@
 import { IoMdRefresh } from "react-icons/io";
 import { Image, Link, Text } from "theme-ui";
 
+import { useSectionsExperiment } from "@/features/builder/useSectionsExperiment";
 import { Button } from "@/legacy/components/Button";
 
 import FullPage from "../FullPage";
 
-const FailedConnect = ({ onRetrigger }: { onRetrigger: () => void }) => (
-  <FullPage>
-    <Image src="/iframe-not-running.png" sx={{ width: "320px" }} />
-    <Text
-      sx={{
-        color: "textClear",
-        mb: 2,
-        fontSize: "14px",
-        lineHeight: "24px",
-        fontWeight: "600",
-      }}
-    >
-      Slice Machine can't render your Slice
-    </Text>
-    <Text
-      sx={{
-        color: "failedConnectText",
-        maxWidth: "400px",
-        textAlign: "center",
-        fontSize: "12px",
-        lineHeight: "22px",
-      }}
-    >
-      Ensure your website's development server is running by typing
-      <br />
+const FailedConnect = ({ onRetrigger }: { onRetrigger: () => void }) => {
+  const sectionsExperiment = useSectionsExperiment();
+
+  return (
+    <FullPage>
+      <Image src="/iframe-not-running.png" sx={{ width: "320px" }} />
       <Text
-        as="code"
-        variant="styles.inlineCode"
-        sx={{ padding: "4px", borderRadius: "6px" }}
-      >
-        npm run dev
-      </Text>
-      &nbsp; in your terminal at the root of your website directory.
-      <br /> If that doesn't work, see the&nbsp;
-      <Link
-        target="_blank"
-        href="https://prismic.io/docs/slice-machine#simulate-slices"
         sx={{
-          color: "link",
+          color: "textClear",
+          mb: 2,
+          fontSize: "14px",
+          lineHeight: "24px",
+          fontWeight: "600",
         }}
       >
-        troubleshooting instructions.
-      </Link>
-    </Text>
-    <Button
-      onClick={onRetrigger}
-      label="Refresh"
-      Icon={IoMdRefresh}
-      iconSize={20}
-      iconFill="#6F6E77"
-      variant="secondaryMedium"
-      sx={{
-        mt: "16px",
-      }}
-    />
-  </FullPage>
-);
+        Slice Machine can't render your {sectionsExperiment.singular.uppercase}
+      </Text>
+      <Text
+        sx={{
+          color: "failedConnectText",
+          maxWidth: "400px",
+          textAlign: "center",
+          fontSize: "12px",
+          lineHeight: "22px",
+        }}
+      >
+        Ensure your website's development server is running by typing
+        <br />
+        <Text
+          as="code"
+          variant="styles.inlineCode"
+          sx={{ padding: "4px", borderRadius: "6px" }}
+        >
+          npm run dev
+        </Text>
+        &nbsp; in your terminal at the root of your website directory.
+        <br /> If that doesn't work, see the&nbsp;
+        <Link
+          target="_blank"
+          href="https://prismic.io/docs/slice-machine#simulate-slices"
+          sx={{
+            color: "link",
+          }}
+        >
+          troubleshooting instructions.
+        </Link>
+      </Text>
+      <Button
+        onClick={onRetrigger}
+        label="Refresh"
+        Icon={IoMdRefresh}
+        iconSize={20}
+        iconFill="#6F6E77"
+        variant="secondaryMedium"
+        sx={{
+          mt: "16px",
+        }}
+      />
+    </FullPage>
+  );
+};
 
 export default FailedConnect;

--- a/packages/slice-machine/src/legacy/components/Simulator/components/FailedConnect/index.tsx
+++ b/packages/slice-machine/src/legacy/components/Simulator/components/FailedConnect/index.tsx
@@ -3,11 +3,12 @@ import { Image, Link, Text } from "theme-ui";
 
 import { useSectionsNamingExperiment } from "@/features/builder/useSectionsNamingExperiment";
 import { Button } from "@/legacy/components/Button";
+import { capitalizeFirstLetter } from "@/utils/textConversion";
 
 import FullPage from "../FullPage";
 
 const FailedConnect = ({ onRetrigger }: { onRetrigger: () => void }) => {
-  const sectionsExperiment = useSectionsNamingExperiment();
+  const sectionsNamingExperiment = useSectionsNamingExperiment();
 
   return (
     <FullPage>
@@ -21,7 +22,8 @@ const FailedConnect = ({ onRetrigger }: { onRetrigger: () => void }) => {
           fontWeight: "600",
         }}
       >
-        Slice Machine can't render your {sectionsExperiment.singular.uppercase}
+        Slice Machine can't render your{" "}
+        {capitalizeFirstLetter(sectionsNamingExperiment.value)}
       </Text>
       <Text
         sx={{

--- a/packages/slice-machine/src/legacy/components/Simulator/components/FailedConnect/index.tsx
+++ b/packages/slice-machine/src/legacy/components/Simulator/components/FailedConnect/index.tsx
@@ -3,7 +3,6 @@ import { Image, Link, Text } from "theme-ui";
 
 import { useSectionsNamingExperiment } from "@/features/builder/useSectionsNamingExperiment";
 import { Button } from "@/legacy/components/Button";
-import { capitalizeFirstLetter } from "@/utils/textConversion";
 
 import FullPage from "../FullPage";
 
@@ -22,8 +21,7 @@ const FailedConnect = ({ onRetrigger }: { onRetrigger: () => void }) => {
           fontWeight: "600",
         }}
       >
-        Slice Machine can't render your{" "}
-        {capitalizeFirstLetter(sectionsNamingExperiment.value)}
+        Slice Machine can't render your {sectionsNamingExperiment.value}
       </Text>
       <Text
         sx={{

--- a/packages/slice-machine/src/legacy/components/Simulator/components/FailedConnect/index.tsx
+++ b/packages/slice-machine/src/legacy/components/Simulator/components/FailedConnect/index.tsx
@@ -1,13 +1,13 @@
 import { IoMdRefresh } from "react-icons/io";
 import { Image, Link, Text } from "theme-ui";
 
-import { useSectionsExperiment } from "@/features/builder/useSectionsExperiment";
+import { useSectionsNamingExperiment } from "@/features/builder/useSectionsNamingExperiment";
 import { Button } from "@/legacy/components/Button";
 
 import FullPage from "../FullPage";
 
 const FailedConnect = ({ onRetrigger }: { onRetrigger: () => void }) => {
-  const sectionsExperiment = useSectionsExperiment();
+  const sectionsExperiment = useSectionsNamingExperiment();
 
   return (
     <FullPage>

--- a/packages/slice-machine/src/legacy/components/ToasterContainer/index.tsx
+++ b/packages/slice-machine/src/legacy/components/ToasterContainer/index.tsx
@@ -8,6 +8,7 @@ import {
 } from "react-toastify";
 
 import { useSectionsNamingExperiment } from "@/features/builder/useSectionsNamingExperiment";
+import { capitalizeFirstLetter } from "@/utils/textConversion";
 
 const getIconAccordingToasterType = ({
   type,
@@ -70,11 +71,13 @@ export const ToastMessageWithPath: React.FC<{
 export const SliceToastMessage: React.FC<{
   path: string;
 }> = (props) => {
-  const sectionsExperiment = useSectionsNamingExperiment();
+  const sectionsNamingExperiment = useSectionsNamingExperiment();
 
   return (
     <ToastMessageWithPath
-      message={`${sectionsExperiment.singular.uppercase} saved successfully at `}
+      message={`${capitalizeFirstLetter(
+        sectionsNamingExperiment.value,
+      )} saved successfully at `}
       {...props}
     />
   );

--- a/packages/slice-machine/src/legacy/components/ToasterContainer/index.tsx
+++ b/packages/slice-machine/src/legacy/components/ToasterContainer/index.tsx
@@ -7,7 +7,7 @@ import {
   TypeOptions,
 } from "react-toastify";
 
-import { useSectionsExperiment } from "@/features/builder/useSectionsExperiment";
+import { useSectionsNamingExperiment } from "@/features/builder/useSectionsNamingExperiment";
 
 const getIconAccordingToasterType = ({
   type,
@@ -70,7 +70,7 @@ export const ToastMessageWithPath: React.FC<{
 export const SliceToastMessage: React.FC<{
   path: string;
 }> = (props) => {
-  const sectionsExperiment = useSectionsExperiment();
+  const sectionsExperiment = useSectionsNamingExperiment();
 
   return (
     <ToastMessageWithPath

--- a/packages/slice-machine/src/legacy/components/ToasterContainer/index.tsx
+++ b/packages/slice-machine/src/legacy/components/ToasterContainer/index.tsx
@@ -7,7 +7,7 @@ import {
   TypeOptions,
 } from "react-toastify";
 
-import { useSectionsNamingExperiment } from "@/features/builder/useSectionsNamingExperiment";
+import { UseSectionsNamingExperimentReturnType } from "@/features/builder/useSectionsNamingExperiment";
 import { capitalizeFirstLetter } from "@/utils/textConversion";
 
 const getIconAccordingToasterType = ({
@@ -70,13 +70,12 @@ export const ToastMessageWithPath: React.FC<{
 
 export const SliceToastMessage: React.FC<{
   path: string;
+  sectionsNamingExperiment: UseSectionsNamingExperimentReturnType;
 }> = (props) => {
-  const sectionsNamingExperiment = useSectionsNamingExperiment();
-
   return (
     <ToastMessageWithPath
       message={`${capitalizeFirstLetter(
-        sectionsNamingExperiment.value,
+        props.sectionsNamingExperiment.value,
       )} saved successfully at `}
       {...props}
     />

--- a/packages/slice-machine/src/legacy/components/ToasterContainer/index.tsx
+++ b/packages/slice-machine/src/legacy/components/ToasterContainer/index.tsx
@@ -7,6 +7,8 @@ import {
   TypeOptions,
 } from "react-toastify";
 
+import { useSectionsExperiment } from "@/features/builder/useSectionsExperiment";
+
 const getIconAccordingToasterType = ({
   type,
 }: {
@@ -67,6 +69,13 @@ export const ToastMessageWithPath: React.FC<{
 
 export const SliceToastMessage: React.FC<{
   path: string;
-}> = (props) => (
-  <ToastMessageWithPath message="Slice saved successfully at " {...props} />
-);
+}> = (props) => {
+  const sectionsExperiment = useSectionsExperiment();
+
+  return (
+    <ToastMessageWithPath
+      message={`${sectionsExperiment.singular.uppercase} saved successfully at `}
+      {...props}
+    />
+  );
+};

--- a/packages/slice-machine/src/legacy/lib/builders/CustomTypeBuilder/SliceZone/SlicesTemplatesModal.tsx
+++ b/packages/slice-machine/src/legacy/lib/builders/CustomTypeBuilder/SliceZone/SlicesTemplatesModal.tsx
@@ -3,6 +3,7 @@ import { FC } from "react";
 import { Text } from "theme-ui";
 
 import { getState } from "@/apiClient";
+import { useSectionsExperiment } from "@/features/builder/useSectionsExperiment";
 import { createSlicesTemplates } from "@/features/slicesTemplates/actions/createSlicesTemplates";
 import { SliceTemplate } from "@/features/slicesTemplates/useSlicesTemplates";
 import ModalFormCard from "@/legacy/components/ModalFormCard";
@@ -37,6 +38,7 @@ export const SlicesTemplatesModal: FC<UpdateSliceModalProps> = ({
   location,
 }) => {
   const { createSliceSuccess } = useSliceMachineActions();
+  const sectionsExperiment = useSectionsExperiment();
 
   return (
     <ModalFormCard
@@ -80,7 +82,7 @@ export const SlicesTemplatesModal: FC<UpdateSliceModalProps> = ({
         sliceKeys: [],
       }}
       content={{
-        title: "Use template slices",
+        title: `Use template ${sectionsExperiment.plural.lowercase}`,
       }}
       validate={(values) => {
         if (values.sliceKeys.length === 0) {

--- a/packages/slice-machine/src/legacy/lib/builders/CustomTypeBuilder/SliceZone/SlicesTemplatesModal.tsx
+++ b/packages/slice-machine/src/legacy/lib/builders/CustomTypeBuilder/SliceZone/SlicesTemplatesModal.tsx
@@ -3,7 +3,7 @@ import { FC } from "react";
 import { Text } from "theme-ui";
 
 import { getState } from "@/apiClient";
-import { useSectionsExperiment } from "@/features/builder/useSectionsExperiment";
+import { useSectionsNamingExperiment } from "@/features/builder/useSectionsNamingExperiment";
 import { createSlicesTemplates } from "@/features/slicesTemplates/actions/createSlicesTemplates";
 import { SliceTemplate } from "@/features/slicesTemplates/useSlicesTemplates";
 import ModalFormCard from "@/legacy/components/ModalFormCard";
@@ -38,7 +38,7 @@ export const SlicesTemplatesModal: FC<UpdateSliceModalProps> = ({
   location,
 }) => {
   const { createSliceSuccess } = useSliceMachineActions();
-  const sectionsExperiment = useSectionsExperiment();
+  const sectionsExperiment = useSectionsNamingExperiment();
 
   return (
     <ModalFormCard

--- a/packages/slice-machine/src/legacy/lib/builders/CustomTypeBuilder/SliceZone/SlicesTemplatesModal.tsx
+++ b/packages/slice-machine/src/legacy/lib/builders/CustomTypeBuilder/SliceZone/SlicesTemplatesModal.tsx
@@ -12,6 +12,7 @@ import { LibraryUI } from "@/legacy/lib/models/common/LibraryUI";
 import { Slices } from "@/legacy/lib/models/common/Slice";
 import { managerClient } from "@/managerClient";
 import useSliceMachineActions from "@/modules/useSliceMachineActions";
+import { pluralize } from "@/utils/textConversion";
 
 import { sliceTemplatesComingSoon } from "./sliceTemplatesComingSoon";
 import UpdateSliceZoneModalList from "./UpdateSliceZoneModalList";
@@ -38,7 +39,7 @@ export const SlicesTemplatesModal: FC<UpdateSliceModalProps> = ({
   location,
 }) => {
   const { createSliceSuccess } = useSliceMachineActions();
-  const sectionsExperiment = useSectionsNamingExperiment();
+  const sectionsNamingExperiment = useSectionsNamingExperiment();
 
   return (
     <ModalFormCard
@@ -82,7 +83,7 @@ export const SlicesTemplatesModal: FC<UpdateSliceModalProps> = ({
         sliceKeys: [],
       }}
       content={{
-        title: `Use template ${sectionsExperiment.plural.lowercase}`,
+        title: `Use template ${pluralize(sectionsNamingExperiment.value)}`,
       }}
       validate={(values) => {
         if (values.sliceKeys.length === 0) {

--- a/packages/slice-machine/src/legacy/lib/builders/CustomTypeBuilder/SliceZone/UpdateSliceZoneModal.tsx
+++ b/packages/slice-machine/src/legacy/lib/builders/CustomTypeBuilder/SliceZone/UpdateSliceZoneModal.tsx
@@ -1,6 +1,7 @@
 import { SharedSlice } from "@prismicio/types-internal/lib/customtypes";
 import { Text } from "theme-ui";
 
+import { useSectionsExperiment } from "@/features/builder/useSectionsExperiment";
 import ModalFormCard from "@/legacy/components/ModalFormCard";
 import { ComponentUI } from "@/legacy/lib/models/common/ComponentUI";
 
@@ -23,6 +24,8 @@ const UpdateSliceZoneModal: React.FC<UpdateSliceModalProps> = ({
   onSubmit,
   availableSlices,
 }) => {
+  const sectionsExperiment = useSectionsExperiment();
+
   return (
     <ModalFormCard
       isOpen
@@ -43,7 +46,7 @@ const UpdateSliceZoneModal: React.FC<UpdateSliceModalProps> = ({
         sliceKeys: [],
       }}
       content={{
-        title: "Select existing slices",
+        title: `Select existing ${sectionsExperiment.plural.lowercase}`,
       }}
       testId="update-slices-modal"
       validate={(values) => {

--- a/packages/slice-machine/src/legacy/lib/builders/CustomTypeBuilder/SliceZone/UpdateSliceZoneModal.tsx
+++ b/packages/slice-machine/src/legacy/lib/builders/CustomTypeBuilder/SliceZone/UpdateSliceZoneModal.tsx
@@ -4,6 +4,7 @@ import { Text } from "theme-ui";
 import { useSectionsNamingExperiment } from "@/features/builder/useSectionsNamingExperiment";
 import ModalFormCard from "@/legacy/components/ModalFormCard";
 import { ComponentUI } from "@/legacy/lib/models/common/ComponentUI";
+import { pluralize } from "@/utils/textConversion";
 
 import UpdateSliceZoneModalList from "./UpdateSliceZoneModalList";
 
@@ -24,7 +25,7 @@ const UpdateSliceZoneModal: React.FC<UpdateSliceModalProps> = ({
   onSubmit,
   availableSlices,
 }) => {
-  const sectionsExperiment = useSectionsNamingExperiment();
+  const sectionsNamingExperiment = useSectionsNamingExperiment();
 
   return (
     <ModalFormCard
@@ -46,7 +47,7 @@ const UpdateSliceZoneModal: React.FC<UpdateSliceModalProps> = ({
         sliceKeys: [],
       }}
       content={{
-        title: `Select existing ${sectionsExperiment.plural.lowercase}`,
+        title: `Select existing ${pluralize(sectionsNamingExperiment.value)}`,
       }}
       testId="update-slices-modal"
       validate={(values) => {

--- a/packages/slice-machine/src/legacy/lib/builders/CustomTypeBuilder/SliceZone/UpdateSliceZoneModal.tsx
+++ b/packages/slice-machine/src/legacy/lib/builders/CustomTypeBuilder/SliceZone/UpdateSliceZoneModal.tsx
@@ -1,7 +1,7 @@
 import { SharedSlice } from "@prismicio/types-internal/lib/customtypes";
 import { Text } from "theme-ui";
 
-import { useSectionsExperiment } from "@/features/builder/useSectionsExperiment";
+import { useSectionsNamingExperiment } from "@/features/builder/useSectionsNamingExperiment";
 import ModalFormCard from "@/legacy/components/ModalFormCard";
 import { ComponentUI } from "@/legacy/lib/models/common/ComponentUI";
 
@@ -24,7 +24,7 @@ const UpdateSliceZoneModal: React.FC<UpdateSliceModalProps> = ({
   onSubmit,
   availableSlices,
 }) => {
-  const sectionsExperiment = useSectionsExperiment();
+  const sectionsExperiment = useSectionsNamingExperiment();
 
   return (
     <ModalFormCard

--- a/packages/slice-machine/src/legacy/lib/builders/CustomTypeBuilder/SliceZone/index.tsx
+++ b/packages/slice-machine/src/legacy/lib/builders/CustomTypeBuilder/SliceZone/index.tsx
@@ -42,6 +42,7 @@ import {
 } from "@/modules/slices";
 import useSliceMachineActions from "@/modules/useSliceMachineActions";
 import type { SliceMachineStoreType } from "@/redux/type";
+import { capitalizeFirstLetter, pluralize } from "@/utils/textConversion";
 
 import { DeleteSliceZoneModal } from "./DeleteSliceZoneModal";
 import { SlicesList } from "./List";
@@ -134,10 +135,10 @@ const SliceZone: React.FC<SliceZoneProps> = ({
   const { setCustomType } = useCustomTypeState();
   const { completeStep } = useOnboarding();
   const { openLoginModal } = useSliceMachineActions();
-  const sectionsExperiment = useSectionsNamingExperiment();
+  const sectionsNamingExperiment = useSectionsNamingExperiment();
   const sliceCreationOptions = getSliceCreationOptions({
     menuType: "Dropdown",
-    sectionsExperiment,
+    sectionsNamingExperiment,
   });
 
   const localLibraries: readonly LibraryUI[] = libraries.filter(
@@ -300,7 +301,7 @@ const SliceZone: React.FC<SliceZoneProps> = ({
           ) : undefined
         }
       >
-        {sectionsExperiment.plural.uppercase}
+        {pluralize(capitalizeFirstLetter(sectionsNamingExperiment.value))}
       </ListHeader>
 
       {sliceZone ? (
@@ -372,7 +373,11 @@ const SliceZone: React.FC<SliceZoneProps> = ({
             setCustomType(CustomTypes.fromSM(newCustomType), () => {
               toast.success(
                 <ToastMessageWithPath
-                  message={`${sectionsExperiment.singular.uppercase} template(s) added to ${sectionsExperiment.singular.lowercase} zone and created at: `}
+                  message={`${capitalizeFirstLetter(
+                    sectionsNamingExperiment.value,
+                  )} template(s) added to ${
+                    sectionsNamingExperiment.value
+                  } zone and created at: `}
                   path={`${localLibraries[0].name}/`}
                 />,
               );
@@ -405,7 +410,7 @@ const SliceZone: React.FC<SliceZoneProps> = ({
             setCustomType(CustomTypes.fromSM(newCustomType), () => {
               toast.success(
                 <ToastMessageWithPath
-                  message={`New ${sectionsExperiment.singular.lowercase} added to ${sectionsExperiment.singular.lowercase} zone and created at: `}
+                  message={`New ${sectionsNamingExperiment.value} added to ${sectionsNamingExperiment.value} zone and created at: `}
                   path={`${localLibraries[0].name}/`}
                 />,
               );
@@ -430,7 +435,11 @@ const SliceZone: React.FC<SliceZoneProps> = ({
           setCustomType(CustomTypes.fromSM(newCustomType), () => {
             toast.success(
               <ToastMessageWithPath
-                message={`${sectionsExperiment.singular.uppercase}(s) added to ${sectionsExperiment.singular.lowercase} zone and created at: `}
+                message={`${capitalizeFirstLetter(
+                  sectionsNamingExperiment.value,
+                )}(s) added to ${
+                  sectionsNamingExperiment.value
+                } zone and created at: `}
                 path={library}
               />,
             );

--- a/packages/slice-machine/src/legacy/lib/builders/CustomTypeBuilder/SliceZone/index.tsx
+++ b/packages/slice-machine/src/legacy/lib/builders/CustomTypeBuilder/SliceZone/index.tsx
@@ -1,5 +1,4 @@
 import {
-  BackgroundIcon,
   Box,
   Button,
   DropdownMenu,
@@ -17,8 +16,10 @@ import { BaseStyles } from "theme-ui";
 import { telemetry } from "@/apiClient";
 import { ListHeader } from "@/components/List";
 import { useAiSliceGenerationExperiment } from "@/features/builder/useAiSliceGenerationExperiment";
+import { useSectionsExperiment } from "@/features/builder/useSectionsExperiment";
 import { CreateSliceFromImageModal } from "@/features/customTypes/customTypesBuilder/CreateSliceFromImageModal";
 import { useCustomTypeState } from "@/features/customTypes/customTypesBuilder/CustomTypeProvider";
+import { getSliceCreationOptions } from "@/features/customTypes/customTypesBuilder/sliceCreationOptions";
 import { SliceZoneBlankSlate } from "@/features/customTypes/customTypesBuilder/SliceZoneBlankSlate";
 import { useOnboarding } from "@/features/onboarding/useOnboarding";
 import { addSlicesToSliceZone } from "@/features/slices/actions/addSlicesToSliceZone";
@@ -133,6 +134,11 @@ const SliceZone: React.FC<SliceZoneProps> = ({
   const { setCustomType } = useCustomTypeState();
   const { completeStep } = useOnboarding();
   const { openLoginModal } = useSliceMachineActions();
+  const sectionsExperiment = useSectionsExperiment();
+  const sliceCreationOptions = getSliceCreationOptions({
+    menuType: "Dropdown",
+    sectionsExperiment,
+  });
 
   const localLibraries: readonly LibraryUI[] = libraries.filter(
     (library) => library.isLocal,
@@ -231,74 +237,46 @@ const SliceZone: React.FC<SliceZoneProps> = ({
               <DropdownMenuContent align="end">
                 {aiSliceGenerationExperiment.eligible && (
                   <DropdownMenuItem
-                    renderStartIcon={() => (
-                      <BackgroundIcon
-                        name="autoFixHigh"
-                        size="extraSmall"
-                        iconSize="small"
-                        radius={6}
-                        variant="solid"
-                        color="purple"
-                      />
-                    )}
+                    renderStartIcon={() =>
+                      sliceCreationOptions.fromImage.BackgroundIcon
+                    }
                     onSelect={() => void openCreateSliceFromImageModal()}
-                    description="Build a Slice based on your design image."
+                    description={sliceCreationOptions.fromImage.description}
                   >
-                    Generate from image
+                    {sliceCreationOptions.fromImage.title}
                   </DropdownMenuItem>
                 )}
                 <DropdownMenuItem
-                  renderStartIcon={() => (
-                    <BackgroundIcon
-                      name="add"
-                      size="extraSmall"
-                      iconSize="small"
-                      radius={6}
-                      variant="solid"
-                      color="white"
-                    />
-                  )}
+                  renderStartIcon={() =>
+                    sliceCreationOptions.fromScratch.BackgroundIcon
+                  }
                   onSelect={openCreateSliceModal}
-                  description="Build a custom Slice your way."
+                  description={sliceCreationOptions.fromScratch.description}
                 >
-                  Start from scratch
+                  {sliceCreationOptions.fromScratch.title}
                 </DropdownMenuItem>
 
                 {availableSlicesTemplates.length > 0 ? (
                   <DropdownMenuItem
                     onSelect={openSlicesTemplatesModal}
-                    renderStartIcon={() => (
-                      <BackgroundIcon
-                        name="contentCopy"
-                        size="extraSmall"
-                        iconSize="small"
-                        radius={6}
-                        variant="solid"
-                        color="white"
-                      />
-                    )}
-                    description="Choose from ready-made examples."
+                    renderStartIcon={() =>
+                      sliceCreationOptions.fromTemplate.BackgroundIcon
+                    }
+                    description={sliceCreationOptions.fromTemplate.description}
                   >
-                    Use a template
+                    {sliceCreationOptions.fromTemplate.title}
                   </DropdownMenuItem>
                 ) : undefined}
 
                 {availableSlicesToAdd.length > 0 ? (
                   <DropdownMenuItem
                     onSelect={openUpdateSliceZoneModal}
-                    renderStartIcon={() => (
-                      <BackgroundIcon
-                        name="folder"
-                        size="extraSmall"
-                        iconSize="small"
-                        radius={6}
-                        variant="solid"
-                        color="white"
-                      />
-                    )}
-                    description="Select from your created Slices."
+                    renderStartIcon={() =>
+                      sliceCreationOptions.fromExisting.BackgroundIcon
+                    }
+                    description={sliceCreationOptions.fromExisting.description}
                   >
-                    Reuse an existing Slice
+                    {sliceCreationOptions.fromExisting.title}
                   </DropdownMenuItem>
                 ) : undefined}
               </DropdownMenuContent>
@@ -322,7 +300,7 @@ const SliceZone: React.FC<SliceZoneProps> = ({
           ) : undefined
         }
       >
-        Slices
+        {sectionsExperiment.plural.uppercase}
       </ListHeader>
 
       {sliceZone ? (
@@ -394,7 +372,7 @@ const SliceZone: React.FC<SliceZoneProps> = ({
             setCustomType(CustomTypes.fromSM(newCustomType), () => {
               toast.success(
                 <ToastMessageWithPath
-                  message="Slice template(s) added to slice zone and created at: "
+                  message={`${sectionsExperiment.singular.uppercase} template(s) added to ${sectionsExperiment.singular.lowercase} zone and created at: `}
                   path={`${localLibraries[0].name}/`}
                 />,
               );
@@ -427,7 +405,7 @@ const SliceZone: React.FC<SliceZoneProps> = ({
             setCustomType(CustomTypes.fromSM(newCustomType), () => {
               toast.success(
                 <ToastMessageWithPath
-                  message="New slice added to slice zone and created at: "
+                  message={`New ${sectionsExperiment.singular.lowercase} added to ${sectionsExperiment.singular.lowercase} zone and created at: `}
                   path={`${localLibraries[0].name}/`}
                 />,
               );
@@ -452,7 +430,7 @@ const SliceZone: React.FC<SliceZoneProps> = ({
           setCustomType(CustomTypes.fromSM(newCustomType), () => {
             toast.success(
               <ToastMessageWithPath
-                message="Slice(s) added to slice zone and created at: "
+                message={`${sectionsExperiment.singular.uppercase}(s) added to ${sectionsExperiment.singular.lowercase} zone and created at: `}
                 path={library}
               />,
             );

--- a/packages/slice-machine/src/legacy/lib/builders/CustomTypeBuilder/SliceZone/index.tsx
+++ b/packages/slice-machine/src/legacy/lib/builders/CustomTypeBuilder/SliceZone/index.tsx
@@ -16,7 +16,7 @@ import { BaseStyles } from "theme-ui";
 import { telemetry } from "@/apiClient";
 import { ListHeader } from "@/components/List";
 import { useAiSliceGenerationExperiment } from "@/features/builder/useAiSliceGenerationExperiment";
-import { useSectionsExperiment } from "@/features/builder/useSectionsExperiment";
+import { useSectionsNamingExperiment } from "@/features/builder/useSectionsNamingExperiment";
 import { CreateSliceFromImageModal } from "@/features/customTypes/customTypesBuilder/CreateSliceFromImageModal";
 import { useCustomTypeState } from "@/features/customTypes/customTypesBuilder/CustomTypeProvider";
 import { getSliceCreationOptions } from "@/features/customTypes/customTypesBuilder/sliceCreationOptions";
@@ -134,7 +134,7 @@ const SliceZone: React.FC<SliceZoneProps> = ({
   const { setCustomType } = useCustomTypeState();
   const { completeStep } = useOnboarding();
   const { openLoginModal } = useSliceMachineActions();
-  const sectionsExperiment = useSectionsExperiment();
+  const sectionsExperiment = useSectionsNamingExperiment();
   const sliceCreationOptions = getSliceCreationOptions({
     menuType: "Dropdown",
     sectionsExperiment,

--- a/packages/slice-machine/src/legacy/lib/builders/SliceBuilder/index.tsx
+++ b/packages/slice-machine/src/legacy/lib/builders/SliceBuilder/index.tsx
@@ -15,6 +15,7 @@ import {
   AppLayoutHeader,
 } from "@/legacy/components/AppLayout";
 import SimulatorButton from "@/legacy/lib/builders/SliceBuilder/SimulatorButton";
+import { capitalizeFirstLetter, pluralize } from "@/utils/textConversion";
 
 import FieldZones from "./FieldZones";
 import { VariationsList } from "./VariationsList";
@@ -22,7 +23,7 @@ import { VariationsList } from "./VariationsList";
 export const SliceBuilder: FC = () => {
   const { slice, actionQueueStatus } = useSliceState();
   const horizontalScroll = useMediaQuery({ max: "large" });
-  const sectionsExperiment = useSectionsNamingExperiment();
+  const sectionsNamingExperiment = useSectionsNamingExperiment();
 
   const contentDisplayProps = horizontalScroll
     ? { gridTemplateRows: "304px 1fr" }
@@ -33,7 +34,9 @@ export const SliceBuilder: FC = () => {
       <AppLayoutHeader>
         <AppLayoutBackButton url="/slices" />
         <AppLayoutBreadcrumb>
-          <BreadcrumbItem>{sectionsExperiment.plural.uppercase}</BreadcrumbItem>
+          <BreadcrumbItem>
+            {pluralize(capitalizeFirstLetter(sectionsNamingExperiment.value))}
+          </BreadcrumbItem>
           <BreadcrumbItem active>{slice.model.name}</BreadcrumbItem>
         </AppLayoutBreadcrumb>
         <AppLayoutActions>

--- a/packages/slice-machine/src/legacy/lib/builders/SliceBuilder/index.tsx
+++ b/packages/slice-machine/src/legacy/lib/builders/SliceBuilder/index.tsx
@@ -3,7 +3,7 @@ import { type FC } from "react";
 
 import { BreadcrumbItem } from "@/components/Breadcrumb";
 import { AutoSaveStatusIndicator } from "@/features/autoSave/AutoSaveStatusIndicator";
-import { useSectionsExperiment } from "@/features/builder/useSectionsExperiment";
+import { useSectionsNamingExperiment } from "@/features/builder/useSectionsNamingExperiment";
 import { FloatingBackButton } from "@/features/slices/sliceBuilder/FloatingBackButton";
 import { useSliceState } from "@/features/slices/sliceBuilder/SliceBuilderProvider";
 import {
@@ -22,7 +22,7 @@ import { VariationsList } from "./VariationsList";
 export const SliceBuilder: FC = () => {
   const { slice, actionQueueStatus } = useSliceState();
   const horizontalScroll = useMediaQuery({ max: "large" });
-  const sectionsExperiment = useSectionsExperiment();
+  const sectionsExperiment = useSectionsNamingExperiment();
 
   const contentDisplayProps = horizontalScroll
     ? { gridTemplateRows: "304px 1fr" }

--- a/packages/slice-machine/src/legacy/lib/builders/SliceBuilder/index.tsx
+++ b/packages/slice-machine/src/legacy/lib/builders/SliceBuilder/index.tsx
@@ -3,6 +3,7 @@ import { type FC } from "react";
 
 import { BreadcrumbItem } from "@/components/Breadcrumb";
 import { AutoSaveStatusIndicator } from "@/features/autoSave/AutoSaveStatusIndicator";
+import { useSectionsExperiment } from "@/features/builder/useSectionsExperiment";
 import { FloatingBackButton } from "@/features/slices/sliceBuilder/FloatingBackButton";
 import { useSliceState } from "@/features/slices/sliceBuilder/SliceBuilderProvider";
 import {
@@ -21,6 +22,7 @@ import { VariationsList } from "./VariationsList";
 export const SliceBuilder: FC = () => {
   const { slice, actionQueueStatus } = useSliceState();
   const horizontalScroll = useMediaQuery({ max: "large" });
+  const sectionsExperiment = useSectionsExperiment();
 
   const contentDisplayProps = horizontalScroll
     ? { gridTemplateRows: "304px 1fr" }
@@ -31,7 +33,7 @@ export const SliceBuilder: FC = () => {
       <AppLayoutHeader>
         <AppLayoutBackButton url="/slices" />
         <AppLayoutBreadcrumb>
-          <BreadcrumbItem>Slices</BreadcrumbItem>
+          <BreadcrumbItem>{sectionsExperiment.plural.uppercase}</BreadcrumbItem>
           <BreadcrumbItem active>{slice.model.name}</BreadcrumbItem>
         </AppLayoutBreadcrumb>
         <AppLayoutActions>

--- a/packages/slice-machine/src/legacy/lib/builders/common/Zone/components/ZoneEmptyState/ZoneEmptyState.tsx
+++ b/packages/slice-machine/src/legacy/lib/builders/common/Zone/components/ZoneEmptyState/ZoneEmptyState.tsx
@@ -12,10 +12,10 @@ type ZoneEmptyStateProps = {
 };
 
 export const ZoneEmptyState: FC<ZoneEmptyStateProps> = (props) => {
-  const sectionsExperiment = useSectionsNamingExperiment();
+  const sectionsNamingExperiment = useSectionsNamingExperiment();
   const modifiedZoneType =
     props.zoneType === "slice"
-      ? sectionsExperiment.singular.lowercase
+      ? sectionsNamingExperiment.value
       : props.zoneType;
 
   const { heading = `Your ${modifiedZoneType} has no fields yet`, action } =

--- a/packages/slice-machine/src/legacy/lib/builders/common/Zone/components/ZoneEmptyState/ZoneEmptyState.tsx
+++ b/packages/slice-machine/src/legacy/lib/builders/common/Zone/components/ZoneEmptyState/ZoneEmptyState.tsx
@@ -1,7 +1,7 @@
 import { Text } from "@prismicio/editor-ui";
 import { FC, ReactNode } from "react";
 
-import { useSectionsExperiment } from "@/features/builder/useSectionsExperiment";
+import { useSectionsNamingExperiment } from "@/features/builder/useSectionsNamingExperiment";
 
 import styles from "./ZoneEmptyState.module.css";
 
@@ -12,7 +12,7 @@ type ZoneEmptyStateProps = {
 };
 
 export const ZoneEmptyState: FC<ZoneEmptyStateProps> = (props) => {
-  const sectionsExperiment = useSectionsExperiment();
+  const sectionsExperiment = useSectionsNamingExperiment();
   const modifiedZoneType =
     props.zoneType === "slice"
       ? sectionsExperiment.singular.lowercase

--- a/packages/slice-machine/src/legacy/lib/builders/common/Zone/components/ZoneEmptyState/ZoneEmptyState.tsx
+++ b/packages/slice-machine/src/legacy/lib/builders/common/Zone/components/ZoneEmptyState/ZoneEmptyState.tsx
@@ -1,6 +1,8 @@
 import { Text } from "@prismicio/editor-ui";
 import { FC, ReactNode } from "react";
 
+import { useSectionsExperiment } from "@/features/builder/useSectionsExperiment";
+
 import styles from "./ZoneEmptyState.module.css";
 
 type ZoneEmptyStateProps = {
@@ -10,11 +12,14 @@ type ZoneEmptyStateProps = {
 };
 
 export const ZoneEmptyState: FC<ZoneEmptyStateProps> = (props) => {
-  const {
-    zoneType,
-    heading = `Your ${zoneType} has no fields yet`,
-    action,
-  } = props;
+  const sectionsExperiment = useSectionsExperiment();
+  const modifiedZoneType =
+    props.zoneType === "slice"
+      ? sectionsExperiment.singular.lowercase
+      : props.zoneType;
+
+  const { heading = `Your ${modifiedZoneType} has no fields yet`, action } =
+    props;
 
   return (
     <div className={styles.root}>

--- a/packages/slice-machine/src/pages/slices.tsx
+++ b/packages/slice-machine/src/pages/slices.tsx
@@ -1,5 +1,4 @@
 import {
-  BackgroundIcon,
   Button,
   DropdownMenu,
   DropdownMenuContent,
@@ -16,7 +15,9 @@ import { BaseStyles, Flex, Link, Text } from "theme-ui";
 
 import { BreadcrumbItem } from "@/components/Breadcrumb";
 import { useAiSliceGenerationExperiment } from "@/features/builder/useAiSliceGenerationExperiment";
+import { useSectionsExperiment } from "@/features/builder/useSectionsExperiment";
 import { CreateSliceFromImageModal } from "@/features/customTypes/customTypesBuilder/CreateSliceFromImageModal";
+import { getSliceCreationOptions } from "@/features/customTypes/customTypesBuilder/sliceCreationOptions";
 import { SharedSliceCard } from "@/features/slices/sliceCards/SharedSliceCard";
 import { SLICES_CONFIG } from "@/features/slices/slicesConfig";
 import { useScreenshotChangesModal } from "@/hooks/useScreenshotChangesModal";
@@ -49,6 +50,11 @@ const SlicesIndex: React.FunctionComponent = () => {
   const router = useRouter();
   const { modalPayload, onOpenModal } = useScreenshotChangesModal();
   const { openLoginModal } = useSliceMachineActions();
+  const sectionsExperiment = useSectionsExperiment();
+  const sliceCreationOptions = getSliceCreationOptions({
+    menuType: "Dropdown",
+    sectionsExperiment,
+  });
 
   const { sliceFilterFn, defaultVariationSelector } = modalPayload;
 
@@ -106,12 +112,14 @@ const SlicesIndex: React.FunctionComponent = () => {
   return (
     <>
       <Head>
-        <title>Slices - Slice Machine</title>
+        <title>{sectionsExperiment.plural.uppercase} - Slice Machine</title>
       </Head>
       <AppLayout>
         <AppLayoutHeader>
           <AppLayoutBreadcrumb>
-            <BreadcrumbItem>Slices</BreadcrumbItem>
+            <BreadcrumbItem>
+              {sectionsExperiment.plural.uppercase}
+            </BreadcrumbItem>
           </AppLayoutBreadcrumb>
           {localLibraries?.length !== 0 && sliceCount !== 0 ? (
             <DropdownMenu>
@@ -128,37 +136,23 @@ const SlicesIndex: React.FunctionComponent = () => {
               <DropdownMenuContent align="end">
                 {aiSliceGenerationExperiment.eligible && (
                   <DropdownMenuItem
-                    renderStartIcon={() => (
-                      <BackgroundIcon
-                        name="autoFixHigh"
-                        size="extraSmall"
-                        iconSize="small"
-                        radius={6}
-                        variant="solid"
-                        color="purple"
-                      />
-                    )}
+                    renderStartIcon={() =>
+                      sliceCreationOptions.fromImage.BackgroundIcon
+                    }
                     onSelect={() => void openCreateSliceFromImageModal()}
-                    description="Build a Slice based on your design image."
+                    description={sliceCreationOptions.fromImage.description}
                   >
-                    Generate from image
+                    {sliceCreationOptions.fromImage.title}
                   </DropdownMenuItem>
                 )}
                 <DropdownMenuItem
-                  renderStartIcon={() => (
-                    <BackgroundIcon
-                      name="add"
-                      size="extraSmall"
-                      iconSize="small"
-                      radius={6}
-                      variant="solid"
-                      color="white"
-                    />
-                  )}
+                  renderStartIcon={() =>
+                    sliceCreationOptions.fromScratch.BackgroundIcon
+                  }
                   onSelect={() => setIsCreateSliceModalOpen(true)}
-                  description="Build a custom Slice your way."
+                  description={sliceCreationOptions.fromScratch.description}
                 >
-                  Start from scratch
+                  {sliceCreationOptions.fromScratch.title}
                 </DropdownMenuItem>
               </DropdownMenuContent>
             </DropdownMenu>
@@ -182,7 +176,7 @@ const SlicesIndex: React.FunctionComponent = () => {
                     }}
                   >
                     <EmptyState
-                      title={"What are Slices?"}
+                      title={`What are ${sectionsExperiment.plural.uppercase}?`}
                       onCreateNew={() => {
                         setIsCreateSliceModalOpen(true);
                       }}
@@ -190,9 +184,11 @@ const SlicesIndex: React.FunctionComponent = () => {
                       videoPublicIdUrl={VIDEO_WHAT_ARE_SLICES}
                       documentationComponent={
                         <>
-                          Slices are sections of your website. Prismic documents
-                          contain a dynamic "Slice Zone" that allows content
-                          creators to add, edit, and rearrange Slices to compose
+                          {sectionsExperiment.plural.uppercase} are sections of
+                          your website. Prismic documents contain a dynamic "
+                          {sectionsExperiment.singular.uppercase} Zone" that
+                          allows content creators to add, edit, and rearrange{" "}
+                          {sectionsExperiment.plural.uppercase} to compose
                           dynamic layouts for any page design.{" "}
                           <Link
                             target={"_blank"}
@@ -239,7 +235,12 @@ const SlicesIndex: React.FunctionComponent = () => {
                               mb: 1,
                             }}
                           >
-                            <Text>{name}</Text>
+                            <Text>
+                              {sectionsExperiment.eligible &&
+                              sortedLibraries.length === 1
+                                ? `Your ${sectionsExperiment.plural.uppercase}`
+                                : name}
+                            </Text>
                           </Flex>
                           {!isLocal && (
                             <p>⚠️ External libraries are read-only</p>
@@ -340,7 +341,7 @@ const SlicesIndex: React.FunctionComponent = () => {
             onSuccess={({ library }) => {
               toast.success(
                 <ToastMessageWithPath
-                  message="Slice(s) added to slice zone and created at: "
+                  message={`${sectionsExperiment.singular.uppercase}(s) added to ${sectionsExperiment.singular.lowercase} zone and created at: `}
                   path={library}
                 />,
               );

--- a/packages/slice-machine/src/pages/slices.tsx
+++ b/packages/slice-machine/src/pages/slices.tsx
@@ -15,7 +15,7 @@ import { BaseStyles, Flex, Link, Text } from "theme-ui";
 
 import { BreadcrumbItem } from "@/components/Breadcrumb";
 import { useAiSliceGenerationExperiment } from "@/features/builder/useAiSliceGenerationExperiment";
-import { useSectionsExperiment } from "@/features/builder/useSectionsExperiment";
+import { useSectionsNamingExperiment } from "@/features/builder/useSectionsNamingExperiment";
 import { CreateSliceFromImageModal } from "@/features/customTypes/customTypesBuilder/CreateSliceFromImageModal";
 import { getSliceCreationOptions } from "@/features/customTypes/customTypesBuilder/sliceCreationOptions";
 import { SharedSliceCard } from "@/features/slices/sliceCards/SharedSliceCard";
@@ -50,7 +50,7 @@ const SlicesIndex: React.FunctionComponent = () => {
   const router = useRouter();
   const { modalPayload, onOpenModal } = useScreenshotChangesModal();
   const { openLoginModal } = useSliceMachineActions();
-  const sectionsExperiment = useSectionsExperiment();
+  const sectionsExperiment = useSectionsNamingExperiment();
   const sliceCreationOptions = getSliceCreationOptions({
     menuType: "Dropdown",
     sectionsExperiment,

--- a/packages/slice-machine/src/pages/slices.tsx
+++ b/packages/slice-machine/src/pages/slices.tsx
@@ -44,16 +44,17 @@ import { managerClient } from "@/managerClient";
 import { getLibraries, getRemoteSlices } from "@/modules/slices";
 import useSliceMachineActions from "@/modules/useSliceMachineActions";
 import { SliceMachineStoreType } from "@/redux/type";
+import { capitalizeFirstLetter, pluralize } from "@/utils/textConversion";
 
 const SlicesIndex: React.FunctionComponent = () => {
   const aiSliceGenerationExperiment = useAiSliceGenerationExperiment();
   const router = useRouter();
   const { modalPayload, onOpenModal } = useScreenshotChangesModal();
   const { openLoginModal } = useSliceMachineActions();
-  const sectionsExperiment = useSectionsNamingExperiment();
+  const sectionsNamingExperiment = useSectionsNamingExperiment();
   const sliceCreationOptions = getSliceCreationOptions({
     menuType: "Dropdown",
-    sectionsExperiment,
+    sectionsNamingExperiment,
   });
 
   const { sliceFilterFn, defaultVariationSelector } = modalPayload;
@@ -112,13 +113,16 @@ const SlicesIndex: React.FunctionComponent = () => {
   return (
     <>
       <Head>
-        <title>{sectionsExperiment.plural.uppercase} - Slice Machine</title>
+        <title>
+          {pluralize(capitalizeFirstLetter(sectionsNamingExperiment.value))} -
+          Slice Machine
+        </title>
       </Head>
       <AppLayout>
         <AppLayoutHeader>
           <AppLayoutBreadcrumb>
             <BreadcrumbItem>
-              {sectionsExperiment.plural.uppercase}
+              {pluralize(capitalizeFirstLetter(sectionsNamingExperiment.value))}
             </BreadcrumbItem>
           </AppLayoutBreadcrumb>
           {localLibraries?.length !== 0 && sliceCount !== 0 ? (
@@ -176,7 +180,9 @@ const SlicesIndex: React.FunctionComponent = () => {
                     }}
                   >
                     <EmptyState
-                      title={`What are ${sectionsExperiment.plural.uppercase}?`}
+                      title={`What are ${pluralize(
+                        capitalizeFirstLetter(sectionsNamingExperiment.value),
+                      )}?`}
                       onCreateNew={() => {
                         setIsCreateSliceModalOpen(true);
                       }}
@@ -184,12 +190,24 @@ const SlicesIndex: React.FunctionComponent = () => {
                       videoPublicIdUrl={VIDEO_WHAT_ARE_SLICES}
                       documentationComponent={
                         <>
-                          {sectionsExperiment.plural.uppercase} are sections of
-                          your website. Prismic documents contain a dynamic "
-                          {sectionsExperiment.singular.uppercase} Zone" that
-                          allows content creators to add, edit, and rearrange{" "}
-                          {sectionsExperiment.plural.uppercase} to compose
-                          dynamic layouts for any page design.{" "}
+                          {pluralize(
+                            capitalizeFirstLetter(
+                              sectionsNamingExperiment.value,
+                            ),
+                          )}{" "}
+                          are sections of your website. Prismic documents
+                          contain a dynamic "
+                          {capitalizeFirstLetter(
+                            sectionsNamingExperiment.value,
+                          )}{" "}
+                          Zone" that allows content creators to add, edit, and
+                          rearrange{" "}
+                          {pluralize(
+                            capitalizeFirstLetter(
+                              sectionsNamingExperiment.value,
+                            ),
+                          )}{" "}
+                          to compose dynamic layouts for any page design.{" "}
                           <Link
                             target={"_blank"}
                             href={
@@ -236,9 +254,13 @@ const SlicesIndex: React.FunctionComponent = () => {
                             }}
                           >
                             <Text>
-                              {sectionsExperiment.eligible &&
+                              {sectionsNamingExperiment.eligible &&
                               sortedLibraries.length === 1
-                                ? `Your ${sectionsExperiment.plural.uppercase}`
+                                ? `Your ${pluralize(
+                                    capitalizeFirstLetter(
+                                      sectionsNamingExperiment.value,
+                                    ),
+                                  )}`
                                 : name}
                             </Text>
                           </Flex>
@@ -341,7 +363,11 @@ const SlicesIndex: React.FunctionComponent = () => {
             onSuccess={({ library }) => {
               toast.success(
                 <ToastMessageWithPath
-                  message={`${sectionsExperiment.singular.uppercase}(s) added to ${sectionsExperiment.singular.lowercase} zone and created at: `}
+                  message={`${capitalizeFirstLetter(
+                    sectionsNamingExperiment.value,
+                  )}(s) added to ${
+                    sectionsNamingExperiment.value
+                  } zone and created at: `}
                   path={library}
                 />,
               );

--- a/packages/slice-machine/src/pages/slices.tsx
+++ b/packages/slice-machine/src/pages/slices.tsx
@@ -181,7 +181,7 @@ const SlicesIndex: React.FunctionComponent = () => {
                   >
                     <EmptyState
                       title={`What are ${pluralize(
-                        capitalizeFirstLetter(sectionsNamingExperiment.value),
+                        sectionsNamingExperiment.value,
                       )}?`}
                       onCreateNew={() => {
                         setIsCreateSliceModalOpen(true);
@@ -201,12 +201,7 @@ const SlicesIndex: React.FunctionComponent = () => {
                             sectionsNamingExperiment.value,
                           )}{" "}
                           Zone" that allows content creators to add, edit, and
-                          rearrange{" "}
-                          {pluralize(
-                            capitalizeFirstLetter(
-                              sectionsNamingExperiment.value,
-                            ),
-                          )}{" "}
+                          rearrange {pluralize(sectionsNamingExperiment.value)}{" "}
                           to compose dynamic layouts for any page design.{" "}
                           <Link
                             target={"_blank"}
@@ -257,9 +252,7 @@ const SlicesIndex: React.FunctionComponent = () => {
                               {sectionsNamingExperiment.eligible &&
                               sortedLibraries.length === 1
                                 ? `Your ${pluralize(
-                                    capitalizeFirstLetter(
-                                      sectionsNamingExperiment.value,
-                                    ),
+                                    sectionsNamingExperiment.value,
                                   )}`
                                 : name}
                             </Text>

--- a/packages/slice-machine/src/pages/slices.tsx
+++ b/packages/slice-machine/src/pages/slices.tsx
@@ -321,6 +321,7 @@ const SlicesIndex: React.FunctionComponent = () => {
                 void router.push(sliceLocation);
                 toast.success(
                   SliceToastMessage({
+                    sectionsNamingExperiment,
                     path: `${libraryName}/${newSlice.name}/model.json`,
                   }),
                 );

--- a/packages/slice-machine/src/utils/textConversion.ts
+++ b/packages/slice-machine/src/utils/textConversion.ts
@@ -1,0 +1,11 @@
+export function capitalizeFirstLetter(string: string) {
+  return string.charAt(0).toUpperCase() + string.slice(1);
+}
+
+export function pluralize(
+  singular: string,
+  count: number = 2,
+  plural?: string,
+) {
+  return count === 1 ? singular : plural ?? `${singular}s`;
+}

--- a/playwright/pages/shared/TypeBuilderPage.ts
+++ b/playwright/pages/shared/TypeBuilderPage.ts
@@ -109,7 +109,7 @@ export class TypeBuilderPage extends BuilderPage {
         exact: true,
       });
     this.sliceZoneBlankSlateSelectExistingAction =
-      this.sliceZoneBlankSlate.getByText("Reuse an existing Slice", {
+      this.sliceZoneBlankSlate.getByText("Reuse an existing slice", {
         exact: true,
       });
     this.sliceZoneBlankSlateCreateNewAction =
@@ -122,7 +122,7 @@ export class TypeBuilderPage extends BuilderPage {
       .getByText("Use a template", { exact: true });
     this.sliceZoneAddDropdownSelectExistingAction = page
       .getByRole("menu")
-      .getByText("Reuse an existing Slice", { exact: true });
+      .getByText("Reuse an existing slice", { exact: true });
     this.sliceZoneAddDropdownCreateNewAction = page
       .getByRole("menu")
       .getByText("Start from scratch", { exact: true });


### PR DESCRIPTION
Resolves: [DT-2680](https://linear.app/prismic/issue/DT-2680/slice-to-section-experiment-build-and-test-the-new-copy-experiment)

### Description

Adds an experiment to the Slice Machine UI to use "Sections" instead of "Slices".

### Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- Don't hesitate to ask for help! -->

- [x] A comprehensive Linear ticket, providing sufficient context and details to facilitate the review of the PR, is linked to the PR.
- [ ] If my changes require tests, I added them.
- [ ] If my changes affect backward compatibility, it has been discussed.
- [ ] If my changes require an update to the CONTRIBUTING.md guide, I updated it.

### Preview

https://www.notion.so/prismic/Slices-Sections-Blocks-1d23bee0866980c5af35c247e207c50a

### How to QA [^1]

<!-- When relevant, describe how to QA your changes. -->

<!-- Your favorite emoji is welcome to close your PR! -->

<!-- A note for reviewers: -->

[^1]:
	Please use these labels when submitting a review:
	:question: #ask:&ensp;Ask a question.
	:bulb: #idea:&ensp;Suggest an idea.
	:warning: #issue:&ensp;Strongly suggest a change.
	:tada: #nice:&ensp;Share a compliment.
