### PR TITLE
[DT-2688] fix: remove CR update recursion and prevent different path updates

### DIFF
--- a/packages/manager/src/managers/customTypes/CustomTypesManager.ts
+++ b/packages/manager/src/managers/customTypes/CustomTypesManager.ts
@@ -198,8 +198,13 @@ export class CustomTypesManager extends BaseManager {
 		const previousId = previousPath[0];
 		const newId = newPath[0];
 
-		if (!previousId || !newId || typeof customType === "string") {
-			return customType; // we don't support custom type id renaming
+		if (
+			!previousId ||
+			!newId ||
+			// we don't support custom type id renaming
+			typeof customType === "string"
+		) {
+			return customType;
 		}
 
 		if (customType.fields) {
@@ -239,8 +244,13 @@ export class CustomTypesManager extends BaseManager {
 						const previousId = previousPath[0];
 						const newId = newPath[0];
 
-						if (!previousId || !newId || typeof customType === "string") {
-							return customType; // we don't support custom type id renaming
+						if (
+							!previousId ||
+							!newId ||
+							// we don't support custom type id renaming
+							typeof customType === "string"
+						) {
+							return customType;
 						}
 
 						if (customType.fields) {

--- a/packages/manager/src/managers/customTypes/CustomTypesManager.ts
+++ b/packages/manager/src/managers/customTypes/CustomTypesManager.ts
@@ -214,12 +214,18 @@ export class CustomTypesManager extends BaseManager {
 			return customType; // we don't support custom type id renaming
 		}
 
+		const matchedCustomTypeId = customType.id === previousCustomTypeId;
+
 		if (customType.fields) {
 			const newFields = customType.fields.map((fieldArg) => {
 				const nestedField = shallowClone(fieldArg);
 
 				if (typeof nestedField === "string") {
-					if (nestedField === previousFieldId && nestedField !== newFieldId) {
+					if (
+						matchedCustomTypeId &&
+						nestedField === previousFieldId &&
+						nestedField !== newFieldId
+					) {
 						// We have reached a field id that matches the id that was renamed,
 						// so we update it new one. The field is a string, so return the new
 						// id.
@@ -229,15 +235,14 @@ export class CustomTypesManager extends BaseManager {
 					return nestedField;
 				}
 
-				if (
-					nestedField.id === previousFieldId &&
-					nestedField.id !== newFieldId
-				) {
-					// We have reached a field id that matches the id that was renamed,
-					// so we update it new one.
-					// Since field is not a string, we don't exit, as we might have
-					// something to update further down in customtypes.
-					nestedField.id = newFieldId;
+				if (nestedField.id === previousFieldId) {
+					if (matchedCustomTypeId && nestedField.id !== newFieldId) {
+						// We have reached a field id that matches the id that was renamed,
+						// so we update it new one.
+						// Since field is not a string, we don't exit, as we might have
+						// something to update further down in customtypes.
+						nestedField.id = newFieldId;
+					}
 				}
 
 				return {
@@ -249,6 +254,9 @@ export class CustomTypesManager extends BaseManager {
 							return customTypeField; // we don't support custom type id renaming
 						}
 
+						const matchedNestedCustomTypeId =
+							customTypeField.id === previousCustomTypeId;
+
 						if (customTypeField.fields) {
 							return {
 								...customTypeField,
@@ -256,6 +264,7 @@ export class CustomTypesManager extends BaseManager {
 									const nestedCustomTypeField = shallowClone(fieldArg);
 
 									if (
+										matchedNestedCustomTypeId &&
 										nestedCustomTypeField === previousFieldId &&
 										nestedCustomTypeField !== newFieldId
 									) {

--- a/packages/manager/src/managers/customTypes/CustomTypesManager.ts
+++ b/packages/manager/src/managers/customTypes/CustomTypesManager.ts
@@ -216,54 +216,60 @@ export class CustomTypesManager extends BaseManager {
 
 		if (customType.fields) {
 			const newFields = customType.fields.map((fieldArg) => {
-				const field = shallowClone(fieldArg);
+				const nestedField = shallowClone(fieldArg);
 
-				if (typeof field === "string") {
-					if (field === previousFieldId && field !== newFieldId) {
+				if (typeof nestedField === "string") {
+					if (nestedField === previousFieldId && nestedField !== newFieldId) {
 						// We have reached a field id that matches the id that was renamed,
 						// so we update it new one. The field is a string, so return the new
 						// id.
 						return newFieldId;
 					}
 
-					return field;
+					return nestedField;
 				}
 
-				if (field.id === previousFieldId && field.id !== newFieldId) {
+				if (
+					nestedField.id === previousFieldId &&
+					nestedField.id !== newFieldId
+				) {
 					// We have reached a field id that matches the id that was renamed,
 					// so we update it new one.
 					// Since field is not a string, we don't exit, as we might have
 					// something to update further down in customtypes.
-					field.id = newFieldId;
+					nestedField.id = newFieldId;
 				}
 
 				return {
-					...field,
-					customtypes: field.customtypes.map((customTypeArg) => {
-						const customType = shallowClone(customTypeArg);
+					...nestedField,
+					customtypes: nestedField.customtypes.map((customTypeArg) => {
+						const customTypeField = shallowClone(customTypeArg);
 
-						if (typeof customType === "string") {
-							return customType; // we don't support custom type id renaming
+						if (typeof customTypeField === "string") {
+							return customTypeField; // we don't support custom type id renaming
 						}
 
-						if (customType.fields) {
+						if (customTypeField.fields) {
 							return {
-								...customType,
-								fields: customType.fields.map((fieldArg) => {
-									const field = shallowClone(fieldArg);
+								...customTypeField,
+								fields: customTypeField.fields.map((fieldArg) => {
+									const nestedCustomTypeField = shallowClone(fieldArg);
 
-									if (field === previousFieldId && field !== newFieldId) {
+									if (
+										nestedCustomTypeField === previousFieldId &&
+										nestedCustomTypeField !== newFieldId
+									) {
 										// Matches the previous id, so we update it and return because
 										// it's the last level.
 										return newFieldId;
 									}
 
-									return field;
+									return nestedCustomTypeField;
 								}),
 							};
 						}
 
-						return customType;
+						return customTypeField;
 					}),
 				};
 			});

--- a/packages/manager/src/managers/customTypes/CustomTypesManager.ts
+++ b/packages/manager/src/managers/customTypes/CustomTypesManager.ts
@@ -195,12 +195,18 @@ export class CustomTypesManager extends BaseManager {
 
 		const customType = shallowClone(args.customType);
 
-		const previousCustomTypeId = previousPath[0];
-		const newCustomTypeId = newPath[0];
+		const [previousCustomTypeId, previousFieldId] = previousPath;
+		const [newCustomTypeId, newFieldId] = newPath;
 
 		if (!previousCustomTypeId || !newCustomTypeId) {
 			throw new Error(
-				"Didn't find any customtype id, which should not be possible",
+				"Didn't find any customtype id, which should not be possible.",
+			);
+		}
+
+		if (!previousFieldId || !newFieldId) {
+			throw new Error(
+				"Didn't find any field id, which should not be possible.",
 			);
 		}
 
@@ -211,15 +217,6 @@ export class CustomTypesManager extends BaseManager {
 		if (customType.fields) {
 			const newFields = customType.fields.map((fieldArg) => {
 				const field = shallowClone(fieldArg);
-
-				const previousFieldId = previousPath[1];
-				const newFieldId = newPath[1];
-
-				if (!previousFieldId || !newFieldId) {
-					throw new Error(
-						"Didn't find any field id, which should not be possible",
-					);
-				}
 
 				if (typeof field === "string") {
 					if (field === previousFieldId && field !== newFieldId) {
@@ -244,12 +241,6 @@ export class CustomTypesManager extends BaseManager {
 					...field,
 					customtypes: field.customtypes.map((customTypeArg) => {
 						const customType = shallowClone(customTypeArg);
-
-						if (!previousCustomTypeId || !newCustomTypeId) {
-							throw new Error(
-								"Didn't find any customtype id, which should not be possible",
-							);
-						}
 
 						if (typeof customType === "string") {
 							return customType; // we don't support custom type id renaming

--- a/packages/manager/src/managers/customTypes/CustomTypesManager.ts
+++ b/packages/manager/src/managers/customTypes/CustomTypesManager.ts
@@ -199,7 +199,7 @@ export class CustomTypesManager extends BaseManager {
 		const [newId] = newPath;
 
 		if (!previousId || !newId || typeof customType === "string") {
-			return customType;
+			return customType;  // we don't support custom type id renaming
 		}
 
 		if (customType.fields) {
@@ -239,17 +239,8 @@ export class CustomTypesManager extends BaseManager {
 						const previousId = previousPath[2];
 						const newId = newPath[2];
 
-						if (!previousId || !newId) {
-							return customType;
-						}
-
-						if (typeof customType === "string") {
-							if (customType === previousId && customType !== newId) {
-								// Matches the previous id, so we update it.
-								return newId;
-							}
-
-							return customType;
+						if (!previousId || !newId || typeof customType === "string") {
+							return customType; // we don't support custom type id renaming
 						}
 
 						if (customType.id === previousId && customType.id !== newId) {

--- a/packages/manager/src/managers/customTypes/CustomTypesManager.ts
+++ b/packages/manager/src/managers/customTypes/CustomTypesManager.ts
@@ -195,11 +195,11 @@ export class CustomTypesManager extends BaseManager {
 
 		const customType = shallowClone(args.customType);
 
-		const [previousId] = previousPath;
-		const [newId] = newPath;
+		const previousId = previousPath[0];
+		const newId = newPath[0];
 
 		if (!previousId || !newId || typeof customType === "string") {
-			return customType;  // we don't support custom type id renaming
+			return customType; // we don't support custom type id renaming
 		}
 
 		if (customType.fields) {
@@ -236,17 +236,30 @@ export class CustomTypesManager extends BaseManager {
 					...field,
 					customtypes: field.customtypes.map((customTypeArg) => {
 						const customType = shallowClone(customTypeArg);
-						const previousId = previousPath[2];
-						const newId = newPath[2];
+						const previousId = previousPath[0];
+						const newId = newPath[0];
 
 						if (!previousId || !newId || typeof customType === "string") {
 							return customType; // we don't support custom type id renaming
 						}
 
-						if (customType.id === previousId && customType.id !== newId) {
-							// Matches the previous id, so we update it and return because
-							// it's the last level.
-							return { ...customType, id: newId };
+						if (customType.fields) {
+							return {
+								...customType,
+								fields: customType.fields.map((fieldArg) => {
+									const field = shallowClone(fieldArg);
+									const previousId = previousPath[1];
+									const newId = newPath[1];
+
+									if (field === previousId && field !== newId) {
+										// Matches the previous id, so we update it and return because
+										// it's the last level.
+										return newId;
+									}
+
+									return field;
+								}),
+							};
 						}
 
 						return customType;

--- a/packages/manager/src/managers/customTypes/CustomTypesManager.ts
+++ b/packages/manager/src/managers/customTypes/CustomTypesManager.ts
@@ -215,13 +215,13 @@ export class CustomTypesManager extends BaseManager {
 		const matchedCustomTypeId = customType.id === previousCustomTypeId;
 
 		const newFields = customType.fields.map((fieldArg) => {
-			const nestedField = shallowCloneIfObject(fieldArg);
+			const customTypeField = shallowCloneIfObject(fieldArg);
 
-			if (typeof nestedField === "string") {
+			if (typeof customTypeField === "string") {
 				if (
 					matchedCustomTypeId &&
-					nestedField === previousFieldId &&
-					nestedField !== newFieldId
+					customTypeField === previousFieldId &&
+					customTypeField !== newFieldId
 				) {
 					// We have reached a field id that matches the id that was renamed,
 					// so we update it new one. The field is a string, so return the new
@@ -229,40 +229,43 @@ export class CustomTypesManager extends BaseManager {
 					return newFieldId;
 				}
 
-				return nestedField;
+				return customTypeField;
 			}
 
 			if (
 				matchedCustomTypeId &&
-				nestedField.id === previousFieldId &&
-				nestedField.id !== newFieldId
+				customTypeField.id === previousFieldId &&
+				customTypeField.id !== newFieldId
 			) {
 				// We have reached a field id that matches the id that was renamed,
 				// so we update it new one.
 				// Since field is not a string, we don't exit, as we might have
 				// something to update further down in customtypes.
-				nestedField.id = newFieldId;
+				customTypeField.id = newFieldId;
 			}
 
 			return {
-				...nestedField,
-				customtypes: nestedField.customtypes.map((customTypeArg) => {
-					const customTypeField = shallowCloneIfObject(customTypeArg);
+				...customTypeField,
+				customtypes: customTypeField.customtypes.map((customTypeArg) => {
+					const nestedCustomType = shallowCloneIfObject(customTypeArg);
 
-					if (typeof customTypeField === "string" || !customTypeField.fields) {
-						return customTypeField;
+					if (
+						typeof nestedCustomType === "string" ||
+						!nestedCustomType.fields ||
+						// Since we are on the last level, if we don't start matching right
+						// at the custom type id, we can return exit early because it's not
+						// a match.
+						nestedCustomType.id !== previousCustomTypeId
+					) {
+						return nestedCustomType;
 					}
 
-					const matchedNestedCustomTypeId =
-						customTypeField.id === previousCustomTypeId;
-
 					return {
-						...customTypeField,
-						fields: customTypeField.fields.map((fieldArg) => {
+						...nestedCustomType,
+						fields: nestedCustomType.fields.map((fieldArg) => {
 							const nestedCustomTypeField = shallowCloneIfObject(fieldArg);
 
 							if (
-								matchedNestedCustomTypeId &&
 								nestedCustomTypeField === previousFieldId &&
 								nestedCustomTypeField !== newFieldId
 							) {

--- a/packages/manager/src/managers/customTypes/CustomTypesManager.ts
+++ b/packages/manager/src/managers/customTypes/CustomTypesManager.ts
@@ -195,62 +195,64 @@ export class CustomTypesManager extends BaseManager {
 
 		const customType = shallowClone(args.customType);
 
-		const previousId = previousPath[0];
-		const newId = newPath[0];
+		const previousCustomTypeId = previousPath[0];
+		const newCustomTypeId = newPath[0];
 
-		if (
-			!previousId ||
-			!newId ||
-			// we don't support custom type id renaming
-			typeof customType === "string"
-		) {
-			return customType;
+		if (!previousCustomTypeId || !newCustomTypeId) {
+			throw new Error(
+				"Didn't find any customtype id, which should not be possible",
+			);
+		}
+
+		if (typeof customType === "string") {
+			return customType; // we don't support custom type id renaming
 		}
 
 		if (customType.fields) {
 			const newFields = customType.fields.map((fieldArg) => {
 				const field = shallowClone(fieldArg);
 
-				const previousId = previousPath[1];
-				const newId = newPath[1];
+				const previousFieldId = previousPath[1];
+				const newFieldId = newPath[1];
 
-				if (!previousId || !newId) {
-					return field;
+				if (!previousFieldId || !newFieldId) {
+					throw new Error(
+						"Didn't find any field id, which should not be possible",
+					);
 				}
 
 				if (typeof field === "string") {
-					if (field === previousId && field !== newId) {
+					if (field === previousFieldId && field !== newFieldId) {
 						// We have reached a field id that matches the id that was renamed,
 						// so we update it new one. The field is a string, so return the new
 						// id.
-						return newId;
+						return newFieldId;
 					}
 
 					return field;
 				}
 
-				if (field.id === previousId && field.id !== newId) {
+				if (field.id === previousFieldId && field.id !== newFieldId) {
 					// We have reached a field id that matches the id that was renamed,
 					// so we update it new one.
 					// Since field is not a string, we don't exit, as we might have
 					// something to update further down in customtypes.
-					field.id = newId;
+					field.id = newFieldId;
 				}
 
 				return {
 					...field,
 					customtypes: field.customtypes.map((customTypeArg) => {
 						const customType = shallowClone(customTypeArg);
-						const previousId = previousPath[0];
-						const newId = newPath[0];
 
-						if (
-							!previousId ||
-							!newId ||
-							// we don't support custom type id renaming
-							typeof customType === "string"
-						) {
-							return customType;
+						if (!previousCustomTypeId || !newCustomTypeId) {
+							throw new Error(
+								"Didn't find any customtype id, which should not be possible",
+							);
+						}
+
+						if (typeof customType === "string") {
+							return customType; // we don't support custom type id renaming
 						}
 
 						if (customType.fields) {
@@ -258,13 +260,11 @@ export class CustomTypesManager extends BaseManager {
 								...customType,
 								fields: customType.fields.map((fieldArg) => {
 									const field = shallowClone(fieldArg);
-									const previousId = previousPath[1];
-									const newId = newPath[1];
 
-									if (field === previousId && field !== newId) {
+									if (field === previousFieldId && field !== newFieldId) {
 										// Matches the previous id, so we update it and return because
 										// it's the last level.
-										return newId;
+										return newFieldId;
 									}
 
 									return field;


### PR DESCRIPTION
Resolves: DT-2688

### Description

1. Fix: Prevent updating field that have the same field name but different path from the update
2. Refactor: Remove an unnecessary recursive call and deals with the updates inside the map itself. This decreases the type complexity and removes a `@ts-expect-error`.
3. Refactor: Simplify some logic in the `updateCRCustomType` function.

### How to QA [^1]

<!-- When relevant, describe how to QA your changes. -->

<!-- Your favorite emoji is welcome to close your PR! -->

<!-- A note for reviewers: -->

[^1]:
	Please use these labels when submitting a review:
	:question: #ask:&ensp;Ask a question.
	:bulb: #idea:&ensp;Suggest an idea.
	:warning: #issue:&ensp;Strongly suggest a change.
	:tada: #nice:&ensp;Share a compliment.
