### PR TITLE
[DT-2692] feat: pick nested content relationship fields

### DIFF
--- a/packages/slice-machine/src/features/customTypes/fields/ContentRelationshipFieldPicker.tsx
+++ b/packages/slice-machine/src/features/customTypes/fields/ContentRelationshipFieldPicker.tsx
@@ -170,21 +170,21 @@ function TreeViewCustomType(props: TreeViewCustomTypeProps) {
       subtitle={fieldCount > 0 ? `(${fieldCountLabel} exposed)` : undefined}
       badge="Custom type"
     >
-      {customType.fields.map((field) => {
-        const checkboxState = fieldCheckMap?.[field];
+      {customType.fields.map((fieldId) => {
+        const checked = fieldCheckMap?.[fieldId].value ?? false;
 
         function onCheckedChange(value: boolean) {
           onChange((currentFields) => ({
             ...currentFields,
-            [field]: { type: "checkbox", value },
+            [fieldId]: { type: "checkbox", value },
           }));
         }
 
         return (
           <TreeViewCheckbox
-            key={field}
-            title={field}
-            checked={checkboxState?.value ?? false}
+            key={fieldId}
+            title={fieldId}
+            checked={checked}
             onCheckedChange={onCheckedChange}
           />
         );

--- a/packages/slice-machine/src/features/customTypes/fields/ContentRelationshipFieldPicker.tsx
+++ b/packages/slice-machine/src/features/customTypes/fields/ContentRelationshipFieldPicker.tsx
@@ -10,6 +10,8 @@ import { useSelector } from "react-redux";
 
 import { selectAllCustomTypes } from "@/modules/availableCustomTypes";
 
+// picker state types
+
 type PickerCheckboxField = {
   type: "checkbox";
   value: boolean;
@@ -41,7 +43,7 @@ export function ContentRelationshipFieldPicker(
   props: ContentRelationshipFieldPickerProps,
 ) {
   const { initialValues } = props;
-  const customTypes = useCustomTypes();
+  const { customTypes, labels } = useCustomTypes();
 
   const [state, setState] = useState<PickerCustomTypeFields>(
     initialValues ? convertCustomTypesToState(initialValues) : {},
@@ -73,13 +75,13 @@ export function ContentRelationshipFieldPicker(
           title="Exposed fields"
           subtitle={`(${countPickedFields(state)})`}
         >
-          {customTypes.customTypes.map((customType) => (
+          {customTypes.map((customType) => (
             <TreeViewCustomType
               key={customType.id}
               customType={customType}
               state={state[customType.id]}
               onChange={onChange}
-              labels={customTypes.labels}
+              labels={labels}
             />
           ))}
         </TreeView>

--- a/packages/slice-machine/src/features/customTypes/fields/ContentRelationshipFieldPicker.tsx
+++ b/packages/slice-machine/src/features/customTypes/fields/ContentRelationshipFieldPicker.tsx
@@ -73,19 +73,15 @@ export function ContentRelationshipFieldPicker(
           title="Exposed fields"
           subtitle={`(${countPickedFields(state)})`}
         >
-          {customTypes.customTypes.map((customType) => {
-            if (typeof customType === "string") return null;
-
-            return (
-              <TreeViewCustomType
-                key={customType.id}
-                customType={customType}
-                state={state[customType.id]}
-                onChange={onChange}
-                labels={customTypes.labels}
-              />
-            );
-          })}
+          {customTypes.customTypes.map((customType) => (
+            <TreeViewCustomType
+              key={customType.id}
+              customType={customType}
+              state={state[customType.id]}
+              onChange={onChange}
+              labels={customTypes.labels}
+            />
+          ))}
         </TreeView>
       </Box>
       <Box backgroundColor="white" flexDirection="column" padding={12}>

--- a/packages/slice-machine/src/features/customTypes/fields/ContentRelationshipFieldPicker.tsx
+++ b/packages/slice-machine/src/features/customTypes/fields/ContentRelationshipFieldPicker.tsx
@@ -228,15 +228,10 @@ function convertCustomTypesToState(value: TICustomTypeFields) {
 /** Convert the picked fields map to the customtypes config and filter out empty customtypes */
 function convertStateToCustomTypes(fields: PickerCustomTypeFields) {
   return Object.entries(fields).flatMap<TICustomType>(([ctId, ctFields]) => {
-    const ctFieldEntries = Object.entries(ctFields);
-    if (!ctFieldEntries.some(([_, checked]) => checked)) return [];
-
-    const fields = ctFieldEntries.flatMap(([id, checkbox]) =>
-      checkbox.value ? [id] : [],
+    const fields = Object.entries(ctFields).flatMap(([fieldId, checkbox]) =>
+      checkbox.value ? [fieldId] : [],
     );
-
-    if (fields.length === 0) return [];
-    return { id: ctId, fields };
+    return fields.length > 0 ? { id: ctId, fields } : [];
   });
 }
 

--- a/packages/slice-machine/src/features/customTypes/fields/ContentRelationshipFieldPicker.tsx
+++ b/packages/slice-machine/src/features/customTypes/fields/ContentRelationshipFieldPicker.tsx
@@ -72,8 +72,6 @@ interface TICustomType {
   fields: readonly string[];
 }
 
-type Updater<T> = (prev: T) => T;
-
 interface ContentRelationshipFieldPickerProps {
   value: TICustomTypes | undefined;
   onChange: (fields: TICustomTypes) => void;
@@ -86,7 +84,9 @@ export function ContentRelationshipFieldPicker(
   const customTypes = useCustomTypes();
   const fieldCheckMap = value ? convertCustomTypesToFieldCheckMap(value) : {};
 
-  function onCustomTypesChange(updater: Updater<PickerCustomTypes>) {
+  function onCustomTypesChange(
+    updater: (prev: PickerCustomTypes) => PickerCustomTypes,
+  ) {
     onChange(convertFieldCheckMapToCustomTypes(updater(fieldCheckMap)));
   }
 
@@ -111,7 +111,9 @@ export function ContentRelationshipFieldPicker(
           subtitle={`(${countPickedFields(fieldCheckMap)})`}
         >
           {customTypes.map((customType) => {
-            const onCustomTypeChange = (updater: Updater<PickerCustomType>) => {
+            const onCustomTypeChange = (
+              updater: (prev: PickerCustomType) => PickerCustomType,
+            ) => {
               onCustomTypesChange((currentCustomTypes) => ({
                 ...currentCustomTypes,
                 [customType.id]: updater(
@@ -152,7 +154,7 @@ export function ContentRelationshipFieldPicker(
 interface TreeViewCustomTypeProps {
   customType: TICustomType;
   fieldCheckMap: PickerCustomType | undefined;
-  onChange: (fn: Updater<PickerCustomType>) => void;
+  onChange: (fn: (prev: PickerCustomType) => PickerCustomType) => void;
 }
 
 function TreeViewCustomType(props: TreeViewCustomTypeProps) {

--- a/packages/slice-machine/src/features/customTypes/fields/ContentRelationshipFieldPicker.tsx
+++ b/packages/slice-machine/src/features/customTypes/fields/ContentRelationshipFieldPicker.tsx
@@ -227,17 +227,16 @@ function convertCustomTypesToState(value: TICustomTypeFields) {
 
 /** Convert the picked fields map to the customtypes config and filter out empty customtypes */
 function convertStateToCustomTypes(fields: PickerCustomTypeFields) {
-  return Object.entries(fields).flatMap<TICustomType>(([ctId, fields]) => {
-    const fieldEntries = Object.entries(fields);
-    if (!fieldEntries.some(([_, checked]) => checked)) return [];
-    return [
-      {
-        id: ctId,
-        fields: fieldEntries.flatMap(([id, checkbox]) =>
-          checkbox.value ? [id] : [],
-        ),
-      },
-    ];
+  return Object.entries(fields).flatMap<TICustomType>(([ctId, ctFields]) => {
+    const ctFieldEntries = Object.entries(ctFields);
+    if (!ctFieldEntries.some(([_, checked]) => checked)) return [];
+
+    const fields = ctFieldEntries.flatMap(([id, checkbox]) =>
+      checkbox.value ? [id] : [],
+    );
+
+    if (fields.length === 0) return [];
+    return { id: ctId, fields };
   });
 }
 

--- a/packages/slice-machine/src/features/customTypes/fields/ContentRelationshipFieldPicker.tsx
+++ b/packages/slice-machine/src/features/customTypes/fields/ContentRelationshipFieldPicker.tsx
@@ -234,7 +234,7 @@ function TreeViewCustomType(props: TreeViewCustomTypeProps) {
           );
         }
 
-        const nestedCtState = state?.[fieldOrNestedCt.id].value;
+        const nestedCtState = state?.[fieldOrNestedCt.id]?.value;
 
         const onNestedCustomTypeChange = (
           value: SetStateAction<PickerNestedCustomTypeValue>,
@@ -257,7 +257,7 @@ function TreeViewCustomType(props: TreeViewCustomTypeProps) {
         return fieldOrNestedCt.customtypes.map((nestedCt) => {
           if (typeof nestedCt === "string" || !nestedCt.fields) return null;
 
-          const nestedCtFields: PickerNestedCustomTypeFieldValue =
+          const nestedCtFields: PickerNestedCustomTypeFieldValue | undefined =
             nestedCtState !== undefined && typeof nestedCtState !== "boolean"
               ? nestedCtState[nestedCt.id]
               : {};

--- a/packages/slice-machine/src/features/customTypes/fields/ContentRelationshipFieldPicker.tsx
+++ b/packages/slice-machine/src/features/customTypes/fields/ContentRelationshipFieldPicker.tsx
@@ -453,7 +453,7 @@ function convertCustomTypesToFieldCheckMap(
         if (typeof field === "string") {
           customTypeFields[field] = { type: "checkbox", value: true };
         } else if (field.customtypes !== undefined) {
-          customTypeFields[field.id] = createNestedCustomTypeState(field);
+          customTypeFields[field.id] = createNestedCustomTypeField(field);
         }
 
         return customTypeFields;
@@ -464,7 +464,7 @@ function convertCustomTypesToFieldCheckMap(
   }, {});
 }
 
-function createNestedCustomTypeState(
+function createNestedCustomTypeField(
   field: TIContentRelationshipFieldValue,
 ): PickerContentRelationshipField {
   const crField: PickerContentRelationshipField = {

--- a/packages/slice-machine/src/features/customTypes/fields/ContentRelationshipFieldPicker.tsx
+++ b/packages/slice-machine/src/features/customTypes/fields/ContentRelationshipFieldPicker.tsx
@@ -10,29 +10,64 @@ import { useSelector } from "react-redux";
 
 import { selectAllCustomTypes } from "@/modules/availableCustomTypes";
 
-// picker state types
-
-type PickerCheckboxField = {
-  type: "checkbox";
-  value: boolean;
+/**
+ * Picker state types. Used internally to store the state of the TreeView.
+ *
+ * @example
+ * {
+ *   category: {
+ *     name: {
+ *       type: "checkbox",
+ *       value: true
+ *     }
+ *   },
+ *   author: {
+ *     firstName: {
+ *       type: "checkbox",
+ *       value: true
+ *     }
+ *     lastName: {
+ *       type: "checkbox",
+ *       value: false
+ *     }
+ *   }
+ * }
+ *
+ **/
+type PickerCustomTypes = {
+  [customTypeId: string]: PickerCustomType;
 };
 
 type PickerCustomType = {
   [fieldId: string]: PickerCheckboxField;
 };
 
-type PickerCustomTypes = {
-  [customTypeId: string]: PickerCustomType;
+type PickerCheckboxField = {
+  type: "checkbox";
+  value: boolean;
 };
 
-// copy of types-internal Link customtypes
+/**
+ * Copy of types-internal Link customtypes.
+ *
+ * @example
+ * [
+ *   {
+ *     id: "category",
+ *     fields: ["name"],
+ *   },
+ *   {
+ *     id: "author",
+ *     fields: ["firstName", "lastName"],
+ *   },
+ * ],
+ */
+type TICustomTypes = readonly (string | TICustomType)[];
 
 type TICustomType = {
   id: string;
   fields?: readonly string[] | undefined;
 };
-
-type TICustomTypes = readonly (string | TICustomType)[];
 
 interface ContentRelationshipFieldPickerProps {
   initialValues: TICustomTypes | undefined;
@@ -207,7 +242,10 @@ function useCustomTypes() {
   }, [allCustomTypes]);
 }
 
-/** Convert the customtypes config to the picker state */
+/**
+ * Converts a Link config `customtypes` ({@link TICustomTypes}) structure into
+ * picker state ({@link PickerCustomTypes}).
+ */
 function convertCustomTypesToState(value: TICustomTypes) {
   return value.reduce<PickerCustomTypes>((customTypes, customType) => {
     if (typeof customType === "string") {
@@ -230,7 +268,10 @@ function convertCustomTypesToState(value: TICustomTypes) {
   }, {});
 }
 
-/** Convert the picked fields map to the customtypes config and filter out empty customtypes */
+/**
+ * Converts a picker state structure ({@link PickerCustomTypes}) into Link
+ * config `customtypes` ({@link TICustomTypes} and filter out empty Custom types.
+ */
 function convertStateToCustomTypes(fields: PickerCustomTypes) {
   return Object.entries(fields).flatMap<TICustomType>(([ctId, ctFields]) => {
     const fields = Object.entries(ctFields).flatMap(([fieldId, checkbox]) =>

--- a/packages/slice-machine/src/features/customTypes/fields/ContentRelationshipFieldPicker.tsx
+++ b/packages/slice-machine/src/features/customTypes/fields/ContentRelationshipFieldPicker.tsx
@@ -211,8 +211,11 @@ function useCustomTypes() {
 
         const fields = customType.tabs.flatMap((tab) => {
           return tab.value.flatMap((field) => {
-            // filter out uid fields because it's a special field returned by the
+            // Filter out uid fields because it's a special field returned by the
             // API and is not part of the data object in the document.
+            // We also filter by key "uid", because (as of the time of writing
+            // this), creating any field with that API id will result in it being
+            // used for metadata.
             if (field.value.type === "UID" || field.key === "uid") {
               return [];
             }

--- a/packages/slice-machine/src/features/customTypes/fields/ContentRelationshipFieldPicker.tsx
+++ b/packages/slice-machine/src/features/customTypes/fields/ContentRelationshipFieldPicker.tsx
@@ -162,6 +162,10 @@ function TreeViewCustomType(props: TreeViewCustomTypeProps) {
   );
 }
 
+/**
+ * Get all the existing local custom types from the store and process them into
+ * a single array to be rendered by the picker.
+ */
 function useCustomTypes() {
   const allCustomTypes = useSelector(selectAllCustomTypes);
 
@@ -203,6 +207,7 @@ function useCustomTypes() {
   }, [allCustomTypes]);
 }
 
+/** Convert the customtypes config to the picker state */
 function convertCustomTypesToState(value: TICustomTypeFields) {
   return value.reduce<PickerCustomTypeFields>((customTypes, customType) => {
     if (typeof customType === "string") {

--- a/packages/slice-machine/src/features/customTypes/fields/ContentRelationshipFieldPicker.tsx
+++ b/packages/slice-machine/src/features/customTypes/fields/ContentRelationshipFieldPicker.tsx
@@ -1,4 +1,3 @@
-import { useStableCallback } from "@prismicio/editor-support/React";
 import {
   Box,
   Text,
@@ -6,7 +5,7 @@ import {
   TreeViewCheckbox,
   TreeViewSection,
 } from "@prismicio/editor-ui";
-import { SetStateAction, useEffect, useMemo, useState } from "react";
+import { SetStateAction, useMemo, useState } from "react";
 import { useSelector } from "react-redux";
 
 import { selectAllCustomTypes } from "@/modules/availableCustomTypes";
@@ -41,21 +40,18 @@ interface ContentRelationshipFieldPickerProps {
 export function ContentRelationshipFieldPicker(
   props: ContentRelationshipFieldPickerProps,
 ) {
-  const { initialValues, onChange } = props;
+  const { initialValues } = props;
   const customTypes = useCustomTypes();
 
-  const stableOnChange = useStableCallback(onChange);
   const [state, setState] = useState<PickerCustomTypeFields>(
     initialValues ? convertCustomTypesToState(initialValues) : {},
   );
 
-  useEffect(() => {
-    console.log("state", state);
-  }, [state]);
-
-  useEffect(() => {
-    stableOnChange(convertStateToCustomTypes(state));
-  }, [state, stableOnChange]);
+  function onChange(updated: SetStateAction<PickerCustomTypeFields>) {
+    const newState = typeof updated === "function" ? updated(state) : updated;
+    setState(newState);
+    props.onChange(convertStateToCustomTypes(newState));
+  }
 
   return (
     <Box overflow="hidden" flexDirection="column" border borderRadius={6}>
@@ -85,7 +81,7 @@ export function ContentRelationshipFieldPicker(
                 key={customType.id}
                 customType={customType}
                 state={state[customType.id]}
-                onChange={setState}
+                onChange={onChange}
                 labels={customTypes.labels}
               />
             );

--- a/packages/slice-machine/src/features/customTypes/fields/ContentRelationshipFieldPicker.tsx
+++ b/packages/slice-machine/src/features/customTypes/fields/ContentRelationshipFieldPicker.tsx
@@ -127,7 +127,7 @@ export function ContentRelationshipFieldPicker(
                 key={customType.id}
                 customType={customType}
                 onChange={onCustomTypeChange}
-                fieldCheckMap={fieldCheckMap[customType.id]}
+                fieldCheckMap={fieldCheckMap[customType.id] ?? {}}
               />
             );
           })}
@@ -153,7 +153,7 @@ export function ContentRelationshipFieldPicker(
 
 interface TreeViewCustomTypeProps {
   customType: TICustomType;
-  fieldCheckMap: PickerCustomType | undefined;
+  fieldCheckMap: PickerCustomType;
   onChange: (fn: (prev: PickerCustomType) => PickerCustomType) => void;
 }
 
@@ -171,7 +171,7 @@ function TreeViewCustomType(props: TreeViewCustomTypeProps) {
       badge="Custom type"
     >
       {customType.fields.map((fieldId) => {
-        const checked = fieldCheckMap?.[fieldId].value ?? false;
+        const checked = fieldCheckMap[fieldId]?.value ?? false;
 
         function onCheckedChange(value: boolean) {
           onChange((currentFields) => ({

--- a/packages/slice-machine/src/features/customTypes/fields/ContentRelationshipFieldPicker.tsx
+++ b/packages/slice-machine/src/features/customTypes/fields/ContentRelationshipFieldPicker.tsx
@@ -17,26 +17,26 @@ type PickerCheckboxField = {
   value: boolean;
 };
 
-type PickerCustomTypeField = {
+type PickerCustomType = {
   [fieldId: string]: PickerCheckboxField;
 };
 
-type PickerCustomTypeFields = {
-  [customTypeId: string]: PickerCustomTypeField;
+type PickerCustomTypes = {
+  [customTypeId: string]: PickerCustomType;
 };
 
-// copy of types-internal types
+// copy of types-internal Link customtypes
 
 type TICustomType = {
   id: string;
   fields?: readonly string[] | undefined;
 };
 
-type TICustomTypeFields = readonly (string | TICustomType)[];
+type TICustomTypes = readonly (string | TICustomType)[];
 
 interface ContentRelationshipFieldPickerProps {
-  initialValues: TICustomTypeFields | undefined;
-  onChange: (fields: TICustomTypeFields) => void;
+  initialValues: TICustomTypes | undefined;
+  onChange: (fields: TICustomTypes) => void;
 }
 
 export function ContentRelationshipFieldPicker(
@@ -45,11 +45,11 @@ export function ContentRelationshipFieldPicker(
   const { initialValues } = props;
   const { customTypes, labels } = useCustomTypes();
 
-  const [state, setState] = useState<PickerCustomTypeFields>(
+  const [state, setState] = useState<PickerCustomTypes>(
     initialValues ? convertCustomTypesToState(initialValues) : {},
   );
 
-  function onChange(updated: SetStateAction<PickerCustomTypeFields>) {
+  function onChange(updated: SetStateAction<PickerCustomTypes>) {
     const newState = typeof updated === "function" ? updated(state) : updated;
     setState(newState);
     props.onChange(convertStateToCustomTypes(newState));
@@ -106,8 +106,8 @@ export function ContentRelationshipFieldPicker(
 
 interface TreeViewCustomTypeProps {
   customType: TICustomType;
-  state: PickerCustomTypeField | undefined;
-  onChange: (state: SetStateAction<PickerCustomTypeFields>) => void;
+  state: PickerCustomType | undefined;
+  onChange: (state: SetStateAction<PickerCustomTypes>) => void;
   labels: Record<string, string>;
 }
 
@@ -116,7 +116,7 @@ function TreeViewCustomType(props: TreeViewCustomTypeProps) {
 
   if (!customType.fields) return null;
 
-  function onLevelChange(values: SetStateAction<PickerCustomTypeField>) {
+  function onLevelChange(values: SetStateAction<PickerCustomType>) {
     onChange((prev) => {
       const newState = { ...prev };
       if (typeof values === "function") {
@@ -208,8 +208,8 @@ function useCustomTypes() {
 }
 
 /** Convert the customtypes config to the picker state */
-function convertCustomTypesToState(value: TICustomTypeFields) {
-  return value.reduce<PickerCustomTypeFields>((customTypes, customType) => {
+function convertCustomTypesToState(value: TICustomTypes) {
+  return value.reduce<PickerCustomTypes>((customTypes, customType) => {
     if (typeof customType === "string") {
       customTypes[customType] = {};
       return customTypes;
@@ -218,7 +218,7 @@ function convertCustomTypesToState(value: TICustomTypeFields) {
     const { id, fields } = customType;
     if (fields === undefined) return customTypes;
 
-    customTypes[id] = fields.reduce<PickerCustomTypeField>(
+    customTypes[id] = fields.reduce<PickerCustomType>(
       (customTypeFields, field) => {
         customTypeFields[field] = { type: "checkbox", value: true };
         return customTypeFields;
@@ -231,7 +231,7 @@ function convertCustomTypesToState(value: TICustomTypeFields) {
 }
 
 /** Convert the picked fields map to the customtypes config and filter out empty customtypes */
-function convertStateToCustomTypes(fields: PickerCustomTypeFields) {
+function convertStateToCustomTypes(fields: PickerCustomTypes) {
   return Object.entries(fields).flatMap<TICustomType>(([ctId, ctFields]) => {
     const fields = Object.entries(ctFields).flatMap(([fieldId, checkbox]) =>
       checkbox.value ? [fieldId] : [],

--- a/packages/slice-machine/src/features/customTypes/fields/ContentRelationshipFieldPicker.tsx
+++ b/packages/slice-machine/src/features/customTypes/fields/ContentRelationshipFieldPicker.tsx
@@ -45,7 +45,9 @@ export function ContentRelationshipFieldPicker(
   const customTypes = useCustomTypes();
 
   const stableOnChange = useStableCallback(onChange);
-  const [state, setState] = useState<PickerCustomTypeFields>({});
+  const [state, setState] = useState<PickerCustomTypeFields>(
+    initialValues ? convertCustomTypesToState(initialValues) : {},
+  );
 
   useEffect(() => {
     console.log("state", state);

--- a/packages/slice-machine/src/features/customTypes/fields/ContentRelationshipFieldPicker.tsx
+++ b/packages/slice-machine/src/features/customTypes/fields/ContentRelationshipFieldPicker.tsx
@@ -194,7 +194,9 @@ function TreeViewCustomType(props: TreeViewCustomTypeProps) {
 
 /**
  * Get all the existing local custom types from the store and process them into
- * a single array to be rendered by the picker.
+ * a single array to be rendered by the picker. For this we use the same as the
+ * Link config `customtypes` structure {@link TICustomTypes}. Also creates a map
+ * of each custom type and field path and its corresponding label.
  */
 function useCustomTypes() {
   const allCustomTypes = useSelector(selectAllCustomTypes);

--- a/packages/slice-machine/src/features/customTypes/fields/ContentRelationshipFieldPicker.tsx
+++ b/packages/slice-machine/src/features/customTypes/fields/ContentRelationshipFieldPicker.tsx
@@ -84,8 +84,8 @@ export function ContentRelationshipFieldPicker(
     convertCustomTypesToState(initialValues),
   );
 
-  function onChange(updated: SetStateAction<PickerCustomTypes>) {
-    const newState = typeof updated === "function" ? updated(state) : updated;
+  function onChange(value: SetStateAction<PickerCustomTypes>) {
+    const newState = typeof value === "function" ? value(state) : value;
     setState(newState);
     props.onChange(convertStateToCustomTypes(newState));
   }
@@ -151,17 +151,12 @@ function TreeViewCustomType(props: TreeViewCustomTypeProps) {
 
   if (!customType.fields) return null;
 
-  function onLevelChange(values: SetStateAction<PickerCustomType>) {
-    onChange((prev) => {
-      const newState = { ...prev };
-      if (typeof values === "function") {
-        newState[customType.id] = values(prev[customType.id]);
-      } else {
-        newState[customType.id] = values;
-      }
-
-      return newState;
-    });
+  function onCustomTypeChange(value: SetStateAction<PickerCustomType>) {
+    onChange((prev) => ({
+      ...prev,
+      [customType.id]:
+        typeof value === "function" ? value(prev[customType.id]) : value,
+    }));
   }
 
   const fieldCount = countPickedFields(state);
@@ -177,10 +172,10 @@ function TreeViewCustomType(props: TreeViewCustomTypeProps) {
       {customType.fields.map((field) => {
         const checkboxState = state?.[field];
 
-        function onCheckedChange(checked: boolean) {
-          onLevelChange((prev) => ({
+        function onCheckedChange(value: boolean) {
+          onCustomTypeChange((prev) => ({
             ...prev,
-            [field]: { type: "checkbox", value: checked },
+            [field]: { type: "checkbox", value },
           }));
         }
 

--- a/packages/slice-machine/src/features/customTypes/fields/ContentRelationshipFieldPicker.tsx
+++ b/packages/slice-machine/src/features/customTypes/fields/ContentRelationshipFieldPicker.tsx
@@ -204,14 +204,11 @@ function TreeViewCustomType(props: TreeViewCustomTypeProps) {
     }));
   };
 
-  const fieldCount = countPickedFields(state);
-  const fieldCountLabel = fieldCount === 1 ? "1 field" : `${fieldCount} fields`;
-
   return (
     <TreeViewSection
       key={customType.id}
       title={customType.id}
-      subtitle={fieldCount > 0 ? `(${fieldCountLabel} exposed)` : undefined}
+      subtitle={getExposedFieldsLabel(countPickedFields(state))}
       badge="Custom type"
     >
       {customType.fields.map((fieldOrNestedCt) => {
@@ -308,7 +305,12 @@ function TreeViewContentRelationshipField(
     };
 
     return (
-      <TreeViewSection key={customType.id} title={customType.id}>
+      <TreeViewSection
+        key={customType.id}
+        title={customType.id}
+        subtitle={getExposedFieldsLabel(countPickedFields(fieldsState))}
+        badge="Custom type"
+      >
         {customType.fields.map((field) => {
           const { type, value: checked } = fieldsState?.[field] ?? {};
 
@@ -331,6 +333,11 @@ function TreeViewContentRelationshipField(
       </TreeViewSection>
     );
   });
+}
+
+function getExposedFieldsLabel(count: number) {
+  if (count === 0) return undefined;
+  return count === 1 ? "(1 field exposed)" : `(${count} fields exposed)`;
 }
 
 /**

--- a/packages/slice-machine/src/features/customTypes/fields/ContentRelationshipFieldPicker.tsx
+++ b/packages/slice-machine/src/features/customTypes/fields/ContentRelationshipFieldPicker.tsx
@@ -34,18 +34,18 @@ import { selectAllCustomTypes } from "@/modules/availableCustomTypes";
  * }
  *
  **/
-type PickerCustomTypes = {
+interface PickerCustomTypes {
   [customTypeId: string]: PickerCustomType;
-};
+}
 
-type PickerCustomType = {
+interface PickerCustomType {
   [fieldId: string]: PickerCheckboxField;
-};
+}
 
-type PickerCheckboxField = {
+interface PickerCheckboxField {
   type: "checkbox";
   value: boolean;
-};
+}
 
 /**
  * Copy of types-internal Link customtypes.
@@ -64,10 +64,10 @@ type PickerCheckboxField = {
  */
 type TICustomTypes = readonly (string | TICustomType)[];
 
-type TICustomType = {
+interface TICustomType {
   id: string;
   fields?: readonly string[] | undefined;
-};
+}
 
 interface ContentRelationshipFieldPickerProps {
   initialValues: TICustomTypes | undefined;
@@ -81,7 +81,7 @@ export function ContentRelationshipFieldPicker(
   const { customTypes, labels } = useCustomTypes();
 
   const [state, setState] = useState<PickerCustomTypes>(
-    initialValues ? convertCustomTypesToState(initialValues) : {},
+    convertCustomTypesToState(initialValues),
   );
 
   function onChange(updated: SetStateAction<PickerCustomTypes>) {
@@ -177,12 +177,12 @@ function TreeViewCustomType(props: TreeViewCustomTypeProps) {
       {customType.fields.map((field) => {
         const checkboxState = state?.[field];
 
-        const onCheckedChange = (checked: boolean) => {
+        function onCheckedChange(checked: boolean) {
           onLevelChange((prev) => ({
             ...prev,
             [field]: { type: "checkbox", value: checked },
           }));
-        };
+        }
 
         return (
           <TreeViewCheckbox
@@ -246,7 +246,9 @@ function useCustomTypes() {
  * Converts a Link config `customtypes` ({@link TICustomTypes}) structure into
  * picker state ({@link PickerCustomTypes}).
  */
-function convertCustomTypesToState(value: TICustomTypes) {
+function convertCustomTypesToState(value: TICustomTypes | undefined) {
+  if (value === undefined) return {};
+
   return value.reduce<PickerCustomTypes>((customTypes, customType) => {
     if (typeof customType === "string") {
       customTypes[customType] = {};

--- a/packages/slice-machine/src/features/customTypes/fields/ContentRelationshipFieldPicker.tsx
+++ b/packages/slice-machine/src/features/customTypes/fields/ContentRelationshipFieldPicker.tsx
@@ -220,7 +220,7 @@ function TreeViewCustomType(props: TreeViewCustomTypeProps) {
     >
       {customType.fields.map((field) => {
         if (typeof field === "string") {
-          const { type, value: checked } = fieldCheckMap[field] ?? {};
+          const checked = fieldCheckMap[field]?.value ?? false;
 
           const onCheckedChange = (value: boolean) => {
             onCustomTypeChange((currentFields) => ({
@@ -233,7 +233,7 @@ function TreeViewCustomType(props: TreeViewCustomTypeProps) {
             <TreeViewCheckbox
               key={field}
               title={field}
-              checked={type === "checkbox" ? checked : false}
+              checked={checked === true}
               onCheckedChange={onCheckedChange}
             />
           );
@@ -319,21 +319,21 @@ function TreeViewContentRelationshipField(
         )}
         badge="Custom type"
       >
-        {customType.fields.map((field) => {
-          const { type, value: checked } = customTypeFieldCheckMap[field] ?? {};
+        {customType.fields.map((fieldId) => {
+          const checked = customTypeFieldCheckMap[fieldId]?.value ?? false;
 
           const onCheckedChange = (value: boolean) => {
             onNestedCustomTypeChange((currentFields) => ({
               ...currentFields,
-              [field]: { type: "checkbox", value },
+              [fieldId]: { type: "checkbox", value },
             }));
           };
 
           return (
             <TreeViewCheckbox
-              key={field}
-              title={field}
-              checked={type === "checkbox" ? checked : false}
+              key={fieldId}
+              title={fieldId}
+              checked={checked === true}
               onCheckedChange={onCheckedChange}
             />
           );

--- a/packages/slice-machine/src/legacy/lib/models/common/widgets/ContentRelationship/Form.tsx
+++ b/packages/slice-machine/src/legacy/lib/models/common/widgets/ContentRelationship/Form.tsx
@@ -7,6 +7,7 @@ import { Col, Flex as FlexGrid } from "@/legacy/components/Flex";
 import WidgetFormField from "@/legacy/lib/builders/common/EditModal/Field";
 import { createFieldNameFromKey } from "@/legacy/lib/forms";
 import { DefaultFields } from "@/legacy/lib/forms/defaults";
+import { LinkConfig } from "@prismicio/types-internal/lib/customtypes";
 
 const FormFields = {
   label: DefaultFields.label,
@@ -43,7 +44,7 @@ type FormProps = {
   config: {
     label: string;
     select: string;
-    customtypes?: (string | { id: string; fields: string[] })[];
+    customtypes?: LinkConfig["customtypes"];
   };
   id: string;
   // TODO: this exists in the yup schema but this doesn't seem to be validated by formik

--- a/packages/slice-machine/src/legacy/lib/models/common/widgets/ContentRelationship/Form.tsx
+++ b/packages/slice-machine/src/legacy/lib/models/common/widgets/ContentRelationship/Form.tsx
@@ -11,16 +11,29 @@ import { DefaultFields } from "@/legacy/lib/forms/defaults";
 const FormFields = {
   label: DefaultFields.label,
   id: DefaultFields.id,
+  // TODO: Validate customtypes using existing types-internal codec
   customtypes: {
     validate: () =>
       yup.array(
-        yup.lazy((value) => {
-          return typeof value === "object"
-            ? yup.object({
-                id: yup.string(),
-                fields: yup.array(yup.string()),
-              })
-            : yup.string();
+        yup.object({
+          id: yup.string().required(),
+          fields: yup.array(
+            yup.lazy((value) =>
+              typeof value === "object"
+                ? yup.object({
+                    id: yup.string().required(),
+                    customtypes: yup
+                      .array(
+                        yup.object({
+                          id: yup.string().required(),
+                          fields: yup.array(yup.string()).required(),
+                        }),
+                      )
+                      .required(),
+                  })
+                : yup.string(),
+            ),
+          ),
         }),
       ),
   },

--- a/packages/slice-machine/src/legacy/lib/models/common/widgets/ContentRelationship/Form.tsx
+++ b/packages/slice-machine/src/legacy/lib/models/common/widgets/ContentRelationship/Form.tsx
@@ -1,3 +1,4 @@
+import { LinkConfig } from "@prismicio/types-internal/lib/customtypes";
 import { FormikProps } from "formik";
 import { Box } from "theme-ui";
 import * as yup from "yup";
@@ -7,7 +8,6 @@ import { Col, Flex as FlexGrid } from "@/legacy/components/Flex";
 import WidgetFormField from "@/legacy/lib/builders/common/EditModal/Field";
 import { createFieldNameFromKey } from "@/legacy/lib/forms";
 import { DefaultFields } from "@/legacy/lib/forms/defaults";
-import { LinkConfig } from "@prismicio/types-internal/lib/customtypes";
 
 const FormFields = {
   label: DefaultFields.label,

--- a/packages/slice-machine/src/legacy/lib/models/common/widgets/ContentRelationship/Form.tsx
+++ b/packages/slice-machine/src/legacy/lib/models/common/widgets/ContentRelationship/Form.tsx
@@ -38,6 +38,7 @@ type FormProps = {
 
 const WidgetForm = ({
   initialValues,
+  values,
   setFieldValue,
   fields,
 }: FormikProps<FormProps> & { fields: Record<string, unknown> }) => {
@@ -59,7 +60,7 @@ const WidgetForm = ({
       </FlexGrid>
       <Box mt={20}>
         <ContentRelationshipFieldPicker
-          initialValues={initialValues.config.customtypes}
+          value={values.config.customtypes}
           onChange={(fields) => {
             void setFieldValue("config.customtypes", fields);
           }}

--- a/packages/slice-machine/src/legacy/lib/models/common/widgets/ContentRelationship/index.ts
+++ b/packages/slice-machine/src/legacy/lib/models/common/widgets/ContentRelationship/index.ts
@@ -16,10 +16,10 @@ import Form, { FormFields } from "./Form";
  *   "type": "Link",
  *   "config": {
  *     "select": "document",
+ *     "label": "relationship"
  *     "customtypes": [
  *       "page"
  *     ],
- *     "label": "relationship"
  *   }
  * }
  *
@@ -28,13 +28,24 @@ import Form, { FormFields } from "./Form";
  *   "type": "Link",
  *   "config": {
  *     "select": "document",
+ *     "label": "relationship"
  *     "customtypes": [
  *       {
  *         "id": "page",
- *         "fields": ["uid", "country"]
+ *         "fields": [
+ *           "category",
+ *           {
+ *             "id": "countryRelation",
+ *             "customtypes": [
+ *               {
+ *                 "id": "country",
+ *                 "fields": ["name"]
+ *               }
+ *             ]
+ *           }
+ *         ]
  *       }
  *     ],
- *     "label": "relationship"
  *   }
  * }
  */
@@ -50,18 +61,30 @@ const contentRelationShipConfigSchema = linkConfigSchema.shape({
     .string()
     .required()
     .matches(/^document$/, { excludeEmptyString: true }),
+  // TODO: Validate customtypes using existing types-internal codec
   customtypes: yup
     .array(
-      yup.lazy((value) => {
-        return typeof value === "object"
-          ? yup.object({
-              id: yup.string(),
-              fields: yup.array(yup.string()),
-            })
-          : yup.string();
+      yup.object({
+        id: yup.string().required(),
+        fields: yup.array(
+          yup.lazy((value) =>
+            typeof value === "object"
+              ? yup.object({
+                  id: yup.string().required(),
+                  customtypes: yup
+                    .array(
+                      yup.object({
+                        id: yup.string().required(),
+                        fields: yup.array(yup.string()).required(),
+                      }),
+                    )
+                    .required(),
+                })
+              : yup.string(),
+          ),
+        ),
       }),
     )
-    .strict()
     .optional(),
 });
 

--- a/packages/slice-machine/src/utils/isValidObject.ts
+++ b/packages/slice-machine/src/utils/isValidObject.ts
@@ -1,0 +1,9 @@
+export function isValidObject(value: unknown): value is Record<string, unknown> {
+  if (typeof value !== "object" || value === null) return false;
+  if (Array.isArray(value)) return false;
+  return !(
+    value instanceof Date ||
+    value instanceof RegExp ||
+    value instanceof Error
+  );
+}

--- a/packages/slice-machine/src/utils/isValidObject.ts
+++ b/packages/slice-machine/src/utils/isValidObject.ts
@@ -1,11 +1,32 @@
+/**
+ * Ensure that the value is an record/object with string keys and existing
+ * properties. Accepts empty objects and objects created with
+ * `Object.create(null)`.
+ */
 export function isValidObject(
   value: unknown,
 ): value is Record<string, unknown> {
   if (typeof value !== "object" || value === null) return false;
+
   if (Array.isArray(value)) return false;
-  return !(
+
+  if (
     value instanceof Date ||
     value instanceof RegExp ||
     value instanceof Error
-  );
+  ) {
+    return false;
+  }
+
+  // Check if all keys are strings and all values are valid
+  for (const key in value) {
+    if (
+      typeof key !== "string" ||
+      !Object.prototype.hasOwnProperty.call(value, key)
+    ) {
+      return false;
+    }
+  }
+
+  return true;
 }

--- a/packages/slice-machine/src/utils/isValidObject.ts
+++ b/packages/slice-machine/src/utils/isValidObject.ts
@@ -1,4 +1,6 @@
-export function isValidObject(value: unknown): value is Record<string, unknown> {
+export function isValidObject(
+  value: unknown,
+): value is Record<string, unknown> {
   if (typeof value !== "object" || value === null) return false;
   if (Array.isArray(value)) return false;
   return !(


### PR DESCRIPTION
Relates to: DT-2692

### Description

For the new Content Relationship field picker, add the ability to pick fields inside a nested Content Relationship.

### Illustration
```
customTypeA
├── fieldA1 (Text)
├── fieldA2 (Image)
└── fieldA3 (Content Relationship → customTypeB)
    ├── fieldB1 (Text)
    └── fieldB2 (Image) ✅ Checked
```

### Preview

![Screenshot 2025-06-03 at 11 42 54](https://github.com/user-attachments/assets/0d63ea1b-7f39-438f-b62b-d8bafc07b00b)

https://github.com/user-attachments/assets/06bced19-2607-4644-9256-30da1db11140

### How to QA [^1]

<!-- When relevant, describe how to QA your changes. -->

<!-- Your favorite emoji is welcome to close your PR! -->

<!-- A note for reviewers: -->

[^1]:
	Please use these labels when submitting a review:
	:question: #ask:&ensp;Ask a question.
	:bulb: #idea:&ensp;Suggest an idea.
	:warning: #issue:&ensp;Strongly suggest a change.
	:tada: #nice:&ensp;Share a compliment.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for selecting nested content relationship fields within custom types, allowing users to configure and expose fields in linked custom types at multiple levels.
  - Enhanced the picker interface to display and manage nested field selections with improved labeling and user feedback.

- **Bug Fixes**
  - Improved validation for custom type relationship fields, ensuring correct structure for deeply nested configurations.

- **Documentation**
  - Updated example JSON and comments to reflect new nested relationship support and labeling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->