### PR TITLE
[DT-2692] feat: pick content relationship GROUP fields

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "connected-next-router/react-redux": "8.0.7",
     "react-beautiful-dnd/react-redux": "8.0.7",
     "express": "4.20.0",
-    "@prismicio/types-internal": "3.10.0"
+    "@prismicio/types-internal": "3.10.1"
   },
   "workspaces": [
     "playwright",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "connected-next-router/react-redux": "8.0.7",
     "react-beautiful-dnd/react-redux": "8.0.7",
     "express": "4.20.0",
-    "@prismicio/types-internal": "3.11.0-alpha.0"
+    "@prismicio/types-internal": "3.11.0"
   },
   "workspaces": [
     "playwright",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "connected-next-router/react-redux": "8.0.7",
     "react-beautiful-dnd/react-redux": "8.0.7",
     "express": "4.20.0",
-    "@prismicio/types-internal": "3.10.1"
+    "@prismicio/types-internal": "3.11.0-alpha.0"
   },
   "workspaces": [
     "playwright",

--- a/packages/adapter-next/package.json
+++ b/packages/adapter-next/package.json
@@ -67,7 +67,7 @@
 	},
 	"dependencies": {
 		"@prismicio/simulator": "^0.1.4",
-		"@prismicio/types-internal": "3.11.0-alpha.0",
+		"@prismicio/types-internal": "3.11.0",
 		"@slicemachine/plugin-kit": "workspace:*",
 		"common-tags": "^1.8.2",
 		"fp-ts": "^2.13.1",

--- a/packages/adapter-next/package.json
+++ b/packages/adapter-next/package.json
@@ -67,7 +67,7 @@
 	},
 	"dependencies": {
 		"@prismicio/simulator": "^0.1.4",
-		"@prismicio/types-internal": "3.10.1",
+		"@prismicio/types-internal": "3.11.0-alpha.0",
 		"@slicemachine/plugin-kit": "workspace:*",
 		"common-tags": "^1.8.2",
 		"fp-ts": "^2.13.1",

--- a/packages/adapter-next/package.json
+++ b/packages/adapter-next/package.json
@@ -67,7 +67,7 @@
 	},
 	"dependencies": {
 		"@prismicio/simulator": "^0.1.4",
-		"@prismicio/types-internal": "3.10.0",
+		"@prismicio/types-internal": "3.10.1",
 		"@slicemachine/plugin-kit": "workspace:*",
 		"common-tags": "^1.8.2",
 		"fp-ts": "^2.13.1",

--- a/packages/adapter-nuxt/package.json
+++ b/packages/adapter-nuxt/package.json
@@ -60,7 +60,7 @@
 	},
 	"dependencies": {
 		"@prismicio/simulator": "^0.1.4",
-		"@prismicio/types-internal": "3.11.0-alpha.0",
+		"@prismicio/types-internal": "3.11.0",
 		"@slicemachine/plugin-kit": "workspace:*",
 		"common-tags": "^1.8.2",
 		"fp-ts": "^2.13.1",

--- a/packages/adapter-nuxt/package.json
+++ b/packages/adapter-nuxt/package.json
@@ -60,7 +60,7 @@
 	},
 	"dependencies": {
 		"@prismicio/simulator": "^0.1.4",
-		"@prismicio/types-internal": "3.10.0",
+		"@prismicio/types-internal": "3.10.1",
 		"@slicemachine/plugin-kit": "workspace:*",
 		"common-tags": "^1.8.2",
 		"fp-ts": "^2.13.1",

--- a/packages/adapter-nuxt/package.json
+++ b/packages/adapter-nuxt/package.json
@@ -60,7 +60,7 @@
 	},
 	"dependencies": {
 		"@prismicio/simulator": "^0.1.4",
-		"@prismicio/types-internal": "3.10.1",
+		"@prismicio/types-internal": "3.11.0-alpha.0",
 		"@slicemachine/plugin-kit": "workspace:*",
 		"common-tags": "^1.8.2",
 		"fp-ts": "^2.13.1",

--- a/packages/adapter-nuxt2/package.json
+++ b/packages/adapter-nuxt2/package.json
@@ -60,7 +60,7 @@
 	},
 	"dependencies": {
 		"@prismicio/simulator": "^0.1.4",
-		"@prismicio/types-internal": "3.11.0-alpha.0",
+		"@prismicio/types-internal": "3.11.0",
 		"@slicemachine/plugin-kit": "workspace:*",
 		"common-tags": "^1.8.2",
 		"fp-ts": "^2.13.1",

--- a/packages/adapter-nuxt2/package.json
+++ b/packages/adapter-nuxt2/package.json
@@ -60,7 +60,7 @@
 	},
 	"dependencies": {
 		"@prismicio/simulator": "^0.1.4",
-		"@prismicio/types-internal": "3.10.0",
+		"@prismicio/types-internal": "3.10.1",
 		"@slicemachine/plugin-kit": "workspace:*",
 		"common-tags": "^1.8.2",
 		"fp-ts": "^2.13.1",

--- a/packages/adapter-nuxt2/package.json
+++ b/packages/adapter-nuxt2/package.json
@@ -60,7 +60,7 @@
 	},
 	"dependencies": {
 		"@prismicio/simulator": "^0.1.4",
-		"@prismicio/types-internal": "3.10.1",
+		"@prismicio/types-internal": "3.11.0-alpha.0",
 		"@slicemachine/plugin-kit": "workspace:*",
 		"common-tags": "^1.8.2",
 		"fp-ts": "^2.13.1",

--- a/packages/adapter-sveltekit/package.json
+++ b/packages/adapter-sveltekit/package.json
@@ -63,7 +63,7 @@
 	},
 	"dependencies": {
 		"@prismicio/simulator": "^0.1.4",
-		"@prismicio/types-internal": "3.10.1",
+		"@prismicio/types-internal": "3.11.0-alpha.0",
 		"@slicemachine/plugin-kit": "workspace:*",
 		"common-tags": "^1.8.2",
 		"fp-ts": "^2.13.1",

--- a/packages/adapter-sveltekit/package.json
+++ b/packages/adapter-sveltekit/package.json
@@ -63,7 +63,7 @@
 	},
 	"dependencies": {
 		"@prismicio/simulator": "^0.1.4",
-		"@prismicio/types-internal": "3.10.0",
+		"@prismicio/types-internal": "3.10.1",
 		"@slicemachine/plugin-kit": "workspace:*",
 		"common-tags": "^1.8.2",
 		"fp-ts": "^2.13.1",

--- a/packages/adapter-sveltekit/package.json
+++ b/packages/adapter-sveltekit/package.json
@@ -63,7 +63,7 @@
 	},
 	"dependencies": {
 		"@prismicio/simulator": "^0.1.4",
-		"@prismicio/types-internal": "3.11.0-alpha.0",
+		"@prismicio/types-internal": "3.11.0",
 		"@slicemachine/plugin-kit": "workspace:*",
 		"common-tags": "^1.8.2",
 		"fp-ts": "^2.13.1",

--- a/packages/manager/package.json
+++ b/packages/manager/package.json
@@ -68,7 +68,7 @@
 		"@prismicio/client": "7.17.0",
 		"@prismicio/custom-types-client": "2.1.0",
 		"@prismicio/mocks": "2.13.0",
-		"@prismicio/types-internal": "3.10.0",
+		"@prismicio/types-internal": "3.10.1",
 		"@segment/analytics-node": "^2.1.2",
 		"@slicemachine/plugin-kit": "workspace:*",
 		"cookie": "^1.0.1",

--- a/packages/manager/package.json
+++ b/packages/manager/package.json
@@ -68,7 +68,7 @@
 		"@prismicio/client": "7.17.0",
 		"@prismicio/custom-types-client": "2.1.0",
 		"@prismicio/mocks": "2.13.0",
-		"@prismicio/types-internal": "3.11.0-alpha.0",
+		"@prismicio/types-internal": "3.11.0",
 		"@segment/analytics-node": "^2.1.2",
 		"@slicemachine/plugin-kit": "workspace:*",
 		"cookie": "^1.0.1",

--- a/packages/manager/package.json
+++ b/packages/manager/package.json
@@ -68,7 +68,7 @@
 		"@prismicio/client": "7.17.0",
 		"@prismicio/custom-types-client": "2.1.0",
 		"@prismicio/mocks": "2.13.0",
-		"@prismicio/types-internal": "3.10.1",
+		"@prismicio/types-internal": "3.11.0-alpha.0",
 		"@segment/analytics-node": "^2.1.2",
 		"@slicemachine/plugin-kit": "workspace:*",
 		"cookie": "^1.0.1",

--- a/packages/manager/src/managers/customTypes/CustomTypesManager.ts
+++ b/packages/manager/src/managers/customTypes/CustomTypesManager.ts
@@ -674,7 +674,7 @@ function updateFieldContentRelationships<
 
 	const newCustomTypes = field.config.customtypes.map((customType) => {
 		return updateCRCustomType({
-			// TODO: Remove as in https://linear.app/prismic/issue/DT-2704/
+			// TODO: Remove cast in https://linear.app/prismic/issue/DT-2704/
 			customType: customType as CrCustomType,
 			...updateMeta,
 		});

--- a/packages/manager/src/managers/customTypes/CustomTypesManager.ts
+++ b/packages/manager/src/managers/customTypes/CustomTypesManager.ts
@@ -673,7 +673,11 @@ function updateFieldContentRelationships<
 	}
 
 	const newCustomTypes = field.config.customtypes.map((customType) => {
-		return updateCRCustomType({ customType, ...updateMeta });
+		return updateCRCustomType({
+			// TODO: Remove as in https://linear.app/prismic/issue/DT-2704/
+			customType: customType as CrCustomType,
+			...updateMeta,
+		});
 	});
 
 	return {

--- a/packages/plugin-kit/package.json
+++ b/packages/plugin-kit/package.json
@@ -76,7 +76,7 @@
 	},
 	"devDependencies": {
 		"@prismicio/mock": "0.7.1",
-		"@prismicio/types-internal": "3.11.0-alpha.0",
+		"@prismicio/types-internal": "3.11.0",
 		"@size-limit/preset-small-lib": "8.2.4",
 		"@types/common-tags": "1.8.1",
 		"@types/fs-extra": "11.0.1",

--- a/packages/plugin-kit/package.json
+++ b/packages/plugin-kit/package.json
@@ -76,7 +76,7 @@
 	},
 	"devDependencies": {
 		"@prismicio/mock": "0.7.1",
-		"@prismicio/types-internal": "3.10.0",
+		"@prismicio/types-internal": "3.10.1",
 		"@size-limit/preset-small-lib": "8.2.4",
 		"@types/common-tags": "1.8.1",
 		"@types/fs-extra": "11.0.1",

--- a/packages/plugin-kit/package.json
+++ b/packages/plugin-kit/package.json
@@ -76,7 +76,7 @@
 	},
 	"devDependencies": {
 		"@prismicio/mock": "0.7.1",
-		"@prismicio/types-internal": "3.10.1",
+		"@prismicio/types-internal": "3.11.0-alpha.0",
 		"@size-limit/preset-small-lib": "8.2.4",
 		"@types/common-tags": "1.8.1",
 		"@types/fs-extra": "11.0.1",

--- a/packages/slice-machine/package.json
+++ b/packages/slice-machine/package.json
@@ -48,7 +48,7 @@
     "@prismicio/mock": "0.7.1",
     "@prismicio/mocks": "2.13.0",
     "@prismicio/simulator": "0.1.4",
-    "@prismicio/types-internal": "3.10.1",
+    "@prismicio/types-internal": "3.11.0-alpha.0",
     "@radix-ui/react-hover-card": "1.0.6",
     "@radix-ui/react-tabs": "1.0.4",
     "@radix-ui/react-visually-hidden": "1.1.1",

--- a/packages/slice-machine/package.json
+++ b/packages/slice-machine/package.json
@@ -48,7 +48,7 @@
     "@prismicio/mock": "0.7.1",
     "@prismicio/mocks": "2.13.0",
     "@prismicio/simulator": "0.1.4",
-    "@prismicio/types-internal": "3.10.0",
+    "@prismicio/types-internal": "3.10.1",
     "@radix-ui/react-hover-card": "1.0.6",
     "@radix-ui/react-tabs": "1.0.4",
     "@radix-ui/react-visually-hidden": "1.1.1",

--- a/packages/slice-machine/package.json
+++ b/packages/slice-machine/package.json
@@ -48,7 +48,7 @@
     "@prismicio/mock": "0.7.1",
     "@prismicio/mocks": "2.13.0",
     "@prismicio/simulator": "0.1.4",
-    "@prismicio/types-internal": "3.11.0-alpha.0",
+    "@prismicio/types-internal": "3.11.0",
     "@radix-ui/react-hover-card": "1.0.6",
     "@radix-ui/react-tabs": "1.0.4",
     "@radix-ui/react-visually-hidden": "1.1.1",

--- a/packages/slice-machine/src/features/customTypes/fields/ContentRelationshipFieldPicker.tsx
+++ b/packages/slice-machine/src/features/customTypes/fields/ContentRelationshipFieldPicker.tsx
@@ -170,21 +170,21 @@ function TreeViewCustomType(props: TreeViewCustomTypeProps) {
       subtitle={fieldCount > 0 ? `(${fieldCountLabel} exposed)` : undefined}
       badge="Custom type"
     >
-      {customType.fields.map((field) => {
-        const checkboxState = fieldCheckMap?.[field];
+      {customType.fields.map((fieldId) => {
+        const checked = fieldCheckMap?.[fieldId].value ?? false;
 
         function onCheckedChange(value: boolean) {
           onChange((currentFields) => ({
             ...currentFields,
-            [field]: { type: "checkbox", value },
+            [fieldId]: { type: "checkbox", value },
           }));
         }
 
         return (
           <TreeViewCheckbox
-            key={field}
-            title={field}
-            checked={checkboxState?.value ?? false}
+            key={fieldId}
+            title={fieldId}
+            checked={checked}
             onCheckedChange={onCheckedChange}
           />
         );

--- a/packages/slice-machine/src/features/customTypes/fields/ContentRelationshipFieldPicker.tsx
+++ b/packages/slice-machine/src/features/customTypes/fields/ContentRelationshipFieldPicker.tsx
@@ -10,6 +10,8 @@ import { useSelector } from "react-redux";
 
 import { selectAllCustomTypes } from "@/modules/availableCustomTypes";
 
+// picker state types
+
 type PickerCheckboxField = {
   type: "checkbox";
   value: boolean;
@@ -41,7 +43,7 @@ export function ContentRelationshipFieldPicker(
   props: ContentRelationshipFieldPickerProps,
 ) {
   const { initialValues } = props;
-  const customTypes = useCustomTypes();
+  const { customTypes, labels } = useCustomTypes();
 
   const [state, setState] = useState<PickerCustomTypeFields>(
     initialValues ? convertCustomTypesToState(initialValues) : {},
@@ -73,13 +75,13 @@ export function ContentRelationshipFieldPicker(
           title="Exposed fields"
           subtitle={`(${countPickedFields(state)})`}
         >
-          {customTypes.customTypes.map((customType) => (
+          {customTypes.map((customType) => (
             <TreeViewCustomType
               key={customType.id}
               customType={customType}
               state={state[customType.id]}
               onChange={onChange}
-              labels={customTypes.labels}
+              labels={labels}
             />
           ))}
         </TreeView>

--- a/packages/slice-machine/src/features/customTypes/fields/ContentRelationshipFieldPicker.tsx
+++ b/packages/slice-machine/src/features/customTypes/fields/ContentRelationshipFieldPicker.tsx
@@ -73,19 +73,15 @@ export function ContentRelationshipFieldPicker(
           title="Exposed fields"
           subtitle={`(${countPickedFields(state)})`}
         >
-          {customTypes.customTypes.map((customType) => {
-            if (typeof customType === "string") return null;
-
-            return (
-              <TreeViewCustomType
-                key={customType.id}
-                customType={customType}
-                state={state[customType.id]}
-                onChange={onChange}
-                labels={customTypes.labels}
-              />
-            );
-          })}
+          {customTypes.customTypes.map((customType) => (
+            <TreeViewCustomType
+              key={customType.id}
+              customType={customType}
+              state={state[customType.id]}
+              onChange={onChange}
+              labels={customTypes.labels}
+            />
+          ))}
         </TreeView>
       </Box>
       <Box backgroundColor="white" flexDirection="column" padding={12}>

--- a/packages/slice-machine/src/features/customTypes/fields/ContentRelationshipFieldPicker.tsx
+++ b/packages/slice-machine/src/features/customTypes/fields/ContentRelationshipFieldPicker.tsx
@@ -332,7 +332,7 @@ function TreeViewCustomType(props: TreeViewCustomTypeProps) {
 }
 
 interface TreeViewContentRelationshipFieldProps {
-  field: TIContentRelationshipFieldValue | TIGroupFieldValues;
+  field: TIContentRelationshipFieldValue;
   fieldCheckMap: PickerContentRelationshipFieldValue;
   onChange: (updater: (prev: PickerCustomType) => PickerCustomType) => void;
 }
@@ -366,92 +366,88 @@ function TreeViewContentRelationshipField(
     });
   };
 
-  if ("customtypes" in crField) {
-    return crField.customtypes.map((customType) => {
-      if (typeof customType === "string") return null;
+  return crField.customtypes.map((customType) => {
+    if (typeof customType === "string") return null;
 
-      const ctFieldCheckMap = customTypeFieldCheckMap[customType.id] ?? {};
+    const ctFieldCheckMap = customTypeFieldCheckMap[customType.id] ?? {};
 
-      const onNestedCustomTypeChange = (
-        updater: (
-          prev: PickerNestedCustomTypeValue,
-        ) => PickerNestedCustomTypeValue,
-      ) => {
-        onContentRelationshipFieldChange((currentCustomTypes) => ({
-          ...currentCustomTypes,
-          [customType.id]: updater(currentCustomTypes[customType.id] ?? {}),
-        }));
-      };
+    const onNestedCustomTypeChange = (
+      updater: (
+        prev: PickerNestedCustomTypeValue,
+      ) => PickerNestedCustomTypeValue,
+    ) => {
+      onContentRelationshipFieldChange((currentCustomTypes) => ({
+        ...currentCustomTypes,
+        [customType.id]: updater(currentCustomTypes[customType.id] ?? {}),
+      }));
+    };
 
-      return (
-        <TreeViewSection
-          key={customType.id}
-          title={customType.id}
-          subtitle={getExposedFieldsLabel(countPickedFields(ctFieldCheckMap))}
-          badge="Custom type"
-        >
-          {customType.fields.map((field) => {
-            if (typeof field === "string") {
-              const checked = ctFieldCheckMap[field]?.value === true;
+    return (
+      <TreeViewSection
+        key={customType.id}
+        title={customType.id}
+        subtitle={getExposedFieldsLabel(countPickedFields(ctFieldCheckMap))}
+        badge="Custom type"
+      >
+        {customType.fields.map((field) => {
+          if (typeof field === "string") {
+            const checked = ctFieldCheckMap[field]?.value === true;
 
-              const onCheckedChange = (newValue: boolean) => {
-                onNestedCustomTypeChange((currentFields) => ({
-                  ...currentFields,
-                  [field]: { type: "checkbox", value: newValue },
-                }));
-              };
-
-              return (
-                <TreeViewCheckbox
-                  key={field}
-                  title={field}
-                  checked={checked}
-                  onCheckedChange={onCheckedChange}
-                />
-              );
-            }
-
-            const groupFieldCheckMap = ctFieldCheckMap[field.id] ?? {};
-
-            const onGroupFieldsChange = (
-              updater: (
-                prev: PickerGroupFieldWithoutContentRelationshipValue,
-              ) => PickerGroupFieldWithoutContentRelationshipValue,
-            ) => {
-              onNestedCustomTypeChange((currentFields) => {
-                const prevCtValue = currentFields[field.id] ?? {};
-                const prevCtValueNarrowed =
-                  prevCtValue.type === "group" ? prevCtValue.value : {};
-
-                return {
-                  ...currentFields,
-                  [field.id]: {
-                    type: "group",
-                    value: updater(prevCtValueNarrowed),
-                  },
-                };
-              });
+            const onCheckedChange = (newValue: boolean) => {
+              onNestedCustomTypeChange((currentFields) => ({
+                ...currentFields,
+                [field]: { type: "checkbox", value: newValue },
+              }));
             };
 
             return (
-              <TreeViewContentRelationshipFieldNestedGroup
-                key={field.id}
-                group={field}
-                onChange={onGroupFieldsChange}
-                fieldCheckMap={
-                  groupFieldCheckMap.type === "group"
-                    ? groupFieldCheckMap.value
-                    : {}
-                }
+              <TreeViewCheckbox
+                key={field}
+                title={field}
+                checked={checked}
+                onCheckedChange={onCheckedChange}
               />
             );
-          })}
-        </TreeViewSection>
-      );
-    });
-  }
+          }
 
-  return null;
+          const groupFieldCheckMap = ctFieldCheckMap[field.id] ?? {};
+
+          const onGroupFieldsChange = (
+            updater: (
+              prev: PickerGroupFieldWithoutContentRelationshipValue,
+            ) => PickerGroupFieldWithoutContentRelationshipValue,
+          ) => {
+            onNestedCustomTypeChange((currentFields) => {
+              const prevCtValue = currentFields[field.id] ?? {};
+              const prevCtValueNarrowed =
+                prevCtValue.type === "group" ? prevCtValue.value : {};
+
+              return {
+                ...currentFields,
+                [field.id]: {
+                  type: "group",
+                  value: updater(prevCtValueNarrowed),
+                },
+              };
+            });
+          };
+
+          return (
+            <TreeViewContentRelationshipFieldNestedGroup
+              key={field.id}
+              group={field}
+              onChange={onGroupFieldsChange}
+              fieldCheckMap={
+                groupFieldCheckMap.type === "group"
+                  ? groupFieldCheckMap.value
+                  : {}
+              }
+            />
+          );
+        })}
+      </TreeViewSection>
+    );
+  });
 }
 
 interface TreeViewContentRelationshipFieldGroupProps {

--- a/packages/slice-machine/src/features/customTypes/fields/ContentRelationshipFieldPicker.tsx
+++ b/packages/slice-machine/src/features/customTypes/fields/ContentRelationshipFieldPicker.tsx
@@ -228,15 +228,10 @@ function convertCustomTypesToState(value: TICustomTypeFields) {
 /** Convert the picked fields map to the customtypes config and filter out empty customtypes */
 function convertStateToCustomTypes(fields: PickerCustomTypeFields) {
   return Object.entries(fields).flatMap<TICustomType>(([ctId, ctFields]) => {
-    const ctFieldEntries = Object.entries(ctFields);
-    if (!ctFieldEntries.some(([_, checked]) => checked)) return [];
-
-    const fields = ctFieldEntries.flatMap(([id, checkbox]) =>
-      checkbox.value ? [id] : [],
+    const fields = Object.entries(ctFields).flatMap(([fieldId, checkbox]) =>
+      checkbox.value ? [fieldId] : [],
     );
-
-    if (fields.length === 0) return [];
-    return { id: ctId, fields };
+    return fields.length > 0 ? { id: ctId, fields } : [];
   });
 }
 

--- a/packages/slice-machine/src/features/customTypes/fields/ContentRelationshipFieldPicker.tsx
+++ b/packages/slice-machine/src/features/customTypes/fields/ContentRelationshipFieldPicker.tsx
@@ -72,8 +72,6 @@ interface TICustomType {
   fields: readonly string[];
 }
 
-type Updater<T> = (prev: T) => T;
-
 interface ContentRelationshipFieldPickerProps {
   value: TICustomTypes | undefined;
   onChange: (fields: TICustomTypes) => void;
@@ -86,7 +84,9 @@ export function ContentRelationshipFieldPicker(
   const customTypes = useCustomTypes();
   const fieldCheckMap = value ? convertCustomTypesToFieldCheckMap(value) : {};
 
-  function onCustomTypesChange(updater: Updater<PickerCustomTypes>) {
+  function onCustomTypesChange(
+    updater: (prev: PickerCustomTypes) => PickerCustomTypes,
+  ) {
     onChange(convertFieldCheckMapToCustomTypes(updater(fieldCheckMap)));
   }
 
@@ -111,7 +111,9 @@ export function ContentRelationshipFieldPicker(
           subtitle={`(${countPickedFields(fieldCheckMap)})`}
         >
           {customTypes.map((customType) => {
-            const onCustomTypeChange = (updater: Updater<PickerCustomType>) => {
+            const onCustomTypeChange = (
+              updater: (prev: PickerCustomType) => PickerCustomType,
+            ) => {
               onCustomTypesChange((currentCustomTypes) => ({
                 ...currentCustomTypes,
                 [customType.id]: updater(
@@ -152,7 +154,7 @@ export function ContentRelationshipFieldPicker(
 interface TreeViewCustomTypeProps {
   customType: TICustomType;
   fieldCheckMap: PickerCustomType | undefined;
-  onChange: (fn: Updater<PickerCustomType>) => void;
+  onChange: (fn: (prev: PickerCustomType) => PickerCustomType) => void;
 }
 
 function TreeViewCustomType(props: TreeViewCustomTypeProps) {

--- a/packages/slice-machine/src/features/customTypes/fields/ContentRelationshipFieldPicker.tsx
+++ b/packages/slice-machine/src/features/customTypes/fields/ContentRelationshipFieldPicker.tsx
@@ -134,19 +134,21 @@ type TICustomTypes = readonly (string | TICustomType)[];
 
 interface TICustomType {
   id: string;
-  fields?:
-    | readonly (string | TIContentRelationshipFieldValue | TIGroupFieldValues)[]
-    | undefined;
+  fields: readonly (
+    | string
+    | TIContentRelationshipFieldValue
+    | TIGroupFieldValues
+  )[];
 }
 
 interface TICustomTypeRegularFieldValues {
   id: string;
-  fields?: readonly string[] | undefined;
+  fields: readonly string[];
 }
 
 interface TIGroupFieldValues {
   id: string;
-  fields?: readonly (string | TIContentRelationshipFieldValue)[] | undefined;
+  fields: readonly (string | TIContentRelationshipFieldValue)[];
 }
 
 interface TIContentRelationshipFieldValue {
@@ -156,7 +158,7 @@ interface TIContentRelationshipFieldValue {
 
 interface TICustomTypeFieldValues {
   id: string;
-  fields?: readonly (string | TICustomTypeRegularFieldValues)[] | undefined;
+  fields: readonly (string | TICustomTypeRegularFieldValues)[];
 }
 
 interface ContentRelationshipFieldPickerProps {
@@ -250,8 +252,6 @@ function TreeViewCustomType(props: TreeViewCustomTypeProps) {
     fieldCheckMap: customTypeFieldCheckMap,
     onChange: onCustomTypeChange,
   } = props;
-
-  if (!customType.fields) return null;
 
   return (
     <TreeViewSection
@@ -353,8 +353,7 @@ function TreeViewContentRelationshipField(
 
   if ("customtypes" in crField) {
     return crField.customtypes.map((customType) => {
-      // Invalid nested custom type, we need to have fields.
-      if (typeof customType === "string" || !customType.fields) return null;
+      if (typeof customType === "string") return null;
 
       const ctFieldCheckMap = customTypeFieldCheckMap[customType.id] ?? {};
 
@@ -415,7 +414,6 @@ interface TreeViewGroupFieldProps {
 
 function TreeViewGroupField(props: TreeViewGroupFieldProps) {
   const { group, fieldCheckMap, onChange: onCustomTypeChange } = props;
-  if (!group.fields) return null;
 
   const onGroupFieldChange = (
     updater: (prev: PickerGroupFieldValue) => PickerGroupFieldValue,
@@ -544,7 +542,7 @@ function resolveContentRelationshipFields(
 ): TICustomTypeFieldValues[] {
   const fields = customTypesArray.flatMap<TICustomTypeFieldValues>(
     (customType) => {
-      if (typeof customType === "string" || !customType.fields) return [];
+      if (typeof customType === "string") return [];
 
       const matchingCustomType = localCustomTypes.find(
         (ct) => ct.id === customType.id,
@@ -584,9 +582,7 @@ function convertCustomTypesToFieldCheckMap(
   customTypes: TICustomTypes,
 ): PickerCustomTypes {
   return customTypes.reduce<PickerCustomTypes>((customTypes, customType) => {
-    if (typeof customType === "string" || !customType.fields) {
-      return customTypes;
-    }
+    if (typeof customType === "string") return customTypes;
 
     customTypes[customType.id] = customType.fields.reduce<PickerCustomType>(
       (customTypeFields, field) => {
@@ -607,7 +603,6 @@ function convertCustomTypesToFieldCheckMap(
 }
 
 function createGroupField(group: TIGroupFieldValues): PickerGroupField {
-  if (!group.fields) return { type: "group", value: {} };
   return {
     type: "group",
     value: group.fields.reduce<PickerGroupFieldValue>((fields, field) => {
@@ -632,7 +627,7 @@ function createNestedCustomTypeField(
   const crFieldCustomTypes = crField.value;
 
   for (const customType of field.customtypes) {
-    if (typeof customType === "string" || !customType.fields) continue;
+    if (typeof customType === "string") continue;
 
     crFieldCustomTypes[customType.id] ??= {};
     const customTypeFields = crFieldCustomTypes[customType.id];

--- a/packages/slice-machine/src/features/customTypes/fields/ContentRelationshipFieldPicker.tsx
+++ b/packages/slice-machine/src/features/customTypes/fields/ContentRelationshipFieldPicker.tsx
@@ -227,17 +227,16 @@ function convertCustomTypesToState(value: TICustomTypeFields) {
 
 /** Convert the picked fields map to the customtypes config and filter out empty customtypes */
 function convertStateToCustomTypes(fields: PickerCustomTypeFields) {
-  return Object.entries(fields).flatMap<TICustomType>(([ctId, fields]) => {
-    const fieldEntries = Object.entries(fields);
-    if (!fieldEntries.some(([_, checked]) => checked)) return [];
-    return [
-      {
-        id: ctId,
-        fields: fieldEntries.flatMap(([id, checkbox]) =>
-          checkbox.value ? [id] : [],
-        ),
-      },
-    ];
+  return Object.entries(fields).flatMap<TICustomType>(([ctId, ctFields]) => {
+    const ctFieldEntries = Object.entries(ctFields);
+    if (!ctFieldEntries.some(([_, checked]) => checked)) return [];
+
+    const fields = ctFieldEntries.flatMap(([id, checkbox]) =>
+      checkbox.value ? [id] : [],
+    );
+
+    if (fields.length === 0) return [];
+    return { id: ctId, fields };
   });
 }
 

--- a/packages/slice-machine/src/features/customTypes/fields/ContentRelationshipFieldPicker.tsx
+++ b/packages/slice-machine/src/features/customTypes/fields/ContentRelationshipFieldPicker.tsx
@@ -234,7 +234,7 @@ function TreeViewCustomType(props: TreeViewCustomTypeProps) {
           );
         }
 
-        const nestedCtState = state?.[fieldOrNestedCt.id].value;
+        const nestedCtState = state?.[fieldOrNestedCt.id]?.value;
 
         const onNestedCustomTypeChange = (
           value: SetStateAction<PickerNestedCustomTypeValue>,
@@ -257,7 +257,7 @@ function TreeViewCustomType(props: TreeViewCustomTypeProps) {
         return fieldOrNestedCt.customtypes.map((nestedCt) => {
           if (typeof nestedCt === "string" || !nestedCt.fields) return null;
 
-          const nestedCtFields: PickerNestedCustomTypeFieldValue =
+          const nestedCtFields: PickerNestedCustomTypeFieldValue | undefined =
             nestedCtState !== undefined && typeof nestedCtState !== "boolean"
               ? nestedCtState[nestedCt.id]
               : {};

--- a/packages/slice-machine/src/features/customTypes/fields/ContentRelationshipFieldPicker.tsx
+++ b/packages/slice-machine/src/features/customTypes/fields/ContentRelationshipFieldPicker.tsx
@@ -453,7 +453,7 @@ function convertCustomTypesToFieldCheckMap(
         if (typeof field === "string") {
           customTypeFields[field] = { type: "checkbox", value: true };
         } else if (field.customtypes !== undefined) {
-          customTypeFields[field.id] = createNestedCustomTypeState(field);
+          customTypeFields[field.id] = createNestedCustomTypeField(field);
         }
 
         return customTypeFields;
@@ -464,7 +464,7 @@ function convertCustomTypesToFieldCheckMap(
   }, {});
 }
 
-function createNestedCustomTypeState(
+function createNestedCustomTypeField(
   field: TIContentRelationshipFieldValue,
 ): PickerContentRelationshipField {
   const crField: PickerContentRelationshipField = {

--- a/packages/slice-machine/src/features/customTypes/fields/ContentRelationshipFieldPicker.tsx
+++ b/packages/slice-machine/src/features/customTypes/fields/ContentRelationshipFieldPicker.tsx
@@ -10,29 +10,64 @@ import { useSelector } from "react-redux";
 
 import { selectAllCustomTypes } from "@/modules/availableCustomTypes";
 
-// picker state types
-
-type PickerCheckboxField = {
-  type: "checkbox";
-  value: boolean;
+/**
+ * Picker state types. Used internally to store the state of the TreeView.
+ *
+ * @example
+ * {
+ *   category: {
+ *     name: {
+ *       type: "checkbox",
+ *       value: true
+ *     }
+ *   },
+ *   author: {
+ *     firstName: {
+ *       type: "checkbox",
+ *       value: true
+ *     }
+ *     lastName: {
+ *       type: "checkbox",
+ *       value: false
+ *     }
+ *   }
+ * }
+ *
+ **/
+type PickerCustomTypes = {
+  [customTypeId: string]: PickerCustomType;
 };
 
 type PickerCustomType = {
   [fieldId: string]: PickerCheckboxField;
 };
 
-type PickerCustomTypes = {
-  [customTypeId: string]: PickerCustomType;
+type PickerCheckboxField = {
+  type: "checkbox";
+  value: boolean;
 };
 
-// copy of types-internal Link customtypes
+/**
+ * Copy of types-internal Link customtypes.
+ *
+ * @example
+ * [
+ *   {
+ *     id: "category",
+ *     fields: ["name"],
+ *   },
+ *   {
+ *     id: "author",
+ *     fields: ["firstName", "lastName"],
+ *   },
+ * ],
+ */
+type TICustomTypes = readonly (string | TICustomType)[];
 
 type TICustomType = {
   id: string;
   fields?: readonly string[] | undefined;
 };
-
-type TICustomTypes = readonly (string | TICustomType)[];
 
 interface ContentRelationshipFieldPickerProps {
   initialValues: TICustomTypes | undefined;
@@ -207,7 +242,10 @@ function useCustomTypes() {
   }, [allCustomTypes]);
 }
 
-/** Convert the customtypes config to the picker state */
+/**
+ * Converts a Link config `customtypes` ({@link TICustomTypes}) structure into
+ * picker state ({@link PickerCustomTypes}).
+ */
 function convertCustomTypesToState(value: TICustomTypes) {
   return value.reduce<PickerCustomTypes>((customTypes, customType) => {
     if (typeof customType === "string") {
@@ -230,7 +268,10 @@ function convertCustomTypesToState(value: TICustomTypes) {
   }, {});
 }
 
-/** Convert the picked fields map to the customtypes config and filter out empty customtypes */
+/**
+ * Converts a picker state structure ({@link PickerCustomTypes}) into Link
+ * config `customtypes` ({@link TICustomTypes} and filter out empty Custom types.
+ */
 function convertStateToCustomTypes(fields: PickerCustomTypes) {
   return Object.entries(fields).flatMap<TICustomType>(([ctId, ctFields]) => {
     const fields = Object.entries(ctFields).flatMap(([fieldId, checkbox]) =>

--- a/packages/slice-machine/src/features/customTypes/fields/ContentRelationshipFieldPicker.tsx
+++ b/packages/slice-machine/src/features/customTypes/fields/ContentRelationshipFieldPicker.tsx
@@ -284,7 +284,7 @@ function TreeViewCustomType(props: TreeViewCustomTypeProps) {
           );
         }
 
-        const fieldState = customTypeFieldCheckMap[field.id] ?? {};
+        const crOrGroupFieldCheckMap = customTypeFieldCheckMap[field.id] ?? {};
 
         // Group field
         if ("fields" in field) {
@@ -294,7 +294,9 @@ function TreeViewCustomType(props: TreeViewCustomTypeProps) {
               group={field}
               onChange={onCustomTypeChange}
               fieldCheckMap={
-                fieldState.type === "group" ? fieldState.value : {}
+                crOrGroupFieldCheckMap.type === "group"
+                  ? crOrGroupFieldCheckMap.value
+                  : {}
               }
             />
           );
@@ -307,7 +309,9 @@ function TreeViewCustomType(props: TreeViewCustomTypeProps) {
             field={field}
             onChange={onCustomTypeChange}
             fieldCheckMap={
-              fieldState.type === "contentRelationship" ? fieldState.value : {}
+              crOrGroupFieldCheckMap.type === "contentRelationship"
+                ? crOrGroupFieldCheckMap.value
+                : {}
             }
           />
         );
@@ -664,7 +668,7 @@ function convertFieldCheckMapToCustomTypes(map: PickerCustomTypes) {
             return fieldValue.value ? fieldId : [];
           }
 
-          const customTypes = convertContentRelationshipStateToCustomTypes(
+          const customTypes = convertContentRelationshipFieldValueToCustomTypes(
             fieldValue.value,
           );
 
@@ -676,7 +680,7 @@ function convertFieldCheckMapToCustomTypes(map: PickerCustomTypes) {
         return fields.length > 0 ? { id: fieldId, fields } : [];
       }
 
-      const customTypes = convertContentRelationshipStateToCustomTypes(
+      const customTypes = convertContentRelationshipFieldValueToCustomTypes(
         fieldValue.value,
       );
 
@@ -689,7 +693,7 @@ function convertFieldCheckMapToCustomTypes(map: PickerCustomTypes) {
   });
 }
 
-function convertContentRelationshipStateToCustomTypes(
+function convertContentRelationshipFieldValueToCustomTypes(
   value: PickerContentRelationshipFieldValue,
 ): TICustomTypeFieldValues[] {
   return Object.entries(value).flatMap<TICustomTypeFieldValues>(

--- a/packages/slice-machine/src/features/customTypes/fields/ContentRelationshipFieldPicker.tsx
+++ b/packages/slice-machine/src/features/customTypes/fields/ContentRelationshipFieldPicker.tsx
@@ -211,8 +211,11 @@ function useCustomTypes() {
 
         const fields = customType.tabs.flatMap((tab) => {
           return tab.value.flatMap((field) => {
-            // filter out uid fields because it's a special field returned by the
+            // Filter out uid fields because it's a special field returned by the
             // API and is not part of the data object in the document.
+            // We also filter by key "uid", because (as of the time of writing
+            // this), creating any field with that API id will result in it being
+            // used for metadata.
             if (field.value.type === "UID" || field.key === "uid") {
               return [];
             }

--- a/packages/slice-machine/src/features/customTypes/fields/ContentRelationshipFieldPicker.tsx
+++ b/packages/slice-machine/src/features/customTypes/fields/ContentRelationshipFieldPicker.tsx
@@ -162,6 +162,10 @@ function TreeViewCustomType(props: TreeViewCustomTypeProps) {
   );
 }
 
+/**
+ * Get all the existing local custom types from the store and process them into
+ * a single array to be rendered by the picker.
+ */
 function useCustomTypes() {
   const allCustomTypes = useSelector(selectAllCustomTypes);
 
@@ -203,6 +207,7 @@ function useCustomTypes() {
   }, [allCustomTypes]);
 }
 
+/** Convert the customtypes config to the picker state */
 function convertCustomTypesToState(value: TICustomTypeFields) {
   return value.reduce<PickerCustomTypeFields>((customTypes, customType) => {
     if (typeof customType === "string") {

--- a/packages/slice-machine/src/features/customTypes/fields/ContentRelationshipFieldPicker.tsx
+++ b/packages/slice-machine/src/features/customTypes/fields/ContentRelationshipFieldPicker.tsx
@@ -1,4 +1,3 @@
-import { useStableCallback } from "@prismicio/editor-support/React";
 import {
   Box,
   Text,
@@ -6,7 +5,7 @@ import {
   TreeViewCheckbox,
   TreeViewSection,
 } from "@prismicio/editor-ui";
-import { SetStateAction, useEffect, useMemo, useState } from "react";
+import { SetStateAction, useMemo, useState } from "react";
 import { useSelector } from "react-redux";
 
 import { selectAllCustomTypes } from "@/modules/availableCustomTypes";
@@ -41,21 +40,18 @@ interface ContentRelationshipFieldPickerProps {
 export function ContentRelationshipFieldPicker(
   props: ContentRelationshipFieldPickerProps,
 ) {
-  const { initialValues, onChange } = props;
+  const { initialValues } = props;
   const customTypes = useCustomTypes();
 
-  const stableOnChange = useStableCallback(onChange);
   const [state, setState] = useState<PickerCustomTypeFields>(
     initialValues ? convertCustomTypesToState(initialValues) : {},
   );
 
-  useEffect(() => {
-    console.log("state", state);
-  }, [state]);
-
-  useEffect(() => {
-    stableOnChange(convertStateToCustomTypes(state));
-  }, [state, stableOnChange]);
+  function onChange(updated: SetStateAction<PickerCustomTypeFields>) {
+    const newState = typeof updated === "function" ? updated(state) : updated;
+    setState(newState);
+    props.onChange(convertStateToCustomTypes(newState));
+  }
 
   return (
     <Box overflow="hidden" flexDirection="column" border borderRadius={6}>
@@ -85,7 +81,7 @@ export function ContentRelationshipFieldPicker(
                 key={customType.id}
                 customType={customType}
                 state={state[customType.id]}
-                onChange={setState}
+                onChange={onChange}
                 labels={customTypes.labels}
               />
             );

--- a/packages/slice-machine/src/features/customTypes/fields/ContentRelationshipFieldPicker.tsx
+++ b/packages/slice-machine/src/features/customTypes/fields/ContentRelationshipFieldPicker.tsx
@@ -127,7 +127,7 @@ export function ContentRelationshipFieldPicker(
                 key={customType.id}
                 customType={customType}
                 onChange={onCustomTypeChange}
-                fieldCheckMap={fieldCheckMap[customType.id]}
+                fieldCheckMap={fieldCheckMap[customType.id] ?? {}}
               />
             );
           })}
@@ -153,7 +153,7 @@ export function ContentRelationshipFieldPicker(
 
 interface TreeViewCustomTypeProps {
   customType: TICustomType;
-  fieldCheckMap: PickerCustomType | undefined;
+  fieldCheckMap: PickerCustomType;
   onChange: (fn: (prev: PickerCustomType) => PickerCustomType) => void;
 }
 
@@ -171,7 +171,7 @@ function TreeViewCustomType(props: TreeViewCustomTypeProps) {
       badge="Custom type"
     >
       {customType.fields.map((fieldId) => {
-        const checked = fieldCheckMap?.[fieldId].value ?? false;
+        const checked = fieldCheckMap[fieldId]?.value ?? false;
 
         function onCheckedChange(value: boolean) {
           onChange((currentFields) => ({

--- a/packages/slice-machine/src/features/customTypes/fields/ContentRelationshipFieldPicker.tsx
+++ b/packages/slice-machine/src/features/customTypes/fields/ContentRelationshipFieldPicker.tsx
@@ -17,26 +17,26 @@ type PickerCheckboxField = {
   value: boolean;
 };
 
-type PickerCustomTypeField = {
+type PickerCustomType = {
   [fieldId: string]: PickerCheckboxField;
 };
 
-type PickerCustomTypeFields = {
-  [customTypeId: string]: PickerCustomTypeField;
+type PickerCustomTypes = {
+  [customTypeId: string]: PickerCustomType;
 };
 
-// copy of types-internal types
+// copy of types-internal Link customtypes
 
 type TICustomType = {
   id: string;
   fields?: readonly string[] | undefined;
 };
 
-type TICustomTypeFields = readonly (string | TICustomType)[];
+type TICustomTypes = readonly (string | TICustomType)[];
 
 interface ContentRelationshipFieldPickerProps {
-  initialValues: TICustomTypeFields | undefined;
-  onChange: (fields: TICustomTypeFields) => void;
+  initialValues: TICustomTypes | undefined;
+  onChange: (fields: TICustomTypes) => void;
 }
 
 export function ContentRelationshipFieldPicker(
@@ -45,11 +45,11 @@ export function ContentRelationshipFieldPicker(
   const { initialValues } = props;
   const { customTypes, labels } = useCustomTypes();
 
-  const [state, setState] = useState<PickerCustomTypeFields>(
+  const [state, setState] = useState<PickerCustomTypes>(
     initialValues ? convertCustomTypesToState(initialValues) : {},
   );
 
-  function onChange(updated: SetStateAction<PickerCustomTypeFields>) {
+  function onChange(updated: SetStateAction<PickerCustomTypes>) {
     const newState = typeof updated === "function" ? updated(state) : updated;
     setState(newState);
     props.onChange(convertStateToCustomTypes(newState));
@@ -106,8 +106,8 @@ export function ContentRelationshipFieldPicker(
 
 interface TreeViewCustomTypeProps {
   customType: TICustomType;
-  state: PickerCustomTypeField | undefined;
-  onChange: (state: SetStateAction<PickerCustomTypeFields>) => void;
+  state: PickerCustomType | undefined;
+  onChange: (state: SetStateAction<PickerCustomTypes>) => void;
   labels: Record<string, string>;
 }
 
@@ -116,7 +116,7 @@ function TreeViewCustomType(props: TreeViewCustomTypeProps) {
 
   if (!customType.fields) return null;
 
-  function onLevelChange(values: SetStateAction<PickerCustomTypeField>) {
+  function onLevelChange(values: SetStateAction<PickerCustomType>) {
     onChange((prev) => {
       const newState = { ...prev };
       if (typeof values === "function") {
@@ -208,8 +208,8 @@ function useCustomTypes() {
 }
 
 /** Convert the customtypes config to the picker state */
-function convertCustomTypesToState(value: TICustomTypeFields) {
-  return value.reduce<PickerCustomTypeFields>((customTypes, customType) => {
+function convertCustomTypesToState(value: TICustomTypes) {
+  return value.reduce<PickerCustomTypes>((customTypes, customType) => {
     if (typeof customType === "string") {
       customTypes[customType] = {};
       return customTypes;
@@ -218,7 +218,7 @@ function convertCustomTypesToState(value: TICustomTypeFields) {
     const { id, fields } = customType;
     if (fields === undefined) return customTypes;
 
-    customTypes[id] = fields.reduce<PickerCustomTypeField>(
+    customTypes[id] = fields.reduce<PickerCustomType>(
       (customTypeFields, field) => {
         customTypeFields[field] = { type: "checkbox", value: true };
         return customTypeFields;
@@ -231,7 +231,7 @@ function convertCustomTypesToState(value: TICustomTypeFields) {
 }
 
 /** Convert the picked fields map to the customtypes config and filter out empty customtypes */
-function convertStateToCustomTypes(fields: PickerCustomTypeFields) {
+function convertStateToCustomTypes(fields: PickerCustomTypes) {
   return Object.entries(fields).flatMap<TICustomType>(([ctId, ctFields]) => {
     const fields = Object.entries(ctFields).flatMap(([fieldId, checkbox]) =>
       checkbox.value ? [fieldId] : [],

--- a/packages/slice-machine/src/features/customTypes/fields/ContentRelationshipFieldPicker.tsx
+++ b/packages/slice-machine/src/features/customTypes/fields/ContentRelationshipFieldPicker.tsx
@@ -337,7 +337,7 @@ function TreeViewContentRelationshipField(
     ) => PickerContentRelationshipFieldValue,
   ) => {
     onCustomTypeChange((currentCustomTypeFields) => {
-      const prevCtValue = currentCustomTypeFields[crField.id];
+      const prevCtValue = currentCustomTypeFields[crField.id] ?? {};
       const prevCtValueNarrowed =
         prevCtValue?.type === "contentRelationship" ? prevCtValue.value : {};
 
@@ -421,9 +421,9 @@ function TreeViewGroupField(props: TreeViewGroupFieldProps) {
     updater: (prev: PickerGroupFieldValue) => PickerGroupFieldValue,
   ) => {
     onCustomTypeChange((currentCustomTypeFields) => {
-      const prevField = currentCustomTypeFields[group.id];
+      const prevField = currentCustomTypeFields[group.id] ?? {};
       const prevFieldNarrowed =
-        prevField?.type === "group" ? prevField.value : {};
+        prevField.type === "group" ? prevField.value : {};
 
       return {
         ...currentCustomTypeFields,

--- a/packages/slice-machine/src/features/customTypes/fields/ContentRelationshipFieldPicker.tsx
+++ b/packages/slice-machine/src/features/customTypes/fields/ContentRelationshipFieldPicker.tsx
@@ -45,7 +45,9 @@ export function ContentRelationshipFieldPicker(
   const customTypes = useCustomTypes();
 
   const stableOnChange = useStableCallback(onChange);
-  const [state, setState] = useState<PickerCustomTypeFields>({});
+  const [state, setState] = useState<PickerCustomTypeFields>(
+    initialValues ? convertCustomTypesToState(initialValues) : {},
+  );
 
   useEffect(() => {
     console.log("state", state);

--- a/packages/slice-machine/src/features/customTypes/fields/ContentRelationshipFieldPicker.tsx
+++ b/packages/slice-machine/src/features/customTypes/fields/ContentRelationshipFieldPicker.tsx
@@ -194,7 +194,9 @@ function TreeViewCustomType(props: TreeViewCustomTypeProps) {
 
 /**
  * Get all the existing local custom types from the store and process them into
- * a single array to be rendered by the picker.
+ * a single array to be rendered by the picker. For this we use the same as the
+ * Link config `customtypes` structure {@link TICustomTypes}. Also creates a map
+ * of each custom type and field path and its corresponding label.
  */
 function useCustomTypes() {
   const allCustomTypes = useSelector(selectAllCustomTypes);

--- a/packages/slice-machine/src/features/customTypes/fields/ContentRelationshipFieldPicker.tsx
+++ b/packages/slice-machine/src/features/customTypes/fields/ContentRelationshipFieldPicker.tsx
@@ -159,11 +159,6 @@ interface TICustomTypeFieldValues {
   fields?: readonly (string | TICustomTypeRegularFieldValues)[] | undefined;
 }
 
-interface TIGroupFieldValues {
-  id: string;
-  fields?: readonly (string | TIContentRelationshipFieldValue)[] | undefined;
-}
-
 interface ContentRelationshipFieldPickerProps {
   value: TICustomTypes | undefined;
   onChange: (fields: TICustomTypes) => void;

--- a/packages/slice-machine/src/features/customTypes/fields/ContentRelationshipFieldPicker.tsx
+++ b/packages/slice-machine/src/features/customTypes/fields/ContentRelationshipFieldPicker.tsx
@@ -84,8 +84,8 @@ export function ContentRelationshipFieldPicker(
     convertCustomTypesToState(initialValues),
   );
 
-  function onChange(updated: SetStateAction<PickerCustomTypes>) {
-    const newState = typeof updated === "function" ? updated(state) : updated;
+  function onChange(value: SetStateAction<PickerCustomTypes>) {
+    const newState = typeof value === "function" ? value(state) : value;
     setState(newState);
     props.onChange(convertStateToCustomTypes(newState));
   }
@@ -151,17 +151,12 @@ function TreeViewCustomType(props: TreeViewCustomTypeProps) {
 
   if (!customType.fields) return null;
 
-  function onLevelChange(values: SetStateAction<PickerCustomType>) {
-    onChange((prev) => {
-      const newState = { ...prev };
-      if (typeof values === "function") {
-        newState[customType.id] = values(prev[customType.id]);
-      } else {
-        newState[customType.id] = values;
-      }
-
-      return newState;
-    });
+  function onCustomTypeChange(value: SetStateAction<PickerCustomType>) {
+    onChange((prev) => ({
+      ...prev,
+      [customType.id]:
+        typeof value === "function" ? value(prev[customType.id]) : value,
+    }));
   }
 
   const fieldCount = countPickedFields(state);
@@ -177,10 +172,10 @@ function TreeViewCustomType(props: TreeViewCustomTypeProps) {
       {customType.fields.map((field) => {
         const checkboxState = state?.[field];
 
-        function onCheckedChange(checked: boolean) {
-          onLevelChange((prev) => ({
+        function onCheckedChange(value: boolean) {
+          onCustomTypeChange((prev) => ({
             ...prev,
-            [field]: { type: "checkbox", value: checked },
+            [field]: { type: "checkbox", value },
           }));
         }
 

--- a/packages/slice-machine/src/features/customTypes/fields/ContentRelationshipFieldPicker.tsx
+++ b/packages/slice-machine/src/features/customTypes/fields/ContentRelationshipFieldPicker.tsx
@@ -204,14 +204,11 @@ function TreeViewCustomType(props: TreeViewCustomTypeProps) {
     }));
   };
 
-  const fieldCount = countPickedFields(state);
-  const fieldCountLabel = fieldCount === 1 ? "1 field" : `${fieldCount} fields`;
-
   return (
     <TreeViewSection
       key={customType.id}
       title={customType.id}
-      subtitle={fieldCount > 0 ? `(${fieldCountLabel} exposed)` : undefined}
+      subtitle={getExposedFieldsLabel(countPickedFields(state))}
       badge="Custom type"
     >
       {customType.fields.map((fieldOrNestedCt) => {
@@ -308,7 +305,12 @@ function TreeViewContentRelationshipField(
     };
 
     return (
-      <TreeViewSection key={customType.id} title={customType.id}>
+      <TreeViewSection
+        key={customType.id}
+        title={customType.id}
+        subtitle={getExposedFieldsLabel(countPickedFields(fieldsState))}
+        badge="Custom type"
+      >
         {customType.fields.map((field) => {
           const { type, value: checked } = fieldsState?.[field] ?? {};
 
@@ -331,6 +333,11 @@ function TreeViewContentRelationshipField(
       </TreeViewSection>
     );
   });
+}
+
+function getExposedFieldsLabel(count: number) {
+  if (count === 0) return undefined;
+  return count === 1 ? "(1 field exposed)" : `(${count} fields exposed)`;
 }
 
 /**

--- a/packages/slice-machine/src/features/customTypes/fields/ContentRelationshipFieldPicker.tsx
+++ b/packages/slice-machine/src/features/customTypes/fields/ContentRelationshipFieldPicker.tsx
@@ -34,18 +34,18 @@ import { selectAllCustomTypes } from "@/modules/availableCustomTypes";
  * }
  *
  **/
-type PickerCustomTypes = {
+interface PickerCustomTypes {
   [customTypeId: string]: PickerCustomType;
-};
+}
 
-type PickerCustomType = {
+interface PickerCustomType {
   [fieldId: string]: PickerCheckboxField;
-};
+}
 
-type PickerCheckboxField = {
+interface PickerCheckboxField {
   type: "checkbox";
   value: boolean;
-};
+}
 
 /**
  * Copy of types-internal Link customtypes.
@@ -64,10 +64,10 @@ type PickerCheckboxField = {
  */
 type TICustomTypes = readonly (string | TICustomType)[];
 
-type TICustomType = {
+interface TICustomType {
   id: string;
   fields?: readonly string[] | undefined;
-};
+}
 
 interface ContentRelationshipFieldPickerProps {
   initialValues: TICustomTypes | undefined;
@@ -81,7 +81,7 @@ export function ContentRelationshipFieldPicker(
   const { customTypes, labels } = useCustomTypes();
 
   const [state, setState] = useState<PickerCustomTypes>(
-    initialValues ? convertCustomTypesToState(initialValues) : {},
+    convertCustomTypesToState(initialValues),
   );
 
   function onChange(updated: SetStateAction<PickerCustomTypes>) {
@@ -177,12 +177,12 @@ function TreeViewCustomType(props: TreeViewCustomTypeProps) {
       {customType.fields.map((field) => {
         const checkboxState = state?.[field];
 
-        const onCheckedChange = (checked: boolean) => {
+        function onCheckedChange(checked: boolean) {
           onLevelChange((prev) => ({
             ...prev,
             [field]: { type: "checkbox", value: checked },
           }));
-        };
+        }
 
         return (
           <TreeViewCheckbox
@@ -246,7 +246,9 @@ function useCustomTypes() {
  * Converts a Link config `customtypes` ({@link TICustomTypes}) structure into
  * picker state ({@link PickerCustomTypes}).
  */
-function convertCustomTypesToState(value: TICustomTypes) {
+function convertCustomTypesToState(value: TICustomTypes | undefined) {
+  if (value === undefined) return {};
+
   return value.reduce<PickerCustomTypes>((customTypes, customType) => {
     if (typeof customType === "string") {
       customTypes[customType] = {};

--- a/packages/slice-machine/src/features/customTypes/fields/ContentRelationshipFieldPicker.tsx
+++ b/packages/slice-machine/src/features/customTypes/fields/ContentRelationshipFieldPicker.tsx
@@ -220,7 +220,7 @@ function TreeViewCustomType(props: TreeViewCustomTypeProps) {
     >
       {customType.fields.map((field) => {
         if (typeof field === "string") {
-          const { type, value: checked } = fieldCheckMap[field] ?? {};
+          const checked = fieldCheckMap[field]?.value ?? false;
 
           const onCheckedChange = (value: boolean) => {
             onCustomTypeChange((currentFields) => ({
@@ -233,7 +233,7 @@ function TreeViewCustomType(props: TreeViewCustomTypeProps) {
             <TreeViewCheckbox
               key={field}
               title={field}
-              checked={type === "checkbox" ? checked : false}
+              checked={checked === true}
               onCheckedChange={onCheckedChange}
             />
           );
@@ -319,21 +319,21 @@ function TreeViewContentRelationshipField(
         )}
         badge="Custom type"
       >
-        {customType.fields.map((field) => {
-          const { type, value: checked } = customTypeFieldCheckMap[field] ?? {};
+        {customType.fields.map((fieldId) => {
+          const checked = customTypeFieldCheckMap[fieldId]?.value ?? false;
 
           const onCheckedChange = (value: boolean) => {
             onNestedCustomTypeChange((currentFields) => ({
               ...currentFields,
-              [field]: { type: "checkbox", value },
+              [fieldId]: { type: "checkbox", value },
             }));
           };
 
           return (
             <TreeViewCheckbox
-              key={field}
-              title={field}
-              checked={type === "checkbox" ? checked : false}
+              key={fieldId}
+              title={fieldId}
+              checked={checked === true}
               onCheckedChange={onCheckedChange}
             />
           );

--- a/packages/slice-machine/src/features/customTypes/fields/ContentRelationshipFieldPicker.tsx
+++ b/packages/slice-machine/src/features/customTypes/fields/ContentRelationshipFieldPicker.tsx
@@ -184,8 +184,6 @@ export function ContentRelationshipFieldPicker(
   const customTypes = useCustomTypes();
   const fieldCheckMap = value ? convertCustomTypesToFieldCheckMap(value) : {};
 
-  console.log({ value, customTypes, fieldCheckMap });
-
   function onCustomTypesChange(
     updater: (prev: PickerCustomTypes) => PickerCustomTypes,
   ) {
@@ -415,12 +413,6 @@ function TreeViewContentRelationshipField(
 
             const groupFieldCheckMap = ctFieldCheckMap[field.id] ?? {};
 
-            console.log({
-              customTypeFieldCheckMap,
-              ctFieldCheckMap,
-              groupFieldCheckMap,
-            });
-
             const onGroupFieldsChange = (
               updater: (
                 prev: PickerGroupFieldWithoutContentRelationshipValue,
@@ -476,8 +468,6 @@ function TreeViewContentRelationshipFieldNestedGroup(
   props: TreeViewContentRelationshipFieldGroupProps,
 ) {
   const { group, fieldCheckMap, onChange: onGroupFieldsChange } = props;
-
-  console.log("fieldCheckMap", fieldCheckMap);
 
   return (
     <TreeViewSection

--- a/packages/slice-machine/src/legacy/lib/models/common/widgets/ContentRelationship/Form.tsx
+++ b/packages/slice-machine/src/legacy/lib/models/common/widgets/ContentRelationship/Form.tsx
@@ -7,6 +7,7 @@ import { Col, Flex as FlexGrid } from "@/legacy/components/Flex";
 import WidgetFormField from "@/legacy/lib/builders/common/EditModal/Field";
 import { createFieldNameFromKey } from "@/legacy/lib/forms";
 import { DefaultFields } from "@/legacy/lib/forms/defaults";
+import { LinkConfig } from "@prismicio/types-internal/lib/customtypes";
 
 const FormFields = {
   label: DefaultFields.label,
@@ -43,7 +44,7 @@ type FormProps = {
   config: {
     label: string;
     select: string;
-    customtypes?: (string | { id: string; fields: string[] })[];
+    customtypes?: LinkConfig["customtypes"];
   };
   id: string;
   // TODO: this exists in the yup schema but this doesn't seem to be validated by formik

--- a/packages/slice-machine/src/legacy/lib/models/common/widgets/ContentRelationship/Form.tsx
+++ b/packages/slice-machine/src/legacy/lib/models/common/widgets/ContentRelationship/Form.tsx
@@ -1,7 +1,4 @@
-import {
-  CustomTypes,
-  LinkConfig,
-} from "@prismicio/types-internal/lib/customtypes";
+import { LinkConfig } from "@prismicio/types-internal/lib/customtypes";
 import { FormikProps } from "formik";
 import { Box } from "theme-ui";
 import * as yup from "yup";
@@ -16,12 +13,7 @@ const FormFields = {
   label: DefaultFields.label,
   id: DefaultFields.id,
   customtypes: {
-    validate: () =>
-      yup.array().test({
-        message: "Invalid customtypes structure.",
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-        test: (value) => CustomTypes.decode(value)._tag === "Right",
-      }),
+    validate: () => yup.array(),
   },
 };
 

--- a/packages/slice-machine/src/legacy/lib/models/common/widgets/ContentRelationship/Form.tsx
+++ b/packages/slice-machine/src/legacy/lib/models/common/widgets/ContentRelationship/Form.tsx
@@ -1,4 +1,7 @@
-import { LinkConfig } from "@prismicio/types-internal/lib/customtypes";
+import {
+  CustomTypes,
+  LinkConfig,
+} from "@prismicio/types-internal/lib/customtypes";
 import { FormikProps } from "formik";
 import { Box } from "theme-ui";
 import * as yup from "yup";
@@ -9,68 +12,16 @@ import WidgetFormField from "@/legacy/lib/builders/common/EditModal/Field";
 import { createFieldNameFromKey } from "@/legacy/lib/forms";
 import { DefaultFields } from "@/legacy/lib/forms/defaults";
 
-const customTypesSchema = yup.object({
-  id: yup.string().required(),
-  customtypes: yup
-    .array(
-      yup.object({
-        id: yup.string().required(),
-        fields: yup
-          .array(
-            yup.lazy((fieldValue) => {
-              if (typeof fieldValue === "string") {
-                return yup.string();
-              }
-
-              return yup.object({
-                id: yup.string().required(),
-                fields: yup.array(yup.string()).required(),
-              });
-            }),
-          )
-          .required(),
-      }),
-    )
-    .required(),
-});
-
 const FormFields = {
   label: DefaultFields.label,
   id: DefaultFields.id,
-  // TODO: Validate customtypes using existing types-internal codec
   customtypes: {
     validate: () =>
-      yup.array(
-        yup.object({
-          id: yup.string().required(),
-          fields: yup.array(
-            yup.lazy((value) => {
-              if (typeof value === "string") {
-                return yup.string();
-              }
-
-              if ("fields" in value) {
-                return yup.object({
-                  id: yup.string().required(),
-                  fields: yup
-                    .array(
-                      yup.lazy((fieldValue) => {
-                        if (typeof fieldValue === "string") {
-                          return yup.string();
-                        }
-
-                        return customTypesSchema;
-                      }),
-                    )
-                    .required(),
-                });
-              }
-
-              return customTypesSchema;
-            }),
-          ),
-        }),
-      ),
+      yup.array().test({
+        message: "Invalid content relationship structure.",
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        test: (value) => CustomTypes.decode(value)._tag === "Right",
+      }),
   },
 };
 
@@ -89,7 +40,9 @@ const WidgetForm = ({
   values,
   setFieldValue,
   fields,
+  errors,
 }: FormikProps<FormProps> & { fields: Record<string, unknown> }) => {
+  console.log(errors);
   return (
     <>
       <FlexGrid>

--- a/packages/slice-machine/src/legacy/lib/models/common/widgets/ContentRelationship/Form.tsx
+++ b/packages/slice-machine/src/legacy/lib/models/common/widgets/ContentRelationship/Form.tsx
@@ -11,16 +11,29 @@ import { DefaultFields } from "@/legacy/lib/forms/defaults";
 const FormFields = {
   label: DefaultFields.label,
   id: DefaultFields.id,
+  // TODO: Validate customtypes using existing types-internal codec
   customtypes: {
     validate: () =>
       yup.array(
-        yup.lazy((value) => {
-          return typeof value === "object"
-            ? yup.object({
-                id: yup.string(),
-                fields: yup.array(yup.string()),
-              })
-            : yup.string();
+        yup.object({
+          id: yup.string().required(),
+          fields: yup.array(
+            yup.lazy((value) =>
+              typeof value === "object"
+                ? yup.object({
+                    id: yup.string().required(),
+                    customtypes: yup
+                      .array(
+                        yup.object({
+                          id: yup.string().required(),
+                          fields: yup.array(yup.string()).required(),
+                        }),
+                      )
+                      .required(),
+                  })
+                : yup.string(),
+            ),
+          ),
         }),
       ),
   },

--- a/packages/slice-machine/src/legacy/lib/models/common/widgets/ContentRelationship/Form.tsx
+++ b/packages/slice-machine/src/legacy/lib/models/common/widgets/ContentRelationship/Form.tsx
@@ -1,3 +1,4 @@
+import { LinkConfig } from "@prismicio/types-internal/lib/customtypes";
 import { FormikProps } from "formik";
 import { Box } from "theme-ui";
 import * as yup from "yup";
@@ -7,7 +8,6 @@ import { Col, Flex as FlexGrid } from "@/legacy/components/Flex";
 import WidgetFormField from "@/legacy/lib/builders/common/EditModal/Field";
 import { createFieldNameFromKey } from "@/legacy/lib/forms";
 import { DefaultFields } from "@/legacy/lib/forms/defaults";
-import { LinkConfig } from "@prismicio/types-internal/lib/customtypes";
 
 const FormFields = {
   label: DefaultFields.label,

--- a/packages/slice-machine/src/legacy/lib/models/common/widgets/ContentRelationship/Form.tsx
+++ b/packages/slice-machine/src/legacy/lib/models/common/widgets/ContentRelationship/Form.tsx
@@ -18,7 +18,7 @@ const FormFields = {
   customtypes: {
     validate: () =>
       yup.array().test({
-        message: "Invalid content relationship structure.",
+        message: "Invalid customtypes structure.",
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
         test: (value) => CustomTypes.decode(value)._tag === "Right",
       }),

--- a/packages/slice-machine/src/legacy/lib/models/common/widgets/ContentRelationship/Form.tsx
+++ b/packages/slice-machine/src/legacy/lib/models/common/widgets/ContentRelationship/Form.tsx
@@ -38,6 +38,7 @@ type FormProps = {
 
 const WidgetForm = ({
   initialValues,
+  values,
   setFieldValue,
   fields,
 }: FormikProps<FormProps> & { fields: Record<string, unknown> }) => {
@@ -59,7 +60,7 @@ const WidgetForm = ({
       </FlexGrid>
       <Box mt={20}>
         <ContentRelationshipFieldPicker
-          initialValues={initialValues.config.customtypes}
+          value={values.config.customtypes}
           onChange={(fields) => {
             void setFieldValue("config.customtypes", fields);
           }}

--- a/packages/slice-machine/src/legacy/lib/models/common/widgets/ContentRelationship/index.ts
+++ b/packages/slice-machine/src/legacy/lib/models/common/widgets/ContentRelationship/index.ts
@@ -16,10 +16,10 @@ import Form, { FormFields } from "./Form";
  *   "type": "Link",
  *   "config": {
  *     "select": "document",
+ *     "label": "relationship"
  *     "customtypes": [
  *       "page"
  *     ],
- *     "label": "relationship"
  *   }
  * }
  *
@@ -28,13 +28,24 @@ import Form, { FormFields } from "./Form";
  *   "type": "Link",
  *   "config": {
  *     "select": "document",
+ *     "label": "relationship"
  *     "customtypes": [
  *       {
  *         "id": "page",
- *         "fields": ["uid", "country"]
+ *         "fields": [
+ *           "category",
+ *           {
+ *             "id": "countryRelation",
+ *             "customtypes": [
+ *               {
+ *                 "id": "country",
+ *                 "fields": ["name"]
+ *               }
+ *             ]
+ *           }
+ *         ]
  *       }
  *     ],
- *     "label": "relationship"
  *   }
  * }
  */
@@ -50,18 +61,30 @@ const contentRelationShipConfigSchema = linkConfigSchema.shape({
     .string()
     .required()
     .matches(/^document$/, { excludeEmptyString: true }),
+  // TODO: Validate customtypes using existing types-internal codec
   customtypes: yup
     .array(
-      yup.lazy((value) => {
-        return typeof value === "object"
-          ? yup.object({
-              id: yup.string(),
-              fields: yup.array(yup.string()),
-            })
-          : yup.string();
+      yup.object({
+        id: yup.string().required(),
+        fields: yup.array(
+          yup.lazy((value) =>
+            typeof value === "object"
+              ? yup.object({
+                  id: yup.string().required(),
+                  customtypes: yup
+                    .array(
+                      yup.object({
+                        id: yup.string().required(),
+                        fields: yup.array(yup.string()).required(),
+                      }),
+                    )
+                    .required(),
+                })
+              : yup.string(),
+          ),
+        ),
       }),
     )
-    .strict()
     .optional(),
 });
 

--- a/packages/slice-machine/src/legacy/lib/models/common/widgets/ContentRelationship/index.ts
+++ b/packages/slice-machine/src/legacy/lib/models/common/widgets/ContentRelationship/index.ts
@@ -68,8 +68,11 @@ const contentRelationShipConfigSchema = linkConfigSchema.shape({
     .array()
     .test({
       message: "Invalid customtypes structure.",
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-      test: (value) => CustomTypes.decode(value)._tag === "Right",
+      test: (value) => {
+        if (!value) return true; // Still allow to be optional
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        return CustomTypes.decode(value)._tag === "Right";
+      },
     })
     .optional(),
 });

--- a/packages/slice-machine/src/legacy/lib/models/common/widgets/ContentRelationship/index.ts
+++ b/packages/slice-machine/src/legacy/lib/models/common/widgets/ContentRelationship/index.ts
@@ -1,7 +1,4 @@
-import {
-  CustomTypes,
-  Link,
-} from "@prismicio/types-internal/lib/customtypes/widgets/nestable";
+import { Link } from "@prismicio/types-internal/lib/customtypes/widgets/nestable";
 import { MdSettingsEthernet } from "react-icons/md";
 import { useSelector } from "react-redux";
 import * as yup from "yup";
@@ -64,17 +61,7 @@ const contentRelationShipConfigSchema = linkConfigSchema.shape({
     .string()
     .required()
     .matches(/^document$/, { excludeEmptyString: true }),
-  customtypes: yup
-    .array()
-    .test({
-      message: "Invalid customtypes structure.",
-      test: (value) => {
-        if (!value) return true; // Still allow to be optional
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-        return CustomTypes.decode(value)._tag === "Right";
-      },
-    })
-    .optional(),
+  customtypes: yup.array().optional(),
 });
 
 const schema = yup.object().shape({

--- a/packages/slice-machine/src/legacy/lib/models/common/widgets/ContentRelationship/index.ts
+++ b/packages/slice-machine/src/legacy/lib/models/common/widgets/ContentRelationship/index.ts
@@ -1,4 +1,7 @@
-import { Link } from "@prismicio/types-internal/lib/customtypes/widgets/nestable";
+import {
+  CustomTypes,
+  Link,
+} from "@prismicio/types-internal/lib/customtypes/widgets/nestable";
 import { MdSettingsEthernet } from "react-icons/md";
 import { useSelector } from "react-redux";
 import * as yup from "yup";
@@ -54,30 +57,6 @@ const Meta = {
   icon: MdSettingsEthernet,
 };
 
-const customTypesSchema = yup.object({
-  id: yup.string().required(),
-  customtypes: yup
-    .array(
-      yup.object({
-        id: yup.string().required(),
-        fields: yup
-          .array(
-            yup.lazy((fieldValue) => {
-              if (typeof fieldValue === "string") {
-                return yup.string();
-              }
-
-              return yup.object({
-                id: yup.string().required(),
-                fields: yup.array(yup.string()).required(),
-              });
-            }),
-          )
-          .required(),
-      }),
-    )
-    .required(),
-});
 // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
 const contentRelationShipConfigSchema = linkConfigSchema.shape({
   label: yup.string().max(35, "String is too long. Max: 35"),
@@ -85,39 +64,13 @@ const contentRelationShipConfigSchema = linkConfigSchema.shape({
     .string()
     .required()
     .matches(/^document$/, { excludeEmptyString: true }),
-  // TODO: Validate customtypes using existing types-internal codec
   customtypes: yup
-    .array(
-      yup.object({
-        id: yup.string().required(),
-        fields: yup.array(
-          yup.lazy((value) => {
-            if (typeof value === "string") {
-              return yup.string();
-            }
-
-            if ("fields" in value) {
-              return yup.object({
-                id: yup.string().required(),
-                fields: yup
-                  .array(
-                    yup.lazy((fieldValue) => {
-                      if (typeof fieldValue === "string") {
-                        return yup.string();
-                      }
-
-                      return customTypesSchema;
-                    }),
-                  )
-                  .required(),
-              });
-            }
-
-            return customTypesSchema;
-          }),
-        ),
-      }),
-    )
+    .array()
+    .test({
+      message: "Invalid content relationship structure.",
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+      test: (value) => CustomTypes.decode(value)._tag === "Right",
+    })
     .optional(),
 });
 

--- a/packages/slice-machine/src/legacy/lib/models/common/widgets/ContentRelationship/index.ts
+++ b/packages/slice-machine/src/legacy/lib/models/common/widgets/ContentRelationship/index.ts
@@ -67,7 +67,7 @@ const contentRelationShipConfigSchema = linkConfigSchema.shape({
   customtypes: yup
     .array()
     .test({
-      message: "Invalid content relationship structure.",
+      message: "Invalid customtypes structure.",
       // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
       test: (value) => CustomTypes.decode(value)._tag === "Right",
     })

--- a/packages/slice-machine/src/legacy/lib/models/common/widgets/Link/index.ts
+++ b/packages/slice-machine/src/legacy/lib/models/common/widgets/Link/index.ts
@@ -72,7 +72,7 @@ export const linkConfigSchema = yup
       .optional()
       .oneOf(["media", "document", "web", null])
       .nullable(),
-    customtypes: yup.array(yup.string()).strict().optional(),
+    customtypes: yup.array().strict().optional(),
     masks: yup.array(yup.string()).optional(),
     tags: yup.array(yup.string()).optional(),
     allowTargetBlank: yup.boolean().strict().optional(),

--- a/packages/slice-machine/src/utils/isValidObject.ts
+++ b/packages/slice-machine/src/utils/isValidObject.ts
@@ -1,0 +1,9 @@
+export function isValidObject(value: unknown): value is Record<string, unknown> {
+  if (typeof value !== "object" || value === null) return false;
+  if (Array.isArray(value)) return false;
+  return !(
+    value instanceof Date ||
+    value instanceof RegExp ||
+    value instanceof Error
+  );
+}

--- a/packages/slice-machine/src/utils/isValidObject.ts
+++ b/packages/slice-machine/src/utils/isValidObject.ts
@@ -1,11 +1,32 @@
+/**
+ * Ensure that the value is an record/object with string keys and existing
+ * properties. Accepts empty objects and objects created with
+ * `Object.create(null)`.
+ */
 export function isValidObject(
   value: unknown,
 ): value is Record<string, unknown> {
   if (typeof value !== "object" || value === null) return false;
+
   if (Array.isArray(value)) return false;
-  return !(
+
+  if (
     value instanceof Date ||
     value instanceof RegExp ||
     value instanceof Error
-  );
+  ) {
+    return false;
+  }
+
+  // Check if all keys are strings and all values are valid
+  for (const key in value) {
+    if (
+      typeof key !== "string" ||
+      !Object.prototype.hasOwnProperty.call(value, key)
+    ) {
+      return false;
+    }
+  }
+
+  return true;
 }

--- a/packages/slice-machine/src/utils/isValidObject.ts
+++ b/packages/slice-machine/src/utils/isValidObject.ts
@@ -1,4 +1,6 @@
-export function isValidObject(value: unknown): value is Record<string, unknown> {
+export function isValidObject(
+  value: unknown,
+): value is Record<string, unknown> {
   if (typeof value !== "object" || value === null) return false;
   if (Array.isArray(value)) return false;
   return !(

--- a/packages/start-slicemachine/package.json
+++ b/packages/start-slicemachine/package.json
@@ -56,7 +56,7 @@
 	"bin": "./bin/start-slicemachine.js",
 	"dependencies": {
 		"@prismicio/mocks": "2.13.0",
-		"@prismicio/types-internal": "3.10.0",
+		"@prismicio/types-internal": "3.10.1",
 		"@slicemachine/manager": "workspace:*",
 		"body-parser": "^1.20.3",
 		"chalk": "^4.1.2",

--- a/packages/start-slicemachine/package.json
+++ b/packages/start-slicemachine/package.json
@@ -56,7 +56,7 @@
 	"bin": "./bin/start-slicemachine.js",
 	"dependencies": {
 		"@prismicio/mocks": "2.13.0",
-		"@prismicio/types-internal": "3.11.0-alpha.0",
+		"@prismicio/types-internal": "3.11.0",
 		"@slicemachine/manager": "workspace:*",
 		"body-parser": "^1.20.3",
 		"chalk": "^4.1.2",

--- a/packages/start-slicemachine/package.json
+++ b/packages/start-slicemachine/package.json
@@ -56,7 +56,7 @@
 	"bin": "./bin/start-slicemachine.js",
 	"dependencies": {
 		"@prismicio/mocks": "2.13.0",
-		"@prismicio/types-internal": "3.10.1",
+		"@prismicio/types-internal": "3.11.0-alpha.0",
 		"@slicemachine/manager": "workspace:*",
 		"body-parser": "^1.20.3",
 		"chalk": "^4.1.2",

--- a/playwright/package.json
+++ b/playwright/package.json
@@ -16,7 +16,7 @@
     "@msgpack/msgpack": "2.8.0",
     "@playwright/test": "^1",
     "@prismicio/e2e-tests-utils": "1.11.0",
-    "@prismicio/types-internal": "3.10.1",
+    "@prismicio/types-internal": "3.11.0-alpha.0",
     "@slicemachine/manager": "workspace:*",
     "@types/node": "22.15.17",
     "@typescript-eslint/eslint-plugin": "7.17.0",

--- a/playwright/package.json
+++ b/playwright/package.json
@@ -16,7 +16,7 @@
     "@msgpack/msgpack": "2.8.0",
     "@playwright/test": "^1",
     "@prismicio/e2e-tests-utils": "1.11.0",
-    "@prismicio/types-internal": "3.11.0-alpha.0",
+    "@prismicio/types-internal": "3.11.0",
     "@slicemachine/manager": "workspace:*",
     "@types/node": "22.15.17",
     "@typescript-eslint/eslint-plugin": "7.17.0",

--- a/playwright/package.json
+++ b/playwright/package.json
@@ -16,7 +16,7 @@
     "@msgpack/msgpack": "2.8.0",
     "@playwright/test": "^1",
     "@prismicio/e2e-tests-utils": "1.11.0",
-    "@prismicio/types-internal": "3.10.0",
+    "@prismicio/types-internal": "3.10.1",
     "@slicemachine/manager": "workspace:*",
     "@types/node": "22.15.17",
     "@typescript-eslint/eslint-plugin": "7.17.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7140,9 +7140,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@prismicio/types-internal@npm:3.10.1":
-  version: 3.10.1
-  resolution: "@prismicio/types-internal@npm:3.10.1"
+"@prismicio/types-internal@npm:3.11.0-alpha.0":
+  version: 3.11.0-alpha.0
+  resolution: "@prismicio/types-internal@npm:3.11.0-alpha.0"
   dependencies:
     monocle-ts: ^2.3.11
     newtype-ts: ^0.3.5
@@ -7152,7 +7152,7 @@ __metadata:
     fp-ts: ^2.11.8
     io-ts: ^2.2.16
     io-ts-types: ^0.5.16
-  checksum: 1db481da374b8ad9ac3c7f4e639f84a76e80a3abd900251572038382f59d6f564381c74f80b0eb431973064a44c81b5a8e44594d9cd0d28f53efbb4d44cbaf8e
+  checksum: 6cfdf0694ad33a3316be55f6d9e4c5ea85f94d78830b23cb258a7243050afbf9c2af2b61cd877e017add2dc8330141b7b968a112bcefd0b2434d7a500145c8f7
   languageName: node
   linkType: hard
 
@@ -10070,7 +10070,7 @@ __metadata:
   dependencies:
     "@prismicio/mock": 0.7.1
     "@prismicio/simulator": ^0.1.4
-    "@prismicio/types-internal": 3.10.1
+    "@prismicio/types-internal": 3.11.0-alpha.0
     "@size-limit/preset-small-lib": 8.2.4
     "@slicemachine/plugin-kit": "workspace:*"
     "@types/common-tags": 1.8.1
@@ -10115,7 +10115,7 @@ __metadata:
   dependencies:
     "@prismicio/mock": 0.7.1
     "@prismicio/simulator": ^0.1.4
-    "@prismicio/types-internal": 3.10.1
+    "@prismicio/types-internal": 3.11.0-alpha.0
     "@size-limit/preset-small-lib": 8.2.4
     "@slicemachine/plugin-kit": "workspace:*"
     "@typescript-eslint/eslint-plugin": 5.55.0
@@ -10156,7 +10156,7 @@ __metadata:
   dependencies:
     "@prismicio/mock": 0.7.1
     "@prismicio/simulator": ^0.1.4
-    "@prismicio/types-internal": 3.10.1
+    "@prismicio/types-internal": 3.11.0-alpha.0
     "@size-limit/preset-small-lib": 8.2.4
     "@slicemachine/plugin-kit": "workspace:*"
     "@types/common-tags": 1.8.1
@@ -10198,7 +10198,7 @@ __metadata:
   dependencies:
     "@prismicio/mock": 0.7.1
     "@prismicio/simulator": ^0.1.4
-    "@prismicio/types-internal": 3.10.1
+    "@prismicio/types-internal": 3.11.0-alpha.0
     "@size-limit/preset-small-lib": 8.2.4
     "@slicemachine/plugin-kit": "workspace:*"
     "@sveltejs/kit": 2.20.6
@@ -10252,7 +10252,7 @@ __metadata:
     "@msgpack/msgpack": 2.8.0
     "@playwright/test": ^1
     "@prismicio/e2e-tests-utils": 1.11.0
-    "@prismicio/types-internal": 3.10.1
+    "@prismicio/types-internal": 3.11.0-alpha.0
     "@slicemachine/manager": "workspace:*"
     "@types/node": 22.15.17
     "@typescript-eslint/eslint-plugin": 7.17.0
@@ -10324,7 +10324,7 @@ __metadata:
     "@prismicio/custom-types-client": 2.1.0
     "@prismicio/mock": 0.7.1
     "@prismicio/mocks": 2.13.0
-    "@prismicio/types-internal": 3.10.1
+    "@prismicio/types-internal": 3.11.0-alpha.0
     "@segment/analytics-node": ^2.1.2
     "@size-limit/preset-small-lib": 8.2.4
     "@slicemachine/plugin-kit": "workspace:*"
@@ -10382,7 +10382,7 @@ __metadata:
   dependencies:
     "@prismicio/client": 7.17.0
     "@prismicio/mock": 0.7.1
-    "@prismicio/types-internal": 3.10.1
+    "@prismicio/types-internal": 3.11.0-alpha.0
     "@size-limit/preset-small-lib": 8.2.4
     "@types/common-tags": 1.8.1
     "@types/fs-extra": 11.0.1
@@ -33873,7 +33873,7 @@ __metadata:
     "@prismicio/mock": 0.7.1
     "@prismicio/mocks": 2.13.0
     "@prismicio/simulator": 0.1.4
-    "@prismicio/types-internal": 3.10.1
+    "@prismicio/types-internal": 3.11.0-alpha.0
     "@radix-ui/react-hover-card": 1.0.6
     "@radix-ui/react-tabs": 1.0.4
     "@radix-ui/react-visually-hidden": 1.1.1
@@ -34342,7 +34342,7 @@ __metadata:
   resolution: "start-slicemachine@workspace:packages/start-slicemachine"
   dependencies:
     "@prismicio/mocks": 2.13.0
-    "@prismicio/types-internal": 3.10.1
+    "@prismicio/types-internal": 3.11.0-alpha.0
     "@size-limit/preset-small-lib": 8.2.4
     "@slicemachine/manager": "workspace:*"
     "@types/body-parser": 1.19.2

--- a/yarn.lock
+++ b/yarn.lock
@@ -7140,9 +7140,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@prismicio/types-internal@npm:3.10.0":
-  version: 3.10.0
-  resolution: "@prismicio/types-internal@npm:3.10.0"
+"@prismicio/types-internal@npm:3.10.1":
+  version: 3.10.1
+  resolution: "@prismicio/types-internal@npm:3.10.1"
   dependencies:
     monocle-ts: ^2.3.11
     newtype-ts: ^0.3.5
@@ -7152,7 +7152,7 @@ __metadata:
     fp-ts: ^2.11.8
     io-ts: ^2.2.16
     io-ts-types: ^0.5.16
-  checksum: a31bd487e009d549d3abee93d0d6ee4df4e4cb554cf203d9850fd0f239e7459664cd97e69799262c9d6a664c10e335999d4450620cba9b4d5e38f23c79d12300
+  checksum: 1db481da374b8ad9ac3c7f4e639f84a76e80a3abd900251572038382f59d6f564381c74f80b0eb431973064a44c81b5a8e44594d9cd0d28f53efbb4d44cbaf8e
   languageName: node
   linkType: hard
 
@@ -10070,7 +10070,7 @@ __metadata:
   dependencies:
     "@prismicio/mock": 0.7.1
     "@prismicio/simulator": ^0.1.4
-    "@prismicio/types-internal": 3.10.0
+    "@prismicio/types-internal": 3.10.1
     "@size-limit/preset-small-lib": 8.2.4
     "@slicemachine/plugin-kit": "workspace:*"
     "@types/common-tags": 1.8.1
@@ -10115,7 +10115,7 @@ __metadata:
   dependencies:
     "@prismicio/mock": 0.7.1
     "@prismicio/simulator": ^0.1.4
-    "@prismicio/types-internal": 3.10.0
+    "@prismicio/types-internal": 3.10.1
     "@size-limit/preset-small-lib": 8.2.4
     "@slicemachine/plugin-kit": "workspace:*"
     "@typescript-eslint/eslint-plugin": 5.55.0
@@ -10156,7 +10156,7 @@ __metadata:
   dependencies:
     "@prismicio/mock": 0.7.1
     "@prismicio/simulator": ^0.1.4
-    "@prismicio/types-internal": 3.10.0
+    "@prismicio/types-internal": 3.10.1
     "@size-limit/preset-small-lib": 8.2.4
     "@slicemachine/plugin-kit": "workspace:*"
     "@types/common-tags": 1.8.1
@@ -10198,7 +10198,7 @@ __metadata:
   dependencies:
     "@prismicio/mock": 0.7.1
     "@prismicio/simulator": ^0.1.4
-    "@prismicio/types-internal": 3.10.0
+    "@prismicio/types-internal": 3.10.1
     "@size-limit/preset-small-lib": 8.2.4
     "@slicemachine/plugin-kit": "workspace:*"
     "@sveltejs/kit": 2.20.6
@@ -10252,7 +10252,7 @@ __metadata:
     "@msgpack/msgpack": 2.8.0
     "@playwright/test": ^1
     "@prismicio/e2e-tests-utils": 1.11.0
-    "@prismicio/types-internal": 3.10.0
+    "@prismicio/types-internal": 3.10.1
     "@slicemachine/manager": "workspace:*"
     "@types/node": 22.15.17
     "@typescript-eslint/eslint-plugin": 7.17.0
@@ -10324,7 +10324,7 @@ __metadata:
     "@prismicio/custom-types-client": 2.1.0
     "@prismicio/mock": 0.7.1
     "@prismicio/mocks": 2.13.0
-    "@prismicio/types-internal": 3.10.0
+    "@prismicio/types-internal": 3.10.1
     "@segment/analytics-node": ^2.1.2
     "@size-limit/preset-small-lib": 8.2.4
     "@slicemachine/plugin-kit": "workspace:*"
@@ -10382,7 +10382,7 @@ __metadata:
   dependencies:
     "@prismicio/client": 7.17.0
     "@prismicio/mock": 0.7.1
-    "@prismicio/types-internal": 3.10.0
+    "@prismicio/types-internal": 3.10.1
     "@size-limit/preset-small-lib": 8.2.4
     "@types/common-tags": 1.8.1
     "@types/fs-extra": 11.0.1
@@ -33873,7 +33873,7 @@ __metadata:
     "@prismicio/mock": 0.7.1
     "@prismicio/mocks": 2.13.0
     "@prismicio/simulator": 0.1.4
-    "@prismicio/types-internal": 3.10.0
+    "@prismicio/types-internal": 3.10.1
     "@radix-ui/react-hover-card": 1.0.6
     "@radix-ui/react-tabs": 1.0.4
     "@radix-ui/react-visually-hidden": 1.1.1
@@ -34342,7 +34342,7 @@ __metadata:
   resolution: "start-slicemachine@workspace:packages/start-slicemachine"
   dependencies:
     "@prismicio/mocks": 2.13.0
-    "@prismicio/types-internal": 3.10.0
+    "@prismicio/types-internal": 3.10.1
     "@size-limit/preset-small-lib": 8.2.4
     "@slicemachine/manager": "workspace:*"
     "@types/body-parser": 1.19.2

--- a/yarn.lock
+++ b/yarn.lock
@@ -7140,9 +7140,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@prismicio/types-internal@npm:3.11.0-alpha.0":
-  version: 3.11.0-alpha.0
-  resolution: "@prismicio/types-internal@npm:3.11.0-alpha.0"
+"@prismicio/types-internal@npm:3.11.0":
+  version: 3.11.0
+  resolution: "@prismicio/types-internal@npm:3.11.0"
   dependencies:
     monocle-ts: ^2.3.11
     newtype-ts: ^0.3.5
@@ -7152,7 +7152,7 @@ __metadata:
     fp-ts: ^2.11.8
     io-ts: ^2.2.16
     io-ts-types: ^0.5.16
-  checksum: 6cfdf0694ad33a3316be55f6d9e4c5ea85f94d78830b23cb258a7243050afbf9c2af2b61cd877e017add2dc8330141b7b968a112bcefd0b2434d7a500145c8f7
+  checksum: 4cba5ab8627cd857a77750f50d857f08a182ee8a8c4b4026376aa15563c34fcf41d1808fd36d5d6a8843935d2c97e9661ea40cd996553e840d3c3e99454e58da
   languageName: node
   linkType: hard
 
@@ -10070,7 +10070,7 @@ __metadata:
   dependencies:
     "@prismicio/mock": 0.7.1
     "@prismicio/simulator": ^0.1.4
-    "@prismicio/types-internal": 3.11.0-alpha.0
+    "@prismicio/types-internal": 3.11.0
     "@size-limit/preset-small-lib": 8.2.4
     "@slicemachine/plugin-kit": "workspace:*"
     "@types/common-tags": 1.8.1
@@ -10115,7 +10115,7 @@ __metadata:
   dependencies:
     "@prismicio/mock": 0.7.1
     "@prismicio/simulator": ^0.1.4
-    "@prismicio/types-internal": 3.11.0-alpha.0
+    "@prismicio/types-internal": 3.11.0
     "@size-limit/preset-small-lib": 8.2.4
     "@slicemachine/plugin-kit": "workspace:*"
     "@typescript-eslint/eslint-plugin": 5.55.0
@@ -10156,7 +10156,7 @@ __metadata:
   dependencies:
     "@prismicio/mock": 0.7.1
     "@prismicio/simulator": ^0.1.4
-    "@prismicio/types-internal": 3.11.0-alpha.0
+    "@prismicio/types-internal": 3.11.0
     "@size-limit/preset-small-lib": 8.2.4
     "@slicemachine/plugin-kit": "workspace:*"
     "@types/common-tags": 1.8.1
@@ -10198,7 +10198,7 @@ __metadata:
   dependencies:
     "@prismicio/mock": 0.7.1
     "@prismicio/simulator": ^0.1.4
-    "@prismicio/types-internal": 3.11.0-alpha.0
+    "@prismicio/types-internal": 3.11.0
     "@size-limit/preset-small-lib": 8.2.4
     "@slicemachine/plugin-kit": "workspace:*"
     "@sveltejs/kit": 2.20.6
@@ -10252,7 +10252,7 @@ __metadata:
     "@msgpack/msgpack": 2.8.0
     "@playwright/test": ^1
     "@prismicio/e2e-tests-utils": 1.11.0
-    "@prismicio/types-internal": 3.11.0-alpha.0
+    "@prismicio/types-internal": 3.11.0
     "@slicemachine/manager": "workspace:*"
     "@types/node": 22.15.17
     "@typescript-eslint/eslint-plugin": 7.17.0
@@ -10324,7 +10324,7 @@ __metadata:
     "@prismicio/custom-types-client": 2.1.0
     "@prismicio/mock": 0.7.1
     "@prismicio/mocks": 2.13.0
-    "@prismicio/types-internal": 3.11.0-alpha.0
+    "@prismicio/types-internal": 3.11.0
     "@segment/analytics-node": ^2.1.2
     "@size-limit/preset-small-lib": 8.2.4
     "@slicemachine/plugin-kit": "workspace:*"
@@ -10382,7 +10382,7 @@ __metadata:
   dependencies:
     "@prismicio/client": 7.17.0
     "@prismicio/mock": 0.7.1
-    "@prismicio/types-internal": 3.11.0-alpha.0
+    "@prismicio/types-internal": 3.11.0
     "@size-limit/preset-small-lib": 8.2.4
     "@types/common-tags": 1.8.1
     "@types/fs-extra": 11.0.1
@@ -33873,7 +33873,7 @@ __metadata:
     "@prismicio/mock": 0.7.1
     "@prismicio/mocks": 2.13.0
     "@prismicio/simulator": 0.1.4
-    "@prismicio/types-internal": 3.11.0-alpha.0
+    "@prismicio/types-internal": 3.11.0
     "@radix-ui/react-hover-card": 1.0.6
     "@radix-ui/react-tabs": 1.0.4
     "@radix-ui/react-visually-hidden": 1.1.1
@@ -34342,7 +34342,7 @@ __metadata:
   resolution: "start-slicemachine@workspace:packages/start-slicemachine"
   dependencies:
     "@prismicio/mocks": 2.13.0
-    "@prismicio/types-internal": 3.11.0-alpha.0
+    "@prismicio/types-internal": 3.11.0
     "@size-limit/preset-small-lib": 8.2.4
     "@slicemachine/manager": "workspace:*"
     "@types/body-parser": 1.19.2


### PR DESCRIPTION
Relates to: DT-2692

### Description

Support group fields using the new Content Relationship tree view picker.

### Preview

![Screenshot 2025-06-05 at 14 31 22](https://github.com/user-attachments/assets/84a09b1d-ac58-4d91-9917-0bfa3dbb57a7)

### How to QA [^1]

<!-- When relevant, describe how to QA your changes. -->

<!-- Your favorite emoji is welcome to close your PR! -->

<!-- A note for reviewers: -->

[^1]:
	Please use these labels when submitting a review:
	:question: #ask:&ensp;Ask a question.
	:bulb: #idea:&ensp;Suggest an idea.
	:warning: #issue:&ensp;Strongly suggest a change.
	:tada: #nice:&ensp;Share a compliment.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for group fields in the content relationship field picker, allowing nested fields and improved selection flexibility.

- **Bug Fixes**
  - Enhanced validation for custom types, enabling more robust and recursive validation of nested fields and group structures.

- **Chores**
  - Updated internal dependencies to improve stability and maintain compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->