### PR TITLE
fix: rules of hooks error for Content Relationship field modal

### DIFF
--- a/packages/slice-machine/src/legacy/lib/builders/common/EditModal/index.jsx
+++ b/packages/slice-machine/src/legacy/lib/builders/common/EditModal/index.jsx
@@ -1,4 +1,5 @@
 import Modal from "react-modal";
+import { useSelector } from "react-redux";
 import { Box, Button, Close, Flex, useThemeUI } from "theme-ui";
 import * as yup from "yup";
 
@@ -12,15 +13,14 @@ import {
   createInitialValues,
 } from "@/legacy/lib/forms";
 import { DeprecatedMockConfigMessage } from "@/legacy/lib/models/common/DeprecatedMockConfigMessage";
+import { hasLocal } from "@/legacy/lib/models/common/ModelData";
 import { Widgets } from "@/legacy/lib/models/common/widgets";
 import { removeProp } from "@/legacy/lib/utils";
+import { selectAllCustomTypes } from "@/modules/availableCustomTypes";
 
 import { findWidgetByConfigOrType } from "../../utils";
 import WidgetFormField from "./Field";
 import WidgetForm from "./Form";
-import { selectAllCustomTypes } from "@/modules/availableCustomTypes";
-import { useSelector } from "react-redux";
-import { hasLocal } from "@/legacy/lib/models/common/ModelData";
 
 if (process.env.NODE_ENV !== "test") {
   Modal.setAppElement("#__next");

--- a/packages/slice-machine/src/legacy/lib/builders/common/EditModal/index.jsx
+++ b/packages/slice-machine/src/legacy/lib/builders/common/EditModal/index.jsx
@@ -18,6 +18,9 @@ import { removeProp } from "@/legacy/lib/utils";
 import { findWidgetByConfigOrType } from "../../utils";
 import WidgetFormField from "./Field";
 import WidgetForm from "./Form";
+import { selectAllCustomTypes } from "@/modules/availableCustomTypes";
+import { useSelector } from "react-redux";
+import { hasLocal } from "@/legacy/lib/models/common/ModelData";
 
 if (process.env.NODE_ENV !== "test") {
   Modal.setAppElement("#__next");
@@ -27,6 +30,7 @@ const FORM_ID = "edit-modal-form";
 
 const EditModal = ({ close, data, fields, onSave, zoneType }) => {
   const { theme } = useThemeUI();
+  const localCustomTypes = useSelector(selectAllCustomTypes).filter(hasLocal);
 
   // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/strict-boolean-expressions
   if (!data.isOpen) {
@@ -65,7 +69,10 @@ const EditModal = ({ close, data, fields, onSave, zoneType }) => {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/strict-boolean-expressions
     ...(maybeWidget.prepareInitialValues
       ? // eslint-disable-next-line
-        maybeWidget.prepareInitialValues(initialModelValues.config)
+        maybeWidget.prepareInitialValues(
+          localCustomTypes,
+          initialModelValues.config,
+        )
       : // eslint-disable-next-line
         initialModelValues.config),
   };

--- a/packages/slice-machine/src/legacy/lib/builders/common/EditModal/index.jsx
+++ b/packages/slice-machine/src/legacy/lib/builders/common/EditModal/index.jsx
@@ -71,6 +71,7 @@ const EditModal = ({ close, data, fields, onSave, zoneType }) => {
       ? // eslint-disable-next-line
         maybeWidget.prepareInitialValues(
           localCustomTypes,
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
           initialModelValues.config,
         )
       : // eslint-disable-next-line

--- a/packages/slice-machine/src/legacy/lib/models/common/widgets/ContentRelationship/index.ts
+++ b/packages/slice-machine/src/legacy/lib/models/common/widgets/ContentRelationship/index.ts
@@ -1,10 +1,6 @@
 import { Link } from "@prismicio/types-internal/lib/customtypes/widgets/nestable";
 import { MdSettingsEthernet } from "react-icons/md";
-import { useSelector } from "react-redux";
 import * as yup from "yup";
-
-import { hasLocal } from "@/legacy/lib/models/common/ModelData";
-import { selectAllCustomTypes } from "@/modules/availableCustomTypes";
 
 import { linkConfigSchema } from "../Link";
 import { Widget } from "../Widget";
@@ -61,12 +57,7 @@ export const ContentRelationshipWidget: Widget<Link, typeof schema> = {
   FormFields,
   CUSTOM_NAME: "ContentRelationship",
   Form,
-  prepareInitialValues: (initialValues) => {
-    const customTypes =
-      // TODO: fix this error
-      // eslint-disable-next-line react-hooks/rules-of-hooks
-      useSelector(selectAllCustomTypes).filter(hasLocal);
-
+  prepareInitialValues: (customTypes, initialValues) => {
     if (!initialValues?.customtypes) {
       return initialValues;
     }

--- a/packages/slice-machine/src/legacy/lib/models/common/widgets/Widget.ts
+++ b/packages/slice-machine/src/legacy/lib/models/common/widgets/Widget.ts
@@ -4,6 +4,7 @@ import { AnyObjectSchema } from "yup";
 
 import { TabField } from "@/legacy/lib/models/common/CustomType";
 import { GroupSM, NestedGroupSM } from "@/legacy/lib/models/common/Group";
+import { LocalOnlyCustomType } from "@/legacy/lib/models/common/ModelData";
 
 interface WidgetBase<F extends TabField, S extends AnyObjectSchema> {
   TYPE_NAME: FieldType;
@@ -19,7 +20,10 @@ interface WidgetBase<F extends TabField, S extends AnyObjectSchema> {
   CustomListItem?: (props: any) => React.ReactElement;
   // eslint-disable-next-line @typescript-eslint/ban-types, @typescript-eslint/no-explicit-any
   Form?: (props: any) => React.ReactNode;
-  prepareInitialValues?: (props: F["config"]) => F["config"];
+  prepareInitialValues?: (
+    customTypes: LocalOnlyCustomType[],
+    initialValues: F["config"],
+  ) => F["config"];
 }
 
 export type Widget<F extends TabField, S extends AnyObjectSchema> = F extends

--- a/packages/slice-machine/test/lib/builders/EditModal.test.tsx
+++ b/packages/slice-machine/test/lib/builders/EditModal.test.tsx
@@ -7,8 +7,103 @@ import { describe, expect, test, vi } from "vitest";
 import EditModal from "@/legacy/lib/builders/common/EditModal";
 
 import { act, fireEvent, render } from "../../__testutils__";
+import { SliceMachineStoreType } from "@/redux/type";
 
 vi.mock("next/router", () => require("next-router-mock"));
+
+const preloadedState: Partial<SliceMachineStoreType> = {
+  availableCustomTypes: {
+    page: {
+      local: {
+        id: "page",
+        label: "Page",
+        format: "page",
+        repeatable: true,
+        status: true,
+        tabs: [
+          {
+            key: "Main",
+            value: [
+              {
+                key: "uid",
+                value: {
+                  type: "UID",
+                  config: {
+                    label: "UID",
+                    placeholder: "",
+                  },
+                },
+              },
+              {
+                key: "title",
+                value: {
+                  type: "StructuredText",
+                  config: {
+                    label: "Title",
+                    placeholder: "",
+                    allowTargetBlank: true,
+                    single: "heading1",
+                  },
+                },
+              },
+            ],
+            sliceZone: {
+              key: "slices",
+              value: [
+                {
+                  key: "rich_text",
+                  value: {
+                    type: "SharedSlice",
+                  },
+                },
+              ],
+            },
+          },
+          {
+            key: "SEO & Metadata",
+            value: [
+              {
+                key: "meta_title",
+                value: {
+                  type: "Text",
+                  config: {
+                    label: "Meta Title",
+                    placeholder:
+                      "A title of the page used for social media and search engines",
+                  },
+                },
+              },
+              {
+                key: "meta_description",
+                value: {
+                  type: "Text",
+                  config: {
+                    label: "Meta Description",
+                    placeholder: "A brief summary of the page",
+                  },
+                },
+              },
+              {
+                key: "meta_image",
+                value: {
+                  type: "Image",
+                  config: {
+                    label: "Meta Image",
+                    constraint: {
+                      width: 2400,
+                      height: 1260,
+                    },
+                    thumbnails: [],
+                  },
+                },
+              },
+            ],
+          },
+        ],
+      },
+    },
+  },
+};
 
 describe("EditModal", () => {
   const div = document.createElement("div");
@@ -45,6 +140,7 @@ describe("EditModal", () => {
         fields={fields}
         zoneType="slice"
       />,
+      { preloadedState },
     );
 
     const removeButton = document.querySelector(
@@ -52,12 +148,12 @@ describe("EditModal", () => {
     )?.nextSibling;
 
     // @ts-expect-error TS(2345) FIXME: Argument of type 'ChildNode | null | undefined' is... Remove this comment to see the full error message
-    await act(async () => fireEvent.click(removeButton));
+    await act(() => fireEvent.click(removeButton));
 
     const saveButton = document.querySelector('button[type="submit"]');
 
     // @ts-expect-error TS(2345) FIXME: Argument of type 'Element | null' is not assignabl... Remove this comment to see the full error message
-    await act(async () => fireEvent.click(saveButton));
+    await act(() => fireEvent.click(saveButton));
 
     expect(saveFn).toHaveBeenCalled();
 
@@ -100,25 +196,26 @@ describe("EditModal", () => {
         fields={fields}
         zoneType="slice"
       />,
+      { preloadedState },
     );
 
     const labelInput = document.querySelector('input[name="config.label"]');
     const fakeLabel = "rich text";
-    await act(async () =>
+    await act(() =>
       // @ts-expect-error TS(2345) FIXME: Argument of type 'Element | null' is not assignabl... Remove this comment to see the full error message
       fireEvent.change(labelInput, { target: { value: fakeLabel } }),
     );
 
     const idInput = document.querySelector('input[name="id"]');
     const fakeId = "some_id";
-    await act(async () =>
+    await act(() =>
       // @ts-expect-error TS(2345) FIXME: Argument of type 'Element | null' is not assignabl... Remove this comment to see the full error message
       fireEvent.change(idInput, { target: { value: fakeId } }),
     );
 
     const saveButton = document.querySelector('button[type="submit"]');
     // @ts-expect-error TS(2345) FIXME: Argument of type 'Element | null' is not assignabl... Remove this comment to see the full error message
-    await act(async () => fireEvent.click(saveButton));
+    await act(() => fireEvent.click(saveButton));
 
     expect(saveFn).toHaveBeenCalled();
     const saveData = saveFn.mock.calls[0][0];


### PR DESCRIPTION
### Description

Due to the usage of a `useSelector` inside the `prepareInitialValues` function definition for the Content Relationship field `EditModal`, which is [conditionally called](https://github.com/prismicio/slice-machine/blob/5ada132f02a5d53b18db1f7cf669a33acc9bfea1/packages/slice-machine/src/legacy/lib/builders/common/EditModal/index.jsx#L32), the order of hooks was changing, which breaks the rule of hooks, logging an error to the console.

![Screenshot 2025-06-05 at 10 15 54](https://github.com/user-attachments/assets/20089c31-56d1-4de9-855a-ec87f9fda43e)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved widget form initialization by incorporating local custom types into initial value preparation.
  - Enhanced clarity and maintainability by explicitly passing custom types to widget initialization methods instead of relying on internal state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

### How to QA [^1]

<!-- When relevant, describe how to QA your changes. -->

<!-- Your favorite emoji is welcome to close your PR! -->

<!-- A note for reviewers: -->

[^1]:
	Please use these labels when submitting a review:
	:question: #ask:&ensp;Ask a question.
	:bulb: #idea:&ensp;Suggest an idea.
	:warning: #issue:&ensp;Strongly suggest a change.
	:tada: #nice:&ensp;Share a compliment.