### PR TITLE
[DT-2704] feat: sync CR linked group fields on API id rename

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,8 @@
   "resolutions": {
     "connected-next-router/react-redux": "8.0.7",
     "react-beautiful-dnd/react-redux": "8.0.7",
-    "express": "4.20.0"
+    "express": "4.20.0",
+    "@prismicio/types-internal": "3.11.0"
   },
   "workspaces": [
     "playwright",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "connected-next-router/react-redux": "8.0.7",
     "react-beautiful-dnd/react-redux": "8.0.7",
     "express": "4.20.0",
-    "@prismicio/types-internal": "3.11.0"
+    "@prismicio/types-internal": "3.11.2"
   },
   "workspaces": [
     "playwright",

--- a/packages/adapter-next/package.json
+++ b/packages/adapter-next/package.json
@@ -67,7 +67,7 @@
 	},
 	"dependencies": {
 		"@prismicio/simulator": "^0.1.4",
-		"@prismicio/types-internal": "3.10.0",
+		"@prismicio/types-internal": "3.11.0",
 		"@slicemachine/plugin-kit": "workspace:*",
 		"common-tags": "^1.8.2",
 		"fp-ts": "^2.13.1",

--- a/packages/adapter-next/package.json
+++ b/packages/adapter-next/package.json
@@ -67,7 +67,7 @@
 	},
 	"dependencies": {
 		"@prismicio/simulator": "^0.1.4",
-		"@prismicio/types-internal": "3.11.0",
+		"@prismicio/types-internal": "3.11.2",
 		"@slicemachine/plugin-kit": "workspace:*",
 		"common-tags": "^1.8.2",
 		"fp-ts": "^2.13.1",

--- a/packages/adapter-nuxt/package.json
+++ b/packages/adapter-nuxt/package.json
@@ -60,7 +60,7 @@
 	},
 	"dependencies": {
 		"@prismicio/simulator": "^0.1.4",
-		"@prismicio/types-internal": "3.10.0",
+		"@prismicio/types-internal": "3.11.0",
 		"@slicemachine/plugin-kit": "workspace:*",
 		"common-tags": "^1.8.2",
 		"fp-ts": "^2.13.1",

--- a/packages/adapter-nuxt/package.json
+++ b/packages/adapter-nuxt/package.json
@@ -60,7 +60,7 @@
 	},
 	"dependencies": {
 		"@prismicio/simulator": "^0.1.4",
-		"@prismicio/types-internal": "3.11.0",
+		"@prismicio/types-internal": "3.11.2",
 		"@slicemachine/plugin-kit": "workspace:*",
 		"common-tags": "^1.8.2",
 		"fp-ts": "^2.13.1",

--- a/packages/adapter-nuxt2/package.json
+++ b/packages/adapter-nuxt2/package.json
@@ -60,7 +60,7 @@
 	},
 	"dependencies": {
 		"@prismicio/simulator": "^0.1.4",
-		"@prismicio/types-internal": "3.10.0",
+		"@prismicio/types-internal": "3.11.0",
 		"@slicemachine/plugin-kit": "workspace:*",
 		"common-tags": "^1.8.2",
 		"fp-ts": "^2.13.1",

--- a/packages/adapter-nuxt2/package.json
+++ b/packages/adapter-nuxt2/package.json
@@ -60,7 +60,7 @@
 	},
 	"dependencies": {
 		"@prismicio/simulator": "^0.1.4",
-		"@prismicio/types-internal": "3.11.0",
+		"@prismicio/types-internal": "3.11.2",
 		"@slicemachine/plugin-kit": "workspace:*",
 		"common-tags": "^1.8.2",
 		"fp-ts": "^2.13.1",

--- a/packages/adapter-sveltekit/package.json
+++ b/packages/adapter-sveltekit/package.json
@@ -63,7 +63,7 @@
 	},
 	"dependencies": {
 		"@prismicio/simulator": "^0.1.4",
-		"@prismicio/types-internal": "3.10.0",
+		"@prismicio/types-internal": "3.11.0",
 		"@slicemachine/plugin-kit": "workspace:*",
 		"common-tags": "^1.8.2",
 		"fp-ts": "^2.13.1",

--- a/packages/adapter-sveltekit/package.json
+++ b/packages/adapter-sveltekit/package.json
@@ -63,7 +63,7 @@
 	},
 	"dependencies": {
 		"@prismicio/simulator": "^0.1.4",
-		"@prismicio/types-internal": "3.11.0",
+		"@prismicio/types-internal": "3.11.2",
 		"@slicemachine/plugin-kit": "workspace:*",
 		"common-tags": "^1.8.2",
 		"fp-ts": "^2.13.1",

--- a/packages/manager/package.json
+++ b/packages/manager/package.json
@@ -68,7 +68,7 @@
 		"@prismicio/client": "7.17.0",
 		"@prismicio/custom-types-client": "2.1.0",
 		"@prismicio/mocks": "2.13.0",
-		"@prismicio/types-internal": "3.10.0",
+		"@prismicio/types-internal": "3.11.0",
 		"@segment/analytics-node": "^2.1.2",
 		"@slicemachine/plugin-kit": "workspace:*",
 		"cookie": "^1.0.1",

--- a/packages/manager/package.json
+++ b/packages/manager/package.json
@@ -68,7 +68,7 @@
 		"@prismicio/client": "7.17.0",
 		"@prismicio/custom-types-client": "2.1.0",
 		"@prismicio/mocks": "2.13.0",
-		"@prismicio/types-internal": "3.11.0",
+		"@prismicio/types-internal": "3.11.2",
 		"@segment/analytics-node": "^2.1.2",
 		"@slicemachine/plugin-kit": "workspace:*",
 		"cookie": "^1.0.1",

--- a/packages/manager/src/managers/customTypes/CustomTypesManager.ts
+++ b/packages/manager/src/managers/customTypes/CustomTypesManager.ts
@@ -897,6 +897,14 @@ interface CrUpdatePathIds {
 }
 
 function getPathIds(path: CustomTypeUpdatePath): CrUpdatePathIds {
+	if (path.length < 2) {
+		throw new Error(
+			`Unexpected path length ${
+				path.length
+			}. Expected at least 2 segments (got: ${path.join(".")}).`,
+		);
+	}
+
 	const [customTypeId, groupOrFieldId, fieldId] = path;
 
 	return {

--- a/packages/manager/src/managers/customTypes/CustomTypesManager.ts
+++ b/packages/manager/src/managers/customTypes/CustomTypesManager.ts
@@ -578,13 +578,21 @@ function updateCRCustomType(
 
 	if (!previousPath.customTypeId || !newPath.customTypeId) {
 		throw new Error(
-			"Could not find a customtype id in previousPath and/or newPath, which should not be possible.",
+			`Could not find a customtype id in previousPath (${args.previousPath.join(
+				".",
+			)}) and/or newPath (${args.newPath.join(
+				".",
+			)}), which should not be possible.`,
 		);
 	}
 
 	if (!previousPath.fieldId || !newPath.fieldId) {
 		throw new Error(
-			"Could not find a field id in previousPath and/or newPath, which should not be possible.",
+			`Could not find a field id in previousPath (${args.previousPath.join(
+				".",
+			)}) and/or newPath (${args.newPath.join(
+				".",
+			)}), which should not be possible.`,
 		);
 	}
 

--- a/packages/manager/src/managers/customTypes/CustomTypesManager.ts
+++ b/packages/manager/src/managers/customTypes/CustomTypesManager.ts
@@ -77,6 +77,24 @@ type SliceMachineManagerUpdateCustomTypeMocksConfigArgs = {
 	mocksConfig: Record<string, unknown>;
 };
 
+export type SliceMachineManagerUpdateCustomTypeArgs =
+	CustomTypeUpdateHookData & {
+		updateMeta?: {
+			fieldIdChanged?: {
+				/**
+				 * Previous path of the changed field. Can be used to identify the field
+				 * that had an API ID rename (e.g. ["page", "title"])
+				 */
+				previousPath: string[];
+				/**
+				 * New path of the changed field. Can be used to identify the field that
+				 * had an API ID rename (e.g. ["page", "title2"])
+				 */
+				newPath: string[];
+			};
+		};
+	};
+
 type SliceMachineManagerUpdateCustomTypeMocksConfigArgsReturnType = {
 	errors: HookError[];
 };
@@ -287,7 +305,7 @@ export class CustomTypesManager extends BaseManager {
 	}
 
 	async updateCustomType(
-		args: CustomTypeUpdateHookData,
+		args: SliceMachineManagerUpdateCustomTypeArgs,
 	): Promise<CustomTypesMachineManagerUpdateCustomTypeReturnType> {
 		assertPluginsInitialized(this.sliceMachinePluginRunner);
 		const { model } = args;

--- a/packages/manager/src/managers/customTypes/CustomTypesManager.ts
+++ b/packages/manager/src/managers/customTypes/CustomTypesManager.ts
@@ -77,27 +77,29 @@ type SliceMachineManagerUpdateCustomTypeMocksConfigArgs = {
 	mocksConfig: Record<string, unknown>;
 };
 
+/** `[field]` or `[group, field]` – path **inside** the Custom Type */
+type PathWithoutCustomType = [string] | [string, string];
+
 type SliceMachineManagerUpdateCustomTypeFieldIdChanged = {
 	/**
 	 * Previous path of the changed field, excluding the custom type id. Can be
 	 * used to identify the field that had an API ID rename (e.g. ["fieldA"] or
 	 * ["groupA", "fieldA"])
 	 */
-	previousPath: [string] | [string, string];
+	previousPath: PathWithoutCustomType;
 	/**
 	 * New path of the changed field, excluding the custom type id. Can be used to
 	 * identify the field that had an API ID rename (e.g. ["fieldB"] or ["groupA",
 	 * "fieldB"])
 	 */
-	newPath: [string] | [string, string];
+	newPath: PathWithoutCustomType;
 };
 
-export type SliceMachineManagerUpdateCustomTypeArgs =
-	CustomTypeUpdateHookData & {
-		updateMeta?: {
-			fieldIdChanged?: SliceMachineManagerUpdateCustomTypeFieldIdChanged;
-		};
+type SliceMachineManagerUpdateCustomTypeArgs = CustomTypeUpdateHookData & {
+	updateMeta?: {
+		fieldIdChanged?: SliceMachineManagerUpdateCustomTypeFieldIdChanged;
 	};
+};
 
 type SliceMachineManagerUpdateCustomTypeMocksConfigArgsReturnType = {
 	errors: HookError[];
@@ -115,12 +117,12 @@ type CustomTypesMachineManagerUpdateCustomTypeReturnType = {
 	errors: (DecodeError | HookError)[];
 };
 
-/** Path of the changed field, including the custom type id. */
-type CustomTypeUpdatePath = [string, string] | [string, string, string];
+/** `[ct, field]` or `[ct, group, field]` – path **with** Custom Type ID */
+type PathWithCustomType = [string, string] | [string, string, string];
 
 type CustomTypeFieldIdChangedMeta = {
-	previousPath: CustomTypeUpdatePath;
-	newPath: CustomTypeUpdatePath;
+	previousPath: PathWithCustomType;
+	newPath: PathWithCustomType;
 };
 
 type LinkCustomType = NonNullable<LinkConfig["customtypes"]>[number];
@@ -234,8 +236,8 @@ export class CustomTypesManager extends BaseManager {
 
 		if (previousFieldPath.join(".") !== newFieldPath.join(".")) {
 			const { id: ctId } = model;
-			const previousPath: CustomTypeUpdatePath = [ctId, ...previousFieldPath];
-			const newPath: CustomTypeUpdatePath = [ctId, ...newFieldPath];
+			const previousPath: PathWithCustomType = [ctId, ...previousFieldPath];
+			const newPath: PathWithCustomType = [ctId, ...newFieldPath];
 
 			const crUpdates: {
 				updatePromise: Promise<{ errors: HookError[] }>;
@@ -896,7 +898,7 @@ interface CrUpdatePathIds {
 	fieldId: string;
 }
 
-function getPathIds(path: CustomTypeUpdatePath): CrUpdatePathIds {
+function getPathIds(path: PathWithCustomType): CrUpdatePathIds {
 	if (path.length < 2) {
 		throw new Error(
 			`Unexpected path length ${

--- a/packages/manager/src/managers/customTypes/CustomTypesManager.ts
+++ b/packages/manager/src/managers/customTypes/CustomTypesManager.ts
@@ -630,9 +630,22 @@ function updateCRCustomType(
 			// Group field
 			if ("fields" in customTypeField) {
 				if (
+					!previousPath.groupId &&
+					!newPath.groupId &&
+					customTypeField.id === previousPath.fieldId &&
+					customTypeField.id !== newPath.fieldId
+				) {
+					// Only the id of the group has changed. Group id is not defined, so
+					// we can return early.
+					return newPath.fieldId;
+				}
+
+				const matchedGroupId = customTypeField.id === previousPath.groupId;
+
+				if (
 					previousPath.groupId &&
 					newPath.groupId &&
-					customTypeField.id === previousPath.groupId &&
+					matchedGroupId &&
 					customTypeField.id !== newPath.groupId
 				) {
 					// The id of the group field has changed, so we update it. We don't
@@ -648,6 +661,7 @@ function updateCRCustomType(
 						// Regular field inside a group field
 						if (typeof groupField === "string") {
 							if (
+								matchedGroupId &&
 								groupField === previousPath.fieldId &&
 								groupField !== newPath.fieldId
 							) {
@@ -728,18 +742,27 @@ function updateContentRelationshipFields(args: {
 					return nestedCtField;
 				}
 
-				// Further down the path, the field can only be a group field. So if we have
-				// no group id defined, no need to continue.
-				if (!previousPath.groupId || !newPath.groupId) {
-					return nestedCtField;
-				}
-
 				// Group field
 
 				if (
-					nestedCtField.id === previousPath.groupId &&
-					nestedCtField.id !== newPath.groupId
+					nestedCtField.id === previousPath.fieldId &&
+					nestedCtField.id !== newPath.fieldId
 				) {
+					// The id of the field has changed.
+					nestedCtField.id = newPath.fieldId;
+				}
+
+				// Further down the path, the field can only be a group field. So if we have
+				// no group id defined, no need to continue.
+				if (
+					!previousPath.groupId ||
+					!newPath.groupId ||
+					nestedCtField.id !== previousPath.groupId
+				) {
+					return nestedCtField;
+				}
+
+				if (nestedCtField.id !== newPath.groupId) {
 					// The id of the group has changed.
 					nestedCtField.id = newPath.groupId;
 				}

--- a/packages/manager/test/SliceMachineManager-customTypes-updateCustomType.test.ts
+++ b/packages/manager/test/SliceMachineManager-customTypes-updateCustomType.test.ts
@@ -173,7 +173,7 @@ describe("updateCustomTypeContentRelationships", () => {
 		});
 	});
 
-	it("should update GROUP field ids", async () => {
+	it("should update the ids of fields inside a GROUP", async () => {
 		const onUpdate = vi.fn();
 		updateCustomTypeContentRelationships({
 			models: [
@@ -201,7 +201,33 @@ describe("updateCustomTypeContentRelationships", () => {
 				groupIds: ["shortCode_CHANGED", "flag"],
 			}),
 		});
+	});
 
+	it("should update the ids of fields inside a GROUP along with the group id", async () => {
+		const onUpdate = vi.fn();
+		updateCustomTypeContentRelationships({
+			models: [{ model: getCustomTypeModel({ groupIds: ["shortCode"] }) }],
+			previousPath: ["author", "languages", "shortCode"],
+			newPath: ["author", "languages_CHANGED", "shortCode_CHANGED"],
+			onUpdate,
+		});
+
+		expect(onUpdate).toHaveBeenCalledTimes(1);
+
+		expect(onUpdate).toHaveBeenCalledWith({
+			previousModel: getCustomTypeModel({
+				groupId: "languages",
+				groupIds: ["shortCode"],
+			}),
+			model: getCustomTypeModel({
+				groupIds: ["shortCode_CHANGED"],
+				groupId: "languages_CHANGED",
+			}),
+		});
+	});
+
+	it("should update the id of a GROUP", async () => {
+		const onUpdate = vi.fn();
 		updateCustomTypeContentRelationships({
 			models: [{ model: getCustomTypeModel() }],
 			previousPath: ["author", "languages"],
@@ -313,7 +339,7 @@ describe("updateCustomTypeContentRelationships", () => {
 			onUpdate,
 		});
 
-		// Wrong regular field id
+		// Wrong field id
 
 		updateCustomTypeContentRelationships({
 			models: [
@@ -334,13 +360,6 @@ describe("updateCustomTypeContentRelationships", () => {
 			],
 			previousPath: ["author", "languages_WRONG", "shortCode"],
 			newPath: ["author", "languages_NEW", "shortCode_NEW"],
-			onUpdate,
-		});
-
-		updateCustomTypeContentRelationships({
-			models: [{ model: getCustomTypeModel() }],
-			previousPath: ["author", "languages_WRONG"],
-			newPath: ["author", "languages_NEW"],
 			onUpdate,
 		});
 
@@ -431,7 +450,7 @@ describe("updateSharedSliceContentRelationships", () => {
 		});
 	});
 
-	it("should update GROUP field ids", async () => {
+	it("should update the ids of fields inside a GROUP", async () => {
 		const onUpdate = vi.fn();
 		updateSharedSliceContentRelationships({
 			models: [
@@ -459,7 +478,33 @@ describe("updateSharedSliceContentRelationships", () => {
 				groupIds: ["shortCode_CHANGED", "flag"],
 			}),
 		});
+	});
 
+	it("should update the ids of fields inside a GROUP along with the group id", async () => {
+		const onUpdate = vi.fn();
+		updateSharedSliceContentRelationships({
+			models: [{ model: getSharedSliceModel({ groupIds: ["shortCode"] }) }],
+			previousPath: ["author", "languages", "shortCode"],
+			newPath: ["author", "languages_CHANGED", "shortCode_CHANGED"],
+			onUpdate,
+		});
+
+		expect(onUpdate).toHaveBeenCalledTimes(1);
+
+		expect(onUpdate).toHaveBeenCalledWith({
+			previousModel: getSharedSliceModel({
+				groupId: "languages",
+				groupIds: ["shortCode"],
+			}),
+			model: getSharedSliceModel({
+				groupIds: ["shortCode_CHANGED"],
+				groupId: "languages_CHANGED",
+			}),
+		});
+	});
+
+	it("should update the id of a GROUP", async () => {
+		const onUpdate = vi.fn();
 		updateSharedSliceContentRelationships({
 			models: [{ model: getSharedSliceModel() }],
 			previousPath: ["author", "languages"],
@@ -571,7 +616,7 @@ describe("updateSharedSliceContentRelationships", () => {
 			onUpdate,
 		});
 
-		// Wrong regular field id
+		// Wrong field id
 
 		updateSharedSliceContentRelationships({
 			models: [
@@ -592,13 +637,6 @@ describe("updateSharedSliceContentRelationships", () => {
 			],
 			previousPath: ["author", "languages_WRONG", "shortCode"],
 			newPath: ["author", "languages_NEW", "shortCode_NEW"],
-			onUpdate,
-		});
-
-		updateSharedSliceContentRelationships({
-			models: [{ model: getSharedSliceModel() }],
-			previousPath: ["author", "languages_WRONG"],
-			newPath: ["author", "languages_NEW"],
 			onUpdate,
 		});
 

--- a/packages/manager/test/SliceMachineManager-customTypes-updateCustomType.test.ts
+++ b/packages/manager/test/SliceMachineManager-customTypes-updateCustomType.test.ts
@@ -299,20 +299,60 @@ describe("updateCustomTypeContentRelationships", () => {
 		}); // changed
 	});
 
-	it("should not update content relationship ids if the custom type id is not the same", async () => {
+	it("should not update anything if the ids don't match", async () => {
 		const onUpdate = vi.fn();
+		// Wrong custom type id
 
 		updateCustomTypeContentRelationships({
 			models: [
-				{
-					model: getCustomTypeModel({
-						ids: ["sameFieldName"],
-						nestedIds: ["sameFieldName"],
-					}),
-				},
+				{ model: getCustomTypeModel({ ids: ["authorLastName"] }) },
+				{ model: getCustomTypeModel({ ids: ["authorLastName", "address"] }) },
 			],
-			previousPath: ["differentCustomType", "sameFieldName"],
-			newPath: ["differentCustomType", "sameFieldName_CHANGED"],
+			previousPath: ["author_WRONG", "authorLastName"],
+			newPath: ["author_WRONG", "authorLastName_NEW"],
+			onUpdate,
+		});
+
+		// Wrong regular field id
+
+		updateCustomTypeContentRelationships({
+			models: [
+				{ model: getCustomTypeModel({ ids: ["authorLastName"] }) },
+				{ model: getCustomTypeModel({ ids: ["authorLastName", "address"] }) },
+			],
+			previousPath: ["author", "authorLastName_WRONG"],
+			newPath: ["author", "authorLastName_NEW"],
+			onUpdate,
+		});
+
+		// Wrong group id
+
+		updateCustomTypeContentRelationships({
+			models: [
+				{ model: getCustomTypeModel({ groupIds: ["shortCode"] }) },
+				{ model: getCustomTypeModel({ groupIds: ["shortCode", "flag"] }) },
+			],
+			previousPath: ["author", "languages_WRONG", "shortCode"],
+			newPath: ["author", "languages_NEW", "shortCode_NEW"],
+			onUpdate,
+		});
+
+		updateCustomTypeContentRelationships({
+			models: [{ model: getCustomTypeModel() }],
+			previousPath: ["author", "languages_WRONG"],
+			newPath: ["author", "languages_NEW"],
+			onUpdate,
+		});
+
+		// Wrong group field id
+
+		updateCustomTypeContentRelationships({
+			models: [
+				{ model: getCustomTypeModel({ groupIds: ["shortCode"] }) },
+				{ model: getCustomTypeModel({ groupIds: ["shortCode", "flag"] }) },
+			],
+			previousPath: ["author", "languages", "shortCode_WRONG"],
+			newPath: ["author", "languages", "shortCode_NEW"],
 			onUpdate,
 		});
 
@@ -517,20 +557,60 @@ describe("updateSharedSliceContentRelationships", () => {
 		}); // changed
 	});
 
-	it("should not update content relationship ids if the custom type id is not the same", async () => {
+	it("should not update anything if the ids don't match", async () => {
 		const onUpdate = vi.fn();
+		// Wrong custom type id
 
 		updateSharedSliceContentRelationships({
 			models: [
-				{
-					model: getSharedSliceModel({
-						ids: ["sameFieldName"],
-						nestedIds: ["sameFieldName"],
-					}),
-				},
+				{ model: getSharedSliceModel({ ids: ["authorLastName"] }) },
+				{ model: getSharedSliceModel({ ids: ["authorLastName", "address"] }) },
 			],
-			previousPath: ["differentCustomTypeId", "sameFieldName"],
-			newPath: ["differentCustomTypeId", "sameFieldName_CHANGED"],
+			previousPath: ["author_WRONG", "authorLastName"],
+			newPath: ["author_WRONG", "authorLastName_NEW"],
+			onUpdate,
+		});
+
+		// Wrong regular field id
+
+		updateSharedSliceContentRelationships({
+			models: [
+				{ model: getSharedSliceModel({ ids: ["authorLastName"] }) },
+				{ model: getSharedSliceModel({ ids: ["authorLastName", "address"] }) },
+			],
+			previousPath: ["author", "authorLastName_WRONG"],
+			newPath: ["author", "authorLastName_NEW"],
+			onUpdate,
+		});
+
+		// Wrong group id
+
+		updateSharedSliceContentRelationships({
+			models: [
+				{ model: getSharedSliceModel({ groupIds: ["shortCode"] }) },
+				{ model: getSharedSliceModel({ groupIds: ["shortCode", "flag"] }) },
+			],
+			previousPath: ["author", "languages_WRONG", "shortCode"],
+			newPath: ["author", "languages_NEW", "shortCode_NEW"],
+			onUpdate,
+		});
+
+		updateSharedSliceContentRelationships({
+			models: [{ model: getSharedSliceModel() }],
+			previousPath: ["author", "languages_WRONG"],
+			newPath: ["author", "languages_NEW"],
+			onUpdate,
+		});
+
+		// Wrong group field id
+
+		updateSharedSliceContentRelationships({
+			models: [
+				{ model: getSharedSliceModel({ groupIds: ["shortCode"] }) },
+				{ model: getSharedSliceModel({ groupIds: ["shortCode", "flag"] }) },
+			],
+			previousPath: ["author", "languages", "shortCode_WRONG"],
+			newPath: ["author", "languages", "shortCode_NEW"],
 			onUpdate,
 		});
 

--- a/packages/manager/test/SliceMachineManager-customTypes-updateCustomType.test.ts
+++ b/packages/manager/test/SliceMachineManager-customTypes-updateCustomType.test.ts
@@ -382,8 +382,8 @@ describe("updateCustomTypeContentRelationships", () => {
 		expect(() => {
 			return updateCustomTypeContentRelationships({
 				models: [{ model: getCustomTypeModel() }],
-				previousPath: [],
-				newPath: [],
+				previousPath: [] as unknown as [string, string],
+				newPath: [] as unknown as [string, string],
 				onUpdate: vi.fn(),
 			});
 		}).toThrow();
@@ -659,8 +659,8 @@ describe("updateSharedSliceContentRelationships", () => {
 		expect(() => {
 			return updateSharedSliceContentRelationships({
 				models: [{ model: getSharedSliceModel() }],
-				previousPath: [],
-				newPath: [],
+				previousPath: [] as unknown as [string, string],
+				newPath: [] as unknown as [string, string],
 				onUpdate: vi.fn(),
 			});
 		}).toThrow();

--- a/packages/manager/test/SliceMachineManager-customTypes-updateCustomType.test.ts
+++ b/packages/manager/test/SliceMachineManager-customTypes-updateCustomType.test.ts
@@ -215,48 +215,6 @@ describe("updateCustomTypeContentRelationships", () => {
 		}); // changed
 	});
 
-	it("should update NESTED GROUP field ids", async () => {
-		const onUpdate = vi.fn();
-		updateCustomTypeContentRelationships({
-			models: [
-				{ model: getCustomTypeModel({ nestedGroupIds: ["phone"] }) },
-				{ model: getCustomTypeModel({ nestedGroupIds: ["email"] }) },
-				{ model: getCustomTypeModel({ nestedGroupIds: ["phone", "email"] }) },
-			],
-			previousPath: ["address", "contactDetails", "phone"],
-			newPath: ["address", "contactDetails", "phone_CHANGED"],
-			onUpdate,
-		});
-
-		// less calls than models because onUpdate is only called if the model has changed
-		expect(onUpdate).toHaveBeenCalledTimes(2);
-
-		expect(onUpdate).toHaveBeenCalledWith({
-			previousModel: getCustomTypeModel({ nestedGroupIds: ["phone"] }),
-			model: getCustomTypeModel({ nestedGroupIds: ["phone_CHANGED"] }),
-		});
-		expect(onUpdate).toHaveBeenCalledWith({
-			previousModel: getCustomTypeModel({
-				nestedGroupIds: ["phone", "email"],
-			}),
-			model: getCustomTypeModel({
-				nestedGroupIds: ["phone_CHANGED", "email"],
-			}),
-		});
-
-		updateCustomTypeContentRelationships({
-			models: [{ model: getCustomTypeModel() }],
-			previousPath: ["address", "contactDetails"],
-			newPath: ["address", "contactDetails_CHANGED"],
-			onUpdate,
-		});
-
-		expect(onUpdate).toHaveBeenCalledWith({
-			previousModel: getCustomTypeModel({ nestedGroupId: "contactDetails" }),
-			model: getCustomTypeModel({ nestedGroupId: "contactDetails_CHANGED" }),
-		}); // changed
-	});
-
 	it("should update NESTED content relationship ids", async () => {
 		const onUpdate = vi.fn();
 		updateCustomTypeContentRelationships({
@@ -299,6 +257,48 @@ describe("updateCustomTypeContentRelationships", () => {
 		}); // changed
 	});
 
+	it("should update NESTED GROUP field ids", async () => {
+		const onUpdate = vi.fn();
+		updateCustomTypeContentRelationships({
+			models: [
+				{ model: getCustomTypeModel({ nestedGroupIds: ["phone"] }) },
+				{ model: getCustomTypeModel({ nestedGroupIds: ["email"] }) },
+				{ model: getCustomTypeModel({ nestedGroupIds: ["phone", "email"] }) },
+			],
+			previousPath: ["address", "contactDetails", "phone"],
+			newPath: ["address", "contactDetails", "phone_CHANGED"],
+			onUpdate,
+		});
+
+		// less calls than models because onUpdate is only called if the model has changed
+		expect(onUpdate).toHaveBeenCalledTimes(2);
+
+		expect(onUpdate).toHaveBeenCalledWith({
+			previousModel: getCustomTypeModel({ nestedGroupIds: ["phone"] }),
+			model: getCustomTypeModel({ nestedGroupIds: ["phone_CHANGED"] }),
+		});
+		expect(onUpdate).toHaveBeenCalledWith({
+			previousModel: getCustomTypeModel({
+				nestedGroupIds: ["phone", "email"],
+			}),
+			model: getCustomTypeModel({
+				nestedGroupIds: ["phone_CHANGED", "email"],
+			}),
+		});
+
+		updateCustomTypeContentRelationships({
+			models: [{ model: getCustomTypeModel() }],
+			previousPath: ["address", "contactDetails"],
+			newPath: ["address", "contactDetails_CHANGED"],
+			onUpdate,
+		});
+
+		expect(onUpdate).toHaveBeenCalledWith({
+			previousModel: getCustomTypeModel({ nestedGroupId: "contactDetails" }),
+			model: getCustomTypeModel({ nestedGroupId: "contactDetails_CHANGED" }),
+		}); // changed
+	});
+
 	it("should not update content relationship ids if the custom type id is not the same", async () => {
 		const onUpdate = vi.fn();
 
@@ -335,8 +335,12 @@ describe("updateSharedSliceContentRelationships", () => {
 	function getSharedSliceModel(args?: {
 		crId?: string;
 		ids?: string[];
+		groupId?: string;
+		groupIds?: string[];
 		nestedCrId?: string;
+		nestedGroupId?: string;
 		nestedIds?: string[];
+		nestedGroupIds?: string[];
 	}): SharedSlice {
 		return {
 			id: "testSlice",
@@ -387,6 +391,48 @@ describe("updateSharedSliceContentRelationships", () => {
 		});
 	});
 
+	it("should update GROUP field ids", async () => {
+		const onUpdate = vi.fn();
+		updateSharedSliceContentRelationships({
+			models: [
+				{ model: getSharedSliceModel({ groupIds: ["shortCode"] }) },
+				{ model: getSharedSliceModel({ groupIds: ["flag"] }) },
+				{ model: getSharedSliceModel({ groupIds: ["shortCode", "flag"] }) },
+			],
+			previousPath: ["author", "languages", "shortCode"],
+			newPath: ["author", "languages", "shortCode_CHANGED"],
+			onUpdate,
+		});
+
+		// less calls than models because onUpdate is only called if the model has changed
+		expect(onUpdate).toHaveBeenCalledTimes(2);
+
+		expect(onUpdate).toHaveBeenCalledWith({
+			previousModel: getSharedSliceModel({ groupIds: ["shortCode"] }),
+			model: getSharedSliceModel({ groupIds: ["shortCode_CHANGED"] }),
+		});
+		expect(onUpdate).toHaveBeenCalledWith({
+			previousModel: getSharedSliceModel({
+				groupIds: ["shortCode", "flag"],
+			}),
+			model: getSharedSliceModel({
+				groupIds: ["shortCode_CHANGED", "flag"],
+			}),
+		});
+
+		updateSharedSliceContentRelationships({
+			models: [{ model: getSharedSliceModel() }],
+			previousPath: ["author", "languages"],
+			newPath: ["author", "languages_CHANGED"],
+			onUpdate,
+		});
+
+		expect(onUpdate).toHaveBeenCalledWith({
+			previousModel: getSharedSliceModel({ groupId: "languages" }),
+			model: getSharedSliceModel({ groupId: "languages_CHANGED" }),
+		}); // changed
+	});
+
 	it("should update slice NESTED content relationship ids", async () => {
 		const onUpdate = vi.fn();
 		updateSharedSliceContentRelationships({
@@ -426,6 +472,48 @@ describe("updateSharedSliceContentRelationships", () => {
 		expect(onUpdate).toHaveBeenCalledWith({
 			previousModel: getSharedSliceModel({ nestedCrId: "address_cr" }),
 			model: getSharedSliceModel({ nestedCrId: "address_cr_CHANGED" }),
+		}); // changed
+	});
+
+	it("should update NESTED GROUP field ids", async () => {
+		const onUpdate = vi.fn();
+		updateSharedSliceContentRelationships({
+			models: [
+				{ model: getSharedSliceModel({ nestedGroupIds: ["phone"] }) },
+				{ model: getSharedSliceModel({ nestedGroupIds: ["email"] }) },
+				{ model: getSharedSliceModel({ nestedGroupIds: ["phone", "email"] }) },
+			],
+			previousPath: ["address", "contactDetails", "phone"],
+			newPath: ["address", "contactDetails", "phone_CHANGED"],
+			onUpdate,
+		});
+
+		// less calls than models because onUpdate is only called if the model has changed
+		expect(onUpdate).toHaveBeenCalledTimes(2);
+
+		expect(onUpdate).toHaveBeenCalledWith({
+			previousModel: getSharedSliceModel({ nestedGroupIds: ["phone"] }),
+			model: getSharedSliceModel({ nestedGroupIds: ["phone_CHANGED"] }),
+		});
+		expect(onUpdate).toHaveBeenCalledWith({
+			previousModel: getSharedSliceModel({
+				nestedGroupIds: ["phone", "email"],
+			}),
+			model: getSharedSliceModel({
+				nestedGroupIds: ["phone_CHANGED", "email"],
+			}),
+		});
+
+		updateSharedSliceContentRelationships({
+			models: [{ model: getSharedSliceModel() }],
+			previousPath: ["address", "contactDetails"],
+			newPath: ["address", "contactDetails_CHANGED"],
+			onUpdate,
+		});
+
+		expect(onUpdate).toHaveBeenCalledWith({
+			previousModel: getSharedSliceModel({ nestedGroupId: "contactDetails" }),
+			model: getSharedSliceModel({ nestedGroupId: "contactDetails_CHANGED" }),
 		}); // changed
 	});
 

--- a/packages/plugin-kit/package.json
+++ b/packages/plugin-kit/package.json
@@ -76,7 +76,7 @@
 	},
 	"devDependencies": {
 		"@prismicio/mock": "0.7.1",
-		"@prismicio/types-internal": "3.11.0",
+		"@prismicio/types-internal": "3.11.2",
 		"@size-limit/preset-small-lib": "8.2.4",
 		"@types/common-tags": "1.8.1",
 		"@types/fs-extra": "11.0.1",

--- a/packages/plugin-kit/package.json
+++ b/packages/plugin-kit/package.json
@@ -76,7 +76,7 @@
 	},
 	"devDependencies": {
 		"@prismicio/mock": "0.7.1",
-		"@prismicio/types-internal": "3.10.0",
+		"@prismicio/types-internal": "3.11.0",
 		"@size-limit/preset-small-lib": "8.2.4",
 		"@types/common-tags": "1.8.1",
 		"@types/fs-extra": "11.0.1",

--- a/packages/plugin-kit/src/hooks/customType-update.ts
+++ b/packages/plugin-kit/src/hooks/customType-update.ts
@@ -11,20 +11,6 @@ import type {
  */
 export type CustomTypeUpdateHookData = {
 	model: CustomType;
-	updateMeta?: {
-		fieldIdChanged?: {
-			/**
-			 * Previous path of the changed field. Can be used to identify the field
-			 * that had an API ID rename (e.g. ["page", "title"])
-			 */
-			previousPath: string[];
-			/**
-			 * New path of the changed field. Can be used to identify the field that
-			 * had an API ID rename (e.g. ["page", "title2"])
-			 */
-			newPath: string[];
-		};
-	};
 };
 
 /**

--- a/packages/slice-machine/package.json
+++ b/packages/slice-machine/package.json
@@ -48,7 +48,7 @@
     "@prismicio/mock": "0.7.1",
     "@prismicio/mocks": "2.13.0",
     "@prismicio/simulator": "0.1.4",
-    "@prismicio/types-internal": "3.11.0",
+    "@prismicio/types-internal": "3.11.2",
     "@radix-ui/react-hover-card": "1.0.6",
     "@radix-ui/react-tabs": "1.0.4",
     "@radix-ui/react-visually-hidden": "1.1.1",

--- a/packages/slice-machine/package.json
+++ b/packages/slice-machine/package.json
@@ -48,7 +48,7 @@
     "@prismicio/mock": "0.7.1",
     "@prismicio/mocks": "2.13.0",
     "@prismicio/simulator": "0.1.4",
-    "@prismicio/types-internal": "3.10.0",
+    "@prismicio/types-internal": "3.11.0",
     "@radix-ui/react-hover-card": "1.0.6",
     "@radix-ui/react-tabs": "1.0.4",
     "@radix-ui/react-visually-hidden": "1.1.1",

--- a/packages/slice-machine/src/apiClient.ts
+++ b/packages/slice-machine/src/apiClient.ts
@@ -72,15 +72,17 @@ export const getState = async (): Promise<ServerState> => {
 export type CustomTypeUpdateMeta = {
   fieldIdChanged?: {
     /**
-     * Previous path of the changed field. Can be used to identify the field
-     * that had an API ID rename (e.g. ["page", "title"])
+     * Previous path of the changed field, excluding the custom type id. Can be
+     * used to identify the field that had an API ID rename (e.g. ["fieldA"] or
+     * ["groupA", "fieldA"])
      */
-    previousPath: string[];
+    previousPath: [string] | [string, string];
     /**
-     * New path of the changed field. Can be used to identify the field that
-     * had an API ID rename (e.g. ["page", "title2"])
+     * New path of the changed field, excluding the custom type id. Can be used to
+     * identify the field that had an API ID rename (e.g. ["fieldB"] or ["groupA",
+     * "fieldB"])
      */
-    newPath: string[];
+    newPath: [string] | [string, string];
   };
 };
 

--- a/packages/start-slicemachine/package.json
+++ b/packages/start-slicemachine/package.json
@@ -56,7 +56,7 @@
 	"bin": "./bin/start-slicemachine.js",
 	"dependencies": {
 		"@prismicio/mocks": "2.13.0",
-		"@prismicio/types-internal": "3.10.0",
+		"@prismicio/types-internal": "3.11.0",
 		"@slicemachine/manager": "workspace:*",
 		"body-parser": "^1.20.3",
 		"chalk": "^4.1.2",

--- a/packages/start-slicemachine/package.json
+++ b/packages/start-slicemachine/package.json
@@ -56,7 +56,7 @@
 	"bin": "./bin/start-slicemachine.js",
 	"dependencies": {
 		"@prismicio/mocks": "2.13.0",
-		"@prismicio/types-internal": "3.11.0",
+		"@prismicio/types-internal": "3.11.2",
 		"@slicemachine/manager": "workspace:*",
 		"body-parser": "^1.20.3",
 		"chalk": "^4.1.2",

--- a/playwright/package.json
+++ b/playwright/package.json
@@ -16,7 +16,7 @@
     "@msgpack/msgpack": "2.8.0",
     "@playwright/test": "^1",
     "@prismicio/e2e-tests-utils": "1.11.0",
-    "@prismicio/types-internal": "3.10.0",
+    "@prismicio/types-internal": "3.11.0",
     "@slicemachine/manager": "workspace:*",
     "@types/node": "22.15.17",
     "@typescript-eslint/eslint-plugin": "7.17.0",

--- a/playwright/package.json
+++ b/playwright/package.json
@@ -16,7 +16,7 @@
     "@msgpack/msgpack": "2.8.0",
     "@playwright/test": "^1",
     "@prismicio/e2e-tests-utils": "1.11.0",
-    "@prismicio/types-internal": "3.11.0",
+    "@prismicio/types-internal": "3.11.2",
     "@slicemachine/manager": "workspace:*",
     "@types/node": "22.15.17",
     "@typescript-eslint/eslint-plugin": "7.17.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6799,38 +6799,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@prismicio/types-internal@npm:3.9.0, @prismicio/types-internal@npm:^3.9.0":
-  version: 3.9.0
-  resolution: "@prismicio/types-internal@npm:3.9.0"
-  dependencies:
-    monocle-ts: ^2.3.11
-    newtype-ts: ^0.3.5
-    tslib: ^2.3.1
-    uuid: ^9.0.0
-  peerDependencies:
-    fp-ts: ^2.11.8
-    io-ts: ^2.2.16
-    io-ts-types: ^0.5.16
-  checksum: 16f8c7a2fd71b02fc7a3583c871a0366c8d8259fe00e9542ff11e461efd65a52dde9851589e3ddfa6217b9080d226952363abeb72d123b763bc5c118be017682
-  languageName: node
-  linkType: hard
-
-"@prismicio/types-internal@npm:^3.8.0":
-  version: 3.8.0
-  resolution: "@prismicio/types-internal@npm:3.8.0"
-  dependencies:
-    monocle-ts: ^2.3.11
-    newtype-ts: ^0.3.5
-    tslib: ^2.3.1
-    uuid: ^9.0.0
-  peerDependencies:
-    fp-ts: ^2.11.8
-    io-ts: ^2.2.16
-    io-ts-types: ^0.5.16
-  checksum: 9783bab3ae71933676b70b1c6dff37ce0a3599fb41da4b819c678fc126a11e7bf5310827ee18268934a892d6d9f691466952a543bb82c46e1ffc72f45605fa99
-  languageName: node
-  linkType: hard
-
 "@prismicio/types@npm:^0.2.0":
   version: 0.2.8
   resolution: "@prismicio/types@npm:0.2.8"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6783,9 +6783,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@prismicio/types-internal@npm:3.11.0":
-  version: 3.11.0
-  resolution: "@prismicio/types-internal@npm:3.11.0"
+"@prismicio/types-internal@npm:3.11.2":
+  version: 3.11.2
+  resolution: "@prismicio/types-internal@npm:3.11.2"
   dependencies:
     monocle-ts: ^2.3.11
     newtype-ts: ^0.3.5
@@ -6795,7 +6795,7 @@ __metadata:
     fp-ts: ^2.11.8
     io-ts: ^2.2.16
     io-ts-types: ^0.5.16
-  checksum: 4cba5ab8627cd857a77750f50d857f08a182ee8a8c4b4026376aa15563c34fcf41d1808fd36d5d6a8843935d2c97e9661ea40cd996553e840d3c3e99454e58da
+  checksum: 0d0fad71ef0f9b3abd108b6405e04ac5e0f461d41b2168427d9f8d3ade8d3e1322b64eaae406d0768fb60ce08d5c0acc1e12c24c5165de820b1e21f855c1aece
   languageName: node
   linkType: hard
 
@@ -9640,7 +9640,7 @@ __metadata:
   dependencies:
     "@prismicio/mock": 0.7.1
     "@prismicio/simulator": ^0.1.4
-    "@prismicio/types-internal": 3.11.0
+    "@prismicio/types-internal": 3.11.2
     "@size-limit/preset-small-lib": 8.2.4
     "@slicemachine/plugin-kit": "workspace:*"
     "@types/common-tags": 1.8.1
@@ -9685,7 +9685,7 @@ __metadata:
   dependencies:
     "@prismicio/mock": 0.7.1
     "@prismicio/simulator": ^0.1.4
-    "@prismicio/types-internal": 3.11.0
+    "@prismicio/types-internal": 3.11.2
     "@size-limit/preset-small-lib": 8.2.4
     "@slicemachine/plugin-kit": "workspace:*"
     "@typescript-eslint/eslint-plugin": 5.55.0
@@ -9726,7 +9726,7 @@ __metadata:
   dependencies:
     "@prismicio/mock": 0.7.1
     "@prismicio/simulator": ^0.1.4
-    "@prismicio/types-internal": 3.11.0
+    "@prismicio/types-internal": 3.11.2
     "@size-limit/preset-small-lib": 8.2.4
     "@slicemachine/plugin-kit": "workspace:*"
     "@types/common-tags": 1.8.1
@@ -9768,7 +9768,7 @@ __metadata:
   dependencies:
     "@prismicio/mock": 0.7.1
     "@prismicio/simulator": ^0.1.4
-    "@prismicio/types-internal": 3.11.0
+    "@prismicio/types-internal": 3.11.2
     "@size-limit/preset-small-lib": 8.2.4
     "@slicemachine/plugin-kit": "workspace:*"
     "@sveltejs/kit": 2.20.6
@@ -9823,7 +9823,7 @@ __metadata:
     "@msgpack/msgpack": 2.8.0
     "@playwright/test": ^1
     "@prismicio/e2e-tests-utils": 1.11.0
-    "@prismicio/types-internal": 3.11.0
+    "@prismicio/types-internal": 3.11.2
     "@slicemachine/manager": "workspace:*"
     "@types/node": 22.15.17
     "@typescript-eslint/eslint-plugin": 7.17.0
@@ -9895,7 +9895,7 @@ __metadata:
     "@prismicio/custom-types-client": 2.1.0
     "@prismicio/mock": 0.7.1
     "@prismicio/mocks": 2.13.0
-    "@prismicio/types-internal": 3.11.0
+    "@prismicio/types-internal": 3.11.2
     "@segment/analytics-node": ^2.1.2
     "@size-limit/preset-small-lib": 8.2.4
     "@slicemachine/plugin-kit": "workspace:*"
@@ -9953,7 +9953,7 @@ __metadata:
   dependencies:
     "@prismicio/client": 7.17.0
     "@prismicio/mock": 0.7.1
-    "@prismicio/types-internal": 3.11.0
+    "@prismicio/types-internal": 3.11.2
     "@size-limit/preset-small-lib": 8.2.4
     "@types/common-tags": 1.8.1
     "@types/fs-extra": 11.0.1
@@ -33198,7 +33198,7 @@ __metadata:
     "@prismicio/mock": 0.7.1
     "@prismicio/mocks": 2.13.0
     "@prismicio/simulator": 0.1.4
-    "@prismicio/types-internal": 3.11.0
+    "@prismicio/types-internal": 3.11.2
     "@radix-ui/react-hover-card": 1.0.6
     "@radix-ui/react-tabs": 1.0.4
     "@radix-ui/react-visually-hidden": 1.1.1
@@ -33667,7 +33667,7 @@ __metadata:
   resolution: "start-slicemachine@workspace:packages/start-slicemachine"
   dependencies:
     "@prismicio/mocks": 2.13.0
-    "@prismicio/types-internal": 3.11.0
+    "@prismicio/types-internal": 3.11.2
     "@size-limit/preset-small-lib": 8.2.4
     "@slicemachine/manager": "workspace:*"
     "@types/body-parser": 1.19.2

--- a/yarn.lock
+++ b/yarn.lock
@@ -6783,9 +6783,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@prismicio/types-internal@npm:3.10.0":
-  version: 3.10.0
-  resolution: "@prismicio/types-internal@npm:3.10.0"
+"@prismicio/types-internal@npm:3.11.0":
+  version: 3.11.0
+  resolution: "@prismicio/types-internal@npm:3.11.0"
   dependencies:
     monocle-ts: ^2.3.11
     newtype-ts: ^0.3.5
@@ -6795,7 +6795,7 @@ __metadata:
     fp-ts: ^2.11.8
     io-ts: ^2.2.16
     io-ts-types: ^0.5.16
-  checksum: a31bd487e009d549d3abee93d0d6ee4df4e4cb554cf203d9850fd0f239e7459664cd97e69799262c9d6a664c10e335999d4450620cba9b4d5e38f23c79d12300
+  checksum: 4cba5ab8627cd857a77750f50d857f08a182ee8a8c4b4026376aa15563c34fcf41d1808fd36d5d6a8843935d2c97e9661ea40cd996553e840d3c3e99454e58da
   languageName: node
   linkType: hard
 
@@ -9672,7 +9672,7 @@ __metadata:
   dependencies:
     "@prismicio/mock": 0.7.1
     "@prismicio/simulator": ^0.1.4
-    "@prismicio/types-internal": 3.10.0
+    "@prismicio/types-internal": 3.11.0
     "@size-limit/preset-small-lib": 8.2.4
     "@slicemachine/plugin-kit": "workspace:*"
     "@types/common-tags": 1.8.1
@@ -9717,7 +9717,7 @@ __metadata:
   dependencies:
     "@prismicio/mock": 0.7.1
     "@prismicio/simulator": ^0.1.4
-    "@prismicio/types-internal": 3.10.0
+    "@prismicio/types-internal": 3.11.0
     "@size-limit/preset-small-lib": 8.2.4
     "@slicemachine/plugin-kit": "workspace:*"
     "@typescript-eslint/eslint-plugin": 5.55.0
@@ -9758,7 +9758,7 @@ __metadata:
   dependencies:
     "@prismicio/mock": 0.7.1
     "@prismicio/simulator": ^0.1.4
-    "@prismicio/types-internal": 3.10.0
+    "@prismicio/types-internal": 3.11.0
     "@size-limit/preset-small-lib": 8.2.4
     "@slicemachine/plugin-kit": "workspace:*"
     "@types/common-tags": 1.8.1
@@ -9800,7 +9800,7 @@ __metadata:
   dependencies:
     "@prismicio/mock": 0.7.1
     "@prismicio/simulator": ^0.1.4
-    "@prismicio/types-internal": 3.10.0
+    "@prismicio/types-internal": 3.11.0
     "@size-limit/preset-small-lib": 8.2.4
     "@slicemachine/plugin-kit": "workspace:*"
     "@sveltejs/kit": 2.20.6
@@ -9855,7 +9855,7 @@ __metadata:
     "@msgpack/msgpack": 2.8.0
     "@playwright/test": ^1
     "@prismicio/e2e-tests-utils": 1.11.0
-    "@prismicio/types-internal": 3.10.0
+    "@prismicio/types-internal": 3.11.0
     "@slicemachine/manager": "workspace:*"
     "@types/node": 22.15.17
     "@typescript-eslint/eslint-plugin": 7.17.0
@@ -9927,7 +9927,7 @@ __metadata:
     "@prismicio/custom-types-client": 2.1.0
     "@prismicio/mock": 0.7.1
     "@prismicio/mocks": 2.13.0
-    "@prismicio/types-internal": 3.10.0
+    "@prismicio/types-internal": 3.11.0
     "@segment/analytics-node": ^2.1.2
     "@size-limit/preset-small-lib": 8.2.4
     "@slicemachine/plugin-kit": "workspace:*"
@@ -9985,7 +9985,7 @@ __metadata:
   dependencies:
     "@prismicio/client": 7.17.0
     "@prismicio/mock": 0.7.1
-    "@prismicio/types-internal": 3.10.0
+    "@prismicio/types-internal": 3.11.0
     "@size-limit/preset-small-lib": 8.2.4
     "@types/common-tags": 1.8.1
     "@types/fs-extra": 11.0.1
@@ -33230,7 +33230,7 @@ __metadata:
     "@prismicio/mock": 0.7.1
     "@prismicio/mocks": 2.13.0
     "@prismicio/simulator": 0.1.4
-    "@prismicio/types-internal": 3.10.0
+    "@prismicio/types-internal": 3.11.0
     "@radix-ui/react-hover-card": 1.0.6
     "@radix-ui/react-tabs": 1.0.4
     "@radix-ui/react-visually-hidden": 1.1.1
@@ -33699,7 +33699,7 @@ __metadata:
   resolution: "start-slicemachine@workspace:packages/start-slicemachine"
   dependencies:
     "@prismicio/mocks": 2.13.0
-    "@prismicio/types-internal": 3.10.0
+    "@prismicio/types-internal": 3.11.0
     "@size-limit/preset-small-lib": 8.2.4
     "@slicemachine/manager": "workspace:*"
     "@types/body-parser": 1.19.2


### PR DESCRIPTION
Resolves: DT-2704

### Description

When there is a Content Relationship that references a field inside a group, and that field or the group itself has its API ID renamed, update that reference. 

Example diagram:
```md
picture (Custom type)
├── alt (Text)
├── image (Image)
└── keywords (Group)
    └── name (Text) // ✏️ API ID renamed from "name" to "label"

profile (Custom type)
├── name (Text)
├── age (Number)
└── photo (Content Relationship → picture)
    ├── alt
    ├── image
    └── keywords
        └── name // 🔴 This reference also is also update to "label" when the renaming happens
```

### Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- Don't hesitate to ask for help! -->

- [X] A comprehensive Linear ticket, providing sufficient context and details to facilitate the review of the PR, is linked to the PR.
- [X] If my changes require tests, I added them.

### Preview

https://github.com/user-attachments/assets/48997309-2e54-4cc8-80e3-91c1ade4b7d9

### How to QA [^1]

<!-- When relevant, describe how to QA your changes. -->

<!-- Your favorite emoji is welcome to close your PR! -->

<!-- A note for reviewers: -->

[^1]:
	Please use these labels when submitting a review:
	:question: #ask:&ensp;Ask a question.
	:bulb: #idea:&ensp;Suggest an idea.
	:warning: #issue:&ensp;Strongly suggest a change.
	:tada: #nice:&ensp;Share a compliment.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Improved handling of API ID renames within custom types, including support for nested groups and content relationship fields.
- **Bug Fixes**
	- Enhanced update logic for content relationship fields to ensure accurate updates and rollback support.
- **Tests**
	- Expanded test coverage for group and nested group scenarios in custom types and shared slices.
- **Chores**
	- Updated the "@prismicio/types-internal" dependency to version 3.11.2 across multiple packages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->