### PR TITLE
feat: allow only one ct to be selected in a cr

### DIFF
--- a/packages/slice-machine/src/features/builder/fields/ContentRelationshipFieldPicker.tsx
+++ b/packages/slice-machine/src/features/builder/fields/ContentRelationshipFieldPicker.tsx
@@ -328,8 +328,8 @@ function ContentRelationshipFieldPickerContent(
                     subtitle={
                       <>
                         <Text color="inherit" variant="bold">
-                          Legacy mode. Keep one custom type to enable the
-                          improved Content Relationship feature.
+                          Legacy mode. Keep only one type to enable the improved
+                          Content Relationship feature.
                         </Text>
                         <br />
                         <a
@@ -438,7 +438,7 @@ function EmptyView(props: EmptyViewProps) {
           No type selected
         </Text>
         <Text color="grey11" component="p" align="center">
-          Select a type editors can link to.
+          Select the type editors can link to.
           <br />
           Then, choose which fields to return in the API.
         </Text>

--- a/packages/slice-machine/src/features/builder/fields/ContentRelationshipFieldPicker.tsx
+++ b/packages/slice-machine/src/features/builder/fields/ContentRelationshipFieldPicker.tsx
@@ -314,17 +314,48 @@ function ContentRelationshipFieldPickerContent(
                 Allowed type
               </Text>
               <Text color="grey11">
-                Restrict the selection to a specific type your content editors
-                can link to in the Page Builder.
+                Select a single type that editors can link to in the Page
+                Builder.
                 <br />
-                For the selected type, choose which fields to expose in the API
+                For the selected type, choose which fields to include in the API
                 response.
               </Text>
               {pickedCustomTypes.length > 1 && (
                 <Box margin={{ block: 12 }}>
                   <Alert
                     color="warn"
-                    subtitle="This field is using the legacy types selection feature. We recommend having only one type selected in order to switch to the new type selection feature."
+                    icon="alert"
+                    subtitle={
+                      <>
+                        <Text color="inherit" variant="bold">
+                          Legacy mode. Keep one custom type to enable the
+                          improved Content Relationship feature.
+                        </Text>
+                        <br />
+                        <a
+                          href="https://prismic.io/docs/fields/content-relationship"
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          style={{
+                            color: "inherit",
+                            textDecoration: "none",
+                            fontWeight: "bold",
+                            display: "flex",
+                            alignItems: "center",
+                            gap: 4,
+                          }}
+                        >
+                          <Text color="inherit" variant="bold">
+                            See documentation
+                          </Text>
+                          <Icon
+                            name="arrowForward"
+                            size="small"
+                            color="inherit"
+                          />
+                        </a>
+                      </>
+                    }
                   />
                 </Box>
               )}
@@ -404,13 +435,12 @@ function EmptyView(props: EmptyViewProps) {
     >
       <Box flexDirection="column" alignItems="center" gap={4}>
         <Text variant="h5" color="grey12">
-          No types selected yet.
+          No type selected
         </Text>
         <Text color="grey11" component="p" align="center">
-          Add one type your content editors can link to.
+          Select a type editors can link to.
           <br />
-          For the selected type, select the fields to include in the API
-          response (used in your frontend queries).
+          Then, choose which fields to return in the API.
         </Text>
       </Box>
       <Box>
@@ -437,7 +467,7 @@ function AddTypeButton(props: AddTypeButtonProps) {
   const disabledButton = (
     <Box>
       <Tooltip
-        content="No custom type available"
+        content="No type available"
         side="bottom"
         align="start"
         disableHoverableContent

--- a/packages/slice-machine/src/features/builder/fields/ContentRelationshipFieldPicker.tsx
+++ b/packages/slice-machine/src/features/builder/fields/ContentRelationshipFieldPicker.tsx
@@ -1,5 +1,6 @@
 import { pluralize } from "@prismicio/editor-support/String";
 import {
+  Alert,
   AnimatedSuspense,
   Badge,
   Box,
@@ -26,7 +27,7 @@ import {
   LinkConfig,
   NestableWidget,
 } from "@prismicio/types-internal/lib/customtypes";
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 
 import { ErrorBoundary } from "@/ErrorBoundary";
 import {
@@ -260,10 +261,7 @@ function ContentRelationshipFieldPickerContent(
   props: ContentRelationshipFieldPickerProps,
 ) {
   const { value, onChange } = props;
-  const { allCustomTypes, availableCustomTypes, pickedCustomTypes } =
-    useCustomTypes(value);
-
-  const [isNewType, setIsNewType] = useState(false);
+  const { allCustomTypes, pickedCustomTypes } = useCustomTypes(value);
 
   const fieldCheckMap = value
     ? convertLinkCustomtypesToFieldCheckMap(value)
@@ -285,8 +283,6 @@ function ContentRelationshipFieldPickerContent(
   }
 
   function addCustomType(id: string) {
-    setIsNewType(true);
-
     const newFields = value ? [...value, id] : [id];
     onChange(newFields);
   }
@@ -315,15 +311,23 @@ function ContentRelationshipFieldPickerContent(
           <>
             <Box flexDirection="column">
               <Text variant="h4" color="grey12">
-                Allowed Types
+                Allowed type
               </Text>
               <Text color="grey11">
-                Restrict the selection to specific types your content editors
+                Restrict the selection to a specific type your content editors
                 can link to in the Page Builder.
                 <br />
-                For each type, choose which fields to expose in the API
+                For the selected type, choose which fields to expose in the API
                 response.
               </Text>
+              {pickedCustomTypes.length > 1 && (
+                <Box margin={{ block: 12 }}>
+                  <Alert
+                    color="warn"
+                    subtitle="This field is using the legacy types selection feature. We recommend having only one type selected in order to switch to the new type selection feature."
+                  />
+                </Box>
+              )}
             </Box>
             {pickedCustomTypes.map((customType) => (
               <Box
@@ -336,17 +340,21 @@ function ContentRelationshipFieldPickerContent(
                 backgroundColor="white"
                 justifyContent="space-between"
               >
-                <TreeView>
-                  <TreeViewCustomType
-                    customType={customType}
-                    onChange={(value) =>
-                      onCustomTypesChange(customType.id, value)
-                    }
-                    fieldCheckMap={fieldCheckMap[customType.id] ?? {}}
-                    allCustomTypes={allCustomTypes}
-                    isNewType={isNewType}
-                  />
-                </TreeView>
+                {pickedCustomTypes.length > 1 ? (
+                  <Text>{customType.id}</Text>
+                ) : (
+                  <TreeView>
+                    <TreeViewCustomType
+                      customType={customType}
+                      onChange={(value) =>
+                        onCustomTypesChange(customType.id, value)
+                      }
+                      fieldCheckMap={fieldCheckMap[customType.id] ?? {}}
+                      allCustomTypes={allCustomTypes}
+                    />
+                  </TreeView>
+                )}
+
                 <IconButton
                   icon="close"
                   size="small"
@@ -356,17 +364,9 @@ function ContentRelationshipFieldPickerContent(
                 />
               </Box>
             ))}
-            <AddTypeButton
-              onSelect={addCustomType}
-              pickedCustomTypes={pickedCustomTypes}
-              availableCustomTypes={availableCustomTypes}
-            />
           </>
         ) : (
-          <EmptyView
-            onSelect={addCustomType}
-            availableCustomTypes={availableCustomTypes}
-          />
+          <EmptyView onSelect={addCustomType} allCustomTypes={allCustomTypes} />
         )}
       </Box>
       <Box backgroundColor="white" flexDirection="column" padding={12}>
@@ -389,11 +389,11 @@ function ContentRelationshipFieldPickerContent(
 
 type EmptyViewProps = {
   onSelect: (customTypeId: string) => void;
-  availableCustomTypes: CustomType[];
+  allCustomTypes: CustomType[];
 };
 
 function EmptyView(props: EmptyViewProps) {
-  const { availableCustomTypes, onSelect } = props;
+  const { allCustomTypes, onSelect } = props;
 
   return (
     <Box
@@ -407,17 +407,14 @@ function EmptyView(props: EmptyViewProps) {
           No types selected yet.
         </Text>
         <Text color="grey11" component="p" align="center">
-          Add one or more document types your content editors can link to.
+          Add one type your content editors can link to.
           <br />
-          For each type, select the fields to include in the API response (used
-          in your frontend queries).
+          For the selected type, select the fields to include in the API
+          response (used in your frontend queries).
         </Text>
       </Box>
       <Box>
-        <AddTypeButton
-          availableCustomTypes={availableCustomTypes}
-          onSelect={onSelect}
-        />
+        <AddTypeButton allCustomTypes={allCustomTypes} onSelect={onSelect} />
       </Box>
     </Box>
   );
@@ -425,28 +422,22 @@ function EmptyView(props: EmptyViewProps) {
 
 type AddTypeButtonProps = {
   onSelect: (customTypeId: string) => void;
-  disabled?: boolean;
-  availableCustomTypes: CustomType[];
-  pickedCustomTypes?: CustomType[];
+  allCustomTypes: CustomType[];
 };
 
 function AddTypeButton(props: AddTypeButtonProps) {
-  const { availableCustomTypes, onSelect, pickedCustomTypes = [] } = props;
+  const { allCustomTypes, onSelect } = props;
 
   const triggerButton = (
-    <Button
-      startIcon="add"
-      color="grey"
-      disabled={availableCustomTypes.length === 0}
-    >
-      {pickedCustomTypes.length > 0 ? "Add another type" : "Add type"}
+    <Button startIcon="add" color="grey" disabled={allCustomTypes.length === 0}>
+      Add type
     </Button>
   );
 
   const disabledButton = (
     <Box>
       <Tooltip
-        content="All available types have been added"
+        content="No custom type available"
         side="bottom"
         align="start"
         disableHoverableContent
@@ -456,21 +447,17 @@ function AddTypeButton(props: AddTypeButtonProps) {
     </Box>
   );
 
-  if (availableCustomTypes.length === 0) return disabledButton;
+  if (allCustomTypes.length === 0) return disabledButton;
 
   return (
     <Box>
       <DropdownMenu>
         <DropdownMenuTrigger>{triggerButton}</DropdownMenuTrigger>
-        <DropdownMenuContent
-          maxHeight={400}
-          minWidth={256}
-          align={pickedCustomTypes.length > 0 ? "start" : "center"}
-        >
+        <DropdownMenuContent maxHeight={400} minWidth={256} align="center">
           <DropdownMenuLabel>
             <Text color="grey11">Types</Text>
           </DropdownMenuLabel>
-          {availableCustomTypes.map((customType) => (
+          {allCustomTypes.map((customType) => (
             <DropdownMenuItem
               key={customType.id}
               onSelect={() => onSelect(customType.id)}
@@ -502,7 +489,6 @@ interface TreeViewCustomTypeProps {
   fieldCheckMap: PickerCustomType;
   onChange: (newValue: PickerCustomType) => void;
   allCustomTypes: CustomType[];
-  isNewType: boolean;
 }
 
 function TreeViewCustomType(props: TreeViewCustomTypeProps) {
@@ -511,7 +497,6 @@ function TreeViewCustomType(props: TreeViewCustomTypeProps) {
     fieldCheckMap: customTypeFieldsCheckMap,
     onChange: onCustomTypeChange,
     allCustomTypes,
-    isNewType,
   } = props;
 
   const renderedFields = getCustomTypeStaticFields(customType).map(
@@ -610,7 +595,7 @@ function TreeViewCustomType(props: TreeViewCustomTypeProps) {
           : "(No fields returned in the API)"
       }
       badge={getTypeFormatLabel(customType.format)}
-      defaultOpen={isNewType}
+      defaultOpen
     >
       {renderedFields.length > 0 ? (
         renderedFields
@@ -882,10 +867,8 @@ function getTypeFormatLabel(format: CustomType["format"]) {
 
 /** Retrieves all existing page & custom types. */
 function useCustomTypes(value: LinkCustomtypes | undefined): {
-  /** Every existing custom type, used to discover nested custom types down the tree. */
+  /** Every existing custom type, used to discover nested custom types down the tree and the add type dropdown. */
   allCustomTypes: CustomType[];
-  /** The custom types that are not yet picked. */
-  availableCustomTypes: CustomType[];
   /** The custom types that are already picked. */
   pickedCustomTypes: CustomType[];
 } {
@@ -898,7 +881,6 @@ function useCustomTypes(value: LinkCustomtypes | undefined): {
   if (!value) {
     return {
       allCustomTypes,
-      availableCustomTypes: allCustomTypes,
       pickedCustomTypes: [],
     };
   }
@@ -910,9 +892,6 @@ function useCustomTypes(value: LinkCustomtypes | undefined): {
   return {
     allCustomTypes,
     pickedCustomTypes,
-    availableCustomTypes: allCustomTypes.filter(
-      (ct) => pickedCustomTypes.some((pct) => pct.id === ct.id) === false,
-    ),
   };
 }
 


### PR DESCRIPTION
<!-- Please use a Conventional Commit in your PR title -->
<!-- https://conventionalcommits.org -->
<!-- e.g. "feat: support new field type" -->

Resolves: [DT-123](https://linear.app/prismic/issue/DT-2728/m-aadev-in-sm-i-can-only-select-one-custom-type-in-a-cr-field)

### Description

- Ensure only ct can be selected in a cr
- Open by default the only type selected
- Have a legacy support management for when multiple cts are selected
- add type button can always display all custom types

TODO:
- Change copy for the title, description, alert, empty state

<!-- Describe your changes in detail. -->
<!-- Why is this change required? -->
<!-- What problem does it solve? -->

### Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- Don't hesitate to ask for help! -->

- [ ] A comprehensive Linear ticket, providing sufficient context and details to facilitate the review of the PR, is linked to the PR.
- [ ] If my changes require tests, I added them.
- [ ] If my changes affect backward compatibility, it has been discussed.
- [ ] If my changes require an update to the CONTRIBUTING.md guide, I updated it.

### Preview

<!-- If your changes are visual, screenshots or videos are welcome! -->

### How to QA [^1]

<!-- When relevant, describe how to QA your changes. -->

<!-- Your favorite emoji is welcome to close your PR! -->

<!-- A note for reviewers: -->

[^1]:
	Please use these labels when submitting a review:
	:question: #ask:&ensp;Ask a question.
	:bulb: #idea:&ensp;Suggest an idea.
	:warning: #issue:&ensp;Strongly suggest a change.
	:tada: #nice:&ensp;Share a compliment.
