### PR TITLE
feat: add types for content relationship linking

### DIFF
--- a/packages/adapter-next/package.json
+++ b/packages/adapter-next/package.json
@@ -95,7 +95,7 @@
 		"next": "14.2.30",
 		"prettier": "3.0.3",
 		"prettier-plugin-jsdoc": "1.1.1",
-		"prismic-ts-codegen": "0.1.25",
+		"prismic-ts-codegen": "0.1.27-alpha.1",
 		"react": "18.2.0",
 		"rollup-plugin-preserve-directives": "0.4.0",
 		"size-limit": "8.2.4",

--- a/packages/adapter-next/package.json
+++ b/packages/adapter-next/package.json
@@ -95,7 +95,7 @@
 		"next": "14.2.30",
 		"prettier": "3.0.3",
 		"prettier-plugin-jsdoc": "1.1.1",
-		"prismic-ts-codegen": "0.1.27-alpha.1",
+		"prismic-ts-codegen": "0.1.27-alpha.2",
 		"react": "18.2.0",
 		"rollup-plugin-preserve-directives": "0.4.0",
 		"size-limit": "8.2.4",

--- a/packages/adapter-next/package.json
+++ b/packages/adapter-next/package.json
@@ -95,7 +95,7 @@
 		"next": "14.2.30",
 		"prettier": "3.0.3",
 		"prettier-plugin-jsdoc": "1.1.1",
-		"prismic-ts-codegen": "0.1.27-alpha.3",
+		"prismic-ts-codegen": "0.1.27",
 		"react": "18.2.0",
 		"rollup-plugin-preserve-directives": "0.4.0",
 		"size-limit": "8.2.4",

--- a/packages/adapter-next/package.json
+++ b/packages/adapter-next/package.json
@@ -95,7 +95,7 @@
 		"next": "14.2.30",
 		"prettier": "3.0.3",
 		"prettier-plugin-jsdoc": "1.1.1",
-		"prismic-ts-codegen": "0.1.27-alpha.2",
+		"prismic-ts-codegen": "0.1.27-alpha.3",
 		"react": "18.2.0",
 		"rollup-plugin-preserve-directives": "0.4.0",
 		"size-limit": "8.2.4",

--- a/packages/adapter-nuxt/package.json
+++ b/packages/adapter-nuxt/package.json
@@ -86,7 +86,7 @@
 		"nuxt": "3.16.0",
 		"prettier": "3.0.3",
 		"prettier-plugin-jsdoc": "1.1.1",
-		"prismic-ts-codegen": "0.1.27-alpha.3",
+		"prismic-ts-codegen": "0.1.27",
 		"size-limit": "8.2.4",
 		"ts-morph": "17.0.1",
 		"typescript": "4.9.5",

--- a/packages/adapter-nuxt/package.json
+++ b/packages/adapter-nuxt/package.json
@@ -86,7 +86,7 @@
 		"nuxt": "3.16.0",
 		"prettier": "3.0.3",
 		"prettier-plugin-jsdoc": "1.1.1",
-		"prismic-ts-codegen": "0.1.27-alpha.2",
+		"prismic-ts-codegen": "0.1.27-alpha.3",
 		"size-limit": "8.2.4",
 		"ts-morph": "17.0.1",
 		"typescript": "4.9.5",

--- a/packages/adapter-nuxt/package.json
+++ b/packages/adapter-nuxt/package.json
@@ -86,7 +86,7 @@
 		"nuxt": "3.16.0",
 		"prettier": "3.0.3",
 		"prettier-plugin-jsdoc": "1.1.1",
-		"prismic-ts-codegen": "0.1.27-alpha.1",
+		"prismic-ts-codegen": "0.1.27-alpha.2",
 		"size-limit": "8.2.4",
 		"ts-morph": "17.0.1",
 		"typescript": "4.9.5",

--- a/packages/adapter-nuxt/package.json
+++ b/packages/adapter-nuxt/package.json
@@ -86,7 +86,7 @@
 		"nuxt": "3.16.0",
 		"prettier": "3.0.3",
 		"prettier-plugin-jsdoc": "1.1.1",
-		"prismic-ts-codegen": "0.1.25",
+		"prismic-ts-codegen": "0.1.27-alpha.1",
 		"size-limit": "8.2.4",
 		"ts-morph": "17.0.1",
 		"typescript": "4.9.5",

--- a/packages/adapter-nuxt2/package.json
+++ b/packages/adapter-nuxt2/package.json
@@ -85,7 +85,7 @@
 		"nuxt": "2.16.3",
 		"prettier": "3.0.3",
 		"prettier-plugin-jsdoc": "1.1.1",
-		"prismic-ts-codegen": "0.1.27-alpha.3",
+		"prismic-ts-codegen": "0.1.27",
 		"size-limit": "8.2.4",
 		"ts-morph": "17.0.1",
 		"typescript": "4.9.5",

--- a/packages/adapter-nuxt2/package.json
+++ b/packages/adapter-nuxt2/package.json
@@ -85,7 +85,7 @@
 		"nuxt": "2.16.3",
 		"prettier": "3.0.3",
 		"prettier-plugin-jsdoc": "1.1.1",
-		"prismic-ts-codegen": "0.1.27-alpha.2",
+		"prismic-ts-codegen": "0.1.27-alpha.3",
 		"size-limit": "8.2.4",
 		"ts-morph": "17.0.1",
 		"typescript": "4.9.5",

--- a/packages/adapter-nuxt2/package.json
+++ b/packages/adapter-nuxt2/package.json
@@ -85,7 +85,7 @@
 		"nuxt": "2.16.3",
 		"prettier": "3.0.3",
 		"prettier-plugin-jsdoc": "1.1.1",
-		"prismic-ts-codegen": "0.1.25",
+		"prismic-ts-codegen": "0.1.27-alpha.1",
 		"size-limit": "8.2.4",
 		"ts-morph": "17.0.1",
 		"typescript": "4.9.5",

--- a/packages/adapter-nuxt2/package.json
+++ b/packages/adapter-nuxt2/package.json
@@ -85,7 +85,7 @@
 		"nuxt": "2.16.3",
 		"prettier": "3.0.3",
 		"prettier-plugin-jsdoc": "1.1.1",
-		"prismic-ts-codegen": "0.1.27-alpha.1",
+		"prismic-ts-codegen": "0.1.27-alpha.2",
 		"size-limit": "8.2.4",
 		"ts-morph": "17.0.1",
 		"typescript": "4.9.5",

--- a/packages/adapter-sveltekit/package.json
+++ b/packages/adapter-sveltekit/package.json
@@ -94,7 +94,7 @@
 		"eslint-plugin-tsdoc": "0.2.17",
 		"prettier": "3.0.3",
 		"prettier-plugin-jsdoc": "1.1.1",
-		"prismic-ts-codegen": "0.1.25",
+		"prismic-ts-codegen": "0.1.27-alpha.1",
 		"size-limit": "8.2.4",
 		"svelte": "5.33.5",
 		"typescript": "4.9.5",

--- a/packages/adapter-sveltekit/package.json
+++ b/packages/adapter-sveltekit/package.json
@@ -94,7 +94,7 @@
 		"eslint-plugin-tsdoc": "0.2.17",
 		"prettier": "3.0.3",
 		"prettier-plugin-jsdoc": "1.1.1",
-		"prismic-ts-codegen": "0.1.27-alpha.3",
+		"prismic-ts-codegen": "0.1.27",
 		"size-limit": "8.2.4",
 		"svelte": "5.33.5",
 		"typescript": "4.9.5",

--- a/packages/adapter-sveltekit/package.json
+++ b/packages/adapter-sveltekit/package.json
@@ -94,7 +94,7 @@
 		"eslint-plugin-tsdoc": "0.2.17",
 		"prettier": "3.0.3",
 		"prettier-plugin-jsdoc": "1.1.1",
-		"prismic-ts-codegen": "0.1.27-alpha.1",
+		"prismic-ts-codegen": "0.1.27-alpha.2",
 		"size-limit": "8.2.4",
 		"svelte": "5.33.5",
 		"typescript": "4.9.5",

--- a/packages/adapter-sveltekit/package.json
+++ b/packages/adapter-sveltekit/package.json
@@ -94,7 +94,7 @@
 		"eslint-plugin-tsdoc": "0.2.17",
 		"prettier": "3.0.3",
 		"prettier-plugin-jsdoc": "1.1.1",
-		"prismic-ts-codegen": "0.1.27-alpha.2",
+		"prismic-ts-codegen": "0.1.27-alpha.3",
 		"size-limit": "8.2.4",
 		"svelte": "5.33.5",
 		"typescript": "4.9.5",

--- a/packages/plugin-kit/package.json
+++ b/packages/plugin-kit/package.json
@@ -72,7 +72,7 @@
 		"io-ts-reporters": "^2.0.1",
 		"p-limit": "^4.0.0",
 		"prettier": "^3.0.3",
-		"prismic-ts-codegen": "0.1.25"
+		"prismic-ts-codegen": "0.1.27-alpha.1"
 	},
 	"devDependencies": {
 		"@prismicio/mock": "0.7.1",

--- a/packages/plugin-kit/package.json
+++ b/packages/plugin-kit/package.json
@@ -72,7 +72,7 @@
 		"io-ts-reporters": "^2.0.1",
 		"p-limit": "^4.0.0",
 		"prettier": "^3.0.3",
-		"prismic-ts-codegen": "0.1.27-alpha.1"
+		"prismic-ts-codegen": "0.1.27-alpha.2"
 	},
 	"devDependencies": {
 		"@prismicio/mock": "0.7.1",

--- a/packages/plugin-kit/package.json
+++ b/packages/plugin-kit/package.json
@@ -72,7 +72,7 @@
 		"io-ts-reporters": "^2.0.1",
 		"p-limit": "^4.0.0",
 		"prettier": "^3.0.3",
-		"prismic-ts-codegen": "0.1.27-alpha.2"
+		"prismic-ts-codegen": "0.1.27-alpha.3"
 	},
 	"devDependencies": {
 		"@prismicio/mock": "0.7.1",

--- a/packages/plugin-kit/package.json
+++ b/packages/plugin-kit/package.json
@@ -72,7 +72,7 @@
 		"io-ts-reporters": "^2.0.1",
 		"p-limit": "^4.0.0",
 		"prettier": "^3.0.3",
-		"prismic-ts-codegen": "0.1.27-alpha.3"
+		"prismic-ts-codegen": "0.1.27"
 	},
 	"devDependencies": {
 		"@prismicio/mock": "0.7.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10520,7 +10520,7 @@ __metadata:
     pascal-case: ^3.1.2
     prettier: 3.0.3
     prettier-plugin-jsdoc: 1.1.1
-    prismic-ts-codegen: 0.1.27-alpha.3
+    prismic-ts-codegen: 0.1.27
     react: 18.2.0
     rollup-plugin-preserve-directives: 0.4.0
     size-limit: 8.2.4
@@ -10562,7 +10562,7 @@ __metadata:
     pascal-case: ^3.1.2
     prettier: 3.0.3
     prettier-plugin-jsdoc: 1.1.1
-    prismic-ts-codegen: 0.1.27-alpha.3
+    prismic-ts-codegen: 0.1.27
     size-limit: 8.2.4
     ts-morph: 17.0.1
     typescript: 4.9.5
@@ -10604,7 +10604,7 @@ __metadata:
     pascal-case: ^3.1.2
     prettier: 3.0.3
     prettier-plugin-jsdoc: 1.1.1
-    prismic-ts-codegen: 0.1.27-alpha.3
+    prismic-ts-codegen: 0.1.27
     size-limit: 8.2.4
     ts-morph: 17.0.1
     typescript: 4.9.5
@@ -10651,7 +10651,7 @@ __metadata:
     prettier: 3.0.3
     prettier-plugin-jsdoc: 1.1.1
     prettier-plugin-svelte: 3.4.0
-    prismic-ts-codegen: 0.1.27-alpha.3
+    prismic-ts-codegen: 0.1.27
     size-limit: 8.2.4
     svelte: 5.33.5
     typescript: 4.9.5
@@ -10833,7 +10833,7 @@ __metadata:
     p-limit: ^4.0.0
     prettier: ^3.0.3
     prettier-plugin-jsdoc: 1.1.1
-    prismic-ts-codegen: 0.1.27-alpha.3
+    prismic-ts-codegen: 0.1.27
     size-limit: 8.2.4
     typescript: 4.9.5
     vite: 4.5.14
@@ -31291,9 +31291,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prismic-ts-codegen@npm:0.1.27-alpha.3":
-  version: 0.1.27-alpha.3
-  resolution: "prismic-ts-codegen@npm:0.1.27-alpha.3"
+"prismic-ts-codegen@npm:0.1.27":
+  version: 0.1.27
+  resolution: "prismic-ts-codegen@npm:0.1.27"
   dependencies:
     "@prismicio/custom-types-client": ^1.3.1
     common-tags: ^1.8.2
@@ -31314,7 +31314,7 @@ __metadata:
       optional: true
   bin:
     prismic-ts-codegen: bin/prismic-ts-codegen.js
-  checksum: 0aa82360403fa1589afaef1eab2d93a8f2926ab4a959439b210d8e137c2a4bb8128438143de10262ec83c6095d0301acc43dca2e0ac1dfa41126b85e86dff9f2
+  checksum: 394c7c554089f6e6d06ce11ef80b0e07ede73eeea75b8b092f8f0fc81f52fc6372714c4d718508b0c09b9948a07cf71d7a81a10727170779c8cb3269cc70152c
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -10520,7 +10520,7 @@ __metadata:
     pascal-case: ^3.1.2
     prettier: 3.0.3
     prettier-plugin-jsdoc: 1.1.1
-    prismic-ts-codegen: 0.1.27-alpha.2
+    prismic-ts-codegen: 0.1.27-alpha.3
     react: 18.2.0
     rollup-plugin-preserve-directives: 0.4.0
     size-limit: 8.2.4
@@ -10562,7 +10562,7 @@ __metadata:
     pascal-case: ^3.1.2
     prettier: 3.0.3
     prettier-plugin-jsdoc: 1.1.1
-    prismic-ts-codegen: 0.1.27-alpha.2
+    prismic-ts-codegen: 0.1.27-alpha.3
     size-limit: 8.2.4
     ts-morph: 17.0.1
     typescript: 4.9.5
@@ -10604,7 +10604,7 @@ __metadata:
     pascal-case: ^3.1.2
     prettier: 3.0.3
     prettier-plugin-jsdoc: 1.1.1
-    prismic-ts-codegen: 0.1.27-alpha.2
+    prismic-ts-codegen: 0.1.27-alpha.3
     size-limit: 8.2.4
     ts-morph: 17.0.1
     typescript: 4.9.5
@@ -10651,7 +10651,7 @@ __metadata:
     prettier: 3.0.3
     prettier-plugin-jsdoc: 1.1.1
     prettier-plugin-svelte: 3.4.0
-    prismic-ts-codegen: 0.1.27-alpha.2
+    prismic-ts-codegen: 0.1.27-alpha.3
     size-limit: 8.2.4
     svelte: 5.33.5
     typescript: 4.9.5
@@ -10833,7 +10833,7 @@ __metadata:
     p-limit: ^4.0.0
     prettier: ^3.0.3
     prettier-plugin-jsdoc: 1.1.1
-    prismic-ts-codegen: 0.1.27-alpha.2
+    prismic-ts-codegen: 0.1.27-alpha.3
     size-limit: 8.2.4
     typescript: 4.9.5
     vite: 4.5.14
@@ -31291,9 +31291,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prismic-ts-codegen@npm:0.1.27-alpha.2":
-  version: 0.1.27-alpha.2
-  resolution: "prismic-ts-codegen@npm:0.1.27-alpha.2"
+"prismic-ts-codegen@npm:0.1.27-alpha.3":
+  version: 0.1.27-alpha.3
+  resolution: "prismic-ts-codegen@npm:0.1.27-alpha.3"
   dependencies:
     "@prismicio/custom-types-client": ^1.3.1
     common-tags: ^1.8.2
@@ -31314,7 +31314,7 @@ __metadata:
       optional: true
   bin:
     prismic-ts-codegen: bin/prismic-ts-codegen.js
-  checksum: a510f708798b69454dfa32bd23fba75d170ec06b57261c85858451784cb6b922c4dd5a7306b20afc5fd01bb92185993fc7d825877538399aeafe3ab3adb3e2d6
+  checksum: 0aa82360403fa1589afaef1eab2d93a8f2926ab4a959439b210d8e137c2a4bb8128438143de10262ec83c6095d0301acc43dca2e0ac1dfa41126b85e86dff9f2
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -10520,7 +10520,7 @@ __metadata:
     pascal-case: ^3.1.2
     prettier: 3.0.3
     prettier-plugin-jsdoc: 1.1.1
-    prismic-ts-codegen: 0.1.27-alpha.1
+    prismic-ts-codegen: 0.1.27-alpha.2
     react: 18.2.0
     rollup-plugin-preserve-directives: 0.4.0
     size-limit: 8.2.4
@@ -10562,7 +10562,7 @@ __metadata:
     pascal-case: ^3.1.2
     prettier: 3.0.3
     prettier-plugin-jsdoc: 1.1.1
-    prismic-ts-codegen: 0.1.27-alpha.1
+    prismic-ts-codegen: 0.1.27-alpha.2
     size-limit: 8.2.4
     ts-morph: 17.0.1
     typescript: 4.9.5
@@ -10604,7 +10604,7 @@ __metadata:
     pascal-case: ^3.1.2
     prettier: 3.0.3
     prettier-plugin-jsdoc: 1.1.1
-    prismic-ts-codegen: 0.1.27-alpha.1
+    prismic-ts-codegen: 0.1.27-alpha.2
     size-limit: 8.2.4
     ts-morph: 17.0.1
     typescript: 4.9.5
@@ -10651,7 +10651,7 @@ __metadata:
     prettier: 3.0.3
     prettier-plugin-jsdoc: 1.1.1
     prettier-plugin-svelte: 3.4.0
-    prismic-ts-codegen: 0.1.27-alpha.1
+    prismic-ts-codegen: 0.1.27-alpha.2
     size-limit: 8.2.4
     svelte: 5.33.5
     typescript: 4.9.5
@@ -10833,7 +10833,7 @@ __metadata:
     p-limit: ^4.0.0
     prettier: ^3.0.3
     prettier-plugin-jsdoc: 1.1.1
-    prismic-ts-codegen: 0.1.27-alpha.1
+    prismic-ts-codegen: 0.1.27-alpha.2
     size-limit: 8.2.4
     typescript: 4.9.5
     vite: 4.5.14
@@ -31291,9 +31291,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prismic-ts-codegen@npm:0.1.27-alpha.1":
-  version: 0.1.27-alpha.1
-  resolution: "prismic-ts-codegen@npm:0.1.27-alpha.1"
+"prismic-ts-codegen@npm:0.1.27-alpha.2":
+  version: 0.1.27-alpha.2
+  resolution: "prismic-ts-codegen@npm:0.1.27-alpha.2"
   dependencies:
     "@prismicio/custom-types-client": ^1.3.1
     common-tags: ^1.8.2
@@ -31314,7 +31314,7 @@ __metadata:
       optional: true
   bin:
     prismic-ts-codegen: bin/prismic-ts-codegen.js
-  checksum: 4b28f5ae95da6580610237df4bc2d1d2e8279379da193a3cb620d2a62d6511524c47705a3f8c5a7280231c0540635d89a1a0fead86fc17496e41b80c4a6811b9
+  checksum: a510f708798b69454dfa32bd23fba75d170ec06b57261c85858451784cb6b922c4dd5a7306b20afc5fd01bb92185993fc7d825877538399aeafe3ab3adb3e2d6
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -10520,7 +10520,7 @@ __metadata:
     pascal-case: ^3.1.2
     prettier: 3.0.3
     prettier-plugin-jsdoc: 1.1.1
-    prismic-ts-codegen: 0.1.25
+    prismic-ts-codegen: 0.1.27-alpha.1
     react: 18.2.0
     rollup-plugin-preserve-directives: 0.4.0
     size-limit: 8.2.4
@@ -10562,7 +10562,7 @@ __metadata:
     pascal-case: ^3.1.2
     prettier: 3.0.3
     prettier-plugin-jsdoc: 1.1.1
-    prismic-ts-codegen: 0.1.25
+    prismic-ts-codegen: 0.1.27-alpha.1
     size-limit: 8.2.4
     ts-morph: 17.0.1
     typescript: 4.9.5
@@ -10604,7 +10604,7 @@ __metadata:
     pascal-case: ^3.1.2
     prettier: 3.0.3
     prettier-plugin-jsdoc: 1.1.1
-    prismic-ts-codegen: 0.1.25
+    prismic-ts-codegen: 0.1.27-alpha.1
     size-limit: 8.2.4
     ts-morph: 17.0.1
     typescript: 4.9.5
@@ -10651,7 +10651,7 @@ __metadata:
     prettier: 3.0.3
     prettier-plugin-jsdoc: 1.1.1
     prettier-plugin-svelte: 3.4.0
-    prismic-ts-codegen: 0.1.25
+    prismic-ts-codegen: 0.1.27-alpha.1
     size-limit: 8.2.4
     svelte: 5.33.5
     typescript: 4.9.5
@@ -10833,7 +10833,7 @@ __metadata:
     p-limit: ^4.0.0
     prettier: ^3.0.3
     prettier-plugin-jsdoc: 1.1.1
-    prismic-ts-codegen: 0.1.25
+    prismic-ts-codegen: 0.1.27-alpha.1
     size-limit: 8.2.4
     typescript: 4.9.5
     vite: 4.5.14
@@ -31291,9 +31291,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prismic-ts-codegen@npm:0.1.25":
-  version: 0.1.25
-  resolution: "prismic-ts-codegen@npm:0.1.25"
+"prismic-ts-codegen@npm:0.1.27-alpha.1":
+  version: 0.1.27-alpha.1
+  resolution: "prismic-ts-codegen@npm:0.1.27-alpha.1"
   dependencies:
     "@prismicio/custom-types-client": ^1.3.1
     common-tags: ^1.8.2
@@ -31314,7 +31314,7 @@ __metadata:
       optional: true
   bin:
     prismic-ts-codegen: bin/prismic-ts-codegen.js
-  checksum: f481dd514c06c56d0d6cde0289ad382c360cf2319764999aa73b7276996756b8a0c526dd9eb9800ab8a154ae9c22a7aa84b916485196d5d6ee8a4632868f8ded
+  checksum: 4b28f5ae95da6580610237df4bc2d1d2e8279379da193a3cb620d2a62d6511524c47705a3f8c5a7280231c0540635d89a1a0fead86fc17496e41b80c4a6811b9
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Resolves: [DT-2712](https://linear.app/prismic/issue/DT-2712/m-aadev-in-sm-my-generated-types-are-still-working-with-new-content)

### Description

This PR updates the `prismic-ts-codegen` deps to include typing for linked fields in the new content relationship field config.

### Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- Don't hesitate to ask for help! -->

- [x] A comprehensive Linear ticket, providing sufficient context and details to facilitate the review of the PR, is linked to the PR.
- [ ] If my changes require tests, I added them.
- [ ] If my changes affect backward compatibility, it has been discussed.
- [ ] If my changes require an update to the CONTRIBUTING.md guide, I updated it.

### Preview

N/A

### How to QA [^1]

<!-- When relevant, describe how to QA your changes. -->

<!-- Your favorite emoji is welcome to close your PR! -->

<!-- A note for reviewers: -->

[^1]:
	Please use these labels when submitting a review:
	:question: #ask:&ensp;Ask a question.
	:bulb: #idea:&ensp;Suggest an idea.
	:warning: #issue:&ensp;Strongly suggest a change.
	:tada: #nice:&ensp;Share a compliment.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated the version of the `prismic-ts-codegen` dependency to `0.1.27` across multiple packages. No other user-facing changes were made.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->