### PR TITLE
feat: handle CR field picker empty and legacy edge cases

### DIFF
--- a/packages/slice-machine/src/features/builder/fields/ContentRelationshipFieldPicker.tsx
+++ b/packages/slice-machine/src/features/builder/fields/ContentRelationshipFieldPicker.tsx
@@ -563,11 +563,7 @@ function TreeViewCustomType(props: TreeViewCustomTypeProps) {
 
       // Content relationship field with custom types
 
-      if (
-        isContentRelationshipField(field) &&
-        field.config?.customtypes &&
-        field.config.customtypes.length > 0
-      ) {
+      if (isContentRelationshipFieldWithCustomTypes(field)) {
         const onContentRelationshipFieldChange = (
           newCrFields: PickerContentRelationshipFieldValue,
         ) => {
@@ -619,6 +615,7 @@ function TreeViewCustomType(props: TreeViewCustomTypeProps) {
   );
 
   const exposedFieldsCount = countPickedFields(customTypeFieldsCheckMap);
+
   return (
     <TreeViewSection
       key={customType.id}
@@ -837,7 +834,9 @@ function TreeViewFirstLevelGroupField(
       badge="Group"
     >
       {getGroupFields(group).map(({ fieldId, field }) => {
-        if (isContentRelationshipField(field)) {
+        // Content relationship field with custom types
+
+        if (isContentRelationshipFieldWithCustomTypes(field)) {
           const onContentRelationshipFieldChange = (
             newCrFields: PickerContentRelationshipFieldValue,
           ) => {
@@ -867,6 +866,8 @@ function TreeViewFirstLevelGroupField(
             />
           );
         }
+
+        // Regular field
 
         const onCheckedChange = (newChecked: boolean) => {
           onGroupFieldChange({
@@ -1198,6 +1199,16 @@ function isContentRelationshipField(
   field: NestableWidget | Group,
 ): field is Link {
   return field.type === "Link" && field.config?.select === "document";
+}
+
+function isContentRelationshipFieldWithCustomTypes(
+  field: NestableWidget | Group,
+): field is Link {
+  return !!(
+    isContentRelationshipField(field) &&
+    field.config?.customtypes &&
+    field.config.customtypes.length > 0
+  );
 }
 
 function getCustomTypeStaticFields(customType: CustomType) {

--- a/packages/slice-machine/src/features/builder/fields/ContentRelationshipFieldPicker.tsx
+++ b/packages/slice-machine/src/features/builder/fields/ContentRelationshipFieldPicker.tsx
@@ -563,7 +563,7 @@ function TreeViewCustomType(props: TreeViewCustomTypeProps) {
 
       // Content relationship field with custom types
 
-      if (isContentRelationshipFieldWithCustomTypes(field)) {
+      if (isContentRelationshipFieldWithSingleCustomtype(field)) {
         const onContentRelationshipFieldChange = (
           newCrFields: PickerContentRelationshipFieldValue,
         ) => {
@@ -821,7 +821,7 @@ function TreeViewFirstLevelGroupField(
   const renderedFields = getGroupFields(group).map(({ fieldId, field }) => {
     // Content relationship field with custom types
 
-    if (isContentRelationshipFieldWithCustomTypes(field)) {
+    if (isContentRelationshipFieldWithSingleCustomtype(field)) {
       const onContentRelationshipFieldChange = (
         newCrFields: PickerContentRelationshipFieldValue,
       ) => {
@@ -1191,7 +1191,11 @@ function isContentRelationshipField(
   return field.type === "Link" && field.config?.select === "document";
 }
 
-function isContentRelationshipFieldWithCustomTypes(
+/**
+ * Check if the field is a Content Relationship Link with a **single** custom
+ * type. CRs with multiple custom types are not currently supported (legacy).
+ */
+function isContentRelationshipFieldWithSingleCustomtype(
   field: NestableWidget | Group,
 ): field is Link {
   return !!(

--- a/packages/slice-machine/src/features/builder/fields/ContentRelationshipFieldPicker.tsx
+++ b/packages/slice-machine/src/features/builder/fields/ContentRelationshipFieldPicker.tsx
@@ -1216,7 +1216,7 @@ function getCustomTypeStaticFields(customType: CustomType) {
         // used for metadata.
         (field.type !== "UID" || fieldId !== "uid")
       ) {
-        return { fieldId, field };
+        return { fieldId, field: field as NestableWidget | Group };
       }
 
       return [];
@@ -1226,10 +1226,9 @@ function getCustomTypeStaticFields(customType: CustomType) {
 
 function getGroupFields(group: Group) {
   if (!group.config?.fields) return [];
-  return Object.entries(group.config.fields).map(([fieldId, field]) => ({
-    fieldId,
-    field,
-  }));
+  return Object.entries(group.config.fields).map(([fieldId, field]) => {
+    return { fieldId, field: field as NestableWidget };
+  });
 }
 
 /** If it's a string, return it, otherwise return the `id` property. */

--- a/packages/slice-machine/src/features/builder/fields/ContentRelationshipFieldPicker.tsx
+++ b/packages/slice-machine/src/features/builder/fields/ContentRelationshipFieldPicker.tsx
@@ -926,11 +926,9 @@ function resolveContentRelationshipCustomTypes(
   linkCustomtypes: LinkCustomtypes,
   localCustomTypes: CustomType[],
 ): CustomType[] {
-  const fields = linkCustomtypes.flatMap<CustomType>((linkCustomtype) => {
+  return linkCustomtypes.flatMap((linkCustomtype) => {
     return localCustomTypes.find((ct) => ct.id === getId(linkCustomtype)) ?? [];
   });
-
-  return fields;
 }
 
 /**

--- a/packages/slice-machine/src/features/builder/fields/ContentRelationshipFieldPicker.tsx
+++ b/packages/slice-machine/src/features/builder/fields/ContentRelationshipFieldPicker.tsx
@@ -622,7 +622,7 @@ function TreeViewCustomType(props: TreeViewCustomTypeProps) {
       title={customType.id}
       subtitle={
         exposedFieldsCount > 0
-          ? getExposedFieldsLabel(exposedFieldsCount)
+          ? getSelectedFieldsLabel(exposedFieldsCount, "returned in the API")
           : "(No fields returned in the API)"
       }
       badge={getTypeFormatLabel(customType.format)}
@@ -664,7 +664,7 @@ function TreeViewContentRelationshipField(
   return (
     <TreeViewSection
       title={fieldId}
-      subtitle={getExposedFieldsLabel(countPickedFields(crFieldsCheckMap))}
+      subtitle={getSelectedFieldsLabel(countPickedFields(crFieldsCheckMap))}
     >
       {resolvedCustomTypes.map((customType) => {
         if (typeof customType === "string") return null;
@@ -735,7 +735,7 @@ function TreeViewContentRelationshipField(
           <TreeViewSection
             key={customType.id}
             title={customType.id}
-            subtitle={getExposedFieldsLabel(
+            subtitle={getSelectedFieldsLabel(
               countPickedFields(nestedCtFieldsCheckMap),
             )}
             badge={getTypeFormatLabel(customType.format)}
@@ -791,7 +791,7 @@ function TreeViewLeafGroupField(props: TreeViewLeafGroupFieldProps) {
     <TreeViewSection
       key={groupId}
       title={groupId}
-      subtitle={getExposedFieldsLabel(countPickedFields(groupFieldsCheckMap))}
+      subtitle={getSelectedFieldsLabel(countPickedFields(groupFieldsCheckMap))}
       badge="Group"
     >
       {renderedFields.length > 0 ? renderedFields : <NoFieldsAvailable />}
@@ -875,7 +875,7 @@ function TreeViewFirstLevelGroupField(
     <TreeViewSection
       key={groupId}
       title={groupId}
-      subtitle={getExposedFieldsLabel(countPickedFields(groupFieldsCheckMap))}
+      subtitle={getSelectedFieldsLabel(countPickedFields(groupFieldsCheckMap))}
       badge="Group"
     >
       {renderedFields.length > 0 ? renderedFields : <NoFieldsAvailable />}
@@ -883,13 +883,9 @@ function TreeViewFirstLevelGroupField(
   );
 }
 
-function getExposedFieldsLabel(count: number) {
+function getSelectedFieldsLabel(count: number, suffix = "selected") {
   if (count === 0) return undefined;
-  return `(${count} ${pluralize(
-    count,
-    "field",
-    "fields",
-  )} returned in the API)`;
+  return `(${count} ${pluralize(count, "field", "fields")} ${suffix})`;
 }
 
 function getTypeFormatLabel(format: CustomType["format"]) {
@@ -1201,7 +1197,7 @@ function isContentRelationshipFieldWithCustomTypes(
   return !!(
     isContentRelationshipField(field) &&
     field.config?.customtypes &&
-    field.config.customtypes.length > 0
+    field.config.customtypes.length === 1
   );
 }
 

--- a/packages/slice-machine/src/features/builder/fields/ContentRelationshipFieldPicker.tsx
+++ b/packages/slice-machine/src/features/builder/fields/ContentRelationshipFieldPicker.tsx
@@ -1218,7 +1218,7 @@ function getCustomTypeStaticFields(customType: CustomType) {
         // used for metadata.
         (field.type !== "UID" || fieldId !== "uid")
       ) {
-        return { fieldId, field: field as NestableWidget | Group };
+        return { fieldId, field };
       }
 
       return [];
@@ -1228,13 +1228,10 @@ function getCustomTypeStaticFields(customType: CustomType) {
 
 function getGroupFields(group: Group) {
   if (!group.config?.fields) return [];
-
-  const groupFieldEntries = Object.entries(group.config.fields);
-  if (groupFieldEntries.length === 0) return [];
-
-  return groupFieldEntries.map(([fieldId, field]) => {
-    return { fieldId, field: field as NestableWidget };
-  });
+  return Object.entries(group.config.fields).map(([fieldId, field]) => ({
+    fieldId,
+    field,
+  }));
 }
 
 /** If it's a string, return it, otherwise return the `id` property. */

--- a/packages/slice-machine/src/features/builder/fields/ContentRelationshipFieldPicker.tsx
+++ b/packages/slice-machine/src/features/builder/fields/ContentRelationshipFieldPicker.tsx
@@ -923,11 +923,11 @@ function useCustomTypes(value: LinkCustomtypes | undefined): {
 }
 
 function resolveContentRelationshipCustomTypes(
-  customTypes: LinkCustomtypes,
+  linkCustomtypes: LinkCustomtypes,
   localCustomTypes: CustomType[],
 ): CustomType[] {
-  const fields = customTypes.flatMap<CustomType>((customType) => {
-    return localCustomTypes.find((ct) => ct.id === getId(customType)) ?? [];
+  const fields = linkCustomtypes.flatMap<CustomType>((linkCustomtype) => {
+    return localCustomTypes.find((ct) => ct.id === getId(linkCustomtype)) ?? [];
   });
 
   return fields;

--- a/packages/slice-machine/src/features/builder/fields/ContentRelationshipFieldPicker.tsx
+++ b/packages/slice-machine/src/features/builder/fields/ContentRelationshipFieldPicker.tsx
@@ -561,9 +561,13 @@ function TreeViewCustomType(props: TreeViewCustomTypeProps) {
         );
       }
 
-      // Content relationship field
+      // Content relationship field with custom types
 
-      if (isContentRelationshipField(field)) {
+      if (
+        isContentRelationshipField(field) &&
+        field.config?.customtypes &&
+        field.config.customtypes.length > 0
+      ) {
         const onContentRelationshipFieldChange = (
           newCrFields: PickerContentRelationshipFieldValue,
         ) => {
@@ -734,8 +738,6 @@ function TreeViewContentRelationshipField(
           },
         );
 
-        if (renderedFields.length === 0) return null;
-
         return (
           <TreeViewSection
             key={customType.id}
@@ -745,7 +747,11 @@ function TreeViewContentRelationshipField(
             )}
             badge={getTypeFormatLabel(customType.format)}
           >
-            {renderedFields}
+            {renderedFields.length > 0 ? (
+              renderedFields
+            ) : (
+              <Text color="grey11">No available fields to select</Text>
+            )}
           </TreeViewSection>
         );
       })}
@@ -930,8 +936,7 @@ function resolveContentRelationshipCustomTypes(
   localCustomTypes: CustomType[],
 ): CustomType[] {
   const fields = customTypes.flatMap<CustomType>((customType) => {
-    if (typeof customType === "string") return [];
-    return localCustomTypes.find((ct) => ct.id === customType.id) ?? [];
+    return localCustomTypes.find((ct) => ct.id === getId(customType)) ?? [];
   });
 
   return fields;
@@ -1192,11 +1197,7 @@ function isGroupField(field: NestableWidget | Group): field is Group {
 function isContentRelationshipField(
   field: NestableWidget | Group,
 ): field is Link {
-  return (
-    field.type === "Link" &&
-    field.config?.select === "document" &&
-    field.config?.customtypes !== undefined
-  );
+  return field.type === "Link" && field.config?.select === "document";
 }
 
 function getCustomTypeStaticFields(customType: CustomType) {

--- a/packages/slice-machine/src/features/builder/fields/contentRelationship/ContentRelationshipFieldPicker.tsx
+++ b/packages/slice-machine/src/features/builder/fields/contentRelationship/ContentRelationshipFieldPicker.tsx
@@ -621,7 +621,7 @@ function TreeViewCustomType(props: TreeViewCustomTypeProps) {
       title={customType.id}
       subtitle={
         exposedFieldsCount.pickedFields > 0
-          ? getSelectedFieldsLabel(
+          ? getPickedFieldsLabel(
               exposedFieldsCount.pickedFields,
               "returned in the API",
             )
@@ -666,7 +666,7 @@ function TreeViewContentRelationshipField(
   return (
     <TreeViewSection
       title={fieldId}
-      subtitle={getSelectedFieldsLabel(
+      subtitle={getPickedFieldsLabel(
         countPickedFields(crFieldsCheckMap).pickedFields,
       )}
     >
@@ -739,7 +739,7 @@ function TreeViewContentRelationshipField(
           <TreeViewSection
             key={customType.id}
             title={customType.id}
-            subtitle={getSelectedFieldsLabel(
+            subtitle={getPickedFieldsLabel(
               countPickedFields(nestedCtFieldsCheckMap).pickedFields,
             )}
             badge={getTypeFormatLabel(customType.format)}
@@ -795,7 +795,7 @@ function TreeViewLeafGroupField(props: TreeViewLeafGroupFieldProps) {
     <TreeViewSection
       key={groupId}
       title={groupId}
-      subtitle={getSelectedFieldsLabel(
+      subtitle={getPickedFieldsLabel(
         countPickedFields(groupFieldsCheckMap).pickedFields,
       )}
       badge="Group"
@@ -881,7 +881,7 @@ function TreeViewFirstLevelGroupField(
     <TreeViewSection
       key={groupId}
       title={groupId}
-      subtitle={getSelectedFieldsLabel(
+      subtitle={getPickedFieldsLabel(
         countPickedFields(groupFieldsCheckMap).pickedFields,
       )}
       badge="Group"
@@ -891,7 +891,7 @@ function TreeViewFirstLevelGroupField(
   );
 }
 
-function getSelectedFieldsLabel(count: number, suffix = "selected") {
+function getPickedFieldsLabel(count: number, suffix = "selected") {
   if (count === 0) return undefined;
   return `(${count} ${pluralize(count, "field", "fields")} ${suffix})`;
 }

--- a/packages/slice-machine/src/features/builder/fields/contentRelationship/ContentRelationshipFieldPicker.tsx
+++ b/packages/slice-machine/src/features/builder/fields/contentRelationship/ContentRelationshipFieldPicker.tsx
@@ -1229,12 +1229,6 @@ export function countPickedFields(
   );
 }
 
-function isContentRelationshipField(
-  field: NestableWidget | Group,
-): field is Link {
-  return field.type === "Link" && field.config?.select === "document";
-}
-
 /**
  * Check if the field is a Content Relationship Link with a **single** custom
  * type. CRs with multiple custom types are not currently supported (legacy).
@@ -1243,7 +1237,8 @@ function isContentRelationshipFieldWithSingleCustomtype(
   field: NestableWidget | Group,
 ): field is Link {
   return !!(
-    isContentRelationshipField(field) &&
+    field.type === "Link" &&
+    field.config?.select === "document" &&
     field.config?.customtypes &&
     field.config.customtypes.length === 1
   );


### PR DESCRIPTION
### Description

Related to [DT-2722](https://linear.app/prismic/issue/DT-2722):
- Empty group → `"No available fields to select" label`
- Content relationship with a custom type selected, but no fields inside → `"No available fields to select" label`
- Content relationship with no custom types selected → `Checkbox to select as a simple field`
- Content relationship with multiple custom types selected → `Checkbox to select as a simple field`

Resolves DT-2725, DT-2729:
- Simpler label for nested selections →`(X fields selected)`

### Preview

![Screenshot 2025-06-24 at 14 43 42](https://github.com/user-attachments/assets/3e61101a-e058-44ba-a4d7-3d539701dea7)

### How to QA [^1]

<!-- When relevant, describe how to QA your changes. -->

<!-- Your favorite emoji is welcome to close your PR! -->

<!-- A note for reviewers: -->

[^1]:
	Please use these labels when submitting a review:
	:question: #ask:&ensp;Ask a question.
	:bulb: #idea:&ensp;Suggest an idea.
	:warning: #issue:&ensp;Strongly suggest a change.
	:tada: #nice:&ensp;Share a compliment.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved handling of content relationship fields to only support those linking to a single custom type.
  - Updated label generation for selected fields, allowing more flexible subtitle text.
  - Simplified and clarified internal logic for resolving custom types and rendering field groups.

- **New Features**
  - Introduced a consistent "No available fields to select" message when no fields are present in relevant views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->