### PR TITLE
feat: handle invalid CR customtypes reference conversions

### DIFF
--- a/packages/slice-machine/src/features/builder/fields/contentRelationship/ContentRelationshipFieldPicker.tsx
+++ b/packages/slice-machine/src/features/builder/fields/contentRelationship/ContentRelationshipFieldPicker.tsx
@@ -936,10 +936,10 @@ function useCustomTypes(linkCustomtypes: LinkCustomtypes | undefined): {
 
 function resolveContentRelationshipCustomTypes(
   linkCustomtypes: LinkCustomtypes,
-  localCustomTypes: CustomType[],
+  allCustomTypes: CustomType[],
 ): CustomType[] {
   return linkCustomtypes.flatMap((linkCustomtype) => {
-    return localCustomTypes.find((ct) => ct.id === getId(linkCustomtype)) ?? [];
+    return allCustomTypes.find((ct) => ct.id === getId(linkCustomtype)) ?? [];
   });
 }
 

--- a/packages/slice-machine/src/features/builder/fields/contentRelationship/ContentRelationshipFieldPicker.tsx
+++ b/packages/slice-machine/src/features/builder/fields/contentRelationship/ContentRelationshipFieldPicker.tsx
@@ -1362,7 +1362,9 @@ type CustomTypeFlatFieldMap = {
 function getCustomTypeFlatFieldMap(
   customType?: CustomType,
 ): CustomTypeFlatFieldMap | { isAvailable: false; get: null; has: null } {
-  if (!customType) return { isAvailable: false, get: null, has: null };
+  if (!customType) {
+    return { isAvailable: false, get: null, has: null };
+  }
 
   const ctFieldMap = Object.values(customType.json).reduce((acc, tabFields) => {
     for (const [fieldId, field] of Object.entries(tabFields)) {

--- a/packages/slice-machine/src/features/builder/fields/contentRelationship/ContentRelationshipFieldPicker.tsx
+++ b/packages/slice-machine/src/features/builder/fields/contentRelationship/ContentRelationshipFieldPicker.tsx
@@ -1168,36 +1168,38 @@ function createContentRelationshipFieldCheckMap(args: {
               return nestedFields;
             }
 
-            // Group field
-            const groupFields =
-              nestedField.fields.reduce<PickerLeafGroupFieldValue>(
-                (groupFields, groupField) => {
-                  const existingField = getGroupFieldFromMap(
-                    ctFlatFieldMap,
-                    nestedField.id,
-                    groupField,
-                  );
+            if ("fields" in nestedField && nestedField.fields !== undefined) {
+              // Group field
+              const groupFields =
+                nestedField.fields.reduce<PickerLeafGroupFieldValue>(
+                  (groupFields, groupField) => {
+                    const existingField = getGroupFieldFromMap(
+                      ctFlatFieldMap,
+                      nestedField.id,
+                      groupField,
+                    );
 
-                  // Check if the field matched the existing one in the custom type (only if validating)
-                  if (
-                    shouldValidate &&
-                    (existingField === undefined ||
-                      existingField.type === "Group")
-                  ) {
+                    // Check if the field matched the existing one in the custom type (only if validating)
+                    if (
+                      shouldValidate &&
+                      (existingField === undefined ||
+                        existingField.type === "Group")
+                    ) {
+                      return groupFields;
+                    }
+
+                    groupFields[groupField] = { type: "checkbox", value: true };
                     return groupFields;
-                  }
+                  },
+                  {},
+                );
 
-                  groupFields[groupField] = { type: "checkbox", value: true };
-                  return groupFields;
-                },
-                {},
-              );
-
-            if (Object.keys(groupFields).length > 0) {
-              nestedFields[nestedField.id] = {
-                type: "group",
-                value: groupFields,
-              };
+              if (Object.keys(groupFields).length > 0) {
+                nestedFields[nestedField.id] = {
+                  type: "group",
+                  value: groupFields,
+                };
+              }
             }
 
             return nestedFields;

--- a/packages/slice-machine/src/features/builder/fields/contentRelationship/ContentRelationshipFieldPicker.tsx
+++ b/packages/slice-machine/src/features/builder/fields/contentRelationship/ContentRelationshipFieldPicker.tsx
@@ -1294,6 +1294,8 @@ function createCustomTypeFieldMap(customType: CustomType) {
       if (!isValidField(fieldId, field)) continue;
 
       if (field.type === "Group") {
+        acc.set(fieldId, field)
+
         if (!field.config?.fields) continue;
 
         for (const [groupId, group] of Object.entries(field.config.fields)) {

--- a/packages/slice-machine/src/features/builder/fields/contentRelationship/ContentRelationshipFieldPicker.tsx
+++ b/packages/slice-machine/src/features/builder/fields/contentRelationship/ContentRelationshipFieldPicker.tsx
@@ -961,28 +961,25 @@ export function convertLinkCustomtypesToFieldCheckMap(args: {
       const ctFieldMap = createCustomTypeFieldMap(existingCt);
 
       const customTypeFields = customType.fields.reduce((fields, field) => {
+        // Check if the field exists
+        if (!ctFieldMap.has(getId(field))) return fields;
+
         if (typeof field === "string") {
           // Regular field
-          if (ctFieldMap.has(field)) {
-            fields[field] = { type: "checkbox", value: true };
-          }
+          fields[field] = { type: "checkbox", value: true };
         } else if ("fields" in field && field.fields !== undefined) {
           // Group field
-          if (ctFieldMap.has(field.id)) {
-            fields[field.id] = createGroupFieldCheckMap({
-              group: field,
-              allCustomTypes,
-              ctFieldMap,
-            });
-          }
+          fields[field.id] = createGroupFieldCheckMap({
+            group: field,
+            allCustomTypes,
+            ctFieldMap,
+          });
         } else if ("customtypes" in field && field.customtypes !== undefined) {
           // Content relationship field
-          if (ctFieldMap.has(field.id)) {
-            fields[field.id] = createContentRelationshipFieldCheckMap({
-              field,
-              allCustomTypes,
-            });
-          }
+          fields[field.id] = createContentRelationshipFieldCheckMap({
+            field,
+            allCustomTypes,
+          });
         }
 
         return fields;
@@ -1007,19 +1004,18 @@ function createGroupFieldCheckMap(args: {
     type: "group",
     value: group.fields.reduce<PickerFirstLevelGroupFieldValue>(
       (fields, field) => {
+        // Check if the field exists
+        if (!ctFieldMap.has(`${group.id}.${getId(field)}`)) return fields;
+
         if (typeof field === "string") {
           // Regular field
-          if (ctFieldMap.has(`${group.id}.${field}`)) {
-            fields[field] = { type: "checkbox", value: true };
-          }
+          fields[field] = { type: "checkbox", value: true };
         } else if ("customtypes" in field && field.customtypes !== undefined) {
           // Content relationship field
-          if (ctFieldMap.has(`${group.id}.${field.id}`)) {
-            fields[field.id] = createContentRelationshipFieldCheckMap({
-              field,
-              allCustomTypes,
-            });
-          }
+          fields[field.id] = createContentRelationshipFieldCheckMap({
+            field,
+            allCustomTypes,
+          });
         }
 
         return fields;
@@ -1294,7 +1290,7 @@ function createCustomTypeFieldMap(customType: CustomType) {
       if (!isValidField(fieldId, field)) continue;
 
       if (field.type === "Group") {
-        acc.set(fieldId, field)
+        acc.set(fieldId, field);
 
         if (!field.config?.fields) continue;
 

--- a/packages/slice-machine/src/features/builder/fields/contentRelationship/ContentRelationshipFieldPicker.tsx
+++ b/packages/slice-machine/src/features/builder/fields/contentRelationship/ContentRelationshipFieldPicker.tsx
@@ -1078,7 +1078,11 @@ function createGroupFieldCheckMap(args: {
       // Regular field
       if (typeof field === "string") {
         // Check if the field matched the existing one in the custom type (only if validating)
-        if (shouldValidate && existingField && existingField.type === "Group") {
+        if (
+          shouldValidate &&
+          existingField !== undefined &&
+          existingField.type === "Group"
+        ) {
           return fields;
         }
 
@@ -1091,7 +1095,7 @@ function createGroupFieldCheckMap(args: {
         // Check if the field matched the existing one in the custom type (only if validating)
         if (
           shouldValidate &&
-          existingField &&
+          existingField !== undefined &&
           !isContentRelationshipField(existingField)
         ) {
           return fields;
@@ -1150,8 +1154,13 @@ function createContentRelationshipFieldCheckMap(args: {
           (nestedFields, nestedField) => {
             // Regular field
             if (typeof nestedField === "string") {
+              const existingField = ctFlatFieldMap[nestedField];
+
               // Check if the field matched the existing one in the custom type (only if validating)
-              if (shouldValidate && ctFlatFieldMap[nestedField] === undefined) {
+              if (
+                shouldValidate &&
+                (existingField === undefined || existingField.type === "Group")
+              ) {
                 return nestedFields;
               }
 
@@ -1162,17 +1171,24 @@ function createContentRelationshipFieldCheckMap(args: {
             // Group field
             const groupFields =
               nestedField.fields.reduce<PickerLeafGroupFieldValue>(
-                (fields, field) => {
+                (groupFields, groupField) => {
+                  const existingField = getGroupFieldFromMap(
+                    ctFlatFieldMap,
+                    nestedField.id,
+                    groupField,
+                  );
+
                   // Check if the field matched the existing one in the custom type (only if validating)
                   if (
                     shouldValidate &&
-                    !getGroupFieldFromMap(ctFlatFieldMap, nestedField.id, field)
+                    (existingField === undefined ||
+                      existingField.type === "Group")
                   ) {
-                    return fields;
+                    return groupFields;
                   }
 
-                  fields[field] = { type: "checkbox", value: true };
-                  return fields;
+                  groupFields[groupField] = { type: "checkbox", value: true };
+                  return groupFields;
                 },
                 {},
               );

--- a/packages/slice-machine/src/features/builder/fields/contentRelationship/ContentRelationshipFieldPicker.tsx
+++ b/packages/slice-machine/src/features/builder/fields/contentRelationship/ContentRelationshipFieldPicker.tsx
@@ -412,8 +412,9 @@ function ContentRelationshipFieldPickerContent(
             rel="noopener noreferrer"
             style={{ color: "inherit", textDecoration: "underline" }}
           >
-            Please provide your feedback here.
+            Please provide your feedback here
           </a>
+          .
         </Text>
       </Box>
     </Box>

--- a/packages/slice-machine/src/features/builder/fields/contentRelationship/ContentRelationshipFieldPicker.tsx
+++ b/packages/slice-machine/src/features/builder/fields/contentRelationship/ContentRelationshipFieldPicker.tsx
@@ -974,14 +974,14 @@ export function convertLinkCustomtypesToFieldCheckMap(args: {
         (fields, field) => {
           // Check if the field exists (only if validating)
           const existingField = ctFlatFieldMap[getId(field)];
-          if (shouldValidate && !existingField) return fields;
+          if (shouldValidate && existingField === undefined) return fields;
 
           // Regular field
           if (typeof field === "string") {
             // Check if the field matched the existing one in the custom type (only if validating)
             if (
               shouldValidate &&
-              existingField &&
+              existingField !== undefined &&
               existingField.type === "Group"
             ) {
               return fields;
@@ -996,7 +996,7 @@ export function convertLinkCustomtypesToFieldCheckMap(args: {
             // Check if the field matched the existing one in the custom type (only if validating)
             if (
               shouldValidate &&
-              existingField &&
+              existingField !== undefined &&
               existingField.type !== "Group"
             ) {
               return fields;
@@ -1020,7 +1020,7 @@ export function convertLinkCustomtypesToFieldCheckMap(args: {
             // Check if the field matched the existing one in the custom type (only if validating)
             if (
               shouldValidate &&
-              existingField &&
+              existingField !== undefined &&
               !isContentRelationshipField(existingField)
             ) {
               return fields;
@@ -1151,7 +1151,7 @@ function createContentRelationshipFieldCheckMap(args: {
             // Regular field
             if (typeof nestedField === "string") {
               // Check if the field matched the existing one in the custom type (only if validating)
-              if (shouldValidate && !ctFlatFieldMap[nestedField]) {
+              if (shouldValidate && ctFlatFieldMap[nestedField] === undefined) {
                 return nestedFields;
               }
 
@@ -1447,12 +1447,10 @@ function getGroupFieldFromMap(
   flattenFields: Record<string, NestableWidget | Group>,
   groupId: string,
   fieldId: string,
-): Group | undefined {
+) {
   const group = flattenFields[groupId];
-  if (!group || group.type !== "Group") return undefined;
-
-  const field = group.config?.fields?.[fieldId];
-  return field && field.type === "Group" ? field : undefined;
+  if (group === undefined || group.type !== "Group") return undefined;
+  return group.config?.fields?.[fieldId];
 }
 
 function isValidField(

--- a/packages/slice-machine/src/features/builder/fields/contentRelationship/ContentRelationshipFieldPicker.tsx
+++ b/packages/slice-machine/src/features/builder/fields/contentRelationship/ContentRelationshipFieldPicker.tsx
@@ -1080,6 +1080,7 @@ function createContentRelationshipFieldCheckMap(args: {
 
     const customTypeFields = customType.fields.reduce(
       (nestedFields, nestedField) => {
+        // Regular field
         if (typeof nestedField === "string") {
           if (ctFieldMap.has(nestedField)) {
             nestedFields[nestedField] = { type: "checkbox", value: true };
@@ -1087,6 +1088,7 @@ function createContentRelationshipFieldCheckMap(args: {
           return nestedFields;
         }
 
+        // Group field
         const groupFields = nestedField.fields.reduce((fields, field) => {
           if (ctFieldMap.has(`${nestedField.id}.${field}`)) {
             fields[field] = { type: "checkbox", value: true };
@@ -1330,14 +1332,6 @@ function isContentRelationshipFieldWithSingleCustomtype(
     isContentRelationshipField(field) &&
     field.config?.customtypes &&
     field.config.customtypes.length === 1
-  );
-}
-
-function isEmptyContentRelationshipField(field: DynamicWidget): field is Link {
-  return (
-    isContentRelationshipField(field) &&
-    (field.config?.customtypes === undefined ||
-      field.config.customtypes.length === 0)
   );
 }
 

--- a/packages/slice-machine/src/features/builder/fields/contentRelationship/ContentRelationshipFieldPicker.tsx
+++ b/packages/slice-machine/src/features/builder/fields/contentRelationship/ContentRelationshipFieldPicker.tsx
@@ -968,11 +968,8 @@ export function convertLinkCustomtypesToFieldCheckMap(args: {
 
       // Regular field
       if (typeof field === "string") {
-        if (
-          allCustomTypes &&
-          existingField &&
-          existingField?.type === "Group"
-        ) {
+        // Check if the field matched the existing one in the custom type
+        if (allCustomTypes && existingField && existingField.type === "Group") {
           return fields;
         }
 
@@ -982,11 +979,8 @@ export function convertLinkCustomtypesToFieldCheckMap(args: {
 
       // Group field
       if ("fields" in field && field.fields !== undefined) {
-        if (
-          allCustomTypes &&
-          existingField &&
-          existingField?.type !== "Group"
-        ) {
+        // Check if the field matched the existing one in the custom type
+        if (allCustomTypes && existingField && existingField.type !== "Group") {
           return fields;
         }
 
@@ -1005,6 +999,7 @@ export function convertLinkCustomtypesToFieldCheckMap(args: {
 
       // Content relationship field
       if ("customtypes" in field && field.customtypes !== undefined) {
+        // Check if the field matched the existing one in the custom type
         if (
           allCustomTypes &&
           existingField &&
@@ -1052,7 +1047,8 @@ function createGroupFieldCheckMap(args: {
 
     // Regular field
     if (typeof field === "string") {
-      if (allCustomTypes && existingField && existingField?.type === "Group") {
+      // Check if the field matched the existing one in the custom type
+      if (allCustomTypes && existingField && existingField.type === "Group") {
         return fields;
       }
 
@@ -1062,6 +1058,7 @@ function createGroupFieldCheckMap(args: {
 
     // Content relationship field
     if ("customtypes" in field && field.customtypes !== undefined) {
+      // Check if the field matched the existing one in the custom type
       if (
         allCustomTypes &&
         existingField &&
@@ -1110,6 +1107,7 @@ function createContentRelationshipFieldCheckMap(args: {
     const ctFields = customType.fields.reduce((nestedFields, nestedField) => {
       // Regular field
       if (typeof nestedField === "string") {
+        // Check if the field matched the existing one in the custom type
         if (allCustomTypes && !ctFlatFieldMap.has(nestedField)) {
           return nestedFields;
         }
@@ -1120,6 +1118,7 @@ function createContentRelationshipFieldCheckMap(args: {
 
       // Group field
       const groupFields = nestedField.fields.reduce((fields, field) => {
+        // Check if the field matched the existing one in the custom type
         if (
           allCustomTypes &&
           !ctFlatFieldMap.has(`${nestedField.id}.${field}`)

--- a/packages/slice-machine/src/features/builder/fields/contentRelationship/__tests__/ContentRelationshipFieldPicker.test.ts
+++ b/packages/slice-machine/src/features/builder/fields/contentRelationship/__tests__/ContentRelationshipFieldPicker.test.ts
@@ -886,7 +886,7 @@ describe("ContentRelationshipFieldPicker", () => {
       expect(result).toEqual({});
     });
 
-    it.only("do not check for valid field if allCustomTypes is not provided", () => {
+    it("do not check for valid field if allCustomTypes is not provided", () => {
       const result = convertLinkCustomtypesToFieldCheckMap({
         linkCustomtypes: [
           {

--- a/packages/slice-machine/src/features/builder/fields/contentRelationship/__tests__/ContentRelationshipFieldPicker.test.ts
+++ b/packages/slice-machine/src/features/builder/fields/contentRelationship/__tests__/ContentRelationshipFieldPicker.test.ts
@@ -1,10 +1,10 @@
+import { CustomType } from "@prismicio/types-internal/lib/customtypes";
 import { describe, expect, it } from "vitest";
 
 import {
   convertLinkCustomtypesToFieldCheckMap,
   countPickedFields,
 } from "../ContentRelationshipFieldPicker";
-import { CustomType } from "@prismicio/types-internal/lib/customtypes";
 
 describe("ContentRelationshipFieldPicker", () => {
   describe("countPickedFields", () => {
@@ -761,6 +761,72 @@ describe("ContentRelationshipFieldPicker", () => {
       });
 
       console.log(JSON.stringify(result, null, 2));
+
+      expect(result).toEqual({});
+    });
+
+    it("should not include a regular field referenced as a content relationship field", () => {
+      const customType: CustomType = {
+        id: "customType",
+        label: "Custom Type",
+        repeatable: false,
+        status: true,
+        json: {
+          Main: {
+            booleanField: {
+              type: "Boolean",
+            },
+          },
+        },
+      };
+
+      const result = convertLinkCustomtypesToFieldCheckMap({
+        linkCustomtypes: [
+          {
+            id: "customType",
+            fields: [
+              {
+                id: "booleanField",
+                customtypes: [],
+              },
+            ],
+          },
+        ],
+        allCustomTypes: [customType],
+      });
+
+      expect(result).toEqual({});
+    });
+
+    it("should not include a regular field referenced as a group field", () => {
+      const customType: CustomType = {
+        id: "customType",
+        label: "Custom Type",
+        repeatable: false,
+        status: true,
+        json: {
+          Main: {
+            booleanField: {
+              type: "Boolean",
+            },
+          },
+        },
+      };
+
+      const result = convertLinkCustomtypesToFieldCheckMap({
+        linkCustomtypes: [
+          {
+            id: "customType",
+            fields: [
+              {
+                id: "booleanField",
+                fields: [],
+              },
+            ],
+          },
+        ],
+        allCustomTypes: [customType],
+      });
 
       expect(result).toEqual({});
     });

--- a/packages/slice-machine/src/features/builder/fields/contentRelationship/__tests__/ContentRelationshipFieldPicker.test.ts
+++ b/packages/slice-machine/src/features/builder/fields/contentRelationship/__tests__/ContentRelationshipFieldPicker.test.ts
@@ -366,7 +366,7 @@ describe("ContentRelationshipFieldPicker", () => {
   });
 
   describe("createContentRelationshipFieldCheckMap", () => {
-    it("should include existing/valid referenced fields", () => {
+    it("should include existing/valid referenced regular root fields", () => {
       const customType: CustomType = {
         id: "customType",
         label: "Custom Type",
@@ -711,6 +711,75 @@ describe("ContentRelationshipFieldPicker", () => {
               booleanField: {
                 type: "checkbox",
                 value: true,
+              },
+            },
+          },
+        },
+      });
+    });
+
+    it("should include a correctly referenced content relationship field", () => {
+      const customType: CustomType = {
+        id: "customType",
+        label: "Custom Type",
+        repeatable: false,
+        status: true,
+        json: {
+          Main: {
+            booleanField: {
+              type: "Boolean",
+            },
+          },
+        },
+      };
+      const customTypeWithContentRelationship: CustomType = {
+        id: "customTypeWithContentRelationship",
+        label: "Custom Type With Content Relationship",
+        repeatable: false,
+        status: true,
+        json: {
+          Main: {
+            contentRelationshipField: {
+              type: "Link",
+              config: {
+                select: "document",
+                customtypes: ["customType"],
+              },
+            },
+          },
+        },
+      };
+
+      const result = convertLinkCustomtypesToFieldCheckMap({
+        linkCustomtypes: [
+          {
+            id: "customTypeWithContentRelationship",
+            fields: [
+              {
+                id: "contentRelationshipField",
+                customtypes: [
+                  {
+                    id: "customType",
+                    fields: ["booleanField"],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+        allCustomTypes: [customType, customTypeWithContentRelationship],
+      });
+
+      expect(result).toEqual({
+        customTypeWithContentRelationship: {
+          contentRelationshipField: {
+            type: "contentRelationship",
+            value: {
+              customType: {
+                booleanField: {
+                  type: "checkbox",
+                  value: true,
+                },
               },
             },
           },

--- a/packages/slice-machine/src/features/builder/fields/contentRelationship/__tests__/ContentRelationshipFieldPicker.test.ts
+++ b/packages/slice-machine/src/features/builder/fields/contentRelationship/__tests__/ContentRelationshipFieldPicker.test.ts
@@ -4,13 +4,87 @@ import {
   convertLinkCustomtypesToFieldCheckMap,
   countPickedFields,
 } from "../ContentRelationshipFieldPicker";
+import { CustomType } from "@prismicio/types-internal/lib/customtypes";
+
+const allCustomTypes: CustomType[] = [
+  {
+    id: "ct1",
+    label: "CT 1",
+    repeatable: false,
+    status: true,
+    json: {
+      Main: {
+        f1: {
+          type: "Link",
+          config: {
+            select: "document",
+            customtypes: ["ct2"],
+          },
+        },
+        f2: {
+          type: "Link",
+          config: {
+            select: "document",
+            customtypes: ["ct2"],
+          },
+        },
+        g1: {
+          type: "Group",
+          config: {
+            fields: {
+              f1: {
+                type: "Boolean",
+              },
+              f2: {
+                type: "Link",
+                config: {
+                  select: "document",
+                  customtypes: ["ct2"],
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+  {
+    id: "ct2",
+    label: "CT 2",
+    repeatable: false,
+    status: true,
+    json: {
+      Main: {
+        f1: {
+          type: "Boolean",
+        },
+        g2: {
+          type: "Group",
+          config: {
+            fields: {
+              f1: {
+                type: "Boolean",
+              },
+              f2: {
+                type: "Boolean",
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+];
 
 describe("ContentRelationshipFieldPicker", () => {
   it("should count picked fields with a custom type as string", () => {
     const customtypes = ["ct1"];
 
     const result = countPickedFields(
-      convertLinkCustomtypesToFieldCheckMap(customtypes),
+      convertLinkCustomtypesToFieldCheckMap({
+        linkCustomtypes: customtypes,
+        allCustomTypes,
+      }),
     );
 
     expect(result).toEqual({
@@ -23,7 +97,10 @@ describe("ContentRelationshipFieldPicker", () => {
     const customtypes = ["ct1", "ct2"];
 
     const result = countPickedFields(
-      convertLinkCustomtypesToFieldCheckMap(customtypes),
+      convertLinkCustomtypesToFieldCheckMap({
+        linkCustomtypes: customtypes,
+        allCustomTypes,
+      }),
     );
 
     expect(result).toEqual({
@@ -41,7 +118,10 @@ describe("ContentRelationshipFieldPicker", () => {
     ];
 
     const result = countPickedFields(
-      convertLinkCustomtypesToFieldCheckMap(customtypes),
+      convertLinkCustomtypesToFieldCheckMap({
+        linkCustomtypes: customtypes,
+        allCustomTypes,
+      }),
     );
 
     expect(result).toEqual({
@@ -69,7 +149,10 @@ describe("ContentRelationshipFieldPicker", () => {
     ];
 
     const result = countPickedFields(
-      convertLinkCustomtypesToFieldCheckMap(customtypes),
+      convertLinkCustomtypesToFieldCheckMap({
+        linkCustomtypes: customtypes,
+        allCustomTypes,
+      }),
     );
 
     expect(result).toEqual({
@@ -91,9 +174,11 @@ describe("ContentRelationshipFieldPicker", () => {
       },
     ];
 
-    const result = countPickedFields(
-      convertLinkCustomtypesToFieldCheckMap(customtypes),
-    );
+    const test = convertLinkCustomtypesToFieldCheckMap({
+      linkCustomtypes: customtypes,
+      allCustomTypes,
+    });
+    const result = countPickedFields(test);
 
     expect(result).toEqual({
       pickedFields: 2,
@@ -126,7 +211,10 @@ describe("ContentRelationshipFieldPicker", () => {
     ];
 
     const result = countPickedFields(
-      convertLinkCustomtypesToFieldCheckMap(customtypes),
+      convertLinkCustomtypesToFieldCheckMap({
+        linkCustomtypes: customtypes,
+        allCustomTypes,
+      }),
     );
 
     expect(result).toEqual({
@@ -166,7 +254,10 @@ describe("ContentRelationshipFieldPicker", () => {
     ];
 
     const result = countPickedFields(
-      convertLinkCustomtypesToFieldCheckMap(customtypes),
+      convertLinkCustomtypesToFieldCheckMap({
+        linkCustomtypes: customtypes,
+        allCustomTypes,
+      }),
     );
 
     expect(result).toEqual({
@@ -201,7 +292,10 @@ describe("ContentRelationshipFieldPicker", () => {
     ];
 
     const result = countPickedFields(
-      convertLinkCustomtypesToFieldCheckMap(customtypes),
+      convertLinkCustomtypesToFieldCheckMap({
+        linkCustomtypes: customtypes,
+        allCustomTypes,
+      }),
     );
 
     expect(result).toEqual({
@@ -230,7 +324,10 @@ describe("ContentRelationshipFieldPicker", () => {
     ];
 
     const result = countPickedFields(
-      convertLinkCustomtypesToFieldCheckMap(customtypes),
+      convertLinkCustomtypesToFieldCheckMap({
+        linkCustomtypes: customtypes,
+        allCustomTypes,
+      }),
     );
 
     expect(result).toEqual({
@@ -254,7 +351,10 @@ describe("ContentRelationshipFieldPicker", () => {
     ];
 
     const result = countPickedFields(
-      convertLinkCustomtypesToFieldCheckMap(customtypes),
+      convertLinkCustomtypesToFieldCheckMap({
+        linkCustomtypes: customtypes,
+        allCustomTypes,
+      }),
     );
 
     expect(result).toEqual({

--- a/packages/slice-machine/src/features/builder/fields/contentRelationship/__tests__/ContentRelationshipFieldPicker.test.ts
+++ b/packages/slice-machine/src/features/builder/fields/contentRelationship/__tests__/ContentRelationshipFieldPicker.test.ts
@@ -885,5 +885,60 @@ describe("ContentRelationshipFieldPicker", () => {
 
       expect(result).toEqual({});
     });
+
+    it.only("do not check for valid field if allCustomTypes is not provided", () => {
+      const result = convertLinkCustomtypesToFieldCheckMap({
+        linkCustomtypes: [
+          {
+            id: "customTypeA",
+            fields: [
+              "fieldA",
+              {
+                id: "groupA",
+                fields: ["groupFieldA"],
+              },
+              {
+                id: "contentRelationshipA",
+                customtypes: [
+                  {
+                    id: "customTypeB",
+                    fields: ["fieldB"],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      });
+
+      expect(result).toEqual({
+        customTypeA: {
+          fieldA: {
+            type: "checkbox",
+            value: true,
+          },
+          groupA: {
+            type: "group",
+            value: {
+              groupFieldA: {
+                type: "checkbox",
+                value: true,
+              },
+            },
+          },
+          contentRelationshipA: {
+            type: "contentRelationship",
+            value: {
+              customTypeB: {
+                fieldB: {
+                  type: "checkbox",
+                  value: true,
+                },
+              },
+            },
+          },
+        },
+      });
+    });
   });
 });

--- a/packages/slice-machine/src/features/builder/fields/contentRelationship/__tests__/ContentRelationshipFieldPicker.test.ts
+++ b/packages/slice-machine/src/features/builder/fields/contentRelationship/__tests__/ContentRelationshipFieldPicker.test.ts
@@ -366,7 +366,7 @@ describe("ContentRelationshipFieldPicker", () => {
   });
 
   describe("createContentRelationshipFieldCheckMap", () => {
-    it("should include the field if it is a static zone field", () => {
+    it("should include existing/valid referenced fields", () => {
       const customType: CustomType = {
         id: "customType",
         label: "Custom Type",
@@ -523,7 +523,7 @@ describe("ContentRelationshipFieldPicker", () => {
       });
     });
 
-    it("should not include the field if the field is not a static zone field", () => {
+    it("should not include non-existing/invalid referenced fields", () => {
       const customType2: CustomType = {
         id: "customType2",
         label: "Custom Type 2",
@@ -547,9 +547,6 @@ describe("ContentRelationshipFieldPicker", () => {
           Main: {
             mdField: {
               type: "StructuredText",
-              config: {
-                label: "Structured Text Field",
-              },
             },
             crField: {
               type: "Link",
@@ -577,11 +574,8 @@ describe("ContentRelationshipFieldPicker", () => {
           {
             id: "customType",
             fields: [
+              "mdField",
               "nonExistingField",
-              {
-                id: "groupField",
-                fields: ["nonExistingGroupField"],
-              },
               {
                 id: "nonExistingGroup",
                 fields: ["groupFieldA"],
@@ -595,16 +589,27 @@ describe("ContentRelationshipFieldPicker", () => {
                   },
                 ],
               },
+              {
+                id: "groupField",
+                fields: ["nonExistingGroupField"],
+              },
             ],
           },
         ],
         allCustomTypes: [customType, customType2],
       });
 
-      expect(result).toEqual({});
+      expect(result).toEqual({
+        customType: {
+          mdField: {
+            type: "checkbox",
+            value: true,
+          },
+        },
+      });
     });
 
-    it("should not include the field if it is invalid (uid, slices & choice)", () => {
+    it("should not include an invalid field (uid, slices & choice)", () => {
       const customType: CustomType = {
         id: "customType",
         label: "Custom Type",
@@ -612,7 +617,7 @@ describe("ContentRelationshipFieldPicker", () => {
         status: true,
         json: {
           Main: {
-            bool: {
+            booleanField: {
               type: "Boolean",
             },
             typeUid: {
@@ -649,7 +654,7 @@ describe("ContentRelationshipFieldPicker", () => {
         linkCustomtypes: [
           {
             id: "customType",
-            fields: ["bool", "typeUid", "uid", "choice", "slices"],
+            fields: ["booleanField", "typeUid", "uid", "choice", "slices"],
           },
         ],
         allCustomTypes: [customType],
@@ -657,7 +662,7 @@ describe("ContentRelationshipFieldPicker", () => {
 
       expect(result).toEqual({
         customType: {
-          bool: {
+          booleanField: {
             type: "checkbox",
             value: true,
           },
@@ -665,7 +670,7 @@ describe("ContentRelationshipFieldPicker", () => {
       });
     });
 
-    it("should include the field if it correctly references a group field", () => {
+    it("should include a correctly referenced group field", () => {
       const customType: CustomType = {
         id: "customType",
         label: "Custom Type",
@@ -721,7 +726,7 @@ describe("ContentRelationshipFieldPicker", () => {
       });
     });
 
-    it("should include the field if it correctly references a group field inside a nested custom type", () => {
+    it("should include a field correctly referenced as a group inside a nested custom type", () => {
       const customType: CustomType = {
         id: "customType",
         label: "Custom Type",
@@ -812,7 +817,7 @@ describe("ContentRelationshipFieldPicker", () => {
       });
     });
 
-    it("should not include the field if it incorrectly references a regular field as a group field", () => {
+    it("should not include a regular field incorrectly referenced as a group", () => {
       const customType: CustomType = {
         id: "customType",
         label: "Custom Type",
@@ -845,7 +850,40 @@ describe("ContentRelationshipFieldPicker", () => {
       expect(result).toEqual({});
     });
 
-    it("should not include the field if it incorrectly references a group field as a regular field (no picked fields)", () => {
+    it("should not include a field incorrectly referenced as a group when it's not", () => {
+      const customType: CustomType = {
+        id: "customType",
+        label: "Custom Type",
+        repeatable: false,
+        status: true,
+        json: {
+          Main: {
+            booleanField: {
+              type: "Boolean",
+            },
+          },
+        },
+      };
+
+      const result = convertLinkCustomtypesToFieldCheckMap({
+        linkCustomtypes: [
+          {
+            id: "customType",
+            fields: [
+              {
+                id: "booleanField",
+                fields: ["fieldA"],
+              },
+            ],
+          },
+        ],
+        allCustomTypes: [customType],
+      });
+
+      expect(result).toEqual({});
+    });
+
+    it("should not include a group field referenced as a regular field (string/no picked fields)", () => {
       const customType: CustomType = {
         id: "customType",
         label: "Custom Type",
@@ -884,7 +922,7 @@ describe("ContentRelationshipFieldPicker", () => {
       expect(result).toEqual({});
     });
 
-    it("should not include the a content relationship field if it references a non existing custom type", () => {
+    it("should not include a content relationship field if it references a non existing custom type", () => {
       const customTypeWithField: CustomType = {
         id: "customTypeWithField",
         label: "Custom Type With Field",

--- a/packages/slice-machine/src/features/builder/fields/contentRelationship/__tests__/ContentRelationshipFieldPicker.test.ts
+++ b/packages/slice-machine/src/features/builder/fields/contentRelationship/__tests__/ContentRelationshipFieldPicker.test.ts
@@ -850,7 +850,7 @@ describe("ContentRelationshipFieldPicker", () => {
       expect(result).toEqual({});
     });
 
-    it("should not include a field incorrectly referenced as a group when it's not", () => {
+    it("should not include a field referenced as a group field when it's not one", () => {
       const customType: CustomType = {
         id: "customType",
         label: "Custom Type",
@@ -917,6 +917,57 @@ describe("ContentRelationshipFieldPicker", () => {
           },
         ],
         allCustomTypes: [customType],
+      });
+
+      expect(result).toEqual({});
+    });
+
+    it("should not include a field referenced as a content relationship field when it's not one", () => {
+      const customTypeA: CustomType = {
+        id: "customTypeA",
+        label: "Custom Type A",
+        repeatable: false,
+        status: true,
+        json: {
+          Main: {
+            booleanField: {
+              type: "Boolean",
+            },
+          },
+        },
+      };
+      const customTypeB: CustomType = {
+        id: "customTypeB",
+        label: "Custom Type B",
+        repeatable: false,
+        status: true,
+        json: {
+          Main: {
+            colorField: {
+              type: "Color",
+            },
+          },
+        },
+      };
+
+      const result = convertLinkCustomtypesToFieldCheckMap({
+        linkCustomtypes: [
+          {
+            id: "customTypeA",
+            fields: [
+              {
+                id: "booleanField",
+                customtypes: [
+                  {
+                    id: "customTypeB",
+                    fields: ["colorField"],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+        allCustomTypes: [customTypeB, customTypeA],
       });
 
       expect(result).toEqual({});

--- a/packages/slice-machine/src/features/builder/fields/contentRelationship/__tests__/ContentRelationshipFieldPicker.test.ts
+++ b/packages/slice-machine/src/features/builder/fields/contentRelationship/__tests__/ContentRelationshipFieldPicker.test.ts
@@ -633,6 +633,78 @@ describe("ContentRelationshipFieldPicker", () => {
       });
     });
 
+    it("should not include the field if it incorrectly references a regular field as a group field", () => {
+      const customType: CustomType = {
+        id: "customType",
+        label: "Custom Type",
+        repeatable: false,
+        status: true,
+        json: {
+          Main: {
+            booleanField: {
+              type: "Boolean",
+            },
+          },
+        },
+      };
+
+      const result = convertLinkCustomtypesToFieldCheckMap({
+        linkCustomtypes: [
+          {
+            id: "customType",
+            fields: [
+              {
+                id: "groupField",
+                fields: ["booleanField"],
+              },
+            ],
+          },
+        ],
+        allCustomTypes: [customType],
+      });
+
+      expect(result).toEqual({});
+    });
+
+    it("should not include the field if it incorrectly references a group field as a regular field (no picked fields)", () => {
+      const customType: CustomType = {
+        id: "customType",
+        label: "Custom Type",
+        repeatable: false,
+        status: true,
+        json: {
+          Main: {
+            groupField: {
+              type: "Group",
+              config: {
+                label: "Group Field",
+                fields: {
+                  booleanField: {
+                    type: "Boolean",
+                    config: {
+                      label: "Boolean Field",
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      };
+
+      const result = convertLinkCustomtypesToFieldCheckMap({
+        linkCustomtypes: [
+          {
+            id: "customType",
+            fields: ["groupField"],
+          },
+        ],
+        allCustomTypes: [customType],
+      });
+
+      expect(result).toEqual({});
+    });
+
     it("should not include the a content relationship field if it references a non existing custom type", () => {
       const customTypeWithField: CustomType = {
         id: "customTypeWithField",

--- a/packages/slice-machine/src/features/builder/fields/contentRelationship/__tests__/ContentRelationshipFieldPicker.test.ts
+++ b/packages/slice-machine/src/features/builder/fields/contentRelationship/__tests__/ContentRelationshipFieldPicker.test.ts
@@ -842,7 +842,7 @@ describe("ContentRelationshipFieldPicker", () => {
       expect(result).toEqual({});
     });
 
-    it("should not include a regular field that's actually referencing a group", () => {
+    it("should not include a field referencing a group as a regular field (string/no picked fields)", () => {
       const customType: CustomType = {
         id: "customType",
         label: "Custom Type",
@@ -870,6 +870,16 @@ describe("ContentRelationshipFieldPicker", () => {
         status: true,
         json: {
           Main: {
+            groupField: {
+              type: "Group",
+              config: {
+                fields: {
+                  booleanField: {
+                    type: "Boolean",
+                  },
+                },
+              },
+            },
             contentRelationshipField: {
               type: "Link",
               config: {
@@ -886,6 +896,7 @@ describe("ContentRelationshipFieldPicker", () => {
           {
             id: "customTypeWithContentRelationship",
             fields: [
+              "groupField",
               {
                 id: "contentRelationshipField",
                 customtypes: [
@@ -899,45 +910,6 @@ describe("ContentRelationshipFieldPicker", () => {
           },
         ],
         allCustomTypes: [customType, customTypeWithContentRelationship],
-      });
-
-      expect(result).toEqual({});
-    });
-
-    it("should not include a group field referenced as a regular field (string/no picked fields)", () => {
-      const customType: CustomType = {
-        id: "customType",
-        label: "Custom Type",
-        repeatable: false,
-        status: true,
-        json: {
-          Main: {
-            groupField: {
-              type: "Group",
-              config: {
-                label: "Group Field",
-                fields: {
-                  booleanField: {
-                    type: "Boolean",
-                    config: {
-                      label: "Boolean Field",
-                    },
-                  },
-                },
-              },
-            },
-          },
-        },
-      };
-
-      const result = convertLinkCustomtypesToFieldCheckMap({
-        linkCustomtypes: [
-          {
-            id: "customType",
-            fields: ["groupField"],
-          },
-        ],
-        allCustomTypes: [customType],
       });
 
       expect(result).toEqual({});

--- a/packages/slice-machine/src/features/builder/fields/contentRelationship/__tests__/ContentRelationshipFieldPicker.test.ts
+++ b/packages/slice-machine/src/features/builder/fields/contentRelationship/__tests__/ContentRelationshipFieldPicker.test.ts
@@ -400,6 +400,20 @@ describe("ContentRelationshipFieldPicker", () => {
     });
 
     it("should not include the field if the field is not a static zone field", () => {
+      const customType2: CustomType = {
+        id: "customType2",
+        label: "Custom Type 2",
+        repeatable: false,
+        status: true,
+        json: {
+          Main: {
+            booleanField: {
+              type: "Boolean",
+            },
+          },
+        },
+      };
+
       const customType: CustomType = {
         id: "customType",
         label: "Custom Type",
@@ -407,10 +421,27 @@ describe("ContentRelationshipFieldPicker", () => {
         status: true,
         json: {
           Main: {
-            rtField: {
+            mdField: {
               type: "StructuredText",
               config: {
                 label: "Structured Text Field",
+              },
+            },
+            crField: {
+              type: "Link",
+              config: {
+                select: "document",
+                customtypes: ["customType2"],
+              },
+            },
+            groupField: {
+              type: "Group",
+              config: {
+                fields: {
+                  groupFieldA: {
+                    type: "Boolean",
+                  },
+                },
               },
             },
           },
@@ -418,8 +449,32 @@ describe("ContentRelationshipFieldPicker", () => {
       };
 
       const result = convertLinkCustomtypesToFieldCheckMap({
-        linkCustomtypes: [{ id: "customType", fields: ["booleanField"] }],
-        allCustomTypes: [customType],
+        linkCustomtypes: [
+          {
+            id: "customType",
+            fields: [
+              "nonExistingField",
+              {
+                id: "groupField",
+                fields: ["nonExistingGroupField"],
+              },
+              {
+                id: "nonExistingGroup",
+                fields: ["groupFieldA"],
+              },
+              {
+                id: "crField",
+                customtypes: [
+                  {
+                    id: "customType2",
+                    fields: ["nonExistingNestedField"],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+        allCustomTypes: [customType, customType2],
       });
 
       expect(result).toEqual({});

--- a/packages/slice-machine/src/features/builder/fields/contentRelationship/__tests__/ContentRelationshipFieldPicker.test.ts
+++ b/packages/slice-machine/src/features/builder/fields/contentRelationship/__tests__/ContentRelationshipFieldPicker.test.ts
@@ -374,24 +374,148 @@ describe("ContentRelationshipFieldPicker", () => {
         status: true,
         json: {
           Main: {
+            textField: {
+              type: "Text",
+            },
             booleanField: {
               type: "Boolean",
-              config: {
-                label: "Boolean Field",
-              },
+            },
+            structuredTextField: {
+              type: "StructuredText",
+            },
+            imageField: {
+              type: "Image",
+            },
+            linkField: {
+              type: "Link",
+            },
+            colorField: {
+              type: "Color",
+            },
+            dateField: {
+              type: "Date",
+            },
+            geoPointField: {
+              type: "GeoPoint",
+            },
+            slicesField: {
+              type: "GeoPoint",
+            },
+            numberField: {
+              type: "Number",
+            },
+            rangeField: {
+              type: "Range",
+            },
+            selectField: {
+              type: "Select",
+            },
+            timestampField: {
+              type: "Timestamp",
+            },
+            separatorField: {
+              type: "Separator",
+            },
+            tableField: {
+              type: "Table",
+            },
+            integrationFieldsField: {
+              type: "IntegrationFields",
             },
           },
         },
       };
 
       const result = convertLinkCustomtypesToFieldCheckMap({
-        linkCustomtypes: [{ id: "customType", fields: ["booleanField"] }],
+        linkCustomtypes: [
+          {
+            id: "customType",
+            fields: [
+              "textField",
+              "booleanField",
+              "structuredTextField",
+              "imageField",
+              "linkField",
+              "colorField",
+              "dateField",
+              "geoPointField",
+              "slicesField",
+              "numberField",
+              "rangeField",
+              "selectField",
+              "timestampField",
+              "separatorField",
+              "tableField",
+              "integrationFieldsField",
+            ],
+          },
+        ],
         allCustomTypes: [customType],
       });
 
       expect(result).toEqual({
         customType: {
+          textField: {
+            type: "checkbox",
+            value: true,
+          },
           booleanField: {
+            type: "checkbox",
+            value: true,
+          },
+          structuredTextField: {
+            type: "checkbox",
+            value: true,
+          },
+          imageField: {
+            type: "checkbox",
+            value: true,
+          },
+          linkField: {
+            type: "checkbox",
+            value: true,
+          },
+          colorField: {
+            type: "checkbox",
+            value: true,
+          },
+          dateField: {
+            type: "checkbox",
+            value: true,
+          },
+          geoPointField: {
+            type: "checkbox",
+            value: true,
+          },
+          slicesField: {
+            type: "checkbox",
+            value: true,
+          },
+          numberField: {
+            type: "checkbox",
+            value: true,
+          },
+          rangeField: {
+            type: "checkbox",
+            value: true,
+          },
+          selectField: {
+            type: "checkbox",
+            value: true,
+          },
+          timestampField: {
+            type: "checkbox",
+            value: true,
+          },
+          separatorField: {
+            type: "checkbox",
+            value: true,
+          },
+          tableField: {
+            type: "checkbox",
+            value: true,
+          },
+          integrationFieldsField: {
             type: "checkbox",
             value: true,
           },

--- a/packages/slice-machine/src/features/builder/fields/contentRelationship/__tests__/ContentRelationshipFieldPicker.test.ts
+++ b/packages/slice-machine/src/features/builder/fields/contentRelationship/__tests__/ContentRelationshipFieldPicker.test.ts
@@ -791,6 +791,20 @@ describe("ContentRelationshipFieldPicker", () => {
                 customtypes: ["customTypeWithField"],
               },
             },
+            groupField: {
+              type: "Group",
+              config: {
+                fields: {
+                  contentRelationshipFieldInsideGroup: {
+                    type: "Link",
+                    config: {
+                      select: "document",
+                      customtypes: ["customTypeWithField"],
+                    },
+                  },
+                },
+              },
+            },
           },
         },
       };
@@ -806,6 +820,20 @@ describe("ContentRelationshipFieldPicker", () => {
                   {
                     id: "nonExistingCustomType",
                     fields: ["colorField"],
+                  },
+                ],
+              },
+              {
+                id: "groupField",
+                fields: [
+                  {
+                    id: "contentRelationshipFieldInsideGroup",
+                    customtypes: [
+                      {
+                        id: "nonExistingCustomType",
+                        fields: ["colorField"],
+                      },
+                    ],
                   },
                 ],
               },
@@ -884,7 +912,7 @@ describe("ContentRelationshipFieldPicker", () => {
       expect(result).toEqual({});
     });
 
-    it("do not check for valid field if allCustomTypes is not provided", () => {
+    it("should not check for valid fields if allCustomTypes prop is not provided", () => {
       const result = convertLinkCustomtypesToFieldCheckMap({
         linkCustomtypes: [
           {

--- a/packages/slice-machine/src/features/builder/fields/contentRelationship/__tests__/ContentRelationshipFieldPicker.test.ts
+++ b/packages/slice-machine/src/features/builder/fields/contentRelationship/__tests__/ContentRelationshipFieldPicker.test.ts
@@ -809,39 +809,6 @@ describe("ContentRelationshipFieldPicker", () => {
       });
     });
 
-    it("should not include a regular field incorrectly referenced as a group", () => {
-      const customType: CustomType = {
-        id: "customType",
-        label: "Custom Type",
-        repeatable: false,
-        status: true,
-        json: {
-          Main: {
-            booleanField: {
-              type: "Boolean",
-            },
-          },
-        },
-      };
-
-      const result = convertLinkCustomtypesToFieldCheckMap({
-        linkCustomtypes: [
-          {
-            id: "customType",
-            fields: [
-              {
-                id: "groupField",
-                fields: ["booleanField"],
-              },
-            ],
-          },
-        ],
-        allCustomTypes: [customType],
-      });
-
-      expect(result).toEqual({});
-    });
-
     it("should not include a field referenced as a group field when it's not one", () => {
       const customType: CustomType = {
         id: "customType",
@@ -870,6 +837,68 @@ describe("ContentRelationshipFieldPicker", () => {
           },
         ],
         allCustomTypes: [customType],
+      });
+
+      expect(result).toEqual({});
+    });
+
+    it("should not include a regular field that's actually referencing a group", () => {
+      const customType: CustomType = {
+        id: "customType",
+        label: "Custom Type",
+        repeatable: false,
+        status: true,
+        json: {
+          Main: {
+            groupField: {
+              type: "Group",
+              config: {
+                fields: {
+                  booleanField: {
+                    type: "Boolean",
+                  },
+                },
+              },
+            },
+          },
+        },
+      };
+      const customTypeWithContentRelationship: CustomType = {
+        id: "customTypeWithContentRelationship",
+        label: "Custom Type With Content Relationship",
+        repeatable: false,
+        status: true,
+        json: {
+          Main: {
+            contentRelationshipField: {
+              type: "Link",
+              config: {
+                select: "document",
+                customtypes: ["customType"],
+              },
+            },
+          },
+        },
+      };
+
+      const result = convertLinkCustomtypesToFieldCheckMap({
+        linkCustomtypes: [
+          {
+            id: "customTypeWithContentRelationship",
+            fields: [
+              {
+                id: "contentRelationshipField",
+                customtypes: [
+                  {
+                    id: "customType",
+                    fields: ["groupField"],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+        allCustomTypes: [customType, customTypeWithContentRelationship],
       });
 
       expect(result).toEqual({});

--- a/packages/slice-machine/src/features/builder/fields/contentRelationship/__tests__/ContentRelationshipFieldPicker.test.ts
+++ b/packages/slice-machine/src/features/builder/fields/contentRelationship/__tests__/ContentRelationshipFieldPicker.test.ts
@@ -1171,5 +1171,34 @@ describe("ContentRelationshipFieldPicker", () => {
         },
       });
     });
+
+    it("should check for valid fields if allCustomTypes is empty", () => {
+      const result = convertLinkCustomtypesToFieldCheckMap({
+        linkCustomtypes: [
+          {
+            id: "customTypeA",
+            fields: [
+              "fieldA",
+              {
+                id: "groupA",
+                fields: ["groupFieldA"],
+              },
+              {
+                id: "contentRelationshipA",
+                customtypes: [
+                  {
+                    id: "customTypeB",
+                    fields: ["fieldB"],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+        allCustomTypes: [],
+      });
+
+      expect(result).toEqual({});
+    });
   });
 });

--- a/packages/slice-machine/src/features/builder/fields/contentRelationship/__tests__/ContentRelationshipFieldPicker.test.ts
+++ b/packages/slice-machine/src/features/builder/fields/contentRelationship/__tests__/ContentRelationshipFieldPicker.test.ts
@@ -515,153 +515,6 @@ describe("ContentRelationshipFieldPicker", () => {
       });
     });
 
-    it("should not include non-existing/invalid referenced fields", () => {
-      const customType2: CustomType = {
-        id: "customType2",
-        label: "Custom Type 2",
-        repeatable: false,
-        status: true,
-        json: {
-          Main: {
-            booleanField: {
-              type: "Boolean",
-            },
-          },
-        },
-      };
-
-      const customType: CustomType = {
-        id: "customType",
-        label: "Custom Type",
-        repeatable: false,
-        status: true,
-        json: {
-          Main: {
-            mdField: {
-              type: "StructuredText",
-            },
-            crField: {
-              type: "Link",
-              config: {
-                select: "document",
-                customtypes: ["customType2"],
-              },
-            },
-            groupField: {
-              type: "Group",
-              config: {
-                fields: {
-                  groupFieldA: {
-                    type: "Boolean",
-                  },
-                },
-              },
-            },
-          },
-        },
-      };
-
-      const result = convertLinkCustomtypesToFieldCheckMap({
-        linkCustomtypes: [
-          {
-            id: "customType",
-            fields: [
-              "mdField",
-              "nonExistingField",
-              {
-                id: "nonExistingGroup",
-                fields: ["groupFieldA"],
-              },
-              {
-                id: "crField",
-                customtypes: [
-                  {
-                    id: "customType2",
-                    fields: ["nonExistingNestedField"],
-                  },
-                ],
-              },
-              {
-                id: "groupField",
-                fields: ["nonExistingGroupField"],
-              },
-            ],
-          },
-        ],
-        allCustomTypes: [customType, customType2],
-      });
-
-      expect(result).toEqual({
-        customType: {
-          mdField: {
-            type: "checkbox",
-            value: true,
-          },
-        },
-      });
-    });
-
-    it("should not include an invalid field (uid, slices & choice)", () => {
-      const customType: CustomType = {
-        id: "customType",
-        label: "Custom Type",
-        repeatable: false,
-        status: true,
-        json: {
-          Main: {
-            booleanField: {
-              type: "Boolean",
-            },
-            typeUid: {
-              type: "UID",
-            },
-            uid: {
-              type: "Boolean",
-            },
-            choice: {
-              type: "Choice",
-              config: {
-                choices: {
-                  choice1: {
-                    type: "Boolean",
-                  },
-                },
-              },
-            },
-            slices: {
-              type: "Slices",
-              config: {
-                choices: {
-                  slice1: {
-                    type: "SharedSlice",
-                  },
-                },
-              },
-            },
-          },
-        },
-      };
-
-      const result = convertLinkCustomtypesToFieldCheckMap({
-        linkCustomtypes: [
-          {
-            id: "customType",
-            fields: ["booleanField", "typeUid", "uid", "choice", "slices"],
-          },
-        ],
-        allCustomTypes: [customType],
-      });
-
-      expect(result).toEqual({
-        customType: {
-          booleanField: {
-            type: "checkbox",
-            value: true,
-          },
-        },
-      });
-    });
-
     it("should include a correctly referenced group field", () => {
       const customType: CustomType = {
         id: "customType",
@@ -878,7 +731,154 @@ describe("ContentRelationshipFieldPicker", () => {
       });
     });
 
-    it("should not include a field referenced as a group field when it's not one", () => {
+    it("should discard non-existing/invalid referenced fields", () => {
+      const customType2: CustomType = {
+        id: "customType2",
+        label: "Custom Type 2",
+        repeatable: false,
+        status: true,
+        json: {
+          Main: {
+            booleanField: {
+              type: "Boolean",
+            },
+          },
+        },
+      };
+
+      const customType: CustomType = {
+        id: "customType",
+        label: "Custom Type",
+        repeatable: false,
+        status: true,
+        json: {
+          Main: {
+            mdField: {
+              type: "StructuredText",
+            },
+            crField: {
+              type: "Link",
+              config: {
+                select: "document",
+                customtypes: ["customType2"],
+              },
+            },
+            groupField: {
+              type: "Group",
+              config: {
+                fields: {
+                  groupFieldA: {
+                    type: "Boolean",
+                  },
+                },
+              },
+            },
+          },
+        },
+      };
+
+      const result = convertLinkCustomtypesToFieldCheckMap({
+        linkCustomtypes: [
+          {
+            id: "customType",
+            fields: [
+              "mdField",
+              "nonExistingField",
+              {
+                id: "nonExistingGroup",
+                fields: ["groupFieldA"],
+              },
+              {
+                id: "crField",
+                customtypes: [
+                  {
+                    id: "customType2",
+                    fields: ["nonExistingNestedField"],
+                  },
+                ],
+              },
+              {
+                id: "groupField",
+                fields: ["nonExistingGroupField"],
+              },
+            ],
+          },
+        ],
+        allCustomTypes: [customType, customType2],
+      });
+
+      expect(result).toEqual({
+        customType: {
+          mdField: {
+            type: "checkbox",
+            value: true,
+          },
+        },
+      });
+    });
+
+    it("should discard invalid fields (uid, slices & choice)", () => {
+      const customType: CustomType = {
+        id: "customType",
+        label: "Custom Type",
+        repeatable: false,
+        status: true,
+        json: {
+          Main: {
+            booleanField: {
+              type: "Boolean",
+            },
+            typeUid: {
+              type: "UID",
+            },
+            uid: {
+              type: "Boolean",
+            },
+            choice: {
+              type: "Choice",
+              config: {
+                choices: {
+                  choice1: {
+                    type: "Boolean",
+                  },
+                },
+              },
+            },
+            slices: {
+              type: "Slices",
+              config: {
+                choices: {
+                  slice1: {
+                    type: "SharedSlice",
+                  },
+                },
+              },
+            },
+          },
+        },
+      };
+
+      const result = convertLinkCustomtypesToFieldCheckMap({
+        linkCustomtypes: [
+          {
+            id: "customType",
+            fields: ["booleanField", "typeUid", "uid", "choice", "slices"],
+          },
+        ],
+        allCustomTypes: [customType],
+      });
+
+      expect(result).toEqual({
+        customType: {
+          booleanField: {
+            type: "checkbox",
+            value: true,
+          },
+        },
+      });
+    });
+
+    it("should discard a regular field referenced as a group field", () => {
       const customType: CustomType = {
         id: "customType",
         label: "Custom Type",
@@ -900,7 +900,7 @@ describe("ContentRelationshipFieldPicker", () => {
             fields: [
               {
                 id: "booleanField",
-                fields: ["fieldA"],
+                fields: ["something"],
               },
             ],
           },
@@ -911,7 +911,40 @@ describe("ContentRelationshipFieldPicker", () => {
       expect(result).toEqual({});
     });
 
-    it("should not include a field referencing a group as a regular field (string/no picked fields)", () => {
+    it("should discard a regular field referenced as a content relationship field", () => {
+      const customType: CustomType = {
+        id: "customType",
+        label: "Custom Type",
+        repeatable: false,
+        status: true,
+        json: {
+          Main: {
+            booleanField: {
+              type: "Boolean",
+            },
+          },
+        },
+      };
+
+      const result = convertLinkCustomtypesToFieldCheckMap({
+        linkCustomtypes: [
+          {
+            id: "customType",
+            fields: [
+              {
+                id: "booleanField",
+                customtypes: [],
+              },
+            ],
+          },
+        ],
+        allCustomTypes: [customType],
+      });
+
+      expect(result).toEqual({});
+    });
+
+    it("should discard a group field referenced as a regular field (string/no picked fields)", () => {
       const customType: CustomType = {
         id: "customType",
         label: "Custom Type",
@@ -984,7 +1017,7 @@ describe("ContentRelationshipFieldPicker", () => {
       expect(result).toEqual({});
     });
 
-    it("should not include a field referenced as a content relationship field when it's not one", () => {
+    it("should discard a content relationship field reference to a regular field", () => {
       const customTypeA: CustomType = {
         id: "customTypeA",
         label: "Custom Type A",
@@ -1035,7 +1068,7 @@ describe("ContentRelationshipFieldPicker", () => {
       expect(result).toEqual({});
     });
 
-    it("should not include a content relationship field if it references a non existing custom type", () => {
+    it("should discard a content relationship field if it references a non existing custom type", () => {
       const customTypeWithField: CustomType = {
         id: "customTypeWithField",
         label: "Custom Type With Field",
@@ -1121,10 +1154,10 @@ describe("ContentRelationshipFieldPicker", () => {
       expect(result).toEqual({});
     });
 
-    it("should not include a regular field referenced as a content relationship field", () => {
-      const customType: CustomType = {
-        id: "customType",
-        label: "Custom Type",
+    it("should discard content relationship fields referenced at a depth above 2", () => {
+      const thirdCustomType: CustomType = {
+        id: "thirdCustomType",
+        label: "Third Custom Type",
         repeatable: false,
         status: true,
         json: {
@@ -1135,35 +1168,36 @@ describe("ContentRelationshipFieldPicker", () => {
           },
         },
       };
-
-      const result = convertLinkCustomtypesToFieldCheckMap({
-        linkCustomtypes: [
-          {
-            id: "customType",
-            fields: [
-              {
-                id: "booleanField",
-                customtypes: [],
-              },
-            ],
-          },
-        ],
-        allCustomTypes: [customType],
-      });
-
-      expect(result).toEqual({});
-    });
-
-    it("should not include a regular field referenced as a group field", () => {
-      const customType: CustomType = {
-        id: "customType",
-        label: "Custom Type",
+      const secondCustomType: CustomType = {
+        id: "secondCustomType",
+        label: "Second Custom Type",
         repeatable: false,
         status: true,
         json: {
           Main: {
-            booleanField: {
-              type: "Boolean",
+            secondCr: {
+              type: "Link",
+              config: {
+                select: "document",
+                customtypes: ["customType2"],
+              },
+            },
+          },
+        },
+      };
+      const firstCustomType: CustomType = {
+        id: "firstCustomType",
+        label: "First Custom Type",
+        repeatable: false,
+        status: true,
+        json: {
+          Main: {
+            firstCr: {
+              type: "Link",
+              config: {
+                select: "document",
+                customtypes: ["customType"],
+              },
             },
           },
         },
@@ -1172,16 +1206,31 @@ describe("ContentRelationshipFieldPicker", () => {
       const result = convertLinkCustomtypesToFieldCheckMap({
         linkCustomtypes: [
           {
-            id: "customType",
+            id: "firstCustomType",
             fields: [
               {
-                id: "booleanField",
-                fields: [],
+                id: "firstCr",
+                customtypes: [
+                  {
+                    id: "secondCustomType",
+                    fields: [
+                      {
+                        id: "secondCr",
+                        // @ts-expect-error - this is a test
+                        customtypes: [
+                          {
+                            id: "thirdCustomType",
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                ],
               },
             ],
           },
         ],
-        allCustomTypes: [customType],
+        allCustomTypes: [secondCustomType, thirdCustomType, firstCustomType],
       });
 
       expect(result).toEqual({});

--- a/packages/slice-machine/src/features/builder/fields/contentRelationship/__tests__/ContentRelationshipFieldPicker.test.ts
+++ b/packages/slice-machine/src/features/builder/fields/contentRelationship/__tests__/ContentRelationshipFieldPicker.test.ts
@@ -815,8 +815,6 @@ describe("ContentRelationshipFieldPicker", () => {
         allCustomTypes: [customType, customTypeWithField],
       });
 
-      console.log(JSON.stringify(result, null, 2));
-
       expect(result).toEqual({});
     });
 

--- a/packages/slice-machine/src/features/builder/fields/contentRelationship/__tests__/ContentRelationshipFieldPicker.test.ts
+++ b/packages/slice-machine/src/features/builder/fields/contentRelationship/__tests__/ContentRelationshipFieldPicker.test.ts
@@ -398,9 +398,6 @@ describe("ContentRelationshipFieldPicker", () => {
             geoPointField: {
               type: "GeoPoint",
             },
-            slicesField: {
-              type: "GeoPoint",
-            },
             numberField: {
               type: "Number",
             },
@@ -439,7 +436,6 @@ describe("ContentRelationshipFieldPicker", () => {
               "colorField",
               "dateField",
               "geoPointField",
-              "slicesField",
               "numberField",
               "rangeField",
               "selectField",
@@ -484,10 +480,6 @@ describe("ContentRelationshipFieldPicker", () => {
             value: true,
           },
           geoPointField: {
-            type: "checkbox",
-            value: true,
-          },
-          slicesField: {
             type: "checkbox",
             value: true,
           },

--- a/packages/slice-machine/src/features/builder/fields/contentRelationship/__tests__/ContentRelationshipFieldPicker.test.ts
+++ b/packages/slice-machine/src/features/builder/fields/contentRelationship/__tests__/ContentRelationshipFieldPicker.test.ts
@@ -6,242 +6,600 @@ import {
 } from "../ContentRelationshipFieldPicker";
 import { CustomType } from "@prismicio/types-internal/lib/customtypes";
 
-const allCustomTypes: CustomType[] = [
-  {
-    id: "ct1",
-    label: "CT 1",
-    repeatable: false,
-    status: true,
-    json: {
-      Main: {
-        f1: {
-          type: "Link",
-          config: {
-            select: "document",
-            customtypes: ["ct2"],
-          },
-        },
-        f2: {
-          type: "Link",
-          config: {
-            select: "document",
-            customtypes: ["ct2"],
-          },
-        },
-        g1: {
-          type: "Group",
-          config: {
-            fields: {
-              f1: {
-                type: "Boolean",
+describe("ContentRelationshipFieldPicker", () => {
+  describe("countPickedFields", () => {
+    const allCustomTypes: CustomType[] = [
+      {
+        id: "ct1",
+        label: "CT 1",
+        repeatable: false,
+        status: true,
+        json: {
+          Main: {
+            f1: {
+              type: "Link",
+              config: {
+                select: "document",
+                customtypes: ["ct2"],
               },
-              f2: {
-                type: "Link",
-                config: {
-                  select: "document",
-                  customtypes: ["ct2"],
+            },
+            f2: {
+              type: "Link",
+              config: {
+                select: "document",
+                customtypes: ["ct2"],
+              },
+            },
+            g1: {
+              type: "Group",
+              config: {
+                fields: {
+                  f1: {
+                    type: "Boolean",
+                  },
+                  f2: {
+                    type: "Link",
+                    config: {
+                      select: "document",
+                      customtypes: ["ct2"],
+                    },
+                  },
                 },
               },
             },
           },
         },
       },
-    },
-  },
-  {
-    id: "ct2",
-    label: "CT 2",
-    repeatable: false,
-    status: true,
-    json: {
-      Main: {
-        f1: {
-          type: "Boolean",
-        },
-        g2: {
-          type: "Group",
-          config: {
-            fields: {
-              f1: {
-                type: "Boolean",
-              },
-              f2: {
-                type: "Boolean",
+      {
+        id: "ct2",
+        label: "CT 2",
+        repeatable: false,
+        status: true,
+        json: {
+          Main: {
+            f1: {
+              type: "Boolean",
+            },
+            g2: {
+              type: "Group",
+              config: {
+                fields: {
+                  f1: {
+                    type: "Boolean",
+                  },
+                  f2: {
+                    type: "Boolean",
+                  },
+                },
               },
             },
           },
         },
       },
-    },
-  },
-];
-
-describe("ContentRelationshipFieldPicker", () => {
-  it("should count picked fields with a custom type as string", () => {
-    const customtypes = ["ct1"];
-
-    const result = countPickedFields(
-      convertLinkCustomtypesToFieldCheckMap({
-        linkCustomtypes: customtypes,
-        allCustomTypes,
-      }),
-    );
-
-    expect(result).toEqual({
-      pickedFields: 0,
-      nestedPickedFields: 0,
-    });
-  });
-
-  it("should count picked fields with multiple custom types as string", () => {
-    const customtypes = ["ct1", "ct2"];
-
-    const result = countPickedFields(
-      convertLinkCustomtypesToFieldCheckMap({
-        linkCustomtypes: customtypes,
-        allCustomTypes,
-      }),
-    );
-
-    expect(result).toEqual({
-      pickedFields: 0,
-      nestedPickedFields: 0,
-    });
-  });
-
-  it("should count picked fields with custom type as object and one field", () => {
-    const customtypes = [
-      {
-        id: "ct1",
-        fields: ["f1"],
-      },
     ];
 
-    const result = countPickedFields(
-      convertLinkCustomtypesToFieldCheckMap({
+    it("should count picked fields with a custom type as string", () => {
+      const customtypes = ["ct1"];
+
+      const result = countPickedFields(
+        convertLinkCustomtypesToFieldCheckMap({
+          linkCustomtypes: customtypes,
+          allCustomTypes,
+        }),
+      );
+
+      expect(result).toEqual({
+        pickedFields: 0,
+        nestedPickedFields: 0,
+      });
+    });
+
+    it("should count picked fields with multiple custom types as string", () => {
+      const customtypes = ["ct1", "ct2"];
+
+      const result = countPickedFields(
+        convertLinkCustomtypesToFieldCheckMap({
+          linkCustomtypes: customtypes,
+          allCustomTypes,
+        }),
+      );
+
+      expect(result).toEqual({
+        pickedFields: 0,
+        nestedPickedFields: 0,
+      });
+    });
+
+    it("should count picked fields with custom type as object and one field", () => {
+      const customtypes = [
+        {
+          id: "ct1",
+          fields: ["f1"],
+        },
+      ];
+
+      const result = countPickedFields(
+        convertLinkCustomtypesToFieldCheckMap({
+          linkCustomtypes: customtypes,
+          allCustomTypes,
+        }),
+      );
+
+      expect(result).toEqual({
+        pickedFields: 1,
+        nestedPickedFields: 0,
+      });
+    });
+
+    it("should count picked fields with custom type as object and one nested field", () => {
+      const customtypes = [
+        {
+          id: "ct1",
+          fields: [
+            {
+              id: "f1",
+              customtypes: [
+                {
+                  id: "ct2",
+                  fields: ["f1"],
+                },
+              ],
+            },
+          ],
+        },
+      ];
+
+      const result = countPickedFields(
+        convertLinkCustomtypesToFieldCheckMap({
+          linkCustomtypes: customtypes,
+          allCustomTypes,
+        }),
+      );
+
+      expect(result).toEqual({
+        pickedFields: 1,
+        nestedPickedFields: 1,
+      });
+    });
+
+    it("should count picked fields with custom type as object with group field", () => {
+      const customtypes = [
+        {
+          id: "ct1",
+          fields: [
+            {
+              id: "g1",
+              fields: ["f1", "f2"],
+            },
+          ],
+        },
+      ];
+
+      const test = convertLinkCustomtypesToFieldCheckMap({
         linkCustomtypes: customtypes,
         allCustomTypes,
-      }),
-    );
+      });
+      const result = countPickedFields(test);
 
-    expect(result).toEqual({
-      pickedFields: 1,
-      nestedPickedFields: 0,
+      expect(result).toEqual({
+        pickedFields: 2,
+        nestedPickedFields: 0,
+      });
+    });
+
+    it("should count picked fields with custom type as object with group field and nested custom type", () => {
+      const customtypes = [
+        {
+          id: "ct1",
+          fields: [
+            {
+              id: "g1",
+              fields: [
+                "f1",
+                {
+                  id: "f2",
+                  customtypes: [
+                    {
+                      id: "ct2",
+                      fields: ["f1"],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ];
+
+      const result = countPickedFields(
+        convertLinkCustomtypesToFieldCheckMap({
+          linkCustomtypes: customtypes,
+          allCustomTypes,
+        }),
+      );
+
+      expect(result).toEqual({
+        pickedFields: 2,
+        nestedPickedFields: 1,
+      });
+    });
+
+    it("should count picked fields with custom type as object with group field, nested custom type and nested group field", () => {
+      const customtypes = [
+        {
+          id: "ct1",
+          fields: [
+            {
+              id: "g1",
+              fields: [
+                "f1",
+                {
+                  id: "f2",
+                  customtypes: [
+                    {
+                      id: "ct2",
+                      fields: [
+                        "f1",
+                        {
+                          id: "g2",
+                          fields: ["f1", "f2"],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ];
+
+      const result = countPickedFields(
+        convertLinkCustomtypesToFieldCheckMap({
+          linkCustomtypes: customtypes,
+          allCustomTypes,
+        }),
+      );
+
+      expect(result).toEqual({
+        pickedFields: 4,
+        nestedPickedFields: 3,
+      });
+    });
+
+    it("should count picked fields with custom type as object with nested custom type and nested group field", () => {
+      const customtypes = [
+        {
+          id: "ct1",
+          fields: [
+            "f1",
+            {
+              id: "f2",
+              customtypes: [
+                {
+                  id: "ct2",
+                  fields: [
+                    "f1",
+                    {
+                      id: "g2",
+                      fields: ["f1", "f2"],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ];
+
+      const result = countPickedFields(
+        convertLinkCustomtypesToFieldCheckMap({
+          linkCustomtypes: customtypes,
+          allCustomTypes,
+        }),
+      );
+
+      expect(result).toEqual({
+        pickedFields: 4,
+        nestedPickedFields: 3,
+      });
+    });
+
+    it("should count picked fields with custom type as object with nested custom type without fields", () => {
+      const customtypes = [
+        {
+          id: "ct1",
+          fields: [
+            "f1",
+            {
+              id: "f2",
+              customtypes: [
+                {
+                  id: "ct2",
+                  fields: [],
+                },
+              ],
+            },
+          ],
+        },
+      ];
+
+      const result = countPickedFields(
+        convertLinkCustomtypesToFieldCheckMap({
+          linkCustomtypes: customtypes,
+          allCustomTypes,
+        }),
+      );
+
+      expect(result).toEqual({
+        pickedFields: 1,
+        nestedPickedFields: 0,
+      });
+    });
+
+    it("should count picked fields with custom type as object with group field without fields", () => {
+      const customtypes = [
+        {
+          id: "ct1",
+          fields: [
+            "f1",
+            {
+              id: "g1",
+              fields: [],
+            },
+          ],
+        },
+      ];
+
+      const result = countPickedFields(
+        convertLinkCustomtypesToFieldCheckMap({
+          linkCustomtypes: customtypes,
+          allCustomTypes,
+        }),
+      );
+
+      expect(result).toEqual({
+        pickedFields: 1,
+        nestedPickedFields: 0,
+      });
     });
   });
 
-  it("should count picked fields with custom type as object and one nested field", () => {
-    const customtypes = [
-      {
-        id: "ct1",
-        fields: [
-          {
-            id: "f1",
-            customtypes: [
-              {
-                id: "ct2",
-                fields: ["f1"],
+  describe("createContentRelationshipFieldCheckMap", () => {
+    it("should include the field if it is a static zone field", () => {
+      const customType: CustomType = {
+        id: "customType",
+        label: "Custom Type",
+        repeatable: false,
+        status: true,
+        json: {
+          Main: {
+            booleanField: {
+              type: "Boolean",
+              config: {
+                label: "Boolean Field",
               },
-            ],
+            },
           },
-        ],
-      },
-    ];
+        },
+      };
 
-    const result = countPickedFields(
-      convertLinkCustomtypesToFieldCheckMap({
-        linkCustomtypes: customtypes,
-        allCustomTypes,
-      }),
-    );
+      const result = convertLinkCustomtypesToFieldCheckMap({
+        linkCustomtypes: [{ id: "customType", fields: ["booleanField"] }],
+        allCustomTypes: [customType],
+      });
 
-    expect(result).toEqual({
-      pickedFields: 1,
-      nestedPickedFields: 1,
-    });
-  });
-
-  it("should count picked fields with custom type as object with group field", () => {
-    const customtypes = [
-      {
-        id: "ct1",
-        fields: [
-          {
-            id: "g1",
-            fields: ["f1", "f2"],
+      expect(result).toEqual({
+        customType: {
+          booleanField: {
+            type: "checkbox",
+            value: true,
           },
-        ],
-      },
-    ];
-
-    const test = convertLinkCustomtypesToFieldCheckMap({
-      linkCustomtypes: customtypes,
-      allCustomTypes,
+        },
+      });
     });
-    const result = countPickedFields(test);
 
-    expect(result).toEqual({
-      pickedFields: 2,
-      nestedPickedFields: 0,
+    it("should not include the field if the field is not a static zone field", () => {
+      const customType: CustomType = {
+        id: "customType",
+        label: "Custom Type",
+        repeatable: false,
+        status: true,
+        json: {
+          Main: {
+            rtField: {
+              type: "StructuredText",
+              config: {
+                label: "Structured Text Field",
+              },
+            },
+          },
+        },
+      };
+
+      const result = convertLinkCustomtypesToFieldCheckMap({
+        linkCustomtypes: [{ id: "customType", fields: ["booleanField"] }],
+        allCustomTypes: [customType],
+      });
+
+      expect(result).toEqual({});
     });
-  });
 
-  it("should count picked fields with custom type as object with group field and nested custom type", () => {
-    const customtypes = [
-      {
-        id: "ct1",
-        fields: [
-          {
-            id: "g1",
-            fields: [
-              "f1",
-              {
-                id: "f2",
-                customtypes: [
-                  {
-                    id: "ct2",
-                    fields: ["f1"],
+    it("should not include the field if it is invalid (uid, slices & choice)", () => {
+      const customType: CustomType = {
+        id: "customType",
+        label: "Custom Type",
+        repeatable: false,
+        status: true,
+        json: {
+          Main: {
+            bool: {
+              type: "Boolean",
+            },
+            typeUid: {
+              type: "UID",
+            },
+            uid: {
+              type: "Boolean",
+            },
+            choice: {
+              type: "Choice",
+              config: {
+                choices: {
+                  choice1: {
+                    type: "Boolean",
                   },
-                ],
+                },
+              },
+            },
+            slices: {
+              type: "Slices",
+              config: {
+                choices: {
+                  slice1: {
+                    type: "SharedSlice",
+                  },
+                },
+              },
+            },
+          },
+        },
+      };
+
+      const result = convertLinkCustomtypesToFieldCheckMap({
+        linkCustomtypes: [
+          {
+            id: "customType",
+            fields: ["bool", "typeUid", "uid", "choice", "slices"],
+          },
+        ],
+        allCustomTypes: [customType],
+      });
+
+      expect(result).toEqual({
+        customType: {
+          bool: {
+            type: "checkbox",
+            value: true,
+          },
+        },
+      });
+    });
+
+    it("should include the field if it correctly references a group field", () => {
+      const customType: CustomType = {
+        id: "customType",
+        label: "Custom Type",
+        repeatable: false,
+        status: true,
+        json: {
+          Main: {
+            groupField: {
+              type: "Group",
+              config: {
+                label: "Group Field",
+                fields: {
+                  booleanField: {
+                    type: "Boolean",
+                    config: {
+                      label: "Boolean Field",
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      };
+
+      const result = convertLinkCustomtypesToFieldCheckMap({
+        linkCustomtypes: [
+          {
+            id: "customType",
+            fields: [
+              {
+                id: "groupField",
+                fields: ["booleanField"],
               },
             ],
           },
         ],
-      },
-    ];
+        allCustomTypes: [customType],
+      });
 
-    const result = countPickedFields(
-      convertLinkCustomtypesToFieldCheckMap({
-        linkCustomtypes: customtypes,
-        allCustomTypes,
-      }),
-    );
-
-    expect(result).toEqual({
-      pickedFields: 2,
-      nestedPickedFields: 1,
+      expect(result).toEqual({
+        customType: {
+          groupField: {
+            type: "group",
+            value: {
+              booleanField: {
+                type: "checkbox",
+                value: true,
+              },
+            },
+          },
+        },
+      });
     });
-  });
 
-  it("should count picked fields with custom type as object with group field, nested custom type and nested group field", () => {
-    const customtypes = [
-      {
-        id: "ct1",
-        fields: [
+    it("should include the field if it correctly references a group field inside a nested custom type", () => {
+      const customType: CustomType = {
+        id: "customType",
+        label: "Custom Type",
+        repeatable: false,
+        status: true,
+        json: {
+          Main: {
+            groupField: {
+              type: "Group",
+              config: {
+                label: "Group Field",
+                fields: {
+                  booleanField: {
+                    type: "Boolean",
+                    config: {
+                      label: "Boolean Field",
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      };
+
+      const customTypeWithContentRelationship: CustomType = {
+        id: "customTypeWithContentRelationship",
+        label: "Custom Type With Content Relationship",
+        repeatable: false,
+        status: true,
+        json: {
+          Main: {
+            contentRelationshipField: {
+              type: "Link",
+              config: {
+                select: "document",
+                customtypes: ["customType"],
+              },
+            },
+          },
+        },
+      };
+
+      const result = convertLinkCustomtypesToFieldCheckMap({
+        linkCustomtypes: [
           {
-            id: "g1",
+            id: "customTypeWithContentRelationship",
             fields: [
-              "f1",
               {
-                id: "f2",
+                id: "contentRelationshipField",
                 customtypes: [
                   {
-                    id: "ct2",
+                    id: "customType",
                     fields: [
-                      "f1",
                       {
-                        id: "g2",
-                        fields: ["f1", "f2"],
+                        id: "groupField",
+                        fields: ["booleanField"],
                       },
                     ],
                   },
@@ -250,116 +608,89 @@ describe("ContentRelationshipFieldPicker", () => {
             ],
           },
         ],
-      },
-    ];
+        allCustomTypes: [customType, customTypeWithContentRelationship],
+      });
 
-    const result = countPickedFields(
-      convertLinkCustomtypesToFieldCheckMap({
-        linkCustomtypes: customtypes,
-        allCustomTypes,
-      }),
-    );
-
-    expect(result).toEqual({
-      pickedFields: 4,
-      nestedPickedFields: 3,
+      expect(result).toEqual({
+        customTypeWithContentRelationship: {
+          contentRelationshipField: {
+            type: "contentRelationship",
+            value: {
+              customType: {
+                groupField: {
+                  type: "group",
+                  value: {
+                    booleanField: {
+                      type: "checkbox",
+                      value: true,
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      });
     });
-  });
 
-  it("should count picked fields with custom type as object with nested custom type and nested group field", () => {
-    const customtypes = [
-      {
-        id: "ct1",
-        fields: [
-          "f1",
+    it("should not include the a content relationship field if it references a non existing custom type", () => {
+      const customTypeWithField: CustomType = {
+        id: "customTypeWithField",
+        label: "Custom Type With Field",
+        repeatable: false,
+        status: true,
+        json: {
+          Main: {
+            colorField: {
+              type: "Color",
+              config: {
+                label: "Color Field",
+              },
+            },
+          },
+        },
+      };
+      const customType: CustomType = {
+        id: "customType",
+        label: "Custom Type",
+        repeatable: false,
+        status: true,
+        json: {
+          Main: {
+            contentRelationshipField: {
+              type: "Link",
+              config: {
+                select: "document",
+                customtypes: ["customTypeWithField"],
+              },
+            },
+          },
+        },
+      };
+
+      const result = convertLinkCustomtypesToFieldCheckMap({
+        linkCustomtypes: [
           {
-            id: "f2",
-            customtypes: [
+            id: "customType",
+            fields: [
               {
-                id: "ct2",
-                fields: [
-                  "f1",
+                id: "contentRelationshipField",
+                customtypes: [
                   {
-                    id: "g2",
-                    fields: ["f1", "f2"],
+                    id: "nonExistingCustomType",
+                    fields: ["colorField"],
                   },
                 ],
               },
             ],
           },
         ],
-      },
-    ];
+        allCustomTypes: [customType, customTypeWithField],
+      });
 
-    const result = countPickedFields(
-      convertLinkCustomtypesToFieldCheckMap({
-        linkCustomtypes: customtypes,
-        allCustomTypes,
-      }),
-    );
+      console.log(JSON.stringify(result, null, 2));
 
-    expect(result).toEqual({
-      pickedFields: 4,
-      nestedPickedFields: 3,
-    });
-  });
-
-  it("should count picked fields with custom type as object with nested custom type without fields", () => {
-    const customtypes = [
-      {
-        id: "ct1",
-        fields: [
-          "f1",
-          {
-            id: "f2",
-            customtypes: [
-              {
-                id: "ct2",
-                fields: [],
-              },
-            ],
-          },
-        ],
-      },
-    ];
-
-    const result = countPickedFields(
-      convertLinkCustomtypesToFieldCheckMap({
-        linkCustomtypes: customtypes,
-        allCustomTypes,
-      }),
-    );
-
-    expect(result).toEqual({
-      pickedFields: 1,
-      nestedPickedFields: 0,
-    });
-  });
-
-  it("should count picked fields with custom type as object with group field without fields", () => {
-    const customtypes = [
-      {
-        id: "ct1",
-        fields: [
-          "f1",
-          {
-            id: "g1",
-            fields: [],
-          },
-        ],
-      },
-    ];
-
-    const result = countPickedFields(
-      convertLinkCustomtypesToFieldCheckMap({
-        linkCustomtypes: customtypes,
-        allCustomTypes,
-      }),
-    );
-
-    expect(result).toEqual({
-      pickedFields: 1,
-      nestedPickedFields: 0,
+      expect(result).toEqual({});
     });
   });
 });

--- a/packages/slice-machine/src/utils/tracking/getLinkTrackingProperties.ts
+++ b/packages/slice-machine/src/utils/tracking/getLinkTrackingProperties.ts
@@ -15,7 +15,9 @@ export function getLinkTrackingProperties(field: Link) {
       field.config?.customtypes &&
       (() => {
         const { pickedFields, nestedPickedFields } = countPickedFields(
-          convertLinkCustomtypesToFieldCheckMap(field.config?.customtypes),
+          convertLinkCustomtypesToFieldCheckMap({
+            linkCustomtypes: field.config?.customtypes,
+          }),
         );
         return {
           linkPickedFields: pickedFields,


### PR DESCRIPTION
Resolves: DT-2722, DT-2723

### Description

- When converting the `customtypes` array to the field picker component, filter out non-existing fields and wrong references (mismatching type).
- Add multiple unit tests for the `convertLinkCustomtypesToFieldCheckMap`, which takes care of these conversions.

### Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- Don't hesitate to ask for help! -->

- [X] A comprehensive Linear ticket, providing sufficient context and details to facilitate the review of the PR, is linked to the PR.
- [ ] If my changes require tests, I added them.
- [ ] If my changes affect backward compatibility, it has been discussed.
- [ ] If my changes require an update to the CONTRIBUTING.md guide, I updated it.

### Preview

<!-- If your changes are visual, screenshots or videos are welcome! -->

### How to QA [^1]

<!-- When relevant, describe how to QA your changes. -->

<!-- Your favorite emoji is welcome to close your PR! -->

<!-- A note for reviewers: -->

[^1]:
	Please use these labels when submitting a review:
	:question: #ask:&ensp;Ask a question.
	:bulb: #idea:&ensp;Suggest an idea.
	:warning: #issue:&ensp;Strongly suggest a change.
	:tada: #nice:&ensp;Share a compliment.
