### PR TITLE
[DT-2734] feat: ensure customtypes array is set for new CR fields and by the new picker

### DIFF
--- a/packages/slice-machine/src/features/builder/fields/contentRelationship/ContentRelationshipFieldPicker.tsx
+++ b/packages/slice-machine/src/features/builder/fields/contentRelationship/ContentRelationshipFieldPicker.tsx
@@ -267,6 +267,13 @@ function ContentRelationshipFieldPickerContent(
     ? convertLinkCustomtypesToFieldCheckMap(value)
     : {};
 
+  useEffect(() => {
+    // Make sure the field has a customtypes property. We did not create it
+    // before for new Content Relationship fields, but now we do, and we want to
+    // correct most of the cases where it's missing.
+    if (!value) onChange([]);
+  }, [value]);
+
   function onCustomTypesChange(id: string, newCustomType: PickerCustomType) {
     // The picker does not handle strings (custom type ids), as it's only meant
     // to pick fields from custom types (objects). So we need to merge it with

--- a/packages/slice-machine/src/features/builder/fields/contentRelationship/ContentRelationshipFieldPicker.tsx
+++ b/packages/slice-machine/src/features/builder/fields/contentRelationship/ContentRelationshipFieldPicker.tsx
@@ -267,13 +267,6 @@ function ContentRelationshipFieldPickerContent(
     ? convertLinkCustomtypesToFieldCheckMap(value)
     : {};
 
-  useEffect(() => {
-    // Make sure the field has a customtypes property. We did not create it
-    // before for new Content Relationship fields, but now we do, and we want to
-    // correct most of the cases where it's missing.
-    if (!value) onChange([]);
-  }, [value]);
-
   function onCustomTypesChange(id: string, newCustomType: PickerCustomType) {
     // The picker does not handle strings (custom type ids), as it's only meant
     // to pick fields from custom types (objects). So we need to merge it with

--- a/packages/slice-machine/src/legacy/lib/models/common/widgets/ContentRelationship/index.ts
+++ b/packages/slice-machine/src/legacy/lib/models/common/widgets/ContentRelationship/index.ts
@@ -70,12 +70,13 @@ const schema = yup.object().shape({
 });
 
 export const ContentRelationshipWidget: Widget<Link, typeof schema> = {
-  create: (label: string) => ({
+  create: (label: string): Link => ({
     type: "Link",
     config: {
       label,
       select: "document",
       repeat: false,
+      customtypes: [],
     },
   }),
   Meta,


### PR DESCRIPTION
Resolves: DT-2734

### Description

- When creating a Content Relationship field, set an empty `customtypes` array.

### Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- Don't hesitate to ask for help! -->

- [X] A comprehensive Linear ticket, providing sufficient context and details to facilitate the review of the PR, is linked to the PR.
- [ ] If my changes require tests, I added them.
- [ ] If my changes affect backward compatibility, it has been discussed.
- [ ] If my changes require an update to the CONTRIBUTING.md guide, I updated it.

### Preview

<!-- If your changes are visual, screenshots or videos are welcome! -->

### How to QA [^1]

<!-- When relevant, describe how to QA your changes. -->

<!-- Your favorite emoji is welcome to close your PR! -->

<!-- A note for reviewers: -->

[^1]:
	Please use these labels when submitting a review:
	:question: #ask:&ensp;Ask a question.
	:bulb: #idea:&ensp;Suggest an idea.
	:warning: #issue:&ensp;Strongly suggest a change.
	:tada: #nice:&ensp;Share a compliment.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Ensured that new Content Relationship fields always include the required property, preventing missing data issues in certain scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->