### PR TITLE
[DT-2732] Flatten nested CTs section & render checkbox for unresolved CT

### DIFF
--- a/packages/slice-machine/src/features/builder/fields/contentRelationship/ContentRelationshipFieldPicker.tsx
+++ b/packages/slice-machine/src/features/builder/fields/contentRelationship/ContentRelationshipFieldPicker.tsx
@@ -736,6 +736,7 @@ function TreeViewContentRelationshipField(
   return (
     <TreeViewSection
       key={customType.id}
+      // https://linear.app/prismic/issue/DT-2736/
       // @ts-expect-error - TODO: Fix this when we are able to release editor packages
       title={
         <Text>

--- a/packages/slice-machine/src/features/builder/fields/contentRelationship/ContentRelationshipFieldPicker.tsx
+++ b/packages/slice-machine/src/features/builder/fields/contentRelationship/ContentRelationshipFieldPicker.tsx
@@ -1421,17 +1421,10 @@ function isContentRelationshipFieldWithSingleCustomtype(
   field: NestableWidget | Group,
   allCustomTypes: CustomType[],
 ): field is Link {
-  if (
-    !isContentRelationshipField(field) ||
-    !field.config?.customtypes ||
-    field.config.customtypes.length !== 1
-  ) {
-    return false;
-  }
-
   return (
+    isContentRelationshipField(field) &&
     resolveContentRelationshipCustomTypes(
-      field.config.customtypes,
+      field.config?.customtypes,
       allCustomTypes,
     ).length === 1
   );

--- a/packages/slice-machine/src/features/builder/fields/contentRelationship/ContentRelationshipFieldPicker.tsx
+++ b/packages/slice-machine/src/features/builder/fields/contentRelationship/ContentRelationshipFieldPicker.tsx
@@ -665,7 +665,7 @@ function TreeViewContentRelationshipField(
     allCustomTypes,
   );
 
-  if (resolvedCustomTypes.length !== 1) return null;
+  if (resolvedCustomTypes.length === 0) return null;
 
   const [customType] = resolvedCustomTypes;
 


### PR DESCRIPTION
Resolves: DT-2732

### Description

- [X] Since we now only support one Custom type per Content Relationship, we don't need to display a nested section under Content Relationship fields. We removed that extra section and displays the nested Custom type fields right away and moves the id of the Custom type to the title of the field section.
- [X] Fix: When a Content Relationship/Nested Custom type is resolved, if there are no matching custom types, we render as a simple field (checkbox), before we were not rendering anything.
- [X] Remove some impossible states and conditions only there to make TS happy

### Checklist

- [X] A comprehensive Linear ticket, providing sufficient context and details to facilitate the review of the PR, is linked to the PR.
- [ ] If my changes require tests, I added them.
- [ ] If my changes affect backward compatibility, it has been discussed.
- [ ] If my changes require an update to the CONTRIBUTING.md guide, I updated it.

### Preview

| Before | After |
|--------|--------|
| ![Screenshot 2025-06-26 at 17 15 00](https://github.com/user-attachments/assets/92b6b047-27e8-48d8-9133-d67c68241495) | ![Screenshot 2025-06-26 at 17 12 28](https://github.com/user-attachments/assets/76a546c2-891b-44f6-8345-9b24028a299c) | 

### How to QA [^1]

<!-- When relevant, describe how to QA your changes. -->

<!-- Your favorite emoji is welcome to close your PR! -->

<!-- A note for reviewers: -->

[^1]:
	Please use these labels when submitting a review:
	:question: #ask:&ensp;Ask a question.
	:bulb: #idea:&ensp;Suggest an idea.
	:warning: #issue:&ensp;Strongly suggest a change.
	:tada: #nice:&ensp;Share a compliment.
