### PR TITLE
[DT-2708] fix: bind node auth listener server to localhost

### DIFF
--- a/packages/manager/src/auth/PrismicAuthManager.ts
+++ b/packages/manager/src/auth/PrismicAuthManager.ts
@@ -194,7 +194,7 @@ export class PrismicAuthManager {
 				server.once("listening", () => {
 					resolve();
 				});
-				server.listen(args.port);
+				server.listen(args.port, "127.0.0.1");
 			});
 
 			if (args.onListenCallback) {


### PR DESCRIPTION
Resolves: DT-2708

### Description

The server that listens for authentication success in the Slice Machine init is currently binding to port 5555, but on any hostname. This PR changes it to bind to `localhost`.

### Checklist

- [X] A comprehensive Linear ticket, providing sufficient context and details to facilitate the review of the PR, is linked to the PR.

### Preview

#### Before
<img width="803" height="71" alt="Screenshot 2025-07-22 at 15 43 50" src="https://github.com/user-attachments/assets/877237da-d807-451f-a535-ed0d97a70278" />

#### After
<img width="803" height="69" alt="Screenshot 2025-07-22 at 15 44 04" src="https://github.com/user-attachments/assets/c937d720-e45c-46e0-a921-bc746de68a40" />

#### Full init flow demo

https://github.com/user-attachments/assets/5e9b7439-2824-4694-a665-c2efcec8c8fb

### How to QA [^1]

<!-- When relevant, describe how to QA your changes. -->

<!-- Your favorite emoji is welcome to close your PR! -->

<!-- A note for reviewers: -->

[^1]:
	Please use these labels when submitting a review:
	:question: #ask:&ensp;Ask a question.
	:bulb: #idea:&ensp;Suggest an idea.
	:warning: #issue:&ensp;Strongly suggest a change.
	:tada: #nice:&ensp;Share a compliment.
