### PR TITLE
fix: prevent unnecessary sentry errors when address already in use

### DIFF
--- a/packages/start-slicemachine/src/StartSliceMachineProcess.ts
+++ b/packages/start-slicemachine/src/StartSliceMachineProcess.ts
@@ -120,7 +120,19 @@ export class StartSliceMachineProcess {
 		const app = await createSliceMachineExpressApp({
 			sliceMachineManager: this._sliceMachineManager,
 		});
+
 		const server = app.listen(this.port);
+		server.on("error", (error: NodeJS.ErrnoException) => {
+			if (error.code === "EADDRINUSE") {
+				console.error(
+					`Error starting Slice Machine: Port ${this.port} is already in use. Please try a different port.`,
+				);
+			} else {
+				console.error("Error starting Slice Machine:", error);
+			}
+			process.exit(1);
+		});
+
 		const address = server.address() as AddressInfo;
 		const url = `http://localhost:${address.port}`;
 


### PR DESCRIPTION
<!-- Please use a Conventional Commit in your PR title -->
<!-- https://conventionalcommits.org -->
<!-- e.g. "feat: support new field type" -->

Resolves: [DT-2804](https://linear.app/prismic/issue/DT-2804/prevent-sentry-from-being-spammed-with-unnecessary-errors)

### Description

- Ensure if the port is already used, it displays a nice error message

<!-- Describe your changes in detail. -->
<!-- Why is this change required? -->
<!-- What problem does it solve? -->

### Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- Don't hesitate to ask for help! -->

- [ ] A comprehensive Linear ticket, providing sufficient context and details to facilitate the review of the PR, is linked to the PR.
- [ ] If my changes require tests, I added them.
- [ ] If my changes affect backward compatibility, it has been discussed.
- [ ] If my changes require an update to the CONTRIBUTING.md guide, I updated it.

### Preview

<!-- If your changes are visual, screenshots or videos are welcome! -->

### How to QA [^1]

<!-- When relevant, describe how to QA your changes. -->

<!-- Your favorite emoji is welcome to close your PR! -->

<!-- A note for reviewers: -->

[^1]:
	Please use these labels when submitting a review:
	:question: #ask:&ensp;Ask a question.
	:bulb: #idea:&ensp;Suggest an idea.
	:warning: #issue:&ensp;Strongly suggest a change.
	:tada: #nice:&ensp;Share a compliment.
