### PR TITLE
fix: prevent unnecessary sentry errors when not being logged in

### DIFF
--- a/packages/manager/src/managers/SliceMachineManager.ts
+++ b/packages/manager/src/managers/SliceMachineManager.ts
@@ -17,6 +17,7 @@ import {
 	PrismicUserProfile,
 } from "../auth/PrismicAuthManager";
 import { createPrismicAuthManager } from "../auth/createPrismicAuthManager";
+import { UnauthenticatedError } from "../errors";
 
 import { API_ENDPOINTS, APIEndpoints } from "../constants/API_ENDPOINTS";
 
@@ -207,16 +208,17 @@ export class SliceMachineManager {
 								name: "__stub__",
 								message: "__stub__",
 								reason: "__stub__",
-								status: 401,
+								status: 403,
 							};
 						} else if (
+							error instanceof UnauthenticatedError ||
 							error instanceof prismicCustomTypesClient.UnauthorizedError
 						) {
 							authError = {
 								name: "__stub__",
 								message: "__stub__",
 								reason: "__stub__",
-								status: 403,
+								status: 401,
 							};
 						} else {
 							throw error;


### PR DESCRIPTION
<!-- Please use a Conventional Commit in your PR title -->
<!-- https://conventionalcommits.org -->
<!-- e.g. "feat: support new field type" -->

Resolves: [DT-2804](https://linear.app/prismic/issue/DT-2804/prevent-sentry-from-being-spammed-with-unnecessary-errors)

### Description

- Ensure that for unauthorized / unauthenticated errors, we don't report it to Sentry

<!-- Describe your changes in detail. -->
<!-- Why is this change required? -->
<!-- What problem does it solve? -->

### Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- Don't hesitate to ask for help! -->

- [ ] A comprehensive Linear ticket, providing sufficient context and details to facilitate the review of the PR, is linked to the PR.
- [ ] If my changes require tests, I added them.
- [ ] If my changes affect backward compatibility, it has been discussed.
- [ ] If my changes require an update to the CONTRIBUTING.md guide, I updated it.

### Preview

<!-- If your changes are visual, screenshots or videos are welcome! -->

### How to QA [^1]

<!-- When relevant, describe how to QA your changes. -->

<!-- Your favorite emoji is welcome to close your PR! -->

<!-- A note for reviewers: -->

[^1]:
	Please use these labels when submitting a review:
	:question: #ask:&ensp;Ask a question.
	:bulb: #idea:&ensp;Suggest an idea.
	:warning: #issue:&ensp;Strongly suggest a change.
	:tada: #nice:&ensp;Share a compliment.
