### PR TITLE
fix: prevent unnecessary sentry errors when failing to get github releases

### DIFF
--- a/packages/manager/src/lib/fetchGitHubReleaseBodyForRelease.ts
+++ b/packages/manager/src/lib/fetchGitHubReleaseBodyForRelease.ts
@@ -103,13 +103,18 @@ const _fetchGitHubReleaseBodyForRelease = async (
 	const cache = args.cache || {};
 
 	if (Object.keys(cache).length < 1) {
-		const releases = await fetchAllGitHubReleases({
-			repositoryOwner: args.repositoryOwner,
-			repositoryName: args.repositoryName,
-		});
+		try {
+			const releases = await fetchAllGitHubReleases({
+				repositoryOwner: args.repositoryOwner,
+				repositoryName: args.repositoryName,
+			});
 
-		for (const release of releases) {
-			cache[release.name] = release;
+			for (const release of releases) {
+				cache[release.name] = release;
+			}
+		} catch (error) {
+			// noop - Fetch all releases failed, no need to track this error in Sentry.
+			return undefined;
 		}
 	}
 


### PR DESCRIPTION
<!-- Please use a Conventional Commit in your PR title -->
<!-- https://conventionalcommits.org -->
<!-- e.g. "feat: support new field type" -->

Resolves: [DT-2804](https://linear.app/prismic/issue/DT-2804/prevent-sentry-from-being-spammed-with-unnecessary-errors)

### Description

- Ensure that when we cannot get GitHub releases, Sentry tracking is not triggered.

<!-- Describe your changes in detail. -->
<!-- Why is this change required? -->
<!-- What problem does it solve? -->

### Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- Don't hesitate to ask for help! -->

- [ ] A comprehensive Linear ticket, providing sufficient context and details to facilitate the review of the PR, is linked to the PR.
- [ ] If my changes require tests, I added them.
- [ ] If my changes affect backward compatibility, it has been discussed.
- [ ] If my changes require an update to the CONTRIBUTING.md guide, I updated it.

### Preview

<!-- If your changes are visual, screenshots or videos are welcome! -->

### How to QA [^1]

<!-- When relevant, describe how to QA your changes. -->

<!-- Your favorite emoji is welcome to close your PR! -->

<!-- A note for reviewers: -->

[^1]:
	Please use these labels when submitting a review:
	:question: #ask:&ensp;Ask a question.
	:bulb: #idea:&ensp;Suggest an idea.
	:warning: #issue:&ensp;Strongly suggest a change.
	:tada: #nice:&ensp;Share a compliment.
