### PR TITLE
fix: properly handle sm invalid env error

### DIFF
--- a/packages/manager/src/managers/project/ProjectManager.ts
+++ b/packages/manager/src/managers/project/ProjectManager.ts
@@ -86,14 +86,8 @@ type ProjectManagerUpdateEnvironmentArgs = {
 };
 
 type ProjectManagerFetchActiveEnvironmentReturnType =
-	| {
-			activeEnvironment: Environment;
-			error?: never;
-	  }
-	| {
-			activeEnvironment: undefined;
-			error: InvalidActiveEnvironmentError;
-	  };
+	| { type: "ok"; environment: Environment }
+	| { type: "error"; error: InvalidActiveEnvironmentError };
 
 export class ProjectManager extends BaseManager {
 	private _cachedRoot: string | undefined;
@@ -457,7 +451,7 @@ export class ProjectManager extends BaseManager {
 			this._cachedEnvironments || [],
 		);
 		if (cachedActiveEnvironment) {
-			return { activeEnvironment: cachedActiveEnvironment };
+			return { type: "ok", environment: cachedActiveEnvironment };
 		}
 
 		// If the environment is not in the cached environments list, we
@@ -479,12 +473,12 @@ export class ProjectManager extends BaseManager {
 
 		if (!activeEnvironment) {
 			return {
-				activeEnvironment: undefined,
+				type: "error",
 				error: new InvalidActiveEnvironmentError(),
 			};
 		}
 
-		return { activeEnvironment };
+		return { type: "ok", environment: activeEnvironment };
 	}
 
 	async detectVersionControlSystem(): Promise<string | "_unknown"> {

--- a/packages/manager/src/managers/project/ProjectManager.ts
+++ b/packages/manager/src/managers/project/ProjectManager.ts
@@ -86,7 +86,7 @@ type ProjectManagerUpdateEnvironmentArgs = {
 };
 
 type ProjectManagerFetchActiveEnvironmentReturnType =
-	| { type: "ok"; environment: Environment }
+	| { type: "ok"; activeEnvironment: Environment }
 	| { type: "error"; error: InvalidActiveEnvironmentError };
 
 export class ProjectManager extends BaseManager {
@@ -451,7 +451,7 @@ export class ProjectManager extends BaseManager {
 			this._cachedEnvironments || [],
 		);
 		if (cachedActiveEnvironment) {
-			return { type: "ok", environment: cachedActiveEnvironment };
+			return { type: "ok", activeEnvironment: cachedActiveEnvironment };
 		}
 
 		// If the environment is not in the cached environments list, we
@@ -478,7 +478,7 @@ export class ProjectManager extends BaseManager {
 			};
 		}
 
-		return { type: "ok", environment: activeEnvironment };
+		return { type: "ok", activeEnvironment: activeEnvironment };
 	}
 
 	async detectVersionControlSystem(): Promise<string | "_unknown"> {

--- a/packages/manager/src/managers/project/ProjectManager.ts
+++ b/packages/manager/src/managers/project/ProjectManager.ts
@@ -85,9 +85,15 @@ type ProjectManagerUpdateEnvironmentArgs = {
 	environment: string | undefined;
 };
 
-type ProjectManagerFetchActiveEnvironmentReturnType = {
-	activeEnvironment: Environment;
-};
+type ProjectManagerFetchActiveEnvironmentReturnType =
+	| {
+			activeEnvironment: Environment;
+			error?: never;
+	  }
+	| {
+			activeEnvironment: undefined;
+			error: InvalidActiveEnvironmentError;
+	  };
 
 export class ProjectManager extends BaseManager {
 	private _cachedRoot: string | undefined;
@@ -472,7 +478,10 @@ export class ProjectManager extends BaseManager {
 		);
 
 		if (!activeEnvironment) {
-			throw new InvalidActiveEnvironmentError();
+			return {
+				activeEnvironment: undefined,
+				error: new InvalidActiveEnvironmentError(),
+			};
 		}
 
 		return { activeEnvironment };

--- a/packages/manager/src/managers/telemetry/TelemetryManager.ts
+++ b/packages/manager/src/managers/telemetry/TelemetryManager.ts
@@ -116,13 +116,13 @@ export class TelemetryManager extends BaseManager {
 		if (_includeEnvironmentKind) {
 			if (this.project.checkSupportsEnvironments()) {
 				try {
-					const { activeEnvironment, error } =
+					const activeEnvironmentResult =
 						await this.project.fetchActiveEnvironment();
 
-					if (activeEnvironment) {
-						environmentKind = activeEnvironment.kind;
+					if (activeEnvironmentResult.type === "ok") {
+						environmentKind = activeEnvironmentResult.environment.kind;
 					} else {
-						throw error;
+						throw activeEnvironmentResult.error;
 					}
 				} catch {
 					environmentKind = "_unknown";

--- a/packages/manager/src/managers/telemetry/TelemetryManager.ts
+++ b/packages/manager/src/managers/telemetry/TelemetryManager.ts
@@ -116,9 +116,14 @@ export class TelemetryManager extends BaseManager {
 		if (_includeEnvironmentKind) {
 			if (this.project.checkSupportsEnvironments()) {
 				try {
-					const { activeEnvironment } =
+					const { activeEnvironment, error } =
 						await this.project.fetchActiveEnvironment();
-					environmentKind = activeEnvironment.kind;
+
+					if (activeEnvironment) {
+						environmentKind = activeEnvironment.kind;
+					} else {
+						throw error;
+					}
 				} catch {
 					environmentKind = "_unknown";
 				}

--- a/packages/manager/src/managers/telemetry/TelemetryManager.ts
+++ b/packages/manager/src/managers/telemetry/TelemetryManager.ts
@@ -120,7 +120,7 @@ export class TelemetryManager extends BaseManager {
 						await this.project.fetchActiveEnvironment();
 
 					if (activeEnvironmentResult.type === "ok") {
-						environmentKind = activeEnvironmentResult.environment.kind;
+						environmentKind = activeEnvironmentResult.activeEnvironment.kind;
 					} else {
 						throw activeEnvironmentResult.error;
 					}

--- a/packages/manager/test/SliceMachineManager-project-fetchActiveEnvironment.test.ts
+++ b/packages/manager/test/SliceMachineManager-project-fetchActiveEnvironment.test.ts
@@ -71,6 +71,7 @@ it("returns the active environment", async (ctx) => {
 	const res = await manager.project.fetchActiveEnvironment();
 
 	expect(res).toStrictEqual({
+		type: "ok",
 		activeEnvironment: environments[1],
 	});
 });
@@ -133,7 +134,7 @@ it("returns SMInvalidSelectedEnvironmentError if the active environment is inval
 	const res = await manager.project.fetchActiveEnvironment();
 
 	expect(res).toStrictEqual({
-		activeEnvironment: undefined,
+		type: "error",
 		error: expect.any(InvalidActiveEnvironmentError),
 	});
 });

--- a/packages/manager/test/SliceMachineManager-project-fetchActiveEnvironment.test.ts
+++ b/packages/manager/test/SliceMachineManager-project-fetchActiveEnvironment.test.ts
@@ -75,7 +75,7 @@ it("returns the active environment", async (ctx) => {
 	});
 });
 
-it("throws SMInvalidSelectedEnvironmentError if the active environment is invalid", async (ctx) => {
+it("returns SMInvalidSelectedEnvironmentError if the active environment is invalid", async (ctx) => {
 	const shortId = "user-foo";
 	const environments: Environment[] = [
 		{
@@ -130,7 +130,10 @@ it("throws SMInvalidSelectedEnvironmentError if the active environment is invali
 		},
 	});
 
-	await expect(async () => {
-		await manager.project.fetchActiveEnvironment();
-	}).rejects.toThrow(InvalidActiveEnvironmentError);
+	const res = await manager.project.fetchActiveEnvironment();
+
+	expect(res).toStrictEqual({
+		activeEnvironment: undefined,
+		error: expect.any(InvalidActiveEnvironmentError),
+	});
 });

--- a/packages/slice-machine/src/features/environments/actions/getActiveEnvironment.ts
+++ b/packages/slice-machine/src/features/environments/actions/getActiveEnvironment.ts
@@ -19,16 +19,16 @@ export async function getActiveEnvironment(
   isRetry = false,
 ): Promise<GetActiveEnvironmentReturnType> {
   try {
-    const { activeEnvironment, error } =
+    const activeEnvironmentResult =
       await managerClient.project.fetchActiveEnvironment();
 
-    if (error) {
-      const errorInstance = new Error(error.message);
-      errorInstance.name = error.name;
+    if (activeEnvironmentResult.type === "error") {
+      const errorInstance = new Error(activeEnvironmentResult.error.message);
+      errorInstance.name = activeEnvironmentResult.error.name;
       throw errorInstance;
     }
 
-    return { activeEnvironment };
+    return { activeEnvironment: activeEnvironmentResult.environment };
   } catch (error) {
     if (isInvalidActiveEnvironmentError(error) && !isRetry) {
       // Reset to the production environment.

--- a/packages/slice-machine/src/features/environments/actions/getActiveEnvironment.ts
+++ b/packages/slice-machine/src/features/environments/actions/getActiveEnvironment.ts
@@ -34,7 +34,7 @@ export async function getActiveEnvironment(
       throw errorInstance;
     }
 
-    return { activeEnvironment: activeEnvironmentResult.environment };
+    return { activeEnvironment: activeEnvironmentResult.activeEnvironment };
   } catch (error) {
     if (isInvalidActiveEnvironmentError(error) && !retried) {
       // Reset to the production environment.

--- a/packages/slice-machine/src/features/navigation/Navigation.tsx
+++ b/packages/slice-machine/src/features/navigation/Navigation.tsx
@@ -60,11 +60,9 @@ export function Navigation() {
       minWidth={0}
     >
       <Box flexDirection="column" gap={16}>
-        <ErrorBoundary>
-          <Suspense fallback={<Skeleton height={40} />}>
-            <Environment />
-          </Suspense>
-        </ErrorBoundary>
+        <Suspense fallback={<Skeleton height={40} />}>
+          <Environment />
+        </Suspense>
 
         <Separator style="dashed" />
 

--- a/packages/slice-machine/src/legacy/components/AppLayout/index.tsx
+++ b/packages/slice-machine/src/legacy/components/AppLayout/index.tsx
@@ -1,4 +1,12 @@
-import { Box, Button, ButtonGroup } from "@prismicio/editor-ui";
+import {
+  BlankSlate,
+  BlankSlateDescription,
+  BlankSlateIcon,
+  BlankSlateTitle,
+  Box,
+  Button,
+  ButtonGroup,
+} from "@prismicio/editor-ui";
 import { useRouter } from "next/router";
 import { FC, PropsWithChildren, Suspense } from "react";
 
@@ -18,7 +26,31 @@ export const AppLayout: FC<PropsWithChildren> = ({
   ...otherProps
 }) => {
   return (
-    <ErrorBoundary>
+    <ErrorBoundary
+      renderError={(error) => {
+        return (
+          <Box
+            position="absolute"
+            top={64}
+            width="100%"
+            justifyContent="center"
+            flexDirection="column"
+          >
+            <BlankSlate>
+              <BlankSlateIcon
+                lineColor="tomato11"
+                backgroundColor="tomato3"
+                name="alert"
+              />
+              <BlankSlateTitle>Failed to load Slice Machine</BlankSlateTitle>
+              <BlankSlateDescription>
+                {JSON.stringify(error)}
+              </BlankSlateDescription>
+            </BlankSlate>
+          </Box>
+        );
+      }}
+    >
       <Suspense>
         <PageLayoutWithActiveEnvironment {...otherProps}>
           <PageLayoutPane>

--- a/packages/slice-machine/src/legacy/components/Navigation/Environment.tsx
+++ b/packages/slice-machine/src/legacy/components/Navigation/Environment.tsx
@@ -21,7 +21,8 @@ import { SideNavEnvironmentSelector } from "./SideNavEnvironmentSelector/SideNav
 
 export function Environment() {
   const { environments, error: useEnvironmentsError } = useEnvironments();
-  const { activeEnvironment } = useActiveEnvironment();
+  const { activeEnvironment, error: activeEnvironmentError } =
+    useActiveEnvironment();
   const { refreshState, openLoginModal } = useSliceMachineActions();
   const { syncChanges } = useAutoSync();
   const isOnline = useNetwork();
@@ -82,7 +83,10 @@ export function Environment() {
     return <SideNavEnvironmentSelector variant="offline" />;
   }
 
-  if (useEnvironmentsError === undefined) {
+  if (
+    useEnvironmentsError === undefined &&
+    activeEnvironmentError === undefined
+  ) {
     return (
       <SideNavEnvironmentSelector
         environments={environments}
@@ -110,5 +114,9 @@ export function Environment() {
     );
   }
 
-  throw useEnvironmentsError;
+  if (useEnvironmentsError !== undefined) {
+    throw useEnvironmentsError;
+  }
+
+  throw activeEnvironmentError;
 }

--- a/playwright/tests/common/autoSync.spec.ts
+++ b/playwright/tests/common/autoSync.spec.ts
@@ -20,6 +20,7 @@ test.skip("I can see the auto-sync succeed when making a change", async ({
     "project.fetchActiveEnvironment",
     () => ({
       // Dev environment
+      type: "ok",
       activeEnvironment: environments[2],
     }),
     { execute: false },
@@ -64,6 +65,7 @@ test.skip("I can see the auto-sync succeed after a failed attempt", async ({
     "project.fetchActiveEnvironment",
     () => ({
       // Dev environment
+      type: "ok",
       activeEnvironment: environments[2],
     }),
     { execute: false },
@@ -124,6 +126,7 @@ test.skip("I can see the auto-sync fail because of an hard limit", async ({
     "project.fetchActiveEnvironment",
     () => ({
       // Dev environment
+      type: "ok",
       activeEnvironment: environments[2],
     }),
     { execute: false },

--- a/playwright/tests/common/environment.spec.ts
+++ b/playwright/tests/common/environment.spec.ts
@@ -71,7 +71,7 @@ test('I can see "Production" environment when an invalid environment is set', as
     () => {
       const error = new Error();
       error.name = "SMInvalidActiveEnvironmentError";
-      throw error;
+      return { type: "error", error };
     },
     { execute: false, times: 1 },
   );
@@ -93,7 +93,7 @@ test("I can see my current environment if I have one selected", async ({
   );
   procedures.mock(
     "project.fetchActiveEnvironment",
-    () => ({ activeEnvironment: environments[1] }),
+    () => ({ type: "ok", activeEnvironment: environments[1] }),
     { execute: false },
   );
 
@@ -114,7 +114,7 @@ test("I can change my current environment", async ({
   );
   procedures.mock(
     "project.fetchActiveEnvironment",
-    () => ({ activeEnvironment: environments[0] }),
+    () => ({ type: "ok", activeEnvironment: environments[0] }),
     { execute: false },
   );
 
@@ -122,7 +122,7 @@ test("I can change my current environment", async ({
 
   procedures.mock(
     "project.fetchActiveEnvironment",
-    () => ({ activeEnvironment: environments[1] }),
+    () => ({ type: "ok", activeEnvironment: environments[1] }),
     { execute: false },
   );
   await sliceMachinePage.menu.environmentSelector.selectEnvironment(
@@ -170,7 +170,7 @@ test("I can see the dot on the logo depending on the environment", async ({
 
   procedures.mock(
     "project.fetchActiveEnvironment",
-    () => ({ activeEnvironment: environments[0] }),
+    () => ({ type: "ok", activeEnvironment: environments[0] }),
     { execute: false },
   );
   await sliceMachinePage.menu.environmentSelector.selectEnvironment(
@@ -182,7 +182,7 @@ test("I can see the dot on the logo depending on the environment", async ({
 
   procedures.mock(
     "project.fetchActiveEnvironment",
-    () => ({ activeEnvironment: environments[1] }),
+    () => ({ type: "ok", activeEnvironment: environments[1] }),
     { execute: false },
   );
   await sliceMachinePage.menu.environmentSelector.selectEnvironment(
@@ -194,7 +194,7 @@ test("I can see the dot on the logo depending on the environment", async ({
 
   procedures.mock(
     "project.fetchActiveEnvironment",
-    () => ({ activeEnvironment: environments[2] }),
+    () => ({ type: "ok", activeEnvironment: environments[2] }),
     { execute: false },
   );
   await sliceMachinePage.menu.environmentSelector.selectEnvironment(
@@ -216,7 +216,7 @@ test("I can see the window top border depending on the environment", async ({
   );
   procedures.mock(
     "project.fetchActiveEnvironment",
-    () => ({ activeEnvironment: environments[0] }),
+    () => ({ type: "ok", activeEnvironment: environments[0] }),
     { execute: false },
   );
 
@@ -231,7 +231,7 @@ test("I can see the window top border depending on the environment", async ({
 
   procedures.mock(
     "project.fetchActiveEnvironment",
-    () => ({ activeEnvironment: environments[1] }),
+    () => ({ type: "ok", activeEnvironment: environments[1] }),
     { execute: false },
   );
   await sliceMachinePage.menu.environmentSelector.selectEnvironment(
@@ -243,7 +243,7 @@ test("I can see the window top border depending on the environment", async ({
 
   procedures.mock(
     "project.fetchActiveEnvironment",
-    () => ({ activeEnvironment: environments[2] }),
+    () => ({ type: "ok", activeEnvironment: environments[2] }),
     { execute: false },
   );
   await sliceMachinePage.menu.environmentSelector.selectEnvironment(


### PR DESCRIPTION
<!-- Please use a Conventional Commit in your PR title -->
<!-- https://conventionalcommits.org -->
<!-- e.g. "feat: support new field type" -->

Resolves: [DT-2710](https://linear.app/prismic/issue/DT-2710/clean-up-sminvalidactiveenvironmenterror-warning-in-client-logs)

### Description

- Prevent having an infinite loop when there is always an invalid env, it can happen in some weird conf of the user (case of the ticket reported in slack)
- Ensure no error is triggered to Sentry for a known error
- Ensure no network error is visible for a known error
- Add with Benj a global interception error screen in order to totally break if even after a retry the env is still invalid

<!-- Describe your changes in detail. -->
<!-- Why is this change required? -->
<!-- What problem does it solve? -->

### Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- Don't hesitate to ask for help! -->

- [x] A comprehensive Linear ticket, providing sufficient context and details to facilitate the review of the PR, is linked to the PR.
- [ ] If my changes require tests, I added them.
- [ ] If my changes affect backward compatibility, it has been discussed.
- [ ] If my changes require an update to the CONTRIBUTING.md guide, I updated it.

### Preview

<img width="1143" height="734" alt="Screenshot 2025-07-23 at 19 28 09" src="https://github.com/user-attachments/assets/3fd9f21f-1cc7-452c-a3c1-535d51b5f704" />


<!-- If your changes are visual, screenshots or videos are welcome! -->

### How to QA [^1]

<!-- When relevant, describe how to QA your changes. -->

<!-- Your favorite emoji is welcome to close your PR! -->

<!-- A note for reviewers: -->

[^1]:
	Please use these labels when submitting a review:
	:question: #ask:&ensp;Ask a question.
	:bulb: #idea:&ensp;Suggest an idea.
	:warning: #issue:&ensp;Strongly suggest a change.
	:tada: #nice:&ensp;Share a compliment.
