### PR TITLE
[DT-1289] fix: prevent screenshots from being uploaded every time

### DIFF
--- a/packages/init/src/SliceMachineInitProcess.ts
+++ b/packages/init/src/SliceMachineInitProcess.ts
@@ -1197,6 +1197,7 @@ ${chalk.cyan("?")} Your Prismic repository name`.replace("\n", ""),
 										await this.manager.slices.pushSlice({
 											...slice,
 											userAgent: SLICE_MACHINE_INIT_USER_AGENT,
+											variationImageUrlMap: {},
 										});
 										pushed++;
 										task.title = `Pushing slices... (${pushed}/${slices.length})`;

--- a/packages/init/src/SliceMachineInitProcess.ts
+++ b/packages/init/src/SliceMachineInitProcess.ts
@@ -1197,7 +1197,6 @@ ${chalk.cyan("?")} Your Prismic repository name`.replace("\n", ""),
 										await this.manager.slices.pushSlice({
 											...slice,
 											userAgent: SLICE_MACHINE_INIT_USER_AGENT,
-											variationImageUrlMap: {},
 										});
 										pushed++;
 										task.title = `Pushing slices... (${pushed}/${slices.length})`;

--- a/packages/manager/src/managers/prismicRepository/PrismicRepositoryManager.ts
+++ b/packages/manager/src/managers/prismicRepository/PrismicRepositoryManager.ts
@@ -319,14 +319,9 @@ export class PrismicRepositoryManager extends BaseManager {
 								const modelWithScreenshots =
 									await this.slices.updateSliceModelScreenshotsInPlace({
 										libraryID: change.libraryID,
+										variationImageUrlMap: change.variationImageUrlMap,
 										model,
 									});
-
-								// Update the local slice with the uploaded screenshot URL
-								await this.slices.updateSlice({
-									libraryID: change.libraryID,
-									model: modelWithScreenshots,
-								});
 
 								return {
 									id: change.id,
@@ -347,14 +342,9 @@ export class PrismicRepositoryManager extends BaseManager {
 								const modelWithScreenshots =
 									await this.slices.updateSliceModelScreenshotsInPlace({
 										libraryID: change.libraryID,
+										variationImageUrlMap: change.variationImageUrlMap,
 										model,
 									});
-
-								// Update the local slice with the uploaded screenshot URL
-								await this.slices.updateSlice({
-									libraryID: change.libraryID,
-									model: modelWithScreenshots,
-								});
 
 								return {
 									id: change.id,

--- a/packages/manager/src/managers/prismicRepository/PrismicRepositoryManager.ts
+++ b/packages/manager/src/managers/prismicRepository/PrismicRepositoryManager.ts
@@ -322,6 +322,12 @@ export class PrismicRepositoryManager extends BaseManager {
 										model,
 									});
 
+								// Update the local slice with the uploaded screenshot URL
+								await this.slices.updateSlice({
+									libraryID: change.libraryID,
+									model: modelWithScreenshots,
+								});
+
 								return {
 									id: change.id,
 									payload: modelWithScreenshots,
@@ -343,6 +349,12 @@ export class PrismicRepositoryManager extends BaseManager {
 										libraryID: change.libraryID,
 										model,
 									});
+
+								// Update the local slice with the uploaded screenshot URL
+								await this.slices.updateSlice({
+									libraryID: change.libraryID,
+									model: modelWithScreenshots,
+								});
 
 								return {
 									id: change.id,

--- a/packages/manager/src/managers/prismicRepository/types.ts
+++ b/packages/manager/src/managers/prismicRepository/types.ts
@@ -130,7 +130,7 @@ type SliceChange = {
 	 * push slices with the current screenshot. If a matching screenshot is not
 	 * found in this map, the current local screenshot is uploaded again.
 	 */
-	variationImageUrlMap: Record<string, string>;
+	variationImageUrlMap?: Record<string, string>;
 };
 
 export type TransactionalMergeArgs = {

--- a/packages/manager/src/managers/prismicRepository/types.ts
+++ b/packages/manager/src/managers/prismicRepository/types.ts
@@ -130,7 +130,7 @@ type SliceChange = {
 	 * push slices with the current screenshot. If a matching screenshot is not
 	 * found in this map, the current local screenshot is uploaded again.
 	 */
-	variationImageUrlMap?: Record<string, string>;
+	variationImageUrlMap: Record<string, string>;
 };
 
 export type TransactionalMergeArgs = {

--- a/packages/manager/src/managers/prismicRepository/types.ts
+++ b/packages/manager/src/managers/prismicRepository/types.ts
@@ -124,6 +124,10 @@ type SliceChange = {
 	type: "Slice";
 	status: ChangeStatus;
 	libraryID: string;
+	/**
+	 * A map of variation IDs to remote screenshot URLs. Used to detect if a
+	 * screenshot has changed when comparing with local ones.
+	 */
 	variationImageUrlMap: Record<string, string>;
 };
 

--- a/packages/manager/src/managers/prismicRepository/types.ts
+++ b/packages/manager/src/managers/prismicRepository/types.ts
@@ -125,8 +125,9 @@ type SliceChange = {
 	status: ChangeStatus;
 	libraryID: string;
 	/**
-	 * A map of variation IDs to remote screenshot URLs. Used to detect if a
-	 * screenshot has changed when comparing with local ones.
+	 * A map of variation IDs to remote screenshot URLs. These URLs are used to
+	 * detect if a screenshot has changed when comparing with local ones and to
+	 * push slices with the current screenshot.
 	 */
 	variationImageUrlMap: Record<string, string>;
 };

--- a/packages/manager/src/managers/prismicRepository/types.ts
+++ b/packages/manager/src/managers/prismicRepository/types.ts
@@ -124,6 +124,7 @@ type SliceChange = {
 	type: "Slice";
 	status: ChangeStatus;
 	libraryID: string;
+	variationImageUrlMap: Record<string, string>;
 };
 
 export type TransactionalMergeArgs = {

--- a/packages/manager/src/managers/prismicRepository/types.ts
+++ b/packages/manager/src/managers/prismicRepository/types.ts
@@ -127,7 +127,8 @@ type SliceChange = {
 	/**
 	 * A map of variation IDs to remote screenshot URLs. These URLs are used to
 	 * detect if a screenshot has changed when comparing with local ones and to
-	 * push slices with the current screenshot.
+	 * push slices with the current screenshot. If a matching screenshot is not
+	 * found in this map, the current local screenshot is uploaded again.
 	 */
 	variationImageUrlMap: Record<string, string>;
 };

--- a/packages/manager/src/managers/slices/SlicesManager.ts
+++ b/packages/manager/src/managers/slices/SlicesManager.ts
@@ -83,8 +83,9 @@ type SliceMachineManagerPushSliceArgs = {
 	sliceID: string;
 	userAgent?: string;
 	/**
-	 * A map of variation IDs to remote screenshot URLs. Used to detect if a
-	 * screenshot has changed when comparing with local ones.
+	 * A map of variation IDs to remote screenshot URLs. These URLs are used to
+	 * detect if a screenshot has changed when comparing with local ones and to
+	 * push slices with the current screenshot.
 	 */
 	variationImageUrlMap: Record<string, string>;
 };
@@ -156,8 +157,9 @@ type SlicesManagerUpsertHostedSliceScreenshotsArgs = {
 	libraryID: string;
 	model: SharedSlice;
 	/**
-	 * A map of variation IDs to remote screenshot URLs. Used to detect if a
-	 * screenshot has changed when comparing with local ones.
+	 * A map of variation IDs to remote screenshot URLs. These URLs are used to
+	 * detect if a screenshot has changed when comparing with local ones and to
+	 * push slices with the current screenshot.
 	 */
 	variationImageUrlMap: Record<string, string>;
 };

--- a/packages/manager/src/managers/slices/SlicesManager.ts
+++ b/packages/manager/src/managers/slices/SlicesManager.ts
@@ -1038,7 +1038,7 @@ export class SlicesManager extends BaseManager {
 					createContentDigest(screenshot.data),
 				);
 
-				// If screenshot hasn't changed, no need to upload it again, just used
+				// If screenshot hasn't changed, no need to upload it again, just use
 				// the existing variation with the remote image URL if it exists.
 				if (!hasScreenshotChanged) {
 					return {

--- a/packages/manager/src/managers/slices/SlicesManager.ts
+++ b/packages/manager/src/managers/slices/SlicesManager.ts
@@ -88,7 +88,7 @@ type SliceMachineManagerPushSliceArgs = {
 	 * push slices with the current screenshot. If a matching screenshot is not
 	 * found in this map, the current local screenshot is uploaded again.
 	 */
-	variationImageUrlMap: Record<string, string>;
+	variationImageUrlMap?: Record<string, string>;
 };
 
 export type SliceMachineManagerPushSliceReturnType = {
@@ -163,7 +163,7 @@ type SlicesManagerUpsertHostedSliceScreenshotsArgs = {
 	 * push slices with the current screenshot. If a matching screenshot is not
 	 * found in this map, the current local screenshot is uploaded again.
 	 */
-	variationImageUrlMap: Record<string, string>;
+	variationImageUrlMap?: Record<string, string>;
 };
 
 type SliceMachineManagerDeleteSliceArgs = {
@@ -1038,7 +1038,7 @@ export class SlicesManager extends BaseManager {
 					};
 				}
 
-				const remoteImageUrl = args.variationImageUrlMap[variation.id];
+				const remoteImageUrl = args.variationImageUrlMap?.[variation.id];
 				const hasScreenshotChanged = !remoteImageUrl?.includes(
 					createContentDigest(screenshot.data),
 				);

--- a/packages/manager/src/managers/slices/SlicesManager.ts
+++ b/packages/manager/src/managers/slices/SlicesManager.ts
@@ -82,6 +82,7 @@ type SliceMachineManagerPushSliceArgs = {
 	libraryID: string;
 	sliceID: string;
 	userAgent?: string;
+	variationImageUrlMap: Record<string, string>;
 };
 
 export type SliceMachineManagerPushSliceReturnType = {
@@ -150,6 +151,7 @@ type SliceMachineManagerUpdateSliceMocksArgsReturnType = {
 type SlicesManagerUpsertHostedSliceScrenshotsArgs = {
 	libraryID: string;
 	model: SharedSlice;
+	variationImageUrlMap: Record<string, string>;
 };
 
 type SliceMachineManagerDeleteSliceArgs = {
@@ -760,6 +762,7 @@ export class SlicesManager extends BaseManager {
 			const modelWithScreenshots =
 				await this.updateSliceModelScreenshotsInPlace({
 					libraryID: args.libraryID,
+					variationImageUrlMap: args.variationImageUrlMap,
 					model,
 				});
 
@@ -1023,9 +1026,9 @@ export class SlicesManager extends BaseManager {
 					};
 				}
 
-				const hasScreenshotChanged = !variation.imageUrl?.includes(
-					createContentDigest(screenshot.data),
-				);
+				const hasScreenshotChanged = !args.variationImageUrlMap[
+					variation.id
+				]?.includes(createContentDigest(screenshot.data));
 
 				// If screenshot hasn't changed, do nothing
 				if (!hasScreenshotChanged) {

--- a/packages/manager/src/managers/slices/SlicesManager.ts
+++ b/packages/manager/src/managers/slices/SlicesManager.ts
@@ -152,7 +152,7 @@ type SliceMachineManagerUpdateSliceMocksArgsReturnType = {
 	errors: HookError[];
 };
 
-type SlicesManagerUpsertHostedSliceScrenshotsArgs = {
+type SlicesManagerUpsertHostedSliceScreenshotsArgs = {
 	libraryID: string;
 	model: SharedSlice;
 	/**
@@ -1014,7 +1014,7 @@ export class SlicesManager extends BaseManager {
 	}
 
 	async updateSliceModelScreenshotsInPlace(
-		args: SlicesManagerUpsertHostedSliceScrenshotsArgs,
+		args: SlicesManagerUpsertHostedSliceScreenshotsArgs,
 	): Promise<SharedSlice> {
 		const repositoryName = await this.project.getResolvedRepositoryName();
 
@@ -1034,13 +1034,17 @@ export class SlicesManager extends BaseManager {
 					};
 				}
 
-				const hasScreenshotChanged = !args.variationImageUrlMap[
-					variation.id
-				]?.includes(createContentDigest(screenshot.data));
+				const remoteImageUrl = args.variationImageUrlMap[variation.id];
+				const hasScreenshotChanged = !remoteImageUrl?.includes(
+					createContentDigest(screenshot.data),
+				);
 
 				// If screenshot hasn't changed, do nothing
 				if (!hasScreenshotChanged) {
-					return variation;
+					return {
+						...variation,
+						imageUrl: remoteImageUrl ?? variation.imageUrl,
+					};
 				}
 
 				const keyPrefix = [

--- a/packages/manager/src/managers/slices/SlicesManager.ts
+++ b/packages/manager/src/managers/slices/SlicesManager.ts
@@ -82,6 +82,10 @@ type SliceMachineManagerPushSliceArgs = {
 	libraryID: string;
 	sliceID: string;
 	userAgent?: string;
+	/**
+	 * A map of variation IDs to remote screenshot URLs. Used to detect if a
+	 * screenshot has changed when comparing with local ones.
+	 */
 	variationImageUrlMap: Record<string, string>;
 };
 
@@ -151,6 +155,10 @@ type SliceMachineManagerUpdateSliceMocksArgsReturnType = {
 type SlicesManagerUpsertHostedSliceScrenshotsArgs = {
 	libraryID: string;
 	model: SharedSlice;
+	/**
+	 * A map of variation IDs to remote screenshot URLs. Used to detect if a
+	 * screenshot has changed when comparing with local ones.
+	 */
 	variationImageUrlMap: Record<string, string>;
 };
 

--- a/packages/manager/src/managers/slices/SlicesManager.ts
+++ b/packages/manager/src/managers/slices/SlicesManager.ts
@@ -85,7 +85,8 @@ type SliceMachineManagerPushSliceArgs = {
 	/**
 	 * A map of variation IDs to remote screenshot URLs. These URLs are used to
 	 * detect if a screenshot has changed when comparing with local ones and to
-	 * push slices with the current screenshot.
+	 * push slices with the current screenshot. If a matching screenshot is not
+	 * found in this map, the current local screenshot is uploaded again.
 	 */
 	variationImageUrlMap: Record<string, string>;
 };
@@ -159,7 +160,8 @@ type SlicesManagerUpsertHostedSliceScreenshotsArgs = {
 	/**
 	 * A map of variation IDs to remote screenshot URLs. These URLs are used to
 	 * detect if a screenshot has changed when comparing with local ones and to
-	 * push slices with the current screenshot.
+	 * push slices with the current screenshot. If a matching screenshot is not
+	 * found in this map, the current local screenshot is uploaded again.
 	 */
 	variationImageUrlMap: Record<string, string>;
 };

--- a/packages/manager/src/managers/slices/SlicesManager.ts
+++ b/packages/manager/src/managers/slices/SlicesManager.ts
@@ -82,13 +82,6 @@ type SliceMachineManagerPushSliceArgs = {
 	libraryID: string;
 	sliceID: string;
 	userAgent?: string;
-	/**
-	 * A map of variation IDs to remote screenshot URLs. These URLs are used to
-	 * detect if a screenshot has changed when comparing with local ones and to
-	 * push slices with the current screenshot. If a matching screenshot is not
-	 * found in this map, the current local screenshot is uploaded again.
-	 */
-	variationImageUrlMap?: Record<string, string>;
 };
 
 export type SliceMachineManagerPushSliceReturnType = {
@@ -163,7 +156,7 @@ type SlicesManagerUpsertHostedSliceScreenshotsArgs = {
 	 * push slices with the current screenshot. If a matching screenshot is not
 	 * found in this map, the current local screenshot is uploaded again.
 	 */
-	variationImageUrlMap?: Record<string, string>;
+	variationImageUrlMap: Record<string, string>;
 };
 
 type SliceMachineManagerDeleteSliceArgs = {
@@ -773,9 +766,11 @@ export class SlicesManager extends BaseManager {
 		if (model) {
 			const modelWithScreenshots =
 				await this.updateSliceModelScreenshotsInPlace({
-					libraryID: args.libraryID,
-					variationImageUrlMap: args.variationImageUrlMap,
 					model,
+					libraryID: args.libraryID,
+					// We are pushing it for the first time here, no remote image URLs to
+					// use during the update.
+					variationImageUrlMap: {},
 				});
 
 			const authenticationToken = await this.user.getAuthenticationToken();

--- a/packages/manager/src/managers/slices/SlicesManager.ts
+++ b/packages/manager/src/managers/slices/SlicesManager.ts
@@ -1047,6 +1047,7 @@ export class SlicesManager extends BaseManager {
 				if (!hasScreenshotChanged) {
 					return {
 						...variation,
+						// Keep the existing remote screenshot URL if it exists.
 						imageUrl: remoteImageUrl ?? variation.imageUrl,
 					};
 				}

--- a/packages/manager/src/managers/slices/SlicesManager.ts
+++ b/packages/manager/src/managers/slices/SlicesManager.ts
@@ -1043,7 +1043,8 @@ export class SlicesManager extends BaseManager {
 					createContentDigest(screenshot.data),
 				);
 
-				// If screenshot hasn't changed, do nothing
+				// If screenshot hasn't changed, no need to upload it again, just used
+				// the existing variation with the remote image URL if it exists.
 				if (!hasScreenshotChanged) {
 					return {
 						...variation,

--- a/packages/manager/test/SliceMachineManager-prismicRepository-pushChanges.test.ts
+++ b/packages/manager/test/SliceMachineManager-prismicRepository-pushChanges.test.ts
@@ -105,7 +105,7 @@ it("pushes changes using the push API", async (ctx) => {
 	expect(sentModel).toStrictEqual(expectedAPIPayload);
 });
 
-it("pushes slice changes while keeping the same screenshot", async (ctx) => {
+it("pushes slice changes while keeping the same screenshot if it hasn't changed", async (ctx) => {
 	const customTypeModel = ctx.mockPrismic.model.customType();
 
 	const mockScreenshotBuffer = Buffer.from("foo");

--- a/packages/manager/test/SliceMachineManager-prismicRepository-pushChanges.test.ts
+++ b/packages/manager/test/SliceMachineManager-prismicRepository-pushChanges.test.ts
@@ -16,7 +16,7 @@ import { Variation } from "@prismicio/types-internal/lib/customtypes";
 const pushChangesPayload = (
 	sliceIDs = ["slice1"],
 	customTypeIDs = ["slice1"],
-	variationImageUrlMap: Record<string, string>,
+	variationImageUrlMap: Record<string, string> = {},
 ) => ({
 	confirmDeleteDocuments: false,
 	changes: [

--- a/packages/manager/test/SliceMachineManager-prismicRepository-pushChanges.test.ts
+++ b/packages/manager/test/SliceMachineManager-prismicRepository-pushChanges.test.ts
@@ -10,10 +10,13 @@ import { mockSliceMachineAPI } from "./__testutils__/mockSliceMachineAPI";
 
 import { createSliceMachineManager } from "../src";
 import { PushBody, ChangeTypes } from "../src/managers/prismicRepository/types";
+import { createContentDigest } from "../src/lib/createContentDigest";
+import { Variation } from "@prismicio/types-internal/lib/customtypes";
 
 const pushChangesPayload = (
 	sliceIDs = ["slice1"],
 	customTypeIDs = ["slice1"],
+	variationImageUrlMap: Record<string, string>,
 ) => ({
 	confirmDeleteDocuments: false,
 	changes: [
@@ -22,7 +25,7 @@ const pushChangesPayload = (
 			status: "NEW" as const,
 			type: "Slice" as const,
 			libraryID: "slice-library",
-			variationImageUrlMap: {},
+			variationImageUrlMap,
 		})),
 		...customTypeIDs.map((id) => ({
 			id,
@@ -89,6 +92,113 @@ it("pushes changes using the push API", async (ctx) => {
 				id: sharedSliceModel.id,
 				type: ChangeTypes.SLICE_INSERT,
 				payload: sharedSliceModel,
+			},
+			{
+				id: customTypeModel.id,
+				type: ChangeTypes.CUSTOM_TYPE_UPDATE,
+				payload: customTypeModel,
+			},
+		],
+		confirmDeleteDocuments: false,
+	};
+
+	expect(sentModel).toStrictEqual(expectedAPIPayload);
+});
+
+it("pushes slice changes while keeping the same screenshot", async (ctx) => {
+	const customTypeModel = ctx.mockPrismic.model.customType();
+
+	const mockScreenshotBuffer = Buffer.from("foo");
+	const mockScreenshotBufferDigest = createContentDigest(mockScreenshotBuffer);
+
+	const { inputVariations, variationImageUrlMap, expectedVariations } =
+		Array.from({ length: 3 }).reduce<{
+			inputVariations: Variation[];
+			expectedVariations: Variation[];
+			variationImageUrlMap: Record<string, string>;
+		}>(
+			(result) => {
+				const variation = ctx.mockPrismic.model.sharedSliceVariation();
+				const imageUrl = `https://wroom-io.imgix.net/play-macaron-4fd9/shared-slices/rich_text/default/${mockScreenshotBufferDigest}.png?auto=compress%2Cformat`;
+
+				result.expectedVariations.push({ ...variation, imageUrl });
+				result.inputVariations.push({ ...variation, imageUrl: "" });
+				result.variationImageUrlMap[variation.id] = imageUrl;
+
+				return result;
+			},
+			{ inputVariations: [], variationImageUrlMap: {}, expectedVariations: [] },
+		);
+	const sharedSliceModel = ctx.mockPrismic.model.sharedSlice({
+		variations: inputVariations,
+	});
+
+	const adapter = createTestPlugin({
+		setup: ({ hook }) => {
+			hook("custom-type:read", () => {
+				return { model: customTypeModel };
+			});
+			hook("slice:read", () => {
+				return { model: sharedSliceModel };
+			});
+			hook("slice:asset:read", () => {
+				return { data: mockScreenshotBuffer, errors: [] };
+			});
+		},
+	});
+	const cwd = await createTestProject({ adapter });
+	const manager = createSliceMachineManager({
+		nativePlugins: { [adapter.meta.name]: adapter },
+		cwd,
+	});
+
+	await manager.plugins.initPlugins();
+
+	let sentModel;
+
+	mockPrismicUserAPI(ctx);
+	mockPrismicAuthAPI(ctx);
+	mockSliceMachineAPI(ctx, {
+		async onPush(req, res, ctx) {
+			if (req.headers.get("user-agent") === "slice-machine") {
+				sentModel = await req.json();
+
+				return res(ctx.status(204));
+			}
+		},
+	});
+
+	await manager.user.login(createPrismicAuthLoginResponse());
+
+	const authenticationToken = await manager.user.getAuthenticationToken();
+	const sliceMachineConfig = await manager.project.getSliceMachineConfig();
+
+	mockAWSACLAPI(ctx, {
+		createEndpoint: {
+			expectedPrismicRepository: sliceMachineConfig.repositoryName,
+			expectedAuthenticationToken: authenticationToken,
+		},
+	});
+
+	await manager.prismicRepository.pushChanges(
+		pushChangesPayload(
+			[sharedSliceModel.id],
+			[customTypeModel.id],
+			variationImageUrlMap,
+		),
+	);
+
+	const expectedSharedSliceModel = {
+		...sharedSliceModel,
+		variations: expectedVariations,
+	};
+
+	const expectedAPIPayload: PushBody = {
+		changes: [
+			{
+				id: sharedSliceModel.id,
+				type: ChangeTypes.SLICE_INSERT,
+				payload: expectedSharedSliceModel,
 			},
 			{
 				id: customTypeModel.id,

--- a/packages/manager/test/SliceMachineManager-prismicRepository-pushChanges.test.ts
+++ b/packages/manager/test/SliceMachineManager-prismicRepository-pushChanges.test.ts
@@ -119,7 +119,7 @@ it("pushes slice changes while keeping the same screenshot if it hasn't changed"
 		}>(
 			(result) => {
 				const variation = ctx.mockPrismic.model.sharedSliceVariation();
-				const imageUrl = `https://wroom-io.imgix.net/play-macaron-4fd9/shared-slices/rich_text/default/${mockScreenshotBufferDigest}.png?auto=compress%2Cformat`;
+				const imageUrl = `https://example.com/${mockScreenshotBufferDigest}.png`;
 
 				result.expectedVariations.push({ ...variation, imageUrl });
 				result.inputVariations.push({ ...variation, imageUrl: "" });

--- a/packages/manager/test/SliceMachineManager-prismicRepository-pushChanges.test.ts
+++ b/packages/manager/test/SliceMachineManager-prismicRepository-pushChanges.test.ts
@@ -22,6 +22,7 @@ const pushChangesPayload = (
 			status: "NEW" as const,
 			type: "Slice" as const,
 			libraryID: "slice-library",
+			variationImageUrlMap: {},
 		})),
 		...customTypeIDs.map((id) => ({
 			id,

--- a/packages/slice-machine/src/features/sync/actions/pushChanges.ts
+++ b/packages/slice-machine/src/features/sync/actions/pushChanges.ts
@@ -9,7 +9,9 @@ import {
 import { trackPushChangesSuccess } from "./trackPushChangesSuccess";
 
 type PushChangesArgs = {
-  changedSlices: ReadonlyArray<ChangedSlice>;
+  changedSlices: ReadonlyArray<
+    ChangedSlice & { variationImageUrlMap: Record<string, string> }
+  >;
   changedCustomTypes: ReadonlyArray<ChangedCustomType>;
   confirmDeleteDocuments?: boolean;
 };
@@ -29,6 +31,7 @@ export async function pushChanges(
     type: "Slice" as const,
     libraryID: sliceChange.slice.from,
     status: sliceChange.status,
+    variationImageUrlMap: sliceChange.variationImageUrlMap,
   }));
   const customTypeChanges = changedCustomTypes.map((customTypeChange) => ({
     id: customTypeChange.customType.id,

--- a/packages/slice-machine/src/features/sync/actions/pushChanges.ts
+++ b/packages/slice-machine/src/features/sync/actions/pushChanges.ts
@@ -9,9 +9,7 @@ import {
 import { trackPushChangesSuccess } from "./trackPushChangesSuccess";
 
 type PushChangesArgs = {
-  changedSlices: ReadonlyArray<
-    ChangedSlice & { variationImageUrlMap: Record<string, string> }
-  >;
+  changedSlices: ReadonlyArray<ChangedSlice>;
   changedCustomTypes: ReadonlyArray<ChangedCustomType>;
   confirmDeleteDocuments?: boolean;
 };

--- a/packages/slice-machine/src/features/sync/getUnSyncChanges.ts
+++ b/packages/slice-machine/src/features/sync/getUnSyncChanges.ts
@@ -15,6 +15,7 @@ import {
   computeStatuses,
   ModelStatus,
 } from "@/legacy/lib/models/common/ModelStatus";
+import { SliceSM } from "@/legacy/lib/models/common/Slice";
 import { AuthStatus } from "@/modules/userContext/types";
 
 type GetUnSyncedChangesArgs = {
@@ -82,7 +83,7 @@ export function getUnSyncedChanges(
 
       const sliceWithRemote = slices.find((s) => {
         return hasRemote(s) && s.remote.id === slice.model.id;
-      }) as RemoteOnlySlice | undefined;
+      }) as { remote: SliceSM } | undefined;
 
       const imageUrlMap = sliceWithRemote?.remote.variations.reduce<
         Record<string, string>

--- a/packages/slice-machine/src/features/sync/getUnSyncChanges.ts
+++ b/packages/slice-machine/src/features/sync/getUnSyncChanges.ts
@@ -15,7 +15,6 @@ import {
   computeStatuses,
   ModelStatus,
 } from "@/legacy/lib/models/common/ModelStatus";
-import { SliceSM } from "@/legacy/lib/models/common/Slice";
 import { AuthStatus } from "@/modules/userContext/types";
 
 type GetUnSyncedChangesArgs = {
@@ -112,10 +111,7 @@ export function getUnSyncedChanges(
   };
 }
 
-function findRemoteSlice(
-  slices: LocalOrRemoteSlice[],
-  sliceId: string,
-): SliceSM | undefined {
+function findRemoteSlice(slices: LocalOrRemoteSlice[], sliceId: string) {
   const slice = slices.find((s) => hasRemote(s) && s.remote.id === sliceId);
   return slice && hasRemote(slice) ? slice.remote : undefined;
 }

--- a/packages/slice-machine/src/features/sync/getUnSyncChanges.ts
+++ b/packages/slice-machine/src/features/sync/getUnSyncChanges.ts
@@ -31,14 +31,10 @@ const unSyncStatuses = [
   ModelStatus.Deleted,
 ];
 
-type ChangedSliceWithRemote = ChangedSlice & {
-  variationImageUrlMap: Record<string, string>;
-};
-
 export type UnSyncedChanges = {
   changedCustomTypes: ChangedCustomType[];
   unSyncedCustomTypes: LocalOrRemoteCustomType[];
-  changedSlices: ChangedSliceWithRemote[];
+  changedSlices: ChangedSlice[];
   unSyncedSlices: ComponentUI[];
   modelsStatuses: ModelsStatuses;
 };
@@ -103,9 +99,7 @@ export function getUnSyncedChanges(
         variationImageUrlMap: imageUrlMap ?? {},
       };
     })
-    .filter((slice): slice is ChangedSliceWithRemote => {
-      return unSyncStatuses.includes(slice.status);
-    });
+    .filter((s): s is ChangedSlice => unSyncStatuses.includes(s.status));
 
   const changedCustomTypes = unSyncedCustomTypes
     .map((model) => (hasLocal(model) ? model.local : model.remote))

--- a/packages/slice-machine/src/features/sync/getUnSyncChanges.ts
+++ b/packages/slice-machine/src/features/sync/getUnSyncChanges.ts
@@ -81,13 +81,10 @@ export function getUnSyncedChanges(
     .map((slice) => {
       const status = modelsStatuses.slices[slice.model.id];
 
-      const sliceWithRemote = slices.find((s) => {
-        return hasRemote(s) && s.remote.id === slice.model.id;
-      }) as { remote: SliceSM } | undefined;
-
-      const imageUrlMap = sliceWithRemote?.remote.variations.reduce<
-        Record<string, string>
-      >((result, variation) => {
+      const imageUrlMap = findRemoteSlice(
+        slices,
+        slice.model.id,
+      )?.variations.reduce<Record<string, string>>((result, variation) => {
         const { imageUrl } = variation;
         if (imageUrl === undefined || imageUrl === "") return result;
         result[variation.id] = imageUrl;
@@ -113,6 +110,14 @@ export function getUnSyncedChanges(
     unSyncedSlices,
     modelsStatuses,
   };
+}
+
+function findRemoteSlice(
+  slices: LocalOrRemoteSlice[],
+  sliceId: string,
+): SliceSM | undefined {
+  const slice = slices.find((s) => hasRemote(s) && s.remote.id === sliceId);
+  return slice && hasRemote(slice) ? slice.remote : undefined;
 }
 
 // ComponentUI are manipulated on all the relevant pages

--- a/packages/slice-machine/src/features/sync/getUnSyncChanges.ts
+++ b/packages/slice-machine/src/features/sync/getUnSyncChanges.ts
@@ -77,11 +77,11 @@ export function getUnSyncedChanges(
   );
 
   const changedSlices = unSyncedSlices
-    .map((unsyncedSlice) => {
-      const status = modelsStatuses.slices[unsyncedSlice.model.id];
+    .map((slice) => {
+      const status = modelsStatuses.slices[slice.model.id];
 
       const sliceWithRemote = slices.find((s) => {
-        return hasRemote(s) && s.remote.id === unsyncedSlice.model.id;
+        return hasRemote(s) && s.remote.id === slice.model.id;
       }) as RemoteOnlySlice | undefined;
 
       const imageUrlMap = sliceWithRemote?.remote.variations.reduce<
@@ -93,11 +93,7 @@ export function getUnSyncedChanges(
         return result;
       }, {});
 
-      return {
-        status,
-        slice: unsyncedSlice,
-        variationImageUrlMap: imageUrlMap ?? {},
-      };
+      return { status, slice, variationImageUrlMap: imageUrlMap ?? {} };
     })
     .filter((s): s is ChangedSlice => unSyncStatuses.includes(s.status));
 

--- a/packages/slice-machine/src/features/sync/getUnSyncChanges.ts
+++ b/packages/slice-machine/src/features/sync/getUnSyncChanges.ts
@@ -90,11 +90,11 @@ export function getUnSyncedChanges(
 
       const imageUrlMap = sliceWithRemote?.remote.variations.reduce<
         Record<string, string>
-      >((acc, variation) => {
-        console.log("variation", variation);
-        if (variation.imageUrl === undefined) return acc;
-        acc[variation.id] = variation.imageUrl;
-        return acc;
+      >((result, variation) => {
+        const { imageUrl } = variation;
+        if (imageUrl === undefined || imageUrl === "") return result;
+        result[variation.id] = imageUrl;
+        return result;
       }, {});
 
       return {

--- a/packages/slice-machine/src/legacy/lib/models/common/ModelStatus/index.ts
+++ b/packages/slice-machine/src/legacy/lib/models/common/ModelStatus/index.ts
@@ -34,8 +34,9 @@ export type ChangedSlice = {
   status: ChangesStatus;
   slice: ComponentUI;
   /**
-   * A map of variation IDs to remote screenshot URLs. Used to detect if a
-   * screenshot has changed when comparing with local ones.
+   * A map of variation IDs to remote screenshot URLs. These URLs are used to
+   * detect if a screenshot has changed when comparing with local ones and to
+   * push slices with the current screenshot.
    */
   variationImageUrlMap: Record<string, string>;
 };

--- a/packages/slice-machine/src/legacy/lib/models/common/ModelStatus/index.ts
+++ b/packages/slice-machine/src/legacy/lib/models/common/ModelStatus/index.ts
@@ -30,7 +30,11 @@ export type ChangesStatus =
   | ModelStatus.New
   | ModelStatus.Modified;
 
-export type ChangedSlice = { status: ChangesStatus; slice: ComponentUI };
+export type ChangedSlice = {
+  status: ChangesStatus;
+  slice: ComponentUI;
+  variationImageUrlMap: Record<string, string>;
+};
 export type ChangedCustomType = {
   status: ChangesStatus;
   customType: CustomTypeSM;

--- a/packages/slice-machine/src/legacy/lib/models/common/ModelStatus/index.ts
+++ b/packages/slice-machine/src/legacy/lib/models/common/ModelStatus/index.ts
@@ -33,11 +33,7 @@ export type ChangesStatus =
 export type ChangedSlice = {
   status: ChangesStatus;
   slice: ComponentUI;
-  /**
-   * A map of variation IDs to remote screenshot URLs. These URLs are used to
-   * detect if a screenshot has changed when comparing with local ones and to
-   * push slices with the current screenshot.
-   */
+  /** A map of variation IDs to remote screenshot URLs. */
   variationImageUrlMap: Record<string, string>;
 };
 export type ChangedCustomType = {

--- a/packages/slice-machine/src/legacy/lib/models/common/ModelStatus/index.ts
+++ b/packages/slice-machine/src/legacy/lib/models/common/ModelStatus/index.ts
@@ -33,6 +33,10 @@ export type ChangesStatus =
 export type ChangedSlice = {
   status: ChangesStatus;
   slice: ComponentUI;
+  /**
+   * A map of variation IDs to remote screenshot URLs. Used to detect if a
+   * screenshot has changed when comparing with local ones.
+   */
   variationImageUrlMap: Record<string, string>;
 };
 export type ChangedCustomType = {


### PR DESCRIPTION
Resolves: [DT-1289](https://linear.app/prismic/issue/DT-1289)

### Description

Slice screenshots are being uploaded every time a slice changes, even when the screenshot remains the same. This is due to the `imageUrl` being stripped and never stored locally. Mutating the local model would mean that the user would get a git change after pushing, which is not ideal, and was most likely what motivated this decision.

To fix this, this PR proposed passing the remote slice `imageUrl` down to the manager when pushing changes, so that it's used for the comparison and we can avoid firing an image upload request for each slice variation.

### Benchmark

Let's consider a slice with 6 variations, each one with a screenshot with ~600KB.

```
Before improvements:
- 3214 ms
- 2776 ms
- 3003 ms
- 3056 ms
- 3470 ms
- 2932 ms

After improvements:
- 1751 ms
- 1922 ms
- 1746 ms
- 1859 ms
- 1589 ms
- 1817 ms
```

This change can reduce the push time of that slice up to **~40%**.

### How to QA [^1]

<!-- When relevant, describe how to QA your changes. -->

<!-- Your favorite emoji is welcome to close your PR! -->

<!-- A note for reviewers: -->

[^1]:
	Please use these labels when submitting a review:
	:question: #ask:&ensp;Ask a question.
	:bulb: #idea:&ensp;Suggest an idea.
	:warning: #issue:&ensp;Strongly suggest a change.
	:tada: #nice:&ensp;Share a compliment.
