### PR TITLE
[DT-2837] feat: handle unauthorized auth status

### DIFF
--- a/packages/slice-machine/src/features/auth/LogoutButton.tsx
+++ b/packages/slice-machine/src/features/auth/LogoutButton.tsx
@@ -1,7 +1,6 @@
 import { Button, Icon, IconButton, Tooltip } from "@prismicio/editor-ui";
 import * as Sentry from "@sentry/nextjs";
 import { ReactNode } from "react";
-import { toast } from "react-toastify";
 
 import { clearAuth as managerLogout, getState } from "@/apiClient";
 import { invalidateActiveEnvironmentData } from "@/features/environments/useActiveEnvironment";
@@ -10,10 +9,11 @@ import useSliceMachineActions from "@/modules/useSliceMachineActions";
 
 interface LogoutButtonProps {
   children?: ReactNode;
+  onLogoutSuccess?: () => void;
 }
 
 export function LogoutButton(props: LogoutButtonProps) {
-  const { children } = props;
+  const { children, onLogoutSuccess } = props;
 
   const { refreshState } = useSliceMachineActions();
 
@@ -29,7 +29,7 @@ export function LogoutButton(props: LogoutButtonProps) {
     invalidateEnvironmentsData();
     invalidateActiveEnvironmentData();
 
-    toast.success("Logged out");
+    onLogoutSuccess?.();
   }
 
   if (children !== undefined) {

--- a/packages/slice-machine/src/features/auth/LogoutButton.tsx
+++ b/packages/slice-machine/src/features/auth/LogoutButton.tsx
@@ -1,5 +1,6 @@
-import { IconButton, Tooltip } from "@prismicio/editor-ui";
+import { Button, Icon, IconButton, Tooltip } from "@prismicio/editor-ui";
 import * as Sentry from "@sentry/nextjs";
+import { ReactNode } from "react";
 import { toast } from "react-toastify";
 
 import { clearAuth as managerLogout, getState } from "@/apiClient";
@@ -7,7 +8,13 @@ import { invalidateActiveEnvironmentData } from "@/features/environments/useActi
 import { invalidateEnvironmentsData } from "@/features/environments/useEnvironments";
 import useSliceMachineActions from "@/modules/useSliceMachineActions";
 
-export function LogoutButton() {
+interface LogoutButtonProps {
+  children?: ReactNode;
+}
+
+export function LogoutButton(props: LogoutButtonProps) {
+  const { children } = props;
+
   const { refreshState } = useSliceMachineActions();
 
   async function onClick() {
@@ -23,6 +30,18 @@ export function LogoutButton() {
     invalidateActiveEnvironmentData();
 
     toast.success("Logged out");
+  }
+
+  if (children !== undefined) {
+    return (
+      <Button
+        onClick={() => void onClick()}
+        renderEndIcon={() => <Icon name="logout" size="extraSmall" />}
+        color="grey"
+      >
+        {children}
+      </Button>
+    );
   }
 
   return (

--- a/packages/slice-machine/src/features/auth/LogoutButton.tsx
+++ b/packages/slice-machine/src/features/auth/LogoutButton.tsx
@@ -1,4 +1,5 @@
 import { Button, Icon, IconButton, Tooltip } from "@prismicio/editor-ui";
+import { SX } from "@prismicio/editor-ui/dist/theme";
 import * as Sentry from "@sentry/nextjs";
 import { ReactNode } from "react";
 
@@ -10,10 +11,12 @@ import useSliceMachineActions from "@/modules/useSliceMachineActions";
 interface LogoutButtonProps {
   children?: ReactNode;
   onLogoutSuccess?: () => void;
+  isLoading?: boolean;
+  sx?: SX;
 }
 
 export function LogoutButton(props: LogoutButtonProps) {
-  const { children, onLogoutSuccess } = props;
+  const { children, onLogoutSuccess, isLoading, sx } = props;
 
   const { refreshState } = useSliceMachineActions();
 
@@ -38,6 +41,8 @@ export function LogoutButton(props: LogoutButtonProps) {
         onClick={() => void onClick()}
         renderEndIcon={() => <Icon name="logout" size="extraSmall" />}
         color="grey"
+        loading={isLoading}
+        sx={sx}
       >
         {children}
       </Button>
@@ -50,6 +55,8 @@ export function LogoutButton(props: LogoutButtonProps) {
         icon="logout"
         onClick={() => void onClick()}
         hiddenLabel="Log out"
+        loading={isLoading}
+        sx={sx}
       />
     </Tooltip>
   );

--- a/packages/slice-machine/src/legacy/components/AppLayout/index.tsx
+++ b/packages/slice-machine/src/legacy/components/AppLayout/index.tsx
@@ -46,7 +46,7 @@ export const AppLayout: FC<PropsWithChildren> = ({
               />
               <BlankSlateTitle>Failed to load Slice Machine</BlankSlateTitle>
               <BlankSlateDescription>
-                <Box alignItems="center" flexDirection="column" gap={8}>
+                <Box alignItems="center" flexDirection="column" gap={16}>
                   {JSON.stringify(error)}
                   {isUnauthorizedError(error) && (
                     <LogoutButton>Log out</LogoutButton>

--- a/packages/slice-machine/src/legacy/components/AppLayout/index.tsx
+++ b/packages/slice-machine/src/legacy/components/AppLayout/index.tsx
@@ -6,10 +6,11 @@ import {
   Box,
   Button,
   ButtonGroup,
+  Text,
 } from "@prismicio/editor-ui";
 import { isUnauthorizedError } from "@slicemachine/manager/client";
 import { useRouter } from "next/router";
-import { FC, PropsWithChildren, Suspense } from "react";
+import { FC, PropsWithChildren, Suspense, useState } from "react";
 
 import { Breadcrumb } from "@/components/Breadcrumb";
 import {
@@ -46,16 +47,7 @@ export const AppLayout: FC<PropsWithChildren> = ({
               />
               <BlankSlateTitle>Failed to load Slice Machine</BlankSlateTitle>
               <BlankSlateDescription>
-                <Box alignItems="center" flexDirection="column" gap={16}>
-                  {JSON.stringify(error)}
-                  {isUnauthorizedError(error) && (
-                    <LogoutButton
-                      onLogoutSuccess={() => window.location.reload()}
-                    >
-                      Log out
-                    </LogoutButton>
-                  )}
-                </Box>
+                <RenderError error={error} />
               </BlankSlateDescription>
             </BlankSlate>
           </Box>
@@ -73,6 +65,43 @@ export const AppLayout: FC<PropsWithChildren> = ({
     </ErrorBoundary>
   );
 };
+
+function RenderError(args: { error: unknown }) {
+  const { error } = args;
+
+  if (isUnauthorizedError(error)) {
+    return <UnauthorizedErrorView />;
+  }
+  return <>{JSON.stringify(error)}</>;
+}
+
+function UnauthorizedErrorView() {
+  const [isLoggingOut, setIsLoggingOut] = useState(false);
+
+  return (
+    <Box flexDirection="column" gap={16} margin={{ top: 8 }}>
+      <Box flexDirection="column" gap={8} alignItems="center">
+        <Text variant="h3" align="center">
+          It seems like you don't have access to this repository
+        </Text>
+        <Text align="center">
+          Check that the repository name is correct, then contact your
+          repository administrator.
+        </Text>
+      </Box>
+      <LogoutButton
+        isLoading={isLoggingOut}
+        onLogoutSuccess={() => {
+          setIsLoggingOut(true);
+          window.location.reload();
+        }}
+        sx={{ alignSelf: "center" }}
+      >
+        Log out
+      </LogoutButton>
+    </Box>
+  );
+}
 
 const environmentTopBorderColorMap = {
   prod: "purple",

--- a/packages/slice-machine/src/legacy/components/AppLayout/index.tsx
+++ b/packages/slice-machine/src/legacy/components/AppLayout/index.tsx
@@ -7,6 +7,7 @@ import {
   Button,
   ButtonGroup,
 } from "@prismicio/editor-ui";
+import { isUnauthorizedError } from "@slicemachine/manager/client";
 import { useRouter } from "next/router";
 import { FC, PropsWithChildren, Suspense } from "react";
 
@@ -18,6 +19,7 @@ import {
   PageLayoutPane,
 } from "@/components/PageLayout";
 import { ErrorBoundary } from "@/ErrorBoundary";
+import { LogoutButton } from "@/features/auth/LogoutButton";
 import { useActiveEnvironment } from "@/features/environments/useActiveEnvironment";
 import { Navigation } from "@/features/navigation/Navigation";
 
@@ -44,7 +46,12 @@ export const AppLayout: FC<PropsWithChildren> = ({
               />
               <BlankSlateTitle>Failed to load Slice Machine</BlankSlateTitle>
               <BlankSlateDescription>
-                {JSON.stringify(error)}
+                <Box alignItems="center" flexDirection="column" gap={8}>
+                  {JSON.stringify(error)}
+                  {isUnauthorizedError(error) && (
+                    <LogoutButton>Log out</LogoutButton>
+                  )}
+                </Box>
               </BlankSlateDescription>
             </BlankSlate>
           </Box>

--- a/packages/slice-machine/src/legacy/components/AppLayout/index.tsx
+++ b/packages/slice-machine/src/legacy/components/AppLayout/index.tsx
@@ -49,7 +49,11 @@ export const AppLayout: FC<PropsWithChildren> = ({
                 <Box alignItems="center" flexDirection="column" gap={16}>
                   {JSON.stringify(error)}
                   {isUnauthorizedError(error) && (
-                    <LogoutButton>Log out</LogoutButton>
+                    <LogoutButton
+                      onLogoutSuccess={() => window.location.reload()}
+                    >
+                      Log out
+                    </LogoutButton>
                   )}
                 </Box>
               </BlankSlateDescription>

--- a/packages/slice-machine/src/legacy/components/ChangesEmptyState/AuthErrorPage.tsx
+++ b/packages/slice-machine/src/legacy/components/ChangesEmptyState/AuthErrorPage.tsx
@@ -5,7 +5,7 @@ import { AuthStatus } from "@/modules/userContext/types";
 import useSliceMachineActions from "@/modules/useSliceMachineActions";
 
 export type AuthErrorPageProps = {
-  authStatus: AuthStatus.UNAUTHORIZED | AuthStatus.FORBIDDEN;
+  authStatus: AuthStatus.FORBIDDEN;
 };
 
 export const AuthErrorPage: FC<AuthErrorPageProps> = (props) => {
@@ -20,22 +20,12 @@ export const AuthErrorPage: FC<AuthErrorPageProps> = (props) => {
       justifyContent="center"
       gap={8}
     >
-      {authStatus === AuthStatus.FORBIDDEN ? (
+      {authStatus === AuthStatus.FORBIDDEN && (
         <>
           <Text variant="h3" align="center">
             It seems like you are logged out
           </Text>
           <Text align="center">Log in to connect to your repository.</Text>
-        </>
-      ) : (
-        <>
-          <Text variant="h3" align="center">
-            It seems like you don't have access to this repository
-          </Text>
-          <Text align="center">
-            Check that the repository name is correct, then contact your
-            repository administrator.
-          </Text>
         </>
       )}
       <Text align="center">

--- a/packages/slice-machine/src/legacy/components/Navigation/Environment.tsx
+++ b/packages/slice-machine/src/legacy/components/Navigation/Environment.tsx
@@ -1,7 +1,6 @@
 import {
   Environment as EnvironmentType,
   isUnauthenticatedError,
-  isUnauthorizedError,
 } from "@slicemachine/manager/client";
 import { useState } from "react";
 
@@ -98,17 +97,10 @@ export function Environment() {
     );
   }
 
-  if (
-    isUnauthenticatedError(useEnvironmentsError) ||
-    isUnauthorizedError(useEnvironmentsError)
-  ) {
+  if (isUnauthenticatedError(useEnvironmentsError)) {
     return (
       <SideNavEnvironmentSelector
-        variant={
-          isUnauthenticatedError(useEnvironmentsError)
-            ? "unauthenticated"
-            : "unauthorized"
-        }
+        variant="unauthenticated"
         onLogInClick={() => openLoginModal()}
       />
     );

--- a/packages/slice-machine/src/legacy/components/Navigation/SideNavEnvironmentSelector/SideNavEnvironmentSelector.tsx
+++ b/packages/slice-machine/src/legacy/components/Navigation/SideNavEnvironmentSelector/SideNavEnvironmentSelector.tsx
@@ -17,6 +17,7 @@ import * as VisuallyHidden from "@radix-ui/react-visually-hidden";
 import type { Environment } from "@slicemachine/manager/client";
 import { clsx } from "clsx";
 import type { FC, ReactNode } from "react";
+import { toast } from "react-toastify";
 
 import { LogoutButton } from "@/features/auth/LogoutButton";
 import { LoginIcon } from "@/icons/LoginIcon";
@@ -140,7 +141,11 @@ export const SideNavEnvironmentSelector: FC<SideNavEnvironmentSelectorProps> = (
               />
             ) : undefined}
 
-            {variant === "default" && <LogoutButton />}
+            {variant === "default" && (
+              <LogoutButton
+                onLogoutSuccess={() => toast.success("Logged out")}
+              />
+            )}
           </Box>
         </>
       )}

--- a/packages/slice-machine/src/pages/changes.tsx
+++ b/packages/slice-machine/src/pages/changes.tsx
@@ -114,10 +114,7 @@ const Changes: React.FunctionComponent = () => {
     if (!isOnline) {
       return <OfflinePage />;
     }
-    if (
-      authStatus === AuthStatus.UNAUTHORIZED ||
-      authStatus === AuthStatus.FORBIDDEN
-    ) {
+    if (authStatus === AuthStatus.FORBIDDEN) {
       return <AuthErrorPage authStatus={authStatus} />;
     }
     if (numberOfChanges === 0) {

--- a/playwright/pages/ChangesPage.ts
+++ b/playwright/pages/ChangesPage.ts
@@ -10,7 +10,6 @@ export class ChangesPage extends SliceMachinePage {
   readonly pushChangesButton: Locator;
   readonly pushedMessaged: Locator;
   readonly notLoggedInTitle: Locator;
-  readonly notAuthorizedTitle: Locator;
   readonly blankSlateTitle: Locator;
   readonly postPushBlankSlateTitle: Locator;
   readonly unknownErrorMessage: Locator;
@@ -44,10 +43,6 @@ export class ChangesPage extends SliceMachinePage {
     this.notLoggedInTitle = page.getByText("It seems like you are logged out", {
       exact: true,
     });
-    this.notAuthorizedTitle = page.getByText(
-      "It seems like you don't have access to this repository",
-      { exact: true },
-    );
     this.blankSlateTitle = page.getByText("Everything is up-to-date", {
       exact: true,
     });

--- a/playwright/tests/changes/changes.spec.ts
+++ b/playwright/tests/changes/changes.spec.ts
@@ -13,7 +13,6 @@ test("I cannot see the login screen when logged in", async ({
   await changesPage.goto();
   await expect(changesPage.loginButton).not.toBeVisible();
   await expect(changesPage.notLoggedInTitle).not.toBeVisible();
-  await expect(changesPage.notAuthorizedTitle).not.toBeVisible();
 });
 
 test("I can see the login screen when logged out", async ({
@@ -45,7 +44,6 @@ test("I can see the unauthorized screen when not authorized", async ({
 
   await changesPage.goto();
   await expect(changesPage.loginButton).not.toBeVisible();
-  await expect(changesPage.notAuthorizedTitle).toBeVisible();
 });
 
 test("I can see the empty state when I don't have any changes to push", async ({

--- a/playwright/tests/common/environment.spec.ts
+++ b/playwright/tests/common/environment.spec.ts
@@ -147,6 +147,9 @@ test("I see an error page if I'm not authorized", async ({
   await page.goto("/");
   await expect(page.getByText("Failed to load Slice Machine")).toBeVisible();
   await expect(page.getByRole("button", { name: "Log out" })).toBeVisible();
+  await expect(
+    page.getByText("It seems like you don't have access to this repository"),
+  ).toBeVisible();
 });
 
 test("I can see the dot on the logo depending on the environment", async ({

--- a/playwright/tests/common/environment.spec.ts
+++ b/playwright/tests/common/environment.spec.ts
@@ -130,9 +130,9 @@ test("I can change my current environment", async ({
   );
 });
 
-test("I don't see login text or the select if I'm not authorized", async ({
-  sliceMachinePage,
+test("I see an error page if I'm not authorized", async ({
   procedures,
+  page,
 }) => {
   procedures.mock(
     "prismicRepository.fetchEnvironments",
@@ -144,16 +144,9 @@ test("I don't see login text or the select if I'm not authorized", async ({
     { execute: false },
   );
 
-  await sliceMachinePage.gotoDefaultPage();
-  await expect(
-    sliceMachinePage.menu.environmentSelector.loginTextButton,
-  ).not.toBeVisible();
-  await expect(
-    sliceMachinePage.menu.environmentSelector.loginIconButton,
-  ).not.toBeVisible();
-  await expect(
-    sliceMachinePage.menu.environmentSelector.dropdownTrigger,
-  ).not.toBeVisible();
+  await page.goto("/");
+  await expect(page.getByText("Failed to load Slice Machine")).toBeVisible();
+  await expect(page.getByRole("button", { name: "Log out" })).toBeVisible();
 });
 
 test("I can see the dot on the logo depending on the environment", async ({


### PR DESCRIPTION
Resolves: [DT-2837](https://linear.app/prismic/issue/DT-2837)

### Description

Handle unauthorized errors the same way we handle invalid environment, but also display a button to logout.

### Preview

<img width="952" height="302" alt="Screenshot 2025-08-11 at 12 09 35" src="https://github.com/user-attachments/assets/69433aa6-dd52-406e-83f2-16796f82f370" />

### How to QA [^1]

<!-- When relevant, describe how to QA your changes. -->

<!-- Your favorite emoji is welcome to close your PR! -->

<!-- A note for reviewers: -->

[^1]:
	Please use these labels when submitting a review:
	:question: #ask:&ensp;Ask a question.
	:bulb: #idea:&ensp;Suggest an idea.
	:warning: #issue:&ensp;Strongly suggest a change.
	:tada: #nice:&ensp;Share a compliment.
