### PR TITLE
fix: removing msw from @slicemachine/manager's peerDependencies

### DIFF
--- a/packages/manager/package.json
+++ b/packages/manager/package.json
@@ -118,7 +118,7 @@
 		"vitest": "0.32.0"
 	},
 	"peerDependencies": {
-		"msw": "^1.1.0"
+		"msw": ">=1.1.0"
 	},
 	"peerDependenciesMeta": {
 		"msw": {

--- a/packages/manager/package.json
+++ b/packages/manager/package.json
@@ -117,6 +117,14 @@
 		"vite-plugin-sdk": "0.1.1",
 		"vitest": "0.32.0"
 	},
+	"peerDependencies": {
+		"msw": "^1.1.0"
+	},
+	"peerDependenciesMeta": {
+		"msw": {
+			"optional": true
+		}
+	},
 	"engines": {
 		"node": ">=14.15.0"
 	},

--- a/packages/manager/package.json
+++ b/packages/manager/package.json
@@ -117,14 +117,6 @@
 		"vite-plugin-sdk": "0.1.1",
 		"vitest": "0.32.0"
 	},
-	"peerDependencies": {
-		"msw": "^1.1.0"
-	},
-	"peerDependenciesMeta": {
-		"msw": {
-			"optional": true
-		}
-	},
 	"engines": {
 		"node": ">=14.15.0"
 	},

--- a/yarn.lock
+++ b/yarn.lock
@@ -10916,11 +10916,6 @@ __metadata:
     vite: 5.4.20
     vite-plugin-sdk: 0.1.1
     vitest: 0.32.0
-  peerDependencies:
-    msw: ^1.1.0
-  peerDependenciesMeta:
-    msw:
-      optional: true
   languageName: unknown
   linkType: soft
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -10917,7 +10917,7 @@ __metadata:
     vite-plugin-sdk: 0.1.1
     vitest: 0.32.0
   peerDependencies:
-    msw: ^1.1.0
+    msw: ">=1.1.0"
   peerDependenciesMeta:
     msw:
       optional: true

--- a/yarn.lock
+++ b/yarn.lock
@@ -10916,6 +10916,11 @@ __metadata:
     vite: 5.4.20
     vite-plugin-sdk: 0.1.1
     vitest: 0.32.0
+  peerDependencies:
+    msw: ^1.1.0
+  peerDependenciesMeta:
+    msw:
+      optional: true
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
Resolves: https://github.com/prismicio/slice-machine/issues/1714

### Description

Simply removes `msw` from `@slicemachine/manager`'s list of peerDependencies. I checked this package's code and it's only used in tests so it should be safe to remove from here.

This will allow projects using Node 16+ and the latest version of `msw` to install `@slicemachine/manager` without issue.

I'm guessing that adding msw to this peerDependencies was just an oversight. If I'm wrong and there's an underlying reason for it, updating it from `^1.1.0` to `>=1.1.0` would resolve this issue as well.

### Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- Don't hesitate to ask for help! -->

- [x] A comprehensive Linear ticket, providing sufficient context and details to facilitate the review of the PR, is linked to the PR.
- [ ] If my changes require tests, I added them.
- [ ] If my changes affect backward compatibility, it has been discussed.
- [ ] If my changes require an update to the CONTRIBUTING.md guide, I updated it.

### Preview

<!-- If your changes are visual, screenshots or videos are welcome! -->

### How to QA [^1]

We were directed to use this package as part of running this script. The override mentioned in the linked issue allowed this script to work as expected, but I'm not aware of other ways this package is used. 

https://github.com/prismicio-solution-engineering/multi-website/blob/main/scripts/fetch-models.ts

<!-- When relevant, describe how to QA your changes. -->

<!-- Your favorite emoji is welcome to close your PR! -->

<!-- A note for reviewers: -->

[^1]:
	Please use these labels when submitting a review:
	:question: #ask:&ensp;Ask a question.
	:bulb: #idea:&ensp;Suggest an idea.
	:warning: #issue:&ensp;Strongly suggest a change.
	:tada: #nice:&ensp;Share a compliment.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Loosens `msw` peer dependency from `^1.1.0` to `>=1.1.0` in `@slicemachine/manager` and updates lockfile accordingly.
> 
> - **Dependencies**:
>   - Relax `msw` peer constraint in `packages/manager/package.json` from `^1.1.0` to `>=1.1.0`.
>   - Reflects the change in `yarn.lock`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dc9582cc7b0ad84325d93d707b72573045db3d57. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->