### PR TITLE
feat: figma to slice v1

### DIFF
--- a/packages/init/test/__setup__.ts
+++ b/packages/init/test/__setup__.ts
@@ -81,6 +81,13 @@ vi.mock("@segment/analytics-node", () => {
 	};
 });
 
+vi.mock("@anthropic-ai/claude-agent-sdk", () => {
+	return {
+		createClient: vi.fn(),
+		Agent: vi.fn(),
+	};
+});
+
 const mswServer = setupServer();
 
 beforeAll(() => {

--- a/packages/manager/package.json
+++ b/packages/manager/package.json
@@ -65,6 +65,7 @@
 	},
 	"dependencies": {
 		"@antfu/ni": "^0.20.0",
+		"@anthropic-ai/claude-agent-sdk": "0.1.37",
 		"@prismicio/client": "7.17.0",
 		"@prismicio/custom-types-client": "2.1.0",
 		"@prismicio/mocks": "2.14.0",

--- a/packages/manager/src/managers/customTypes/CustomTypesManager.ts
+++ b/packages/manager/src/managers/customTypes/CustomTypesManager.ts
@@ -601,21 +601,6 @@ export class CustomTypesManager extends BaseManager {
 						);
 					}
 
-					let frameworkFileExtension: string | undefined;
-					if (framework.type === "nextjs") {
-						frameworkFileExtension = "tsx";
-					} else if (framework.type === "nuxt") {
-						frameworkFileExtension = "vue";
-					} else if (framework.type === "sveltekit") {
-						frameworkFileExtension = "svelte";
-					}
-
-					if (!frameworkFileExtension) {
-						throw new Error(
-							"Could not determine framework from Slice Machine config.",
-						);
-					}
-
 					const projectRoot = await this.project.getRoot();
 					const libraryAbsPath = joinPath(projectRoot, libraryID);
 					const cwd = libraryAbsPath;

--- a/packages/manager/test/__setup__.ts
+++ b/packages/manager/test/__setup__.ts
@@ -190,6 +190,14 @@ vi.mock("@amplitude/experiment-node-server", () => {
 	};
 });
 
+vi.mock("@anthropic-ai/claude-agent-sdk", () => {
+	return {
+		createClient: vi.fn(),
+		Agent: vi.fn(),
+		query: vi.fn(),
+	};
+});
+
 vi.mock("execa", async () => {
 	const execa: typeof import("execa") = await vi.importActual("execa");
 

--- a/packages/slice-machine/src/features/customTypes/customTypesBuilder/CreateSliceFromImageModal/SliceCard.tsx
+++ b/packages/slice-machine/src/features/customTypes/customTypesBuilder/CreateSliceFromImageModal/SliceCard.tsx
@@ -45,7 +45,7 @@ export function SliceCard(props: SliceCardProps) {
   );
 }
 
-export type Slice = { image: File } & (
+export type Slice = { image: File; source: "upload" | "figma" } & (
   | { status: "uploading" }
   | { status: "uploadError"; onRetry: () => void }
   | { status: "generating"; thumbnailUrl: string }

--- a/packages/slice-machine/test/__setup__.ts
+++ b/packages/slice-machine/test/__setup__.ts
@@ -144,6 +144,13 @@ vi.mock("@segment/analytics-node", () => {
   };
 });
 
+vi.mock("@anthropic-ai/claude-agent-sdk", () => {
+  return {
+    createClient: vi.fn(),
+    Agent: vi.fn(),
+  };
+});
+
 // We have to manually set this environment variable as there's no equivalent of
 // `next/jest` for Vitest. It means Vitest doesn't read Next.js's configuration
 // file and (in our case) the `experimental.newNextLinkBehavior` setting.

--- a/playwright/globalTeardown.ts
+++ b/playwright/globalTeardown.ts
@@ -25,7 +25,15 @@ async function globalTeardown() {
 
   await fs.rm(".repository-name");
   await testUtils.deleteRepository(repository);
-  await fs.rm(`../playgrounds/${repository}`, { recursive: true });
+
+  try {
+    await fs.rm(`../playgrounds/${repository}`, { recursive: true });
+  } catch (error) {
+    console.warn(
+      `[teardown] failed to delete playground (${repository})`,
+      error,
+    );
+  }
 }
 
 export default globalTeardown;

--- a/yarn.lock
+++ b/yarn.lock
@@ -102,6 +102,35 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@anthropic-ai/claude-agent-sdk@npm:0.1.37":
+  version: 0.1.37
+  resolution: "@anthropic-ai/claude-agent-sdk@npm:0.1.37"
+  dependencies:
+    "@img/sharp-darwin-arm64": ^0.33.5
+    "@img/sharp-darwin-x64": ^0.33.5
+    "@img/sharp-linux-arm": ^0.33.5
+    "@img/sharp-linux-arm64": ^0.33.5
+    "@img/sharp-linux-x64": ^0.33.5
+    "@img/sharp-win32-x64": ^0.33.5
+  peerDependencies:
+    zod: ^3.24.1
+  dependenciesMeta:
+    "@img/sharp-darwin-arm64":
+      optional: true
+    "@img/sharp-darwin-x64":
+      optional: true
+    "@img/sharp-linux-arm":
+      optional: true
+    "@img/sharp-linux-arm64":
+      optional: true
+    "@img/sharp-linux-x64":
+      optional: true
+    "@img/sharp-win32-x64":
+      optional: true
+  checksum: 34d0be344a4731e669ee0b042beb63c99d5d928add56cc0fa264a1d7e1b2f943cf851028601350a9b37d65b91d97932d2753e6d0a3785ece11432f5f99888358
+  languageName: node
+  linkType: hard
+
 "@aw-web-design/x-default-browser@npm:1.4.126":
   version: 1.4.126
   resolution: "@aw-web-design/x-default-browser@npm:1.4.126"
@@ -5072,6 +5101,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@img/sharp-darwin-arm64@npm:^0.33.5":
+  version: 0.33.5
+  resolution: "@img/sharp-darwin-arm64@npm:0.33.5"
+  dependencies:
+    "@img/sharp-libvips-darwin-arm64": 1.0.4
+  dependenciesMeta:
+    "@img/sharp-libvips-darwin-arm64":
+      optional: true
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
 "@img/sharp-darwin-x64@npm:0.34.4":
   version: 0.34.4
   resolution: "@img/sharp-darwin-x64@npm:0.34.4"
@@ -5084,10 +5125,36 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@img/sharp-darwin-x64@npm:^0.33.5":
+  version: 0.33.5
+  resolution: "@img/sharp-darwin-x64@npm:0.33.5"
+  dependencies:
+    "@img/sharp-libvips-darwin-x64": 1.0.4
+  dependenciesMeta:
+    "@img/sharp-libvips-darwin-x64":
+      optional: true
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@img/sharp-libvips-darwin-arm64@npm:1.0.4":
+  version: 1.0.4
+  resolution: "@img/sharp-libvips-darwin-arm64@npm:1.0.4"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
 "@img/sharp-libvips-darwin-arm64@npm:1.2.3":
   version: 1.2.3
   resolution: "@img/sharp-libvips-darwin-arm64@npm:1.2.3"
   conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@img/sharp-libvips-darwin-x64@npm:1.0.4":
+  version: 1.0.4
+  resolution: "@img/sharp-libvips-darwin-x64@npm:1.0.4"
+  conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
@@ -5098,10 +5165,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@img/sharp-libvips-linux-arm64@npm:1.0.4":
+  version: 1.0.4
+  resolution: "@img/sharp-libvips-linux-arm64@npm:1.0.4"
+  conditions: os=linux & cpu=arm64 & libc=glibc
+  languageName: node
+  linkType: hard
+
 "@img/sharp-libvips-linux-arm64@npm:1.2.3":
   version: 1.2.3
   resolution: "@img/sharp-libvips-linux-arm64@npm:1.2.3"
   conditions: os=linux & cpu=arm64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@img/sharp-libvips-linux-arm@npm:1.0.5":
+  version: 1.0.5
+  resolution: "@img/sharp-libvips-linux-arm@npm:1.0.5"
+  conditions: os=linux & cpu=arm & libc=glibc
   languageName: node
   linkType: hard
 
@@ -5123,6 +5204,13 @@ __metadata:
   version: 1.2.3
   resolution: "@img/sharp-libvips-linux-s390x@npm:1.2.3"
   conditions: os=linux & cpu=s390x & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@img/sharp-libvips-linux-x64@npm:1.0.4":
+  version: 1.0.4
+  resolution: "@img/sharp-libvips-linux-x64@npm:1.0.4"
+  conditions: os=linux & cpu=x64 & libc=glibc
   languageName: node
   linkType: hard
 
@@ -5159,11 +5247,35 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@img/sharp-linux-arm64@npm:^0.33.5":
+  version: 0.33.5
+  resolution: "@img/sharp-linux-arm64@npm:0.33.5"
+  dependencies:
+    "@img/sharp-libvips-linux-arm64": 1.0.4
+  dependenciesMeta:
+    "@img/sharp-libvips-linux-arm64":
+      optional: true
+  conditions: os=linux & cpu=arm64 & libc=glibc
+  languageName: node
+  linkType: hard
+
 "@img/sharp-linux-arm@npm:0.34.4":
   version: 0.34.4
   resolution: "@img/sharp-linux-arm@npm:0.34.4"
   dependencies:
     "@img/sharp-libvips-linux-arm": 1.2.3
+  dependenciesMeta:
+    "@img/sharp-libvips-linux-arm":
+      optional: true
+  conditions: os=linux & cpu=arm & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@img/sharp-linux-arm@npm:^0.33.5":
+  version: 0.33.5
+  resolution: "@img/sharp-linux-arm@npm:0.33.5"
+  dependencies:
+    "@img/sharp-libvips-linux-arm": 1.0.5
   dependenciesMeta:
     "@img/sharp-libvips-linux-arm":
       optional: true
@@ -5200,6 +5312,18 @@ __metadata:
   resolution: "@img/sharp-linux-x64@npm:0.34.4"
   dependencies:
     "@img/sharp-libvips-linux-x64": 1.2.3
+  dependenciesMeta:
+    "@img/sharp-libvips-linux-x64":
+      optional: true
+  conditions: os=linux & cpu=x64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@img/sharp-linux-x64@npm:^0.33.5":
+  version: 0.33.5
+  resolution: "@img/sharp-linux-x64@npm:0.33.5"
+  dependencies:
+    "@img/sharp-libvips-linux-x64": 1.0.4
   dependenciesMeta:
     "@img/sharp-libvips-linux-x64":
       optional: true
@@ -5257,6 +5381,13 @@ __metadata:
 "@img/sharp-win32-x64@npm:0.34.4":
   version: 0.34.4
   resolution: "@img/sharp-win32-x64@npm:0.34.4"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@img/sharp-win32-x64@npm:^0.33.5":
+  version: 0.33.5
+  resolution: "@img/sharp-win32-x64@npm:0.33.5"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
@@ -10868,6 +10999,7 @@ __metadata:
   dependencies:
     "@amplitude/experiment-node-server": 1.8.1
     "@antfu/ni": ^0.20.0
+    "@anthropic-ai/claude-agent-sdk": 0.1.37
     "@prismicio/client": 7.17.0
     "@prismicio/custom-types-client": 2.1.0
     "@prismicio/mock": 0.7.1


### PR DESCRIPTION
## Description

Code for the Figma to Prismic plugin. First version with only pasting shortcut (CTRL/CMD+V)
- Parsing the clipboard content coming from the plugin and triggering an agent for model & boilerplate code generation.
- Reuses the existing `Generate from image` modal
- The regular generation from uploaded images still uses the same service as before, only pasting from Figma uses the new agent.

## Preview

https://github.com/user-attachments/assets/e26b6684-f2b2-4e8f-981e-98cd9ec7ed28

### How to QA [^1]

<!-- When relevant, describe how to QA your changes. -->

<!-- Your favorite emoji is welcome to close your PR! -->

<!-- A note for reviewers: -->

[^1]:
	Please use these labels when submitting a review:
	:question: #ask:&ensp;Ask a question.
	:bulb: #idea:&ensp;Suggest an idea.
	:warning: #issue:&ensp;Strongly suggest a change.
	:tada: #nice:&ensp;Share a compliment.
