### PR TITLE
feat(figma-to-slice): cancellation

### DIFF
--- a/packages/manager/src/managers/customTypes/CustomTypesManager.ts
+++ b/packages/manager/src/managers/customTypes/CustomTypesManager.ts
@@ -560,10 +560,8 @@ export class CustomTypesManager extends BaseManager {
 		const authToken = await this.user.getAuthenticationToken();
 		const repository = await this.project.getResolvedRepositoryName();
 
-		let abortController: AbortController | undefined;
-		let timeoutId: NodeJS.Timeout | undefined;
-		abortController = new AbortController();
-		timeoutId = setTimeout(
+		const abortController = new AbortController();
+		const timeoutId = setTimeout(
 			() => {
 				if (abortController && !abortController?.signal.aborted) {
 					abortController?.abort();

--- a/packages/manager/src/managers/customTypes/CustomTypesManager.ts
+++ b/packages/manager/src/managers/customTypes/CustomTypesManager.ts
@@ -965,9 +965,7 @@ FINAL REMINDERS:
 		}
 	}
 
-	async cancelInferSlice(args: {
-		requestId: string;
-	}): Promise<{ cancelled: boolean }> {
+	cancelInferSlice(args: { requestId: string }): { cancelled: boolean } {
 		const { requestId } = args;
 		const abortController = this.inferSliceAbortControllers.get(requestId);
 

--- a/packages/manager/src/managers/customTypes/CustomTypesManager.ts
+++ b/packages/manager/src/managers/customTypes/CustomTypesManager.ts
@@ -569,7 +569,7 @@ export class CustomTypesManager extends BaseManager {
 					if (abortController && !abortController?.signal.aborted) {
 						abortController?.abort();
 						console.warn(
-							`inferSlice (${source}) request timed out after 5 minutes`,
+							`inferSlice (${source}) request ${requestId} timed out after 5 minutes`,
 						);
 					}
 				},

--- a/packages/manager/src/managers/customTypes/CustomTypesManager.ts
+++ b/packages/manager/src/managers/customTypes/CustomTypesManager.ts
@@ -573,7 +573,7 @@ export class CustomTypesManager extends BaseManager {
 						);
 					}
 				},
-				1 * 60 * 1000, // 5 minutes
+				5 * 60 * 1000, // 5 minutes
 			);
 			abortController.signal.addEventListener("abort", () => {
 				clearTimeout(timeoutId);
@@ -602,8 +602,6 @@ export class CustomTypesManager extends BaseManager {
 				const { llmProxyUrl } = z
 					.object({ llmProxyUrl: z.string().url() })
 					.parse(exp.payload);
-
-				console.info({ llmProxyUrl });
 
 				let tmpDir: string | undefined;
 				try {

--- a/packages/manager/src/managers/customTypes/CustomTypesManager.ts
+++ b/packages/manager/src/managers/customTypes/CustomTypesManager.ts
@@ -142,6 +142,8 @@ type CustomTypeFieldIdChangedMeta = {
 type LinkCustomType = NonNullable<LinkConfig["customtypes"]>[number];
 
 export class CustomTypesManager extends BaseManager {
+	private inferSliceAbortControllers = new Map<string, AbortController>();
+
 	async readCustomTypeLibrary(): Promise<SliceMachineManagerReadCustomTypeLibraryReturnType> {
 		assertPluginsInitialized(this.sliceMachinePluginRunner);
 
@@ -548,17 +550,30 @@ export class CustomTypesManager extends BaseManager {
 	}
 
 	async inferSlice(
-		args: { imageUrl: string } & (
+		args: { imageUrl: string; requestId?: string } & (
 			| { source: "upload" }
 			| { source: "figma"; libraryID: string }
 		),
 	): Promise<InferSliceResponse> {
-		const { source, imageUrl } = args;
+		const { source, imageUrl, requestId } = args;
 
 		const authToken = await this.user.getAuthenticationToken();
 		const repository = await this.project.getResolvedRepositoryName();
 
-		console.info(`inferSlice (${source}) started`);
+		let abortController: AbortController | undefined;
+		if (requestId) {
+			abortController = new AbortController();
+			abortController.signal.addEventListener("abort", () => {
+				console.warn(`inferSlice (${source}) request ${requestId} was aborted`);
+			});
+			this.inferSliceAbortControllers.set(requestId, abortController);
+		}
+
+		console.info(
+			`inferSlice (${source}) started${
+				requestId ? ` for request ${requestId}` : ""
+			}`,
+		);
 		const startTime = Date.now();
 
 		try {
@@ -846,6 +861,7 @@ FINAL REMINDERS:
 									args: ["-y", "@prismicio/mcp-server@0.0.20-alpha.6"],
 								},
 							},
+							abortController,
 						},
 					});
 
@@ -902,6 +918,7 @@ FINAL REMINDERS:
 					method: "POST",
 					headers: { Authorization: `Bearer ${authToken}` },
 					body: JSON.stringify({ imageUrl }),
+					signal: abortController?.signal,
 				});
 
 				if (!response.ok) {
@@ -913,13 +930,42 @@ FINAL REMINDERS:
 				return InferSliceResponse.parse(json);
 			}
 		} catch (error) {
-			console.error(`inferSlice (${source}) failed`, error);
+			console.error(
+				`inferSlice (${source}) failed${
+					requestId ? ` for request ${requestId}` : ""
+				}`,
+				error,
+			);
 
 			throw error;
 		} finally {
+			if (requestId) {
+				this.inferSliceAbortControllers.delete(requestId);
+			}
+
 			const elapsedTimeSeconds = (Date.now() - startTime) / 1000;
-			console.info(`inferSlice (${source}) took ${elapsedTimeSeconds}s`);
+			console.info(
+				`inferSlice took ${elapsedTimeSeconds}s${
+					requestId ? ` for request ${requestId}` : ""
+				}`,
+			);
 		}
+	}
+
+	async cancelInferSlice(args: {
+		requestId: string;
+	}): Promise<{ cancelled: boolean }> {
+		const { requestId } = args;
+		const abortController = this.inferSliceAbortControllers.get(requestId);
+
+		if (abortController) {
+			abortController.abort();
+			this.inferSliceAbortControllers.delete(requestId);
+
+			return { cancelled: true };
+		}
+
+		return { cancelled: false };
 	}
 }
 

--- a/packages/manager/src/managers/customTypes/CustomTypesManager.ts
+++ b/packages/manager/src/managers/customTypes/CustomTypesManager.ts
@@ -943,7 +943,6 @@ FINAL REMINDERS:
 				return InferSliceResponse.parse(json);
 			}
 		} catch (error) {
-			clearTimeout(timeoutId);
 			console.error(
 				`inferSlice (${source}) failed${
 					requestId ? ` for request ${requestId}` : ""
@@ -956,6 +955,8 @@ FINAL REMINDERS:
 			if (requestId) {
 				this.inferSliceAbortControllers.delete(requestId);
 			}
+
+			clearTimeout(timeoutId);
 
 			const elapsedTimeSeconds = (Date.now() - startTime) / 1000;
 			console.info(

--- a/packages/slice-machine/src/features/customTypes/customTypesBuilder/CreateSliceFromImageModal/CreateSliceFromImageModal.tsx
+++ b/packages/slice-machine/src/features/customTypes/customTypesBuilder/CreateSliceFromImageModal/CreateSliceFromImageModal.tsx
@@ -79,7 +79,7 @@ export function CreateSliceFromImageModal(
   );
 
   useEffect(() => {
-    return () => void cancelActiveRequests();
+    return () => void cancelGeneratingRequests();
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   const setSlice = (args: {
@@ -338,19 +338,6 @@ export function CreateSliceFromImageModal(
     }
   };
 
-  const cancelActiveRequests = async () => {
-    const cancelableIds = slices.flatMap((slice) => {
-      return slice.status === "generating" ? [slice.requestId] : [];
-    });
-    if (cancelableIds.length === 0) return;
-
-    await Promise.all(
-      cancelableIds.map((requestId) => {
-        return managerClient.customTypes.cancelInferSlice({ requestId });
-      }),
-    );
-  };
-
   const onPaste = async () => {
     if (
       !open ||
@@ -473,9 +460,22 @@ export function CreateSliceFromImageModal(
     }
   };
 
+  const cancelGeneratingRequests = async () => {
+    const cancelableIds = slices.flatMap((slice) => {
+      return slice.status === "generating" ? [slice.requestId] : [];
+    });
+    if (cancelableIds.length === 0) return;
+
+    await Promise.all(
+      cancelableIds.map((requestId) => {
+        return managerClient.customTypes.cancelInferSlice({ requestId });
+      }),
+    );
+  };
+
   const onCancelConfirm = async () => {
     setShowCancelConfirmation(false);
-    await cancelActiveRequests();
+    await cancelGeneratingRequests();
   };
 
   return (

--- a/packages/slice-machine/src/features/customTypes/customTypesBuilder/CreateSliceFromImageModal/CreateSliceFromImageModal.tsx
+++ b/packages/slice-machine/src/features/customTypes/customTypesBuilder/CreateSliceFromImageModal/CreateSliceFromImageModal.tsx
@@ -498,7 +498,7 @@ export function CreateSliceFromImageModal(
     if (cancelableIds.length === 0) return;
 
     cancelableIds.forEach((requestId) => {
-      void managerClient.customTypes.cancelInferSlice({ requestId });
+      managerClient.customTypes.cancelInferSlice({ requestId });
     });
   }
 

--- a/packages/slice-machine/src/features/customTypes/customTypesBuilder/CreateSliceFromImageModal/CreateSliceFromImageModal.tsx
+++ b/packages/slice-machine/src/features/customTypes/customTypesBuilder/CreateSliceFromImageModal/CreateSliceFromImageModal.tsx
@@ -78,10 +78,6 @@ export function CreateSliceFromImageModal(
     { enabled: open && isFigmaEnabled },
   );
 
-  useEffect(() => {
-    return () => void cancelGeneratingRequests();
-  }, []); // eslint-disable-line react-hooks/exhaustive-deps
-
   const setSlice = (args: {
     index: number;
     slice: (prevSlice: Slice) => Slice;

--- a/packages/slice-machine/src/features/customTypes/customTypesBuilder/CreateSliceFromImageModal/CreateSliceFromImageModal.tsx
+++ b/packages/slice-machine/src/features/customTypes/customTypesBuilder/CreateSliceFromImageModal/CreateSliceFromImageModal.tsx
@@ -498,7 +498,7 @@ export function CreateSliceFromImageModal(
     if (cancelableIds.length === 0) return;
 
     cancelableIds.forEach((requestId) => {
-      managerClient.customTypes.cancelInferSlice({ requestId });
+      void managerClient.customTypes.cancelInferSlice({ requestId });
     });
   }
 

--- a/packages/slice-machine/src/features/customTypes/customTypesBuilder/CreateSliceFromImageModal/CreateSliceFromImageModal.tsx
+++ b/packages/slice-machine/src/features/customTypes/customTypesBuilder/CreateSliceFromImageModal/CreateSliceFromImageModal.tsx
@@ -284,12 +284,12 @@ export function CreateSliceFromImageModal(
     });
   };
 
-  const uploadingSliceCount = slices.filter((slice) => {
-    return slice.status === "uploading";
-  }).length;
-
   const generatingSliceCount = slices.filter((slice) => {
     return slice.status === "generating";
+  }).length;
+
+  const uploadingSliceCount = slices.filter((slice) => {
+    return slice.status === "uploading";
   }).length;
 
   const loadingSliceCount = generatingSliceCount + uploadingSliceCount;

--- a/packages/slice-machine/src/features/customTypes/customTypesBuilder/CreateSliceFromImageModal/CreateSliceFromImageModal.tsx
+++ b/packages/slice-machine/src/features/customTypes/customTypesBuilder/CreateSliceFromImageModal/CreateSliceFromImageModal.tsx
@@ -476,11 +476,9 @@ export function CreateSliceFromImageModal(
     });
     if (cancelableIds.length === 0) return;
 
-    await Promise.all(
-      cancelableIds.map((requestId) => {
-        return managerClient.customTypes.cancelInferSlice({ requestId });
-      }),
-    );
+    cancelableIds.forEach((requestId) => {
+      managerClient.customTypes.cancelInferSlice({ requestId });
+    });
   };
 
   const onCancelConfirm = async () => {

--- a/packages/slice-machine/src/features/customTypes/customTypesBuilder/CreateSliceFromImageModal/CreateSliceFromImageModal.tsx
+++ b/packages/slice-machine/src/features/customTypes/customTypesBuilder/CreateSliceFromImageModal/CreateSliceFromImageModal.tsx
@@ -534,7 +534,7 @@ export function CreateSliceFromImageModal(
                       color="indigo"
                       onClick={() =>
                         window.open(
-                          "https://www.figma.com/community/plugin/TODO",
+                          "https://www.figma.com/community/plugin/1567955296461153730/figma-to-slice",
                           "_blank",
                         )
                       }

--- a/packages/slice-machine/src/features/customTypes/customTypesBuilder/CreateSliceFromImageModal/CreateSliceFromImageModal.tsx
+++ b/packages/slice-machine/src/features/customTypes/customTypesBuilder/CreateSliceFromImageModal/CreateSliceFromImageModal.tsx
@@ -260,7 +260,10 @@ export function CreateSliceFromImageModal(
         index,
         slice: (prevSlice) => ({
           ...prevSlice,
-          status: "generateError",
+          status:
+            error instanceof Error && error.name === "AbortError"
+              ? "cancelled"
+              : "generateError",
           thumbnailUrl: imageUrl,
           onRetry: () => {
             void inferSlice({ index, imageUrl, source });

--- a/packages/slice-machine/src/features/customTypes/customTypesBuilder/CreateSliceFromImageModal/CreateSliceFromImageModal.tsx
+++ b/packages/slice-machine/src/features/customTypes/customTypesBuilder/CreateSliceFromImageModal/CreateSliceFromImageModal.tsx
@@ -88,18 +88,17 @@ export function CreateSliceFromImageModal(
   useEffect(() => {
     if (!slices.some((slice) => slice.status === "generating")) return;
 
-    const onRouteChange = () => void stableCancelGeneratingRequests();
     const onBeforeUnload = (event: BeforeUnloadEvent) => {
-      void stableCancelGeneratingRequests();
+      stableCancelGeneratingRequests();
       const message = "Your current generating slices will be cancelled.";
       event.returnValue = message;
       return message;
     };
 
-    router.events.on("routeChangeStart", onRouteChange);
+    router.events.on("routeChangeStart", stableCancelGeneratingRequests);
     window.addEventListener("beforeunload", onBeforeUnload);
     return () => {
-      router.events.off("routeChangeStart", onRouteChange);
+      router.events.off("routeChangeStart", stableCancelGeneratingRequests);
       window.removeEventListener("beforeunload", onBeforeUnload);
     };
   }, [slices, router.events, stableCancelGeneratingRequests]);

--- a/packages/slice-machine/src/features/customTypes/customTypesBuilder/CreateSliceFromImageModal/SliceCard.tsx
+++ b/packages/slice-machine/src/features/customTypes/customTypesBuilder/CreateSliceFromImageModal/SliceCard.tsx
@@ -15,13 +15,16 @@ export function SliceCard(props: SliceCardProps) {
   const loading = slice.status === "uploading" || slice.status === "generating";
 
   const error =
-    slice.status === "uploadError" || slice.status === "generateError";
+    slice.status === "uploadError" ||
+    slice.status === "generateError" ||
+    slice.status === "cancelled";
 
   const hasThumbnail =
     slice.status === "pending" ||
     slice.status === "generateError" ||
     slice.status === "generating" ||
-    slice.status === "success";
+    slice.status === "success" ||
+    slice.status === "cancelled";
 
   let action: ReactNode | undefined;
   if (error) {
@@ -61,8 +64,9 @@ export type Slice = { image: File; source: "upload" | "figma" } & (
   | { status: "uploading" }
   | { status: "uploadError"; onRetry: () => void }
   | { status: "pending"; thumbnailUrl: string }
-  | { status: "generating"; thumbnailUrl: string }
+  | { status: "generating"; thumbnailUrl: string; requestId: string }
   | { status: "generateError"; thumbnailUrl: string; onRetry: () => void }
+  | { status: "cancelled"; thumbnailUrl: string; onRetry: () => void }
   | {
       status: "success";
       thumbnailUrl: string;
@@ -85,6 +89,7 @@ function getStartIcon(status: Slice["status"]) {
   switch (status) {
     case "uploadError":
     case "generateError":
+    case "cancelled":
       return "close";
     case "pending":
       return "image";
@@ -117,6 +122,8 @@ function getSubtitle(slice: Slice) {
       return "Generating...";
     case "generateError":
       return "Something went wrong";
+    case "cancelled":
+      return "Cancelled";
     case "success":
       return "Generated";
   }


### PR DESCRIPTION
### Description

`Cancel` button to abort all `inferSlice` processes, both for API and Claude agent.

#### Why?

If the user exits the page (e.g., reload or close the tab), the claude process would continue and eventually make the changes to the codebase anyway.

### Preview

https://github.com/user-attachments/assets/8d794780-8c0f-458f-ab6e-774ef42edb68

### How to QA [^1]

<!-- When relevant, describe how to QA your changes. -->

<!-- Your favorite emoji is welcome to close your PR! -->

<!-- A note for reviewers: -->

[^1]:
	Please use these labels when submitting a review:
	:question: #ask:&ensp;Ask a question.
	:bulb: #idea:&ensp;Suggest an idea.
	:warning: #issue:&ensp;Strongly suggest a change.
	:tada: #nice:&ensp;Share a compliment.
