### PR TITLE
feat: generate from image option with no slices

### DIFF
--- a/packages/manager/src/managers/customTypes/CustomTypesManager.ts
+++ b/packages/manager/src/managers/customTypes/CustomTypesManager.ts
@@ -49,7 +49,6 @@ import {
 	readdir,
 } from "node:fs/promises";
 import { query as queryClaude } from "@anthropic-ai/claude-agent-sdk";
-import { APPLICATION_MODE } from "../../constants/APPLICATION_MODE";
 
 type SliceMachineManagerReadCustomTypeLibraryReturnType = {
 	ids: string[];

--- a/packages/manager/src/managers/customTypes/CustomTypesManager.ts
+++ b/packages/manager/src/managers/customTypes/CustomTypesManager.ts
@@ -872,9 +872,6 @@ FINAL REMINDERS:
 					let newSliceAbsPath: string | undefined;
 
 					for await (const query of queries) {
-						if (process.env.SM_ENV !== APPLICATION_MODE.Production) {
-							console.info(JSON.stringify(query, null, 2));
-						}
 						switch (query.type) {
 							case "result":
 								if (query.subtype === "success") {

--- a/packages/slice-machine/src/features/customTypes/customTypesBuilder/CreateSliceFromImageModal/CreateSliceFromImageModal.tsx
+++ b/packages/slice-machine/src/features/customTypes/customTypesBuilder/CreateSliceFromImageModal/CreateSliceFromImageModal.tsx
@@ -510,7 +510,7 @@ export function CreateSliceFromImageModal(
 
   return (
     <Dialog open={open} onOpenChange={(open) => !open && closeModal()}>
-      <DialogHeader title="Generate with AI" />
+      <DialogHeader title="Generate slices with AI" />
       <DialogContent gap={0}>
         <DialogDescription hidden>
           Upload images to generate slices with AI

--- a/packages/slice-machine/src/legacy/components/EmptyState/index.tsx
+++ b/packages/slice-machine/src/legacy/components/EmptyState/index.tsx
@@ -1,6 +1,4 @@
 import {
-  ActionList,
-  ActionListItem,
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,

--- a/packages/slice-machine/src/legacy/components/EmptyState/index.tsx
+++ b/packages/slice-machine/src/legacy/components/EmptyState/index.tsx
@@ -1,12 +1,22 @@
+import {
+  ActionList,
+  ActionListItem,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@prismicio/editor-ui";
 import { Video } from "cloudinary-react";
 import React from "react";
 import { Box, Button, Heading, Text } from "theme-ui";
 
 import { telemetry } from "@/apiClient";
+import { getSliceCreationOptions } from "@/features/customTypes/customTypesBuilder/sliceCreationOptions";
 
 interface Props {
   title: string;
   onCreateNew: () => void;
+  onCreateFromImage: () => void;
   buttonText: string;
   documentationComponent: React.ReactNode;
   videoPublicIdUrl: string;
@@ -15,111 +25,132 @@ interface Props {
 const EmptyState: React.FunctionComponent<Props> = ({
   title,
   onCreateNew,
+  onCreateFromImage,
   buttonText,
   documentationComponent,
   videoPublicIdUrl,
   ...restProps
-}) => (
-  <Box
-    sx={{
-      display: "flex",
-      width: "80%",
-      flexWrap: "wrap",
-      justifyContent: "center",
-    }}
-    {...restProps}
-  >
-    <Box
-      sx={(theme) => ({
-        display: "flex",
-        flex: 1,
-        alignItems: "center",
-        minWidth: "400px",
-        maxWidth: "70%",
-        border: `1px solid ${theme.colors?.grey02 as string}`,
-      })}
-    >
-      <Video
-        cloudName="dmtf1daqp"
-        controls
-        loop
-        style={{
-          maxWidth: "100%",
-          objectFit: "contain",
-        }}
-        publicId={videoPublicIdUrl}
-        onPlay={() => {
-          void telemetry.track({
-            event: "open-video-tutorials",
-            video: videoPublicIdUrl,
-          });
-        }}
-      />
-    </Box>
+}) => {
+  const sliceCreationOptions = getSliceCreationOptions({
+    menuType: "Dropdown",
+  });
 
+  return (
     <Box
-      sx={(theme) => ({
-        bg: "white",
+      sx={{
         display: "flex",
-        flexDirection: "column",
-        border: `1px solid ${theme.colors?.grey02 as string}`,
-        flex: 1,
-        minWidth: "400px",
-        maxWidth: "70%",
-      })}
+        width: "80%",
+        flexWrap: "wrap",
+        justifyContent: "center",
+      }}
+      {...restProps}
     >
       <Box
         sx={(theme) => ({
           display: "flex",
-          flexDirection: "column",
-          p: 4,
-          borderBottom: `1px solid ${theme.colors?.grey02 as string}`,
+          flex: 1,
+          alignItems: "center",
+          minWidth: "400px",
+          maxWidth: "70%",
+          border: `1px solid ${theme.colors?.grey02 as string}`,
         })}
       >
-        <Heading
-          as="h3"
-          variant={"heading"}
-          sx={{ fontSize: "16px", lineHeight: "24px", mb: 2 }}
-        >
-          {title}
-        </Heading>
-        <Text variant="xs" sx={{ lineHeight: "24px", fontSize: "13px" }}>
-          {documentationComponent}
-        </Text>
+        <Video
+          cloudName="dmtf1daqp"
+          controls
+          loop
+          style={{
+            maxWidth: "100%",
+            objectFit: "contain",
+          }}
+          publicId={videoPublicIdUrl}
+          onPlay={() => {
+            void telemetry.track({
+              event: "open-video-tutorials",
+              video: videoPublicIdUrl,
+            });
+          }}
+        />
       </Box>
+
       <Box
-        sx={{
+        sx={(theme) => ({
+          bg: "white",
           display: "flex",
-          p: 4,
-          alignItems: "center",
-        }}
+          flexDirection: "column",
+          border: `1px solid ${theme.colors?.grey02 as string}`,
+          flex: 1,
+          minWidth: "400px",
+          maxWidth: "70%",
+        })}
       >
-        <Button
-          onClick={onCreateNew}
-          data-testid="empty-state-main-button"
+        <Box
+          sx={(theme) => ({
+            display: "flex",
+            flexDirection: "column",
+            p: 4,
+            borderBottom: `1px solid ${theme.colors?.grey02 as string}`,
+          })}
+        >
+          <Heading
+            as="h3"
+            variant={"heading"}
+            sx={{ fontSize: "16px", lineHeight: "24px", mb: 2 }}
+          >
+            {title}
+          </Heading>
+          <Text variant="xs" sx={{ lineHeight: "24px", fontSize: "13px" }}>
+            {documentationComponent}
+          </Text>
+        </Box>
+        <Box
           sx={{
             display: "flex",
-            justifyContent: "center",
+            p: 4,
             alignItems: "center",
-            flexShrink: 0,
-            mr: 4,
           }}
         >
-          {buttonText}
-        </Button>
-        <Text
-          sx={{
-            fontSize: "12px",
-            color: "grey04",
-            maxWidth: "280px",
-          }}
-        >
-          It will be stored locally and you will be able to push it to your
-          repository
-        </Text>
+          <DropdownMenu>
+            <DropdownMenuTrigger>
+              <Button data-testid="empty-state-main-button" sx={{ mr: 4 }}>
+                {buttonText}
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="center">
+              <DropdownMenuItem
+                renderStartIcon={() =>
+                  sliceCreationOptions.fromImage.BackgroundIcon
+                }
+                onSelect={onCreateFromImage}
+                description={sliceCreationOptions.fromImage.description}
+              >
+                {sliceCreationOptions.fromImage.title}
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                renderStartIcon={() =>
+                  sliceCreationOptions.fromScratch.BackgroundIcon
+                }
+                onSelect={onCreateNew}
+                description={sliceCreationOptions.fromScratch.description}
+              >
+                {sliceCreationOptions.fromScratch.title}
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+          <Text
+            sx={{
+              fontSize: "12px",
+              color: "grey04",
+              maxWidth: "280px",
+            }}
+          >
+            It will be stored locally and you will be able to push it to your
+            repository
+          </Text>
+        </Box>
       </Box>
     </Box>
-  </Box>
-);
+  );
+};
 
 export default EmptyState;

--- a/packages/slice-machine/src/legacy/components/EmptyState/index.tsx
+++ b/packages/slice-machine/src/legacy/components/EmptyState/index.tsx
@@ -110,7 +110,10 @@ const EmptyState: React.FunctionComponent<Props> = ({
         >
           <DropdownMenu>
             <DropdownMenuTrigger>
-              <Button data-testid="empty-state-main-button" sx={{ mr: 4 }}>
+              <Button
+                data-testid="empty-state-main-button"
+                sx={{ flexShrink: 0, mr: 4 }}
+              >
                 {buttonText}
               </Button>
             </DropdownMenuTrigger>

--- a/packages/slice-machine/src/legacy/components/EmptyState/index.tsx
+++ b/packages/slice-machine/src/legacy/components/EmptyState/index.tsx
@@ -114,7 +114,7 @@ const EmptyState: React.FunctionComponent<Props> = ({
                 {buttonText}
               </Button>
             </DropdownMenuTrigger>
-            <DropdownMenuContent align="center">
+            <DropdownMenuContent align="end">
               <DropdownMenuItem
                 renderStartIcon={() =>
                   sliceCreationOptions.fromImage.BackgroundIcon

--- a/packages/slice-machine/src/pages/slices.tsx
+++ b/packages/slice-machine/src/pages/slices.tsx
@@ -171,6 +171,9 @@ const SlicesIndex: React.FunctionComponent = () => {
                       onCreateNew={() => {
                         setIsCreateSliceModalOpen(true);
                       }}
+                      onCreateFromImage={() => {
+                        void openCreateSliceFromImageModal();
+                      }}
                       buttonText={"Create one"}
                       videoPublicIdUrl={VIDEO_WHAT_ARE_SLICES}
                       documentationComponent={

--- a/playwright/tests/slices/slicesList.spec.ts
+++ b/playwright/tests/slices/slicesList.spec.ts
@@ -220,6 +220,7 @@ test("I can create a slice from the empty state", async ({
   await slicesListPage.goto();
   await expect(slicesListPage.blankSlate).toBeVisible();
   await slicesListPage.blankSlateCreateAction.click();
+  await slicesListPage.addSliceDropdownCreateNewAction.click();
 
   const sliceName = "Slice" + generateRandomId();
   procedures.unmock("getState");


### PR DESCRIPTION
### Description

Add a dropdown menu to choose new or generate from image when there are no slices.

### Preview

<img width="1441" height="785" alt="Screenshot 2025-11-21 at 14 33 23" src="https://github.com/user-attachments/assets/07f935e6-cfd2-46ec-a655-a6737822df3f" />

https://github.com/user-attachments/assets/591e276c-dcb6-4f08-916a-114c64d4adc1

### Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- Don't hesitate to ask for help! -->

- [ ] A comprehensive Linear ticket, providing sufficient context and details to facilitate the review of the PR, is linked to the PR.
- [ ] If my changes require tests, I added them.
- [ ] If my changes affect backward compatibility, it has been discussed.
- [ ] If my changes require an update to the CONTRIBUTING.md guide, I updated it.

### Preview

<!-- If your changes are visual, screenshots or videos are welcome! -->

### How to QA [^1]

<!-- When relevant, describe how to QA your changes. -->

<!-- Your favorite emoji is welcome to close your PR! -->

<!-- A note for reviewers: -->

[^1]:
	Please use these labels when submitting a review:
	:question: #ask:&ensp;Ask a question.
	:bulb: #idea:&ensp;Suggest an idea.
	:warning: #issue:&ensp;Strongly suggest a change.
	:tada: #nice:&ensp;Share a compliment.
