### PR TITLE
fix: restore sending documents from starters

### DIFF
--- a/packages/init/src/SliceMachineInitProcess.ts
+++ b/packages/init/src/SliceMachineInitProcess.ts
@@ -435,22 +435,7 @@ Continue with next steps in Slice Machine.
 										this.context.starterId,
 									)}`;
 								} else {
-									const fallbackStarterId: Partial<
-										Record<FrameworkWroomTelemetryID, StarterId>
-									> = {
-										next: "next_minimal",
-										nuxt: "nuxt_minimal",
-										sveltekit: "sveltekit_minimal",
-									};
-									this.context.starterId = this.context.framework
-										? fallbackStarterId[this.context.framework.wroomTelemetryID]
-										: undefined;
-
-									if (this.context.starterId) {
-										task.title = "Using a starter";
-									} else {
-										task.title = "No starter detected";
-									}
+									task.title = "No starter detected";
 								}
 							},
 						},
@@ -943,11 +928,28 @@ ${chalk.cyan("?")} Your Prismic repository name`.replace("\n", ""),
 						"Project framework must be available through context to run `createNewRepository`",
 					);
 
+					// Fallback to minimal starter if no starter detected and --starter flag was passed.
+					// This allows for uploading documents even in unknown starters.
+					let starterId = this.context.starterId;
+					if (!starterId && this.options.starter) {
+						const frameworkToMinimalStarter: Partial<
+							Record<FrameworkWroomTelemetryID, StarterId>
+						> = {
+							next: "next_minimal",
+							nuxt: "nuxt_minimal",
+							sveltekit: "sveltekit_minimal",
+						};
+						starterId =
+							frameworkToMinimalStarter[
+								this.context.framework.wroomTelemetryID
+							];
+					}
+
 					try {
 						await this.manager.prismicRepository.create({
 							domain: this.context.repository.domain,
 							framework: this.context.framework.wroomTelemetryID,
-							starterId: this.context.starterId,
+							starterId,
 						});
 					} catch (error) {
 						// When we have an error here, it's most probably because the user has a stale SESSION cookie
@@ -966,7 +968,7 @@ ${chalk.cyan("?")} Your Prismic repository name`.replace("\n", ""),
 						await this.manager.prismicRepository.create({
 							domain: this.context.repository.domain,
 							framework: this.context.framework.wroomTelemetryID,
-							starterId: this.context.starterId,
+							starterId,
 						});
 					}
 

--- a/packages/init/src/SliceMachineInitProcess.ts
+++ b/packages/init/src/SliceMachineInitProcess.ts
@@ -13,6 +13,7 @@ import pLimit from "p-limit";
 
 import {
 	createSliceMachineManager,
+	FrameworkWroomTelemetryID,
 	PrismicUserProfile,
 	PrismicRepository,
 	SliceMachineManager,
@@ -434,7 +435,22 @@ Continue with next steps in Slice Machine.
 										this.context.starterId,
 									)}`;
 								} else {
-									task.title = "No starter detected";
+									const fallbackStarterId: Partial<
+										Record<FrameworkWroomTelemetryID, StarterId>
+									> = {
+										next: "next_minimal",
+										nuxt: "nuxt_minimal",
+										sveltekit: "sveltekit_minimal",
+									};
+									this.context.starterId = this.context.framework
+										? fallbackStarterId[this.context.framework.wroomTelemetryID]
+										: undefined;
+
+									if (this.context.starterId) {
+										task.title = "Using a starter";
+									} else {
+										task.title = "No starter detected";
+									}
 								}
 							},
 						},
@@ -552,7 +568,7 @@ Continue with next steps in Slice Machine.
 
 	protected getLoggingInTitle(subtitle?: string, ...extra: string[]): string {
 		return `Logging in to Prismic...
-		
+
 ███████████████████████████████████████████████████████████████████████████
 
 ${subtitle ? `* * ${subtitle}` : ""}

--- a/packages/init/src/lib/starters.ts
+++ b/packages/init/src/lib/starters.ts
@@ -4,12 +4,13 @@ import { join } from "node:path";
 import { StarterId } from "@slicemachine/manager";
 
 const STARTERS_REPOSITORY_NAME_TO_ID: Record<string, StarterId> = {
+	"nextjs-starter-prismic-minimal": "next_minimal",
+	"nextjs-starter-prismic-minimal-ts": "next_minimal",
 	"nextjs-starter-prismic-multi-page": "next_multi_page",
-	"nextjs-starter-prismic-blog": "next_blog",
-	"nextjs-starter-prismic-multi-language": "next_multi_lang",
+	"nuxt-starter-prismic-minimal": "nuxt_minimal",
 	"nuxt-starter-prismic-multi-page": "nuxt_multi_page",
-	"nuxt-starter-prismic-blog": "nuxt_blog",
-	"nuxt-starter-prismic-multi-language": "nuxt_multi_lang",
+	"sveltekit-starter-prismic-minimal": "sveltekit_minimal",
+	"sveltekit-starter-prismic-multi-page": "sveltekit_multi_page",
 };
 
 export const detectStarterId = async (

--- a/packages/manager/src/managers/prismicRepository/types.ts
+++ b/packages/manager/src/managers/prismicRepository/types.ts
@@ -150,19 +150,19 @@ export type TransactionalMergeReturnType = PushChangesLimit | null;
 export type FrameworkWroomTelemetryID = "next" | "nuxt" | "sveltekit" | "other";
 
 /**
- * Starter id sent to Segment from wroom.Property used for the "starter"
+ * Starter id sent to Segment from wroom. Property used for the "starter"
  * properties.
  *
  * Values from:
- * https://github.com/prismicio/wroom/blob/65d4f53fd46df7d366d80e7ba9c965339ac7369d/conf/application.conf#L938
+ * https://github.com/prismicio/wroom/blob/main/conf/application.conf
  */
 export type StarterId =
+	| "next_minimal"
 	| "next_multi_page"
-	| "next_blog"
-	| "next_multi_lang"
+	| "nuxt_minimal"
 	| "nuxt_multi_page"
-	| "nuxt_blog"
-	| "nuxt_multi_lang";
+	| "sveltekit_minimal"
+	| "sveltekit_multi_page";
 
 export const Environment = t.type({
 	kind: t.union([t.literal("prod"), t.literal("stage"), t.literal("dev")]),


### PR DESCRIPTION
<!-- Please use a Conventional Commit in your PR title -->
<!-- https://conventionalcommits.org -->
<!-- e.g. "feat: support new field type" -->

Resolves: N/A

### Description

<!-- Describe your changes in detail. -->
<!-- Why is this change required? -->
<!-- What problem does it solve? -->

This PR fixes an issue where some starters don't send their base documents to a newly created repository.

This happens because the `starterId` parameter sent to the repository creation endpoint was incorrect. The hardcoded list in `@slicemachine/manager` was outdated and did not have the latest starters.

The Prismic API requires a correct `starterId` to set a default master language. Because a master language wasn't set on repositories created with certain starters, documents could not be created/pushed.

To fix the issue, this PR updates the list of starters to the default. Furthermore, this PR falls back to the framework's minimal starter when an unknown starter is used (e.g. `nextjs-starter-prismic-landing-page`).

**Future improvement**: Use the https://prismic.io/starters endpoint to dynamically fetch the latest starters.

### Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- Don't hesitate to ask for help! -->

- [ ] A comprehensive Linear ticket, providing sufficient context and details to facilitate the review of the PR, is linked to the PR.
- [ ] If my changes require tests, I added them.
- [ ] If my changes affect backward compatibility, it has been discussed.
- [ ] If my changes require an update to the CONTRIBUTING.md guide, I updated it.

### Preview

<!-- If your changes are visual, screenshots or videos are welcome! -->

### How to QA [^1]

<!-- When relevant, describe how to QA your changes. -->

<!-- Your favorite emoji is welcome to close your PR! -->

<!-- A note for reviewers: -->

[^1]:
	Please use these labels when submitting a review:
	:question: #ask:&ensp;Ask a question.
	:bulb: #idea:&ensp;Suggest an idea.
	:warning: #issue:&ensp;Strongly suggest a change.
	:tada: #nice:&ensp;Share a compliment.
