### PR TITLE
[DT-3152] feat: add more tracking to figma generate from image actions

### DIFF
--- a/packages/manager/src/managers/telemetry/types.ts
+++ b/packages/manager/src/managers/telemetry/types.ts
@@ -45,6 +45,11 @@ export const SegmentEventType = {
 	sharedOnboarding_completed: "shared-onboarding:completed",
 	sharedOnboarding_tutorial: "shared-onboarding:follow-tutorial",
 	sliceGenerationFeedback: "slice-generation-feedback",
+	sliceGeneration_pastedFromFigma: "slice-generation:pasted-from-figma",
+	sliceGeneration_started: "slice-generation:started",
+	sliceGeneration_ended: "slice-generation:ended",
+	sliceGeneration_pluginInstallationClicked:
+		"slice-generation:plugin-installation-clicked",
 	navigation_documentationLinkClicked: "navigation:documentation-link-clicked",
 	sidebar_link_clicked: "sidebar:link-clicked",
 	mcp_promo_link_clicked: "mcp:promo-link-clicked",
@@ -106,6 +111,14 @@ export const HumanSegmentEventType = {
 	[SegmentEventType.sharedOnboarding_tutorial]:
 		"Prismic Onboarding Guide Follow Tutorial",
 	[SegmentEventType.sliceGenerationFeedback]: "Slice Generation Feedback",
+	[SegmentEventType.sliceGeneration_pastedFromFigma]:
+		"SliceMachine Shared Slice Generation - Pasted From Figma",
+	[SegmentEventType.sliceGeneration_started]:
+		"SliceMachine Shared Slice Generation - Started",
+	[SegmentEventType.sliceGeneration_ended]:
+		"SliceMachine Shared Slice Generation - Ended",
+	[SegmentEventType.sliceGeneration_pluginInstallationClicked]:
+		"SliceMachine Shared Slice Generation - Plugin Installation Clicked",
 	[SegmentEventType.navigation_documentationLinkClicked]:
 		"SliceMachine Documentation Link Clicked",
 	[SegmentEventType.sidebar_link_clicked]: "Sidebar Link Clicked",
@@ -428,6 +441,31 @@ type SliceGenerationFeedback = SegmentEvent<
 	}
 >;
 
+type SliceGenerationPastedFromFigma = SegmentEvent<
+	typeof SegmentEventType.sliceGeneration_pastedFromFigma,
+	{
+		source: "shortcut" | "button";
+	}
+>;
+
+type SliceGenerationStarted = SegmentEvent<
+	typeof SegmentEventType.sliceGeneration_started,
+	{
+		source: "figma" | "upload";
+	}
+>;
+
+type SliceGenerationEnded = SegmentEvent<
+	typeof SegmentEventType.sliceGeneration_ended,
+	{
+		error: boolean;
+	}
+>;
+
+type SliceGenerationPluginInstallationClicked = SegmentEvent<
+	typeof SegmentEventType.sliceGeneration_pluginInstallationClicked
+>;
+
 type NavigationDocumentationLinkClicked = SegmentEvent<
 	typeof SegmentEventType.navigation_documentationLinkClicked,
 	{
@@ -502,6 +540,10 @@ export type SegmentEvents =
 	| SliceMachinePostPushToastCtaClicked
 	| SliceMachineExperimentExposure
 	| SliceGenerationFeedback
+	| SliceGenerationPastedFromFigma
+	| SliceGenerationStarted
+	| SliceGenerationEnded
+	| SliceGenerationPluginInstallationClicked
 	| NavigationDocumentationLinkClicked
 	| SidebarLinkClicked
 	| McpPromoLinkClicked

--- a/packages/slice-machine/src/features/customTypes/customTypesBuilder/CreateSliceFromImageModal/CreateSliceFromImageModal.tsx
+++ b/packages/slice-machine/src/features/customTypes/customTypesBuilder/CreateSliceFromImageModal/CreateSliceFromImageModal.tsx
@@ -80,7 +80,7 @@ export function CreateSliceFromImageModal(
     ["meta+v", "ctrl+v"],
     (event) => {
       event.preventDefault();
-      void onPaste();
+      void onPaste({ isShortcut: true });
     },
     { enabled: open && isFigmaEnabled },
   );
@@ -205,6 +205,8 @@ export function CreateSliceFromImageModal(
     });
 
     try {
+      void telemetry.track({ event: "slice-generation:started", source });
+
       const inferResult = await managerClient.customTypes.inferSlice({
         source,
         libraryID,
@@ -268,6 +270,8 @@ export function CreateSliceFromImageModal(
           : { mode: "ai", langSmithUrl: inferResult.langSmithUrl }),
       });
 
+      void telemetry.track({ event: "slice-generation:ended", error: false });
+
       addAiFeedback({
         type: "model",
         library: libraryID,
@@ -292,6 +296,8 @@ export function CreateSliceFromImageModal(
           },
         }),
       });
+
+      void telemetry.track({ event: "slice-generation:ended", error: true });
     }
   };
 
@@ -370,7 +376,9 @@ export function CreateSliceFromImageModal(
     }
   };
 
-  const onPaste = async () => {
+  const onPaste = async (args?: { isShortcut?: boolean }) => {
+    const { isShortcut = false } = args ?? {};
+
     if (
       !open ||
       !isFigmaEnabled ||
@@ -483,6 +491,11 @@ export function CreateSliceFromImageModal(
       // Start uploading the new image
       void uploadImage({ index: newIndex, image, source: "figma" });
 
+      void telemetry.track({
+        event: "slice-generation:pasted-from-figma",
+        source: isShortcut ? "shortcut" : "button",
+      });
+
       toast.success(`Pasted ${imageName}${success ? " from Figma" : ""}`);
     } catch (error) {
       console.error("Failed to paste from clipboard:", error);
@@ -582,14 +595,14 @@ export function CreateSliceFromImageModal(
                   overlay={
                     <UploadBlankSlate
                       onFilesSelected={onImagesSelected}
-                      onPaste={() => void onPaste()}
+                      onPaste={onPaste}
                       droppingFiles
                     />
                   }
                 >
                   <UploadBlankSlate
                     onFilesSelected={onImagesSelected}
-                    onPaste={() => void onPaste()}
+                    onPaste={onPaste}
                   />
                 </FileDropZone>
               </Box>
@@ -723,7 +736,7 @@ export function CreateSliceFromImageModal(
 function UploadBlankSlate(props: {
   droppingFiles?: boolean;
   onFilesSelected: (files: File[]) => void;
-  onPaste: () => void;
+  onPaste: () => void | Promise<void>;
 }) {
   const { droppingFiles = false, onFilesSelected, onPaste } = props;
   const isFigmaEnabled = useIsFigmaEnabled();
@@ -777,7 +790,7 @@ function UploadBlankSlate(props: {
                   size="small"
                   renderStartIcon={() => <FigmaIcon height={16} />}
                   color="grey"
-                  onClick={onPaste}
+                  onClick={() => void onPaste()}
                 >
                   Paste from Figma
                 </Button>

--- a/packages/slice-machine/src/features/customTypes/customTypesBuilder/CreateSliceFromImageModal/CreateSliceFromImageModal.tsx
+++ b/packages/slice-machine/src/features/customTypes/customTypesBuilder/CreateSliceFromImageModal/CreateSliceFromImageModal.tsx
@@ -575,12 +575,15 @@ export function CreateSliceFromImageModal(
                     <Button
                       endIcon="arrowForward"
                       color="indigo"
-                      onClick={() =>
+                      onClick={() => {
                         window.open(
                           "https://www.figma.com/community/plugin/1567955296461153730/figma-to-slice",
                           "_blank",
-                        )
-                      }
+                        );
+                        void telemetry.track({
+                          event: "slice-generation:plugin-installation-clicked",
+                        });
+                      }}
                       sx={{ marginRight: 8 }}
                       invisible
                     >


### PR DESCRIPTION
Resolves: [DT-3152](https://linear.app/prismic/issue/DT-3152)

### Description

More tracking event for the Generate from Image using Paste from Figma.

### Preview

<img width="1040" height="355" alt="Screenshot 2025-12-10 at 17 27 49" src="https://github.com/user-attachments/assets/fd4fcbcd-4c76-40ec-bdaa-49be693967f0" />

### How to QA [^1]

<!-- When relevant, describe how to QA your changes. -->

<!-- Your favorite emoji is welcome to close your PR! -->

<!-- A note for reviewers: -->

[^1]:
	Please use these labels when submitting a review:
	:question: #ask:&ensp;Ask a question.
	:bulb: #idea:&ensp;Suggest an idea.
	:warning: #issue:&ensp;Strongly suggest a change.
	:tada: #nice:&ensp;Share a compliment.
