### PR TITLE
[DT-3154] fix: inferSlice error moving screenshot between volumes 

### DIFF
--- a/packages/manager/src/managers/customTypes/CustomTypesManager.ts
+++ b/packages/manager/src/managers/customTypes/CustomTypesManager.ts
@@ -46,7 +46,7 @@ import {
 	writeFile,
 	readFile,
 	readdir,
-	cp,
+	copyFile,
 } from "node:fs/promises";
 import { query as queryClaude } from "@anthropic-ai/claude-agent-sdk";
 import { trackSentryError } from "../../lib/sentryErrorHandlers";
@@ -916,7 +916,7 @@ FINAL REMINDERS:
 					}
 
 					// copy instead of moving because the file might be in a different volume
-					await cp(
+					await copyFile(
 						tmpImageAbsPath,
 						joinPath(newSliceAbsPath, "screenshot-default.png"),
 					);

--- a/packages/manager/src/managers/customTypes/CustomTypesManager.ts
+++ b/packages/manager/src/managers/customTypes/CustomTypesManager.ts
@@ -925,7 +925,7 @@ FINAL REMINDERS:
 						await rm(tmpImageAbsPath);
 					} catch (error) {
 						console.warn(
-							`Failed to delete temporary slice screenshot at ${tmpImageAbsPath}`,
+							`inferSlice - Failed to delete temporary slice screenshot at ${tmpImageAbsPath}`,
 							error,
 						);
 					}

--- a/packages/manager/src/managers/customTypes/CustomTypesManager.ts
+++ b/packages/manager/src/managers/customTypes/CustomTypesManager.ts
@@ -42,11 +42,11 @@ import { randomUUID } from "node:crypto";
 import { join as joinPath, relative as relativePath } from "node:path";
 import {
 	mkdtemp,
-	rename,
 	rm,
 	writeFile,
 	readFile,
 	readdir,
+	cp,
 } from "node:fs/promises";
 import { query as queryClaude } from "@anthropic-ai/claude-agent-sdk";
 
@@ -897,11 +897,20 @@ FINAL REMINDERS:
 						);
 					}
 
-					// move the screenshot image to the new slice directory
-					await rename(
+					// copy instead of moving because the file might be in a different volume
+					await cp(
 						tmpImageAbsPath,
 						joinPath(newSliceAbsPath, "screenshot-default.png"),
 					);
+
+					try {
+						await rm(tmpImageAbsPath);
+					} catch (error) {
+						console.warn(
+							`Failed to delete temporary slice screenshot at ${tmpImageAbsPath}`,
+							error,
+						);
+					}
 
 					return InferSliceResponse.parse({ slice: JSON.parse(model) });
 				} finally {


### PR DESCRIPTION
Resolves: [DT-3154](https://linear.app/prismic/issue/DT-3154)

### Description

Error encountered in Sentry:

```
EXDEV: cross-device link not permitted, rename 'A:\...\108a93f7.png' -> 'B:\...\screenshot-default.png
```

### Preview

<!-- If your changes are visual, screenshots or videos are welcome! -->

### How to QA [^1]

<!-- When relevant, describe how to QA your changes. -->

<!-- Your favorite emoji is welcome to close your PR! -->

<!-- A note for reviewers: -->

[^1]:
	Please use these labels when submitting a review:
	:question: #ask:&ensp;Ask a question.
	:bulb: #idea:&ensp;Suggest an idea.
	:warning: #issue:&ensp;Strongly suggest a change.
	:tada: #nice:&ensp;Share a compliment.
