### PR TITLE
[DT-3153] feat: avoid capturing abort errors to sentry

### DIFF
--- a/packages/manager/src/errors.ts
+++ b/packages/manager/src/errors.ts
@@ -43,6 +43,10 @@ export class UnsupportedError extends SliceMachineError {
 	name = "SMUnsupportedError" as const;
 }
 
+export class InferSliceAbortError extends SliceMachineError {
+	name = "SMInferSliceAbortError" as const;
+}
+
 type SliceMachineErrorNames =
 	| "SMSliceMachineError"
 	| UnauthorizedError["name"]
@@ -53,7 +57,8 @@ type SliceMachineErrorNames =
 	| PluginError["name"]
 	| PluginHookResultError["name"]
 	| InvalidActiveEnvironmentError["name"]
-	| UnsupportedError["name"];
+	| UnsupportedError["name"]
+	| InferSliceAbortError["name"];
 
 type ShallowSliceMachineError<TName extends SliceMachineErrorNames> = Error & {
 	name: TName;
@@ -116,4 +121,10 @@ export const isUnsupportedError = (
 	error: unknown,
 ): error is ShallowSliceMachineError<"SMUnsupportedError"> => {
 	return isSliceMachineError(error, "SMUnsupportedError");
+};
+
+export const isInferSliceAbortError = (
+	error: unknown,
+): error is ShallowSliceMachineError<"SMInferSliceAbortError"> => {
+	return isSliceMachineError(error, "SMInferSliceAbortError");
 };

--- a/packages/manager/src/index.ts
+++ b/packages/manager/src/index.ts
@@ -41,6 +41,7 @@ export {
 	PluginHookResultError,
 	InvalidActiveEnvironmentError,
 	UnsupportedError,
+	InferSliceAbortError,
 } from "./errors";
 
 export { getEnvironmentInfo } from "./getEnvironmentInfo";

--- a/packages/start-slicemachine/src/lib/sentryErrorHandlers.ts
+++ b/packages/start-slicemachine/src/lib/sentryErrorHandlers.ts
@@ -5,6 +5,7 @@ import {
 	CreateSliceMachineManagerMiddlewareArgs,
 	UnauthenticatedError,
 	UnauthorizedError,
+	InferSliceAbortError,
 } from "@slicemachine/manager";
 
 import { checkIsSentryEnabled } from "./checkIsSentryEnabled";
@@ -13,9 +14,12 @@ export const node = (name: string, error: unknown): void => {
 	if (checkIsSentryEnabled()) {
 		if (
 			error instanceof UnauthenticatedError ||
-			error instanceof UnauthorizedError
+			error instanceof UnauthorizedError ||
+			error instanceof InferSliceAbortError
 		) {
-			// noop - User is not logged in or does not have access to the repository, no need to track this error in Sentry.
+			// noop - No need to track this error in Sentry.
+			// 1. User is not logged in or does not have access to the repository
+			// 2. Infer slice was aborted by the user, not an error
 		} else {
 			Sentry.withScope(function (scope) {
 				scope.setTransactionName(name);


### PR DESCRIPTION
Resolves: [DT-3153](https://linear.app/prismic/issue/DT-3153)

### Description

Cancellation of the slice generation process should not be logged to Sentry as an error.

### Preview

<!-- If your changes are visual, screenshots or videos are welcome! -->

### How to QA [^1]

<!-- When relevant, describe how to QA your changes. -->

<!-- Your favorite emoji is welcome to close your PR! -->

<!-- A note for reviewers: -->

[^1]:
	Please use these labels when submitting a review:
	:question: #ask:&ensp;Ask a question.
	:bulb: #idea:&ensp;Suggest an idea.
	:warning: #issue:&ensp;Strongly suggest a change.
	:tada: #nice:&ensp;Share a compliment.
