### PR TITLE
feat(generate): better logged out feedback and generation tracking

### DIFF
--- a/packages/manager/src/managers/customTypes/CustomTypesManager.ts
+++ b/packages/manager/src/managers/customTypes/CustomTypesManager.ts
@@ -32,11 +32,7 @@ import fetch from "../../lib/fetch";
 import { OnlyHookErrors } from "../../types";
 import { API_ENDPOINTS } from "../../constants/API_ENDPOINTS";
 import { SLICE_MACHINE_USER_AGENT } from "../../constants/SLICE_MACHINE_USER_AGENT";
-import {
-	InferSliceAbortError,
-	UnauthenticatedError,
-	UnauthorizedError,
-} from "../../errors";
+import { InferSliceAbortError, UnauthorizedError } from "../../errors";
 
 import { BaseManager } from "../BaseManager";
 import { CustomTypeFormat } from "./types";

--- a/packages/manager/src/managers/customTypes/CustomTypesManager.ts
+++ b/packages/manager/src/managers/customTypes/CustomTypesManager.ts
@@ -32,7 +32,11 @@ import fetch from "../../lib/fetch";
 import { OnlyHookErrors } from "../../types";
 import { API_ENDPOINTS } from "../../constants/API_ENDPOINTS";
 import { SLICE_MACHINE_USER_AGENT } from "../../constants/SLICE_MACHINE_USER_AGENT";
-import { InferSliceAbortError, UnauthorizedError } from "../../errors";
+import {
+	InferSliceAbortError,
+	UnauthenticatedError,
+	UnauthorizedError,
+} from "../../errors";
 
 import { BaseManager } from "../BaseManager";
 import { CustomTypeFormat } from "./types";
@@ -560,6 +564,11 @@ export class CustomTypesManager extends BaseManager {
 		const { source, imageUrl, requestId } = args;
 
 		const authToken = await this.user.getAuthenticationToken();
+
+		if (!authToken) {
+			throw new UnauthenticatedError("User is not authenticated.");
+		}
+
 		const repository = await this.project.getResolvedRepositoryName();
 
 		const abortController = new AbortController();
@@ -819,6 +828,12 @@ FINAL REMINDERS:
 - You MUST call mcp__prismic__how_to_code_slice in Step 3.1
 - DO NOT ATTEMPT TO BUILD THE APPLICATION
 - START IMMEDIATELY WITH STEP 1.1 - NO PRELIMINARY ANALYSIS`;
+
+					void this.telemetry.track({
+						event: "slice-generation:started",
+						source,
+						proxyUrl: llmProxyUrl,
+					});
 
 					const queries = queryClaude({
 						prompt,

--- a/packages/manager/src/managers/customTypes/CustomTypesManager.ts
+++ b/packages/manager/src/managers/customTypes/CustomTypesManager.ts
@@ -564,11 +564,6 @@ export class CustomTypesManager extends BaseManager {
 		const { source, imageUrl, requestId } = args;
 
 		const authToken = await this.user.getAuthenticationToken();
-
-		if (!authToken) {
-			throw new UnauthenticatedError("User is not authenticated.");
-		}
-
 		const repository = await this.project.getResolvedRepositoryName();
 
 		const abortController = new AbortController();

--- a/packages/manager/src/managers/customTypes/CustomTypesManager.ts
+++ b/packages/manager/src/managers/customTypes/CustomTypesManager.ts
@@ -823,7 +823,7 @@ FINAL REMINDERS:
 					void this.telemetry.track({
 						event: "slice-generation:started",
 						source,
-						proxyUrl: llmProxyUrl,
+						llmProxyUrl,
 					});
 
 					const queries = queryClaude({

--- a/packages/manager/src/managers/telemetry/types.ts
+++ b/packages/manager/src/managers/telemetry/types.ts
@@ -452,6 +452,7 @@ type SliceGenerationStarted = SegmentEvent<
 	typeof SegmentEventType.sliceGeneration_started,
 	{
 		source: "figma" | "upload";
+		proxyUrl: string;
 	}
 >;
 

--- a/packages/manager/src/managers/telemetry/types.ts
+++ b/packages/manager/src/managers/telemetry/types.ts
@@ -452,7 +452,7 @@ type SliceGenerationStarted = SegmentEvent<
 	typeof SegmentEventType.sliceGeneration_started,
 	{
 		source: "figma" | "upload";
-		proxyUrl: string;
+		llmProxyUrl: string;
 	}
 >;
 


### PR DESCRIPTION
### Description

We've been seen a few errors of user trying to generate a slice and being logged out and we're trying to figure out the cause and improve the experience.

1. When `inferSlice` errors out because the user is authenticated, show the login modal again
2. Track `llmProxyUrl` to debug recurrent issue

### How to QA [^1]

<!-- When relevant, describe how to QA your changes. -->

<!-- Your favorite emoji is welcome to close your PR! -->

<!-- A note for reviewers: -->

[^1]:
	Please use these labels when submitting a review:
	:question: #ask:&ensp;Ask a question.
	:bulb: #idea:&ensp;Suggest an idea.
	:warning: #issue:&ensp;Strongly suggest a change.
	:tada: #nice:&ensp;Share a compliment.
