### PR TITLE
feat: send source on generation ended event

### DIFF
--- a/packages/manager/src/managers/telemetry/types.ts
+++ b/packages/manager/src/managers/telemetry/types.ts
@@ -460,6 +460,7 @@ type SliceGenerationEnded = SegmentEvent<
 	typeof SegmentEventType.sliceGeneration_ended,
 	{
 		error: boolean;
+		source: "figma" | "upload";
 	}
 >;
 

--- a/packages/slice-machine/src/features/customTypes/customTypesBuilder/CreateSliceFromImageModal/CreateSliceFromImageModal.tsx
+++ b/packages/slice-machine/src/features/customTypes/customTypesBuilder/CreateSliceFromImageModal/CreateSliceFromImageModal.tsx
@@ -269,7 +269,11 @@ export function CreateSliceFromImageModal(
           : { mode: "ai", langSmithUrl: inferResult.langSmithUrl }),
       });
 
-      void telemetry.track({ event: "slice-generation:ended", error: false });
+      void telemetry.track({
+        event: "slice-generation:ended",
+        error: false,
+        source,
+      });
 
       addAiFeedback({
         type: "model",
@@ -303,7 +307,11 @@ export function CreateSliceFromImageModal(
         return;
       }
 
-      void telemetry.track({ event: "slice-generation:ended", error: true });
+      void telemetry.track({
+        event: "slice-generation:ended",
+        error: true,
+        source,
+      });
     }
   };
 


### PR DESCRIPTION
### Description

Improve slice generate from image tracking with the source.

### How to QA [^1]

<!-- When relevant, describe how to QA your changes. -->

<!-- Your favorite emoji is welcome to close your PR! -->

<!-- A note for reviewers: -->

[^1]:
	Please use these labels when submitting a review:
	:question: #ask:&ensp;Ask a question.
	:bulb: #idea:&ensp;Suggest an idea.
	:warning: #issue:&ensp;Strongly suggest a change.
	:tada: #nice:&ensp;Share a compliment.
