### PR TITLE
feat(generate): display login modal on unauthenticated upload

### DIFF
--- a/packages/slice-machine/src/features/customTypes/customTypesBuilder/CreateSliceFromImageModal/CreateSliceFromImageModal.tsx
+++ b/packages/slice-machine/src/features/customTypes/customTypesBuilder/CreateSliceFromImageModal/CreateSliceFromImageModal.tsx
@@ -140,6 +140,12 @@ export function CreateSliceFromImageModal(
     });
   };
 
+  const showFailedDueToUnauthenticatedError = () => {
+    toast.error("Please log in and try again.");
+    closeModal();
+    openLoginModal();
+  };
+
   const uploadImage = async (args: {
     index: number;
     image: File;
@@ -170,8 +176,9 @@ export function CreateSliceFromImageModal(
           thumbnailUrl: imageUrl,
         }),
       });
-    } catch {
+    } catch (error) {
       if (currentId !== id.current) return;
+
       setSlice({
         index,
         slice: (prevSlice) => ({
@@ -180,6 +187,11 @@ export function CreateSliceFromImageModal(
           onRetry: () => void uploadImage({ index, image, source }),
         }),
       });
+
+      if (isUnauthenticatedError(error)) {
+        showFailedDueToUnauthenticatedError();
+        return;
+      }
     }
   };
 
@@ -301,9 +313,7 @@ export function CreateSliceFromImageModal(
       });
 
       if (isUnauthenticatedError(error)) {
-        toast.error("Please log in and try again.");
-        closeModal();
-        openLoginModal();
+        showFailedDueToUnauthenticatedError();
         return;
       }
 

--- a/packages/slice-machine/src/features/customTypes/customTypesBuilder/CreateSliceFromImageModal/CreateSliceFromImageModal.tsx
+++ b/packages/slice-machine/src/features/customTypes/customTypesBuilder/CreateSliceFromImageModal/CreateSliceFromImageModal.tsx
@@ -140,7 +140,7 @@ export function CreateSliceFromImageModal(
     });
   };
 
-  const showFailedDueToUnauthenticatedError = () => {
+  const failAndPromptLogin = () => {
     toast.error("Please log in and try again.");
     closeModal();
     openLoginModal();
@@ -189,7 +189,7 @@ export function CreateSliceFromImageModal(
       });
 
       if (isUnauthenticatedError(error)) {
-        showFailedDueToUnauthenticatedError();
+        failAndPromptLogin();
         return;
       }
     }
@@ -313,7 +313,7 @@ export function CreateSliceFromImageModal(
       });
 
       if (isUnauthenticatedError(error)) {
-        showFailedDueToUnauthenticatedError();
+        failAndPromptLogin();
         return;
       }
 


### PR DESCRIPTION
### Description

If the user tried to paste from figma but is unauthenticated, display the login modal.

### How to QA [^1]

<!-- When relevant, describe how to QA your changes. -->

<!-- Your favorite emoji is welcome to close your PR! -->

<!-- A note for reviewers: -->

[^1]:
	Please use these labels when submitting a review:
	:question: #ask:&ensp;Ask a question.
	:bulb: #idea:&ensp;Suggest an idea.
	:warning: #issue:&ensp;Strongly suggest a change.
	:tada: #nice:&ensp;Share a compliment.
