### PR TITLE
feat: support Nuxt module v5

### DIFF
--- a/packages/adapter-nuxt/public/AlternateGrid/javascript.vue
+++ b/packages/adapter-nuxt/public/AlternateGrid/javascript.vue
@@ -1,7 +1,5 @@
 <script setup>
-import { isFilled } from "@prismicio/client";
-
-defineProps(getSliceComponentProps(["slice", "index", "slices", "context"]));
+defineProps(getSliceComponentProps());
 </script>
 
 <template>
@@ -13,13 +11,13 @@ defineProps(getSliceComponentProps(["slice", "index", "slices", "context"]));
 		<div
 			:class="[
 				'es-alternate-grid__content',
-				isFilled.image(slice.primary.image)
+				$prismic.isFilled.image(slice.primary.image)
 					? 'es-alternate-grid__content--with-image'
 					: '',
 			]"
 		>
 			<PrismicImage
-				v-if="isFilled.image(slice.primary.image)"
+				v-if="$prismic.isFilled.image(slice.primary.image)"
 				:field="slice.primary.image"
 				class="es-alternate-grid__image"
 				:class="
@@ -31,19 +29,19 @@ defineProps(getSliceComponentProps(["slice", "index", "slices", "context"]));
 			<div class="es-alternate-grid__primary-content">
 				<div className="es-alternate-grid__primary-content__intro">
 					<div
-						v-if="isFilled.keyText(slice.primary.eyebrowHeadline)"
+						v-if="$prismic.isFilled.keyText(slice.primary.eyebrowHeadline)"
 						class="es-alternate-grid__primary-content__intro__eyebrow"
 					>
 						{{ slice.primary.eyebrowHeadline }}
 					</div>
 					<PrismicRichText
-						v-if="isFilled.richText(slice.primary.title)"
+						v-if="$prismic.isFilled.richText(slice.primary.title)"
 						:field="slice.primary.title"
 						class="es-alternate-grid__primary-content__intro__headline"
 						wrapper="div"
 					/>
 					<PrismicRichText
-						v-if="isFilled.richText(slice.primary.description)"
+						v-if="$prismic.isFilled.richText(slice.primary.description)"
 						:field="slice.primary.description"
 						class="es-alternate-grid__primary-content__intro__description"
 						wrapper="div"
@@ -59,13 +57,13 @@ defineProps(getSliceComponentProps(["slice", "index", "slices", "context"]));
 						class="es-alternate-grid__item"
 					>
 						<PrismicRichText
-							v-if="isFilled.richText(item.title)"
+							v-if="$prismic.isFilled.richText(item.title)"
 							:field="item.title"
 							class="es-alternate-grid__item__heading"
 							wrapper="div"
 						/>
 						<PrismicRichText
-							v-if="isFilled.richText(item.description)"
+							v-if="$prismic.isFilled.richText(item.description)"
 							:field="item.description"
 							class="es-alternate-grid__item__description"
 							wrapper="div"

--- a/packages/adapter-nuxt/public/AlternateGrid/typescript.vue
+++ b/packages/adapter-nuxt/public/AlternateGrid/typescript.vue
@@ -1,14 +1,7 @@
 <script setup lang="ts">
-import { type Content, isFilled } from "@prismicio/client";
+import type { Content } from "@prismicio/client";
 
-defineProps(
-	getSliceComponentProps<Content.PascalNameToReplaceSlice>([
-		"slice",
-		"index",
-		"slices",
-		"context",
-	]),
-);
+defineProps(getSliceComponentProps<Content.PascalNameToReplaceSlice>());
 </script>
 
 <template>
@@ -20,13 +13,13 @@ defineProps(
 		<div
 			:class="[
 				'es-alternate-grid__content',
-				isFilled.image(slice.primary.image)
+				$prismic.isFilled.image(slice.primary.image)
 					? 'es-alternate-grid__content--with-image'
 					: '',
 			]"
 		>
 			<PrismicImage
-				v-if="isFilled.image(slice.primary.image)"
+				v-if="$prismic.isFilled.image(slice.primary.image)"
 				:field="slice.primary.image"
 				class="es-alternate-grid__image"
 				:class="
@@ -38,19 +31,19 @@ defineProps(
 			<div class="es-alternate-grid__primary-content">
 				<div className="es-alternate-grid__primary-content__intro">
 					<div
-						v-if="isFilled.keyText(slice.primary.eyebrowHeadline)"
+						v-if="$prismic.isFilled.keyText(slice.primary.eyebrowHeadline)"
 						class="es-alternate-grid__primary-content__intro__eyebrow"
 					>
 						{{ slice.primary.eyebrowHeadline }}
 					</div>
 					<PrismicRichText
-						v-if="isFilled.richText(slice.primary.title)"
+						v-if="$prismic.isFilled.richText(slice.primary.title)"
 						:field="slice.primary.title"
 						class="es-alternate-grid__primary-content__intro__headline"
 						wrapper="div"
 					/>
 					<PrismicRichText
-						v-if="isFilled.richText(slice.primary.description)"
+						v-if="$prismic.isFilled.richText(slice.primary.description)"
 						:field="slice.primary.description"
 						class="es-alternate-grid__primary-content__intro__description"
 						wrapper="div"
@@ -66,13 +59,13 @@ defineProps(
 						class="es-alternate-grid__item"
 					>
 						<PrismicRichText
-							v-if="isFilled.richText(item.title)"
+							v-if="$prismic.isFilled.richText(item.title)"
 							:field="item.title"
 							class="es-alternate-grid__item__heading"
 							wrapper="div"
 						/>
 						<PrismicRichText
-							v-if="isFilled.richText(item.description)"
+							v-if="$prismic.isFilled.richText(item.description)"
 							:field="item.description"
 							class="es-alternate-grid__item__description"
 							wrapper="div"

--- a/packages/adapter-nuxt/public/CallToAction/javascript.vue
+++ b/packages/adapter-nuxt/public/CallToAction/javascript.vue
@@ -1,9 +1,5 @@
 <script setup>
-import { isFilled } from "@prismicio/client";
-
-const props = defineProps(
-	getSliceComponentProps(["slice", "index", "slices", "context"]),
-);
+const props = defineProps(getSliceComponentProps());
 
 const alignment = computed(() => {
 	return props.slice.variation === "alignLeft" ? "left" : "center";
@@ -18,19 +14,19 @@ const alignment = computed(() => {
 	>
 		<div class="es-bounded__content es-call-to-action__content">
 			<PrismicImage
-				v-if="isFilled.image(slice.primary.image)"
+				v-if="$prismic.isFilled.image(slice.primary.image)"
 				:field="slice.primary.image"
 				class="es-call-to-action__image"
 			/>
 			<div class="es-call-to-action__content">
 				<div
-					v-if="isFilled.richText(slice.primary.title)"
+					v-if="$prismic.isFilled.richText(slice.primary.title)"
 					class="es-call-to-action__content__heading"
 				>
 					<PrismicRichText :field="slice.primary.title" />
 				</div>
 				<div
-					v-if="isFilled.richText(slice.primary.paragraph)"
+					v-if="$prismic.isFilled.richText(slice.primary.paragraph)"
 					class="es-call-to-action__content__paragraph"
 				>
 					<PrismicRichText :field="slice.primary.paragraph" />

--- a/packages/adapter-nuxt/public/CallToAction/typescript.vue
+++ b/packages/adapter-nuxt/public/CallToAction/typescript.vue
@@ -1,14 +1,7 @@
 <script setup lang="ts">
-import { type Content, isFilled } from "@prismicio/client";
+import type { Content } from "@prismicio/client";
 
-const props = defineProps(
-	getSliceComponentProps<Content.PascalNameToReplaceSlice>([
-		"slice",
-		"index",
-		"slices",
-		"context",
-	]),
-);
+const props = defineProps(getSliceComponentProps<Content.PascalNameToReplaceSlice>());
 
 const alignment = computed(() => {
 	return props.slice.variation === "alignLeft" ? "left" : "center";
@@ -23,19 +16,19 @@ const alignment = computed(() => {
 	>
 		<div class="es-bounded__content es-call-to-action__content">
 			<PrismicImage
-				v-if="isFilled.image(slice.primary.image)"
+				v-if="$prismic.isFilled.image(slice.primary.image)"
 				:field="slice.primary.image"
 				class="es-call-to-action__image"
 			/>
 			<div class="es-call-to-action__content">
 				<div
-					v-if="isFilled.richText(slice.primary.title)"
+					v-if="$prismic.isFilled.richText(slice.primary.title)"
 					class="es-call-to-action__content__heading"
 				>
 					<PrismicRichText :field="slice.primary.title" />
 				</div>
 				<div
-					v-if="isFilled.richText(slice.primary.paragraph)"
+					v-if="$prismic.isFilled.richText(slice.primary.paragraph)"
 					class="es-call-to-action__content__paragraph"
 				>
 					<PrismicRichText :field="slice.primary.paragraph" />

--- a/packages/adapter-nuxt/public/CallToAction/typescript.vue
+++ b/packages/adapter-nuxt/public/CallToAction/typescript.vue
@@ -1,7 +1,9 @@
 <script setup lang="ts">
 import type { Content } from "@prismicio/client";
 
-const props = defineProps(getSliceComponentProps<Content.PascalNameToReplaceSlice>());
+const props = defineProps(
+	getSliceComponentProps<Content.PascalNameToReplaceSlice>(),
+);
 
 const alignment = computed(() => {
 	return props.slice.variation === "alignLeft" ? "left" : "center";

--- a/packages/adapter-nuxt/public/CustomerLogos/javascript.vue
+++ b/packages/adapter-nuxt/public/CustomerLogos/javascript.vue
@@ -1,7 +1,5 @@
 <script setup>
-import { isFilled } from "@prismicio/client";
-
-defineProps(getSliceComponentProps(["slice", "index", "slices", "context"]));
+defineProps(getSliceComponentProps());
 </script>
 
 <template>
@@ -12,7 +10,7 @@ defineProps(getSliceComponentProps(["slice", "index", "slices", "context"]));
 	>
 		<div class="es-bounded__content es-customer-logos__content">
 			<div
-				v-if="isFilled.richText(slice.primary.eyebrowHeadline)"
+				v-if="$prismic.isFilled.richText(slice.primary.eyebrowHeadline)"
 				class="es-customer-logos__heading"
 			>
 				<PrismicRichText :field="slice.primary.eyebrowHeadline" />

--- a/packages/adapter-nuxt/public/CustomerLogos/typescript.vue
+++ b/packages/adapter-nuxt/public/CustomerLogos/typescript.vue
@@ -1,14 +1,7 @@
 <script setup lang="ts">
-import { type Content, isFilled } from "@prismicio/client";
+import type { Content } from "@prismicio/client";
 
-defineProps(
-	getSliceComponentProps<Content.PascalNameToReplaceSlice>([
-		"slice",
-		"index",
-		"slices",
-		"context",
-	]),
-);
+defineProps(getSliceComponentProps<Content.PascalNameToReplaceSlice>());
 </script>
 
 <template>
@@ -19,7 +12,7 @@ defineProps(
 	>
 		<div class="es-bounded__content es-customer-logos__content">
 			<div
-				v-if="isFilled.richText(slice.primary.eyebrowHeadline)"
+				v-if="$prismic.isFilled.richText(slice.primary.eyebrowHeadline)"
 				class="es-customer-logos__heading"
 			>
 				<PrismicRichText :field="slice.primary.eyebrowHeadline" />

--- a/packages/adapter-nuxt/public/Hero/javascript.vue
+++ b/packages/adapter-nuxt/public/Hero/javascript.vue
@@ -1,7 +1,5 @@
 <script setup>
-import { isFilled } from "@prismicio/client";
-
-defineProps(getSliceComponentProps(["slice", "index", "slices", "context"]));
+defineProps(getSliceComponentProps());
 </script>
 
 <template>
@@ -20,7 +18,7 @@ defineProps(getSliceComponentProps(["slice", "index", "slices", "context"]));
 		>
 			<div>
 				<PrismicImage
-					v-if="isFilled.image(slice.primary.image)"
+					v-if="$prismic.isFilled.image(slice.primary.image)"
 					:field="slice.primary.image"
 					class="es-fullpage-hero__image"
 				/>
@@ -28,19 +26,19 @@ defineProps(getSliceComponentProps(["slice", "index", "slices", "context"]));
 			<div class="es-fullpage-hero__content-right">
 				<div class="es-fullpage-hero__content__intro">
 					<p
-						v-if="isFilled.keyText(slice.primary.eyebrowHeadline)"
+						v-if="$prismic.isFilled.keyText(slice.primary.eyebrowHeadline)"
 						class="es-fullpage-hero__content__intro__eyebrow"
 					>
 						{{ slice.primary.eyebrowHeadline }}
 					</p>
 					<div
-						v-if="isFilled.richText(slice.primary.title)"
+						v-if="$prismic.isFilled.richText(slice.primary.title)"
 						class="es-fullpage-hero__content__intro__headline"
 					>
 						<PrismicRichText :field="slice.primary.title" />
 					</div>
 					<div
-						v-if="isFilled.richText(slice.primary.description)"
+						v-if="$prismic.isFilled.richText(slice.primary.description)"
 						class="es-fullpage-hero__content__intro__description"
 					>
 						<PrismicRichText :field="slice.primary.description" />

--- a/packages/adapter-nuxt/public/Hero/typescript.vue
+++ b/packages/adapter-nuxt/public/Hero/typescript.vue
@@ -1,14 +1,7 @@
 <script setup lang="ts">
-import { type Content, isFilled } from "@prismicio/client";
+import type { Content } from "@prismicio/client";
 
-defineProps(
-	getSliceComponentProps<Content.PascalNameToReplaceSlice>([
-		"slice",
-		"index",
-		"slices",
-		"context",
-	]),
-);
+defineProps(getSliceComponentProps<Content.PascalNameToReplaceSlice>());
 </script>
 
 <template>
@@ -27,7 +20,7 @@ defineProps(
 		>
 			<div>
 				<PrismicImage
-					v-if="isFilled.image(slice.primary.image)"
+					v-if="$prismic.isFilled.image(slice.primary.image)"
 					:field="slice.primary.image"
 					class="es-fullpage-hero__image"
 				/>
@@ -35,19 +28,19 @@ defineProps(
 			<div class="es-fullpage-hero__content-right">
 				<div class="es-fullpage-hero__content__intro">
 					<p
-						v-if="isFilled.keyText(slice.primary.eyebrowHeadline)"
+						v-if="$prismic.isFilled.keyText(slice.primary.eyebrowHeadline)"
 						class="es-fullpage-hero__content__intro__eyebrow"
 					>
 						{{ slice.primary.eyebrowHeadline }}
 					</p>
 					<div
-						v-if="isFilled.richText(slice.primary.title)"
+						v-if="$prismic.isFilled.richText(slice.primary.title)"
 						class="es-fullpage-hero__content__intro__headline"
 					>
 						<PrismicRichText :field="slice.primary.title" />
 					</div>
 					<div
-						v-if="isFilled.richText(slice.primary.description)"
+						v-if="$prismic.isFilled.richText(slice.primary.description)"
 						class="es-fullpage-hero__content__intro__description"
 					>
 						<PrismicRichText :field="slice.primary.description" />

--- a/packages/adapter-nuxt/src/hooks/documentation-read.ts
+++ b/packages/adapter-nuxt/src/hooks/documentation-read.ts
@@ -27,14 +27,15 @@ export const documentationRead: DocumentationReadHook<PluginOptions> = async (
 		if (model.repeatable) {
 			fileContent = stripIndent`
 				<script ${scriptAttributes.join(" ")}>
+				import { asImageSrc } from "@prismicio/client";
 				import { components } from "~/slices";
 
-				const prismic = usePrismic();
 				const route = useRoute();
+				const { client } = usePrismic();
 				const { data: page } = await useAsyncData(\`[${
 					model.id
 				}-uid-\${route.params.uid}]\`, () =>
-					prismic.client.getByUID("${model.id}", route.params.uid${
+					client.getByUID("${model.id}", route.params.uid${
 						isTypeScriptProject ? " as string" : ""
 					})
 				);
@@ -44,26 +45,25 @@ export const documentationRead: DocumentationReadHook<PluginOptions> = async (
 					ogTitle: page.value?.data.meta_title,
 					description: page.value?.data.meta_description,
 					ogDescription: page.value?.data.meta_description,
-					ogImage: computed(() => prismic.asImageSrc(page.value?.data.meta_image)),
+					ogImage: computed(() => asImageSrc(page.value?.data.meta_image)),
 				});
 				</script>
 
 				<template>
-					<SliceZone
-						wrapper="main"
-						:slices="page?.data.slices ?? []"
-						:components="components"
-					/>
+					<main>
+						<SliceZone :slices="page?.data.slices ?? []" :components="components" />
+					</main>
 				</template>
 			`;
 		} else {
 			fileContent = stripIndent`
 				<script ${scriptAttributes.join(" ")}>
+				import { asImageSrc } from "@prismicio/client";
 				import { components } from "~/slices";
 
-				const prismic = usePrismic();
+				const { client } = usePrismic();
 				const { data: page } = await useAsyncData("[${model.id}]", () =>
-					prismic.client.getSingle("${model.id}")
+					client.getSingle("${model.id}")
 				);
 
 				useSeoMeta({
@@ -71,16 +71,14 @@ export const documentationRead: DocumentationReadHook<PluginOptions> = async (
 					ogTitle: page.value?.data.meta_title,
 					description: page.value?.data.meta_description,
 					ogDescription: page.value?.data.meta_description,
-					ogImage: computed(() => prismic.asImageSrc(page.value?.data.meta_image)),
+					ogImage: computed(() => asImageSrc(page.value?.data.meta_image)),
 				});
 				</script>
 
 				<template>
-					<SliceZone
-						wrapper="main"
-						:slices="page?.data.slices ?? []"
-						:components="components"
-					/>
+					<main>
+						<SliceZone :slices="page?.data.slices ?? []" :components="components" />
+					</main>
 				</template>
 			`;
 		}

--- a/packages/adapter-nuxt/src/hooks/slice-create.ts
+++ b/packages/adapter-nuxt/src/hooks/slice-create.ts
@@ -51,11 +51,7 @@ const createComponentFile = async ({
 			<script setup lang="ts">
 			import type { Content } from "@prismicio/client";
 
-			// The array passed to \`getSliceComponentProps\` is purely optional.
-			// Consider it as a visual hint for you when templating your slice.
-			defineProps(getSliceComponentProps<Content.${pascalName}Slice>(
-				["slice", "index", "slices", "context"]
-			));
+			defineProps(getSliceComponentProps<Content.${pascalName}Slice>());
 			</script>
 
 			<template>
@@ -71,9 +67,7 @@ const createComponentFile = async ({
 	} else {
 		contents = stripIndent`
 			<script setup>
-			// The array passed to \`getSliceComponentProps\` is purely optional.
-			// Consider it as a visual hint for you when templating your slice.
-			defineProps(getSliceComponentProps(["slice", "index", "slices", "context"]));
+			defineProps(getSliceComponentProps());
 			</script>
 
 			<template>

--- a/packages/adapter-nuxt/src/hooks/snippet-read.ts
+++ b/packages/adapter-nuxt/src/hooks/snippet-read.ts
@@ -131,7 +131,7 @@ export const snippetRead: SnippetReadHook<PluginOptions> = async (
 				language: "vue",
 				code: await format(
 					stripIndent`
-							<PrismicEmbed :field="${dotPath(fieldPath)}" />
+							<div v-html="${dotPath(fieldPath)}?.html" />
 						`,
 					helpers,
 				),

--- a/packages/adapter-nuxt/test/plugin-snippet-read.test.ts
+++ b/packages/adapter-nuxt/test/plugin-snippet-read.test.ts
@@ -90,7 +90,7 @@ testSnippet(
 
 testSnippet("date", `{{${model.id}.data.date}}`);
 
-testSnippet("embed", `<PrismicEmbed :field="${model.id}.data.embed" />`);
+testSnippet("embed", `<div v-html="${model.id}.data.embed?.html" />`);
 
 testSnippet("geoPoint", `{{${model.id}.data.geoPoint}}`);
 


### PR DESCRIPTION
<!-- Please use a Conventional Commit in your PR title -->
<!-- https://conventionalcommits.org -->
<!-- e.g. "feat: support new field type" -->

Resolves: <!-- GitHub or Linear issue (e.g. #123, DT-123) -->

> [!important]
> Those changes **are** backward compatible. This PR can be merged and released whenever ready. It **should** be released before we release updated SDK.

### Description

We've been working on the next major of Vue and Nuxt SDKs and are getting ready to releasing them:
- `@prismicio/vue` https://github.com/prismicio/prismic-vue/pull/89
- `@nuxtjs/prismic` https://github.com/nuxt-modules/prismic/pull/235
- Docs: https://github.com/prismicio/prismic-docs-v4/pull/3816

This PR updates the Nuxt adapters to adapt to breaking changes coming with the next versions, especially:
- Helpers (except `isFilled`) aren't provided by `usePrismic()` anymore
- `<PrismicEmbed>` was removed
- `wrapper` props aren't supported anymore.

*Question: Should this be ported to https://github.com/prismicio/devtools/tree/main/packages/adapter-nuxt also?*

### Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- Don't hesitate to ask for help! -->

- [x] If my changes require tests, I added them.
- [x] If my changes affect backward compatibility, it has been discussed.
- [x] If my changes require an update to the CONTRIBUTING.md guide, I updated it.

### Preview

<!-- If your changes are visual, screenshots or videos are welcome! -->

### How to QA [^1]

<!-- When relevant, describe how to QA your changes. -->

<!-- Your favorite emoji is welcome to close your PR! -->

<!-- A note for reviewers: -->

[^1]:
	Please use these labels when submitting a review:
	:question: #ask:&ensp;Ask a question.
	:bulb: #idea:&ensp;Suggest an idea.
	:warning: #issue:&ensp;Strongly suggest a change.
	:tada: #nice:&ensp;Share a compliment.
