### PR TITLE
fix: add missing /builder prefix

### DIFF
--- a/packages/slice-machine/src/features/customTypes/customTypesBuilder/ImportSlicesFromLibraryModal/LibrarySlicesDialogContent.tsx
+++ b/packages/slice-machine/src/features/customTypes/customTypesBuilder/ImportSlicesFromLibraryModal/LibrarySlicesDialogContent.tsx
@@ -226,7 +226,7 @@ function LibrarySlicesDialogSuspenseContent(
   };
 
   const configureUrl = new URL(
-    "settings/git-integration",
+    "builder/settings/git-integration",
     prismicRepositoryInformation.repositoryUrl,
   ).toString();
 


### PR DESCRIPTION
### Description

The link to connect/configure the integrations is missing a /builder prefix to open the new Page Builder settings.

### How to QA [^1]

<!-- When relevant, describe how to QA your changes. -->

<!-- Your favorite emoji is welcome to close your PR! -->

<!-- A note for reviewers: -->

[^1]:
	Please use these labels when submitting a review:
	:question: #ask:&ensp;Ask a question.
	:bulb: #idea:&ensp;Suggest an idea.
	:warning: #issue:&ensp;Strongly suggest a change.
	:tada: #nice:&ensp;Share a compliment.
