### PR TITLE
feat(adapter-next): use `<PrismicNextRichText>` in code snippets

### DIFF
--- a/packages/adapter-next/public/AlternateGrid/javascript.jsx
+++ b/packages/adapter-next/public/AlternateGrid/javascript.jsx
@@ -1,6 +1,5 @@
 import { isFilled } from "@prismicio/client";
-import { PrismicNextImage } from "@prismicio/next";
-import { PrismicRichText } from "@prismicio/react";
+import { PrismicNextImage, PrismicNextRichText } from "@prismicio/next";
 
 /**
  * @typedef {import("@prismicio/client").Content.PascalNameToReplaceSlice} PascalNameToReplaceSlice
@@ -48,12 +47,12 @@ const PascalNameToReplace = ({ slice }) => {
 						)}
 						{isFilled.richText(slice.primary.title) && (
 							<div className="es-alternate-grid__primary-content__intro__headline">
-								<PrismicRichText field={slice.primary.title} />
+								<PrismicNextRichText field={slice.primary.title} />
 							</div>
 						)}
 						{isFilled.richText(slice.primary.description) && (
 							<div className="es-alternate-grid__primary-content__intro__description">
-								<PrismicRichText field={slice.primary.description} />
+								<PrismicNextRichText field={slice.primary.description} />
 							</div>
 						)}
 					</div>
@@ -63,12 +62,12 @@ const PascalNameToReplace = ({ slice }) => {
 								<div key={`item-${i + 1}`} className="es-alternate-grid__item">
 									{isFilled.richText(item.title) && (
 										<div className="es-alternate-grid__item__heading">
-											<PrismicRichText field={item.title} />
+											<PrismicNextRichText field={item.title} />
 										</div>
 									)}
 									{isFilled.richText(item.description) && (
 										<div className="es-alternate-grid__item__description">
-											<PrismicRichText field={item.description} />
+											<PrismicNextRichText field={item.description} />
 										</div>
 									)}
 								</div>

--- a/packages/adapter-next/public/AlternateGrid/typescript.tsx
+++ b/packages/adapter-next/public/AlternateGrid/typescript.tsx
@@ -1,7 +1,7 @@
 import { FC } from "react";
 import { Content, isFilled } from "@prismicio/client";
-import { SliceComponentProps, PrismicRichText } from "@prismicio/react";
-import { PrismicNextImage } from "@prismicio/next";
+import { SliceComponentProps } from "@prismicio/react";
+import { PrismicNextImage, PrismicNextRichText } from "@prismicio/next";
 
 export type PascalNameToReplaceProps =
 	SliceComponentProps<Content.PascalNameToReplaceSlice>;
@@ -45,12 +45,12 @@ const PascalNameToReplace: FC<PascalNameToReplaceProps> = ({ slice }) => {
 						)}
 						{isFilled.richText(slice.primary.title) && (
 							<div className="es-alternate-grid__primary-content__intro__headline">
-								<PrismicRichText field={slice.primary.title} />
+								<PrismicNextRichText field={slice.primary.title} />
 							</div>
 						)}
 						{isFilled.richText(slice.primary.description) && (
 							<div className="es-alternate-grid__primary-content__intro__description">
-								<PrismicRichText field={slice.primary.description} />
+								<PrismicNextRichText field={slice.primary.description} />
 							</div>
 						)}
 					</div>
@@ -60,12 +60,12 @@ const PascalNameToReplace: FC<PascalNameToReplaceProps> = ({ slice }) => {
 								<div key={`item-${i + 1}`} className="es-alternate-grid__item">
 									{isFilled.richText(item.title) && (
 										<div className="es-alternate-grid__item__heading">
-											<PrismicRichText field={item.title} />
+											<PrismicNextRichText field={item.title} />
 										</div>
 									)}
 									{isFilled.richText(item.description) && (
 										<div className="es-alternate-grid__item__description">
-											<PrismicRichText field={item.description} />
+											<PrismicNextRichText field={item.description} />
 										</div>
 									)}
 								</div>

--- a/packages/adapter-next/public/CallToAction/javascript.jsx
+++ b/packages/adapter-next/public/CallToAction/javascript.jsx
@@ -1,6 +1,5 @@
 import { isFilled } from "@prismicio/client";
-import { PrismicNextLink, PrismicNextImage } from "@prismicio/next";
-import { PrismicRichText } from "@prismicio/react";
+import { PrismicNextLink, PrismicNextImage, PrismicNextRichText } from "@prismicio/next";
 
 /**
  * @typedef {import("@prismicio/client").Content.PascalNameToReplaceSlice} PascalNameToReplaceSlice
@@ -28,12 +27,12 @@ const PascalNameToReplace = ({ slice }) => {
 				<div className="es-call-to-action__content">
 					{isFilled.richText(slice.primary.title) && (
 						<div className="es-call-to-action__content__heading">
-							<PrismicRichText field={slice.primary.title} />
+							<PrismicNextRichText field={slice.primary.title} />
 						</div>
 					)}
 					{isFilled.richText(slice.primary.paragraph) && (
 						<div className="es-call-to-action__content__paragraph">
-							<PrismicRichText field={slice.primary.paragraph} />
+							<PrismicNextRichText field={slice.primary.paragraph} />
 						</div>
 					)}
 				</div>

--- a/packages/adapter-next/public/CallToAction/javascript.jsx
+++ b/packages/adapter-next/public/CallToAction/javascript.jsx
@@ -1,5 +1,9 @@
 import { isFilled } from "@prismicio/client";
-import { PrismicNextLink, PrismicNextImage, PrismicNextRichText } from "@prismicio/next";
+import {
+	PrismicNextLink,
+	PrismicNextImage,
+	PrismicNextRichText,
+} from "@prismicio/next";
 
 /**
  * @typedef {import("@prismicio/client").Content.PascalNameToReplaceSlice} PascalNameToReplaceSlice

--- a/packages/adapter-next/public/CallToAction/typescript.tsx
+++ b/packages/adapter-next/public/CallToAction/typescript.tsx
@@ -1,7 +1,11 @@
 import { FC } from "react";
 import { Content, isFilled } from "@prismicio/client";
 import { SliceComponentProps } from "@prismicio/react";
-import { PrismicNextLink, PrismicNextImage, PrismicNextRichText } from "@prismicio/next";
+import {
+	PrismicNextLink,
+	PrismicNextImage,
+	PrismicNextRichText,
+} from "@prismicio/next";
 
 export type PascalNameToReplaceProps =
 	SliceComponentProps<Content.PascalNameToReplaceSlice>;

--- a/packages/adapter-next/public/CallToAction/typescript.tsx
+++ b/packages/adapter-next/public/CallToAction/typescript.tsx
@@ -1,7 +1,7 @@
 import { FC } from "react";
 import { Content, isFilled } from "@prismicio/client";
-import { SliceComponentProps, PrismicRichText } from "@prismicio/react";
-import { PrismicNextLink, PrismicNextImage } from "@prismicio/next";
+import { SliceComponentProps } from "@prismicio/react";
+import { PrismicNextLink, PrismicNextImage, PrismicNextRichText } from "@prismicio/next";
 
 export type PascalNameToReplaceProps =
 	SliceComponentProps<Content.PascalNameToReplaceSlice>;
@@ -25,12 +25,12 @@ const PascalNameToReplace: FC<PascalNameToReplaceProps> = ({ slice }) => {
 				<div className="es-call-to-action__content">
 					{isFilled.richText(slice.primary.title) && (
 						<div className="es-call-to-action__content__heading">
-							<PrismicRichText field={slice.primary.title} />
+							<PrismicNextRichText field={slice.primary.title} />
 						</div>
 					)}
 					{isFilled.richText(slice.primary.paragraph) && (
 						<div className="es-call-to-action__content__paragraph">
-							<PrismicRichText field={slice.primary.paragraph} />
+							<PrismicNextRichText field={slice.primary.paragraph} />
 						</div>
 					)}
 				</div>

--- a/packages/adapter-next/public/CustomerLogos/javascript.jsx
+++ b/packages/adapter-next/public/CustomerLogos/javascript.jsx
@@ -1,6 +1,5 @@
 import { isFilled } from "@prismicio/client";
-import { PrismicRichText } from "@prismicio/react";
-import { PrismicNextLink, PrismicNextImage } from "@prismicio/next";
+import { PrismicNextLink, PrismicNextImage, PrismicNextRichText } from "@prismicio/next";
 
 /**
  * @typedef {import("@prismicio/client").Content.PascalNameToReplaceSlice} PascalNameToReplaceSlice
@@ -19,7 +18,7 @@ const PascalNameToReplace = ({ slice }) => {
 			<div className="es-bounded__content es-customer-logos__content">
 				{isFilled.richText(slice.primary.eyebrowHeadline) && (
 					<div className="es-customer-logos__heading">
-						<PrismicRichText field={slice.primary.eyebrowHeadline} />
+						<PrismicNextRichText field={slice.primary.eyebrowHeadline} />
 					</div>
 				)}
 				{slice.primary.logos.length > 0 && (

--- a/packages/adapter-next/public/CustomerLogos/javascript.jsx
+++ b/packages/adapter-next/public/CustomerLogos/javascript.jsx
@@ -1,5 +1,9 @@
 import { isFilled } from "@prismicio/client";
-import { PrismicNextLink, PrismicNextImage, PrismicNextRichText } from "@prismicio/next";
+import {
+	PrismicNextLink,
+	PrismicNextImage,
+	PrismicNextRichText,
+} from "@prismicio/next";
 
 /**
  * @typedef {import("@prismicio/client").Content.PascalNameToReplaceSlice} PascalNameToReplaceSlice

--- a/packages/adapter-next/public/CustomerLogos/typescript.tsx
+++ b/packages/adapter-next/public/CustomerLogos/typescript.tsx
@@ -1,7 +1,11 @@
 import { FC } from "react";
 import { Content, isFilled } from "@prismicio/client";
 import { SliceComponentProps } from "@prismicio/react";
-import { PrismicNextLink, PrismicNextImage, PrismicNextRichText } from "@prismicio/next";
+import {
+	PrismicNextLink,
+	PrismicNextImage,
+	PrismicNextRichText,
+} from "@prismicio/next";
 
 export type PascalNameToReplaceProps =
 	SliceComponentProps<Content.PascalNameToReplaceSlice>;

--- a/packages/adapter-next/public/CustomerLogos/typescript.tsx
+++ b/packages/adapter-next/public/CustomerLogos/typescript.tsx
@@ -1,7 +1,7 @@
 import { FC } from "react";
 import { Content, isFilled } from "@prismicio/client";
-import { SliceComponentProps, PrismicRichText } from "@prismicio/react";
-import { PrismicNextLink, PrismicNextImage } from "@prismicio/next";
+import { SliceComponentProps } from "@prismicio/react";
+import { PrismicNextLink, PrismicNextImage, PrismicNextRichText } from "@prismicio/next";
 
 export type PascalNameToReplaceProps =
 	SliceComponentProps<Content.PascalNameToReplaceSlice>;
@@ -16,7 +16,7 @@ const PascalNameToReplace: FC<PascalNameToReplaceProps> = ({ slice }) => {
 			<div className="es-bounded__content es-customer-logos__content">
 				{isFilled.richText(slice.primary.eyebrowHeadline) && (
 					<div className="es-customer-logos__heading">
-						<PrismicRichText field={slice.primary.eyebrowHeadline} />
+						<PrismicNextRichText field={slice.primary.eyebrowHeadline} />
 					</div>
 				)}
 				{slice.primary.logos.length > 0 && (

--- a/packages/adapter-next/public/Hero/javascript.jsx
+++ b/packages/adapter-next/public/Hero/javascript.jsx
@@ -1,5 +1,9 @@
 import { isFilled } from "@prismicio/client";
-import { PrismicNextLink, PrismicNextImage, PrismicNextRichText } from "@prismicio/next";
+import {
+	PrismicNextLink,
+	PrismicNextImage,
+	PrismicNextRichText,
+} from "@prismicio/next";
 
 /**
  * @typedef {import("@prismicio/client").Content.PascalNameToReplaceSlice} PascalNameToReplaceSlice

--- a/packages/adapter-next/public/Hero/javascript.jsx
+++ b/packages/adapter-next/public/Hero/javascript.jsx
@@ -1,6 +1,5 @@
 import { isFilled } from "@prismicio/client";
-import { PrismicNextLink, PrismicNextImage } from "@prismicio/next";
-import { PrismicRichText } from "@prismicio/react";
+import { PrismicNextLink, PrismicNextImage, PrismicNextRichText } from "@prismicio/next";
 
 /**
  * @typedef {import("@prismicio/client").Content.PascalNameToReplaceSlice} PascalNameToReplaceSlice
@@ -44,12 +43,12 @@ const PascalNameToReplace = ({ slice }) => {
 						)}
 						{isFilled.richText(slice.primary.title) && (
 							<div className="es-fullpage-hero__content__intro__headline">
-								<PrismicRichText field={slice.primary.title} />
+								<PrismicNextRichText field={slice.primary.title} />
 							</div>
 						)}
 						{isFilled.richText(slice.primary.description) && (
 							<div className="es-fullpage-hero__content__intro__description">
-								<PrismicRichText field={slice.primary.description} />
+								<PrismicNextRichText field={slice.primary.description} />
 							</div>
 						)}
 						<PrismicNextLink

--- a/packages/adapter-next/public/Hero/typescript.tsx
+++ b/packages/adapter-next/public/Hero/typescript.tsx
@@ -1,7 +1,11 @@
 import { FC } from "react";
 import { Content, isFilled } from "@prismicio/client";
 import { SliceComponentProps } from "@prismicio/react";
-import { PrismicNextLink, PrismicNextImage, PrismicNextRichText } from "@prismicio/next";
+import {
+	PrismicNextLink,
+	PrismicNextImage,
+	PrismicNextRichText,
+} from "@prismicio/next";
 
 export type PascalNameToReplaceProps =
 	SliceComponentProps<Content.PascalNameToReplaceSlice>;

--- a/packages/adapter-next/public/Hero/typescript.tsx
+++ b/packages/adapter-next/public/Hero/typescript.tsx
@@ -1,7 +1,7 @@
 import { FC } from "react";
 import { Content, isFilled } from "@prismicio/client";
-import { SliceComponentProps, PrismicRichText } from "@prismicio/react";
-import { PrismicNextLink, PrismicNextImage } from "@prismicio/next";
+import { SliceComponentProps } from "@prismicio/react";
+import { PrismicNextLink, PrismicNextImage, PrismicNextRichText } from "@prismicio/next";
 
 export type PascalNameToReplaceProps =
 	SliceComponentProps<Content.PascalNameToReplaceSlice>;
@@ -41,12 +41,12 @@ const PascalNameToReplace: FC<PascalNameToReplaceProps> = ({ slice }) => {
 						)}
 						{isFilled.richText(slice.primary.title) && (
 							<div className="es-fullpage-hero__content__intro__headline">
-								<PrismicRichText field={slice.primary.title} />
+								<PrismicNextRichText field={slice.primary.title} />
 							</div>
 						)}
 						{isFilled.richText(slice.primary.description) && (
 							<div className="es-fullpage-hero__content__intro__description">
-								<PrismicRichText field={slice.primary.description} />
+								<PrismicNextRichText field={slice.primary.description} />
 							</div>
 						)}
 						<PrismicNextLink

--- a/packages/adapter-next/src/hooks/snippet-read.ts
+++ b/packages/adapter-next/src/hooks/snippet-read.ts
@@ -40,7 +40,7 @@ export const snippetRead: SnippetReadHook<PluginOptions> = async (
 					language: "tsx",
 					code: await format(
 						stripIndent`
-							<PrismicRichText field={${dotPath(fieldPath)}} />
+							<PrismicNextRichText field={${dotPath(fieldPath)}} />
 						`,
 						helpers,
 					),

--- a/packages/adapter-next/test/plugin-snippet-read.test.ts
+++ b/packages/adapter-next/test/plugin-snippet-read.test.ts
@@ -145,7 +145,7 @@ testSnippet("richText", [
 	{
 		label: "React (components)",
 		language: "tsx",
-		code: `<PrismicRichText field={${model.id}.data.richText} />`,
+		code: `<PrismicNextRichText field={${model.id}.data.richText} />`,
 	},
 	{
 		label: "React (plain text)",
@@ -169,7 +169,7 @@ testSnippet("title", [
 	{
 		label: "React (components)",
 		language: "tsx",
-		code: `<PrismicRichText field={${model.id}.data.title} />`,
+		code: `<PrismicNextRichText field={${model.id}.data.title} />`,
 	},
 	{
 		label: "React (plain text)",


### PR DESCRIPTION
<!-- Please use a Conventional Commit in your PR title -->
<!-- https://conventionalcommits.org -->
<!-- e.g. "feat: support new field type" -->

Resolves: https://prismic-team.slack.com/archives/C014VAACCQL/p1767998588688969

### Description

Use `PrismicNextRichText` from `@prismicio/next` instead of `PrismicRichText` from `@prismicio/react` in code snippets and slice templates.

### Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- Don't hesitate to ask for help! -->

- [ ] A comprehensive Linear ticket, providing sufficient context and details to facilitate the review of the PR, is linked to the PR.
- [ ] If my changes require tests, I added them.
- [ ] If my changes affect backward compatibility, it has been discussed.
- [ ] If my changes require an update to the CONTRIBUTING.md guide, I updated it.

### Preview

<!-- If your changes are visual, screenshots or videos are welcome! -->

<img width="485" height="203" alt="image" src="https://github.com/user-attachments/assets/8a87f1e2-8b53-4bfe-a579-b4049024210c" />

### How to QA [^1]

<!-- When relevant, describe how to QA your changes. -->

<!-- Your favorite emoji is welcome to close your PR! -->

<!-- A note for reviewers: -->

[^1]:
	Please use these labels when submitting a review:
	:question: #ask:&ensp;Ask a question.
	:bulb: #idea:&ensp;Suggest an idea.
	:warning: #issue:&ensp;Strongly suggest a change.
	:tada: #nice:&ensp;Share a compliment.