### PR TITLE
feat: import updated `<SliceSimulator>` on new projects

### DIFF
--- a/packages/adapter-next/src/hooks/project-init.ts
+++ b/packages/adapter-next/src/hooks/project-init.ts
@@ -279,7 +279,7 @@ const createSliceSimulatorPage = async ({
 					SliceSimulator,
 					SliceSimulatorParams,
 					getSlices,
-				} from "@slicemachine/adapter-next/simulator";
+				} from "@prismicio/next";
 				import { SliceZone } from "@prismicio/react";
 
 				import { components } from "../../slices";
@@ -299,10 +299,7 @@ const createSliceSimulatorPage = async ({
 			`;
 		} else {
 			contents = source`
-				import {
-					SliceSimulator,
-					getSlices,
-				} from "@slicemachine/adapter-next/simulator";
+				import { SliceSimulator, getSlices } from "@prismicio/next";
 				import { SliceZone } from "@prismicio/react";
 
 				import { components } from "../../slices";
@@ -321,7 +318,7 @@ const createSliceSimulatorPage = async ({
 		}
 	} else {
 		contents = source`
-			import { SliceSimulator } from "@slicemachine/adapter-next/simulator";
+			import { SliceSimulator } from "@prismicio/next/pages";
 			import { SliceZone } from "@prismicio/react";
 
 			import { components } from "../slices";

--- a/packages/adapter-next/test/plugin-project-init.test.ts
+++ b/packages/adapter-next/test/plugin-project-init.test.ts
@@ -835,10 +835,7 @@ describe("Slice Simulator route", () => {
 			);
 
 			expect(contents).toMatchInlineSnapshot(`
-				"import {
-				  SliceSimulator,
-				  getSlices,
-				} from \\"@slicemachine/adapter-next/simulator\\";
+				"import { SliceSimulator, getSlices } from \\"@prismicio/next\\";
 				import { SliceZone } from \\"@prismicio/react\\";
 
 				import { components } from \\"../../slices\\";
@@ -901,10 +898,7 @@ describe("Slice Simulator route", () => {
 			);
 
 			expect(contents).toMatchInlineSnapshot(`
-				"import {
-				  SliceSimulator,
-				  getSlices,
-				} from \\"@slicemachine/adapter-next/simulator\\";
+				"import { SliceSimulator, getSlices } from \\"@prismicio/next\\";
 				import { SliceZone } from \\"@prismicio/react\\";
 
 				import { components } from \\"../../slices\\";
@@ -1002,7 +996,7 @@ describe("Slice Simulator route", () => {
 				  SliceSimulator,
 				  SliceSimulatorParams,
 				  getSlices,
-				} from \\"@slicemachine/adapter-next/simulator\\";
+				} from \\"@prismicio/next\\";
 				import { SliceZone } from \\"@prismicio/react\\";
 
 				import { components } from \\"../../slices\\";
@@ -1040,7 +1034,7 @@ describe("Slice Simulator route", () => {
 			);
 
 			expect(contents).toMatchInlineSnapshot(`
-				"import { SliceSimulator } from \\"@slicemachine/adapter-next/simulator\\";
+				"import { SliceSimulator } from \\"@prismicio/next/pages\\";
 				import { SliceZone } from \\"@prismicio/react\\";
 
 				import { components } from \\"../slices\\";
@@ -1097,7 +1091,7 @@ describe("Slice Simulator route", () => {
 			);
 
 			expect(contents).toMatchInlineSnapshot(`
-				"import { SliceSimulator } from \\"@slicemachine/adapter-next/simulator\\";
+				"import { SliceSimulator } from \\"@prismicio/next/pages\\";
 				import { SliceZone } from \\"@prismicio/react\\";
 
 				import { components } from \\"../slices\\";
@@ -1188,7 +1182,7 @@ describe("Slice Simulator route", () => {
 			);
 
 			expect(contents).toMatchInlineSnapshot(`
-				"import { SliceSimulator } from \\"@slicemachine/adapter-next/simulator\\";
+				"import { SliceSimulator } from \\"@prismicio/next/pages\\";
 				import { SliceZone } from \\"@prismicio/react\\";
 
 				import { components } from \\"../slices\\";

--- a/packages/adapter-nuxt/src/hooks/project-init.ts
+++ b/packages/adapter-nuxt/src/hooks/project-init.ts
@@ -156,16 +156,15 @@ const createSliceSimulatorPage = async ({
 	}
 
 	const contents = stripIndent`
+		<script ${scriptAttributes.join(" ")}>
+		import { components } from "~/slices";
+		</script>
+
 		<template>
 			<SliceSimulator #default="{ slices }">
 				<SliceZone :slices="slices" :components="components" />
 			</SliceSimulator>
 		</template>
-
-		<script ${scriptAttributes.join(" ")}>
-		import { SliceSimulator } from "@slicemachine/adapter-nuxt/simulator";
-		import { components } from "~/slices";
-		</script>
 	`;
 
 	await writeProjectFile({

--- a/packages/adapter-nuxt/test/plugin-project-init.test.ts
+++ b/packages/adapter-nuxt/test/plugin-project-init.test.ts
@@ -130,16 +130,15 @@ describe.each(["./app", "./src", "./"])(
 				"utf8",
 			);
 
-			expect(contents).toBe(`<template>
+			expect(contents).toBe(`<script setup>
+import { components } from "~/slices";
+</script>
+
+<template>
   <SliceSimulator #default="{ slices }">
     <SliceZone :slices="slices" :components="components" />
   </SliceSimulator>
 </template>
-
-<script setup>
-import { SliceSimulator } from "@slicemachine/adapter-nuxt/simulator";
-import { components } from "~/slices";
-</script>
 `);
 		});
 
@@ -167,16 +166,15 @@ import { components } from "~/slices";
 				"utf8",
 			);
 
-			expect(contents).toBe(`<template>
+			expect(contents).toBe(`<script setup lang="ts">
+import { components } from "~/slices";
+</script>
+
+<template>
   <SliceSimulator #default="{ slices }">
     <SliceZone :slices="slices" :components="components" />
   </SliceSimulator>
 </template>
-
-<script setup lang="ts">
-import { SliceSimulator } from "@slicemachine/adapter-nuxt/simulator";
-import { components } from "~/slices";
-</script>
 `);
 		});
 
@@ -233,16 +231,15 @@ import { components } from "~/slices";
 						"utf8",
 					);
 
-					expect(contents).toBe(`<template>
+					expect(contents).toBe(`<script setup>
+import { components } from "~/slices";
+</script>
+
+<template>
   <SliceSimulator #default="{ slices }">
     <SliceZone :slices="slices" :components="components" />
   </SliceSimulator>
 </template>
-
-<script setup>
-import { SliceSimulator } from "@slicemachine/adapter-nuxt/simulator";
-import { components } from "~/slices";
-</script>
 `);
 				});
 			},

--- a/packages/adapter-sveltekit/src/hooks/project-init.templates.ts
+++ b/packages/adapter-sveltekit/src/hooks/project-init.templates.ts
@@ -97,8 +97,7 @@ export function sliceSimulatorPageTemplate(args: { version: number }): string {
 
 	const v5 = svelte`
 		<script>
-			import { SliceSimulator } from '@slicemachine/adapter-sveltekit/simulator';
-			import { SliceZone } from '@prismicio/svelte';
+			import { SliceSimulator, SliceZone } from '@prismicio/svelte';
 			import { components } from '$lib/slices';
 		</script>
 
@@ -110,8 +109,7 @@ export function sliceSimulatorPageTemplate(args: { version: number }): string {
 
 	const v4 = svelte`
 		<script>
-			import { SliceSimulator } from '@slicemachine/adapter-sveltekit/simulator';
-			import { SliceZone } from '@prismicio/svelte';
+			import { SliceSimulator, SliceZone } from '@prismicio/svelte';
 			import { components } from '$lib/slices';
 		</script>
 

--- a/packages/adapter-sveltekit/test/plugin-project-init.test.ts
+++ b/packages/adapter-sveltekit/test/plugin-project-init.test.ts
@@ -814,8 +814,7 @@ describe("Slice Simulator route", () => {
 
 		expect(contents).toMatchInlineSnapshot(`
 			"<script>
-			  import { SliceSimulator } from \\"@slicemachine/adapter-sveltekit/simulator\\";
-			  import { SliceZone } from \\"@prismicio/svelte\\";
+			  import { SliceSimulator, SliceZone } from \\"@prismicio/svelte\\";
 			  import { components } from \\"$lib/slices\\";
 			</script>
 
@@ -948,8 +947,7 @@ describe("Slice Simulator route", () => {
 
 			expect(contents).toMatchInlineSnapshot(`
 				"<script>
-				  import { SliceSimulator } from \\"@slicemachine/adapter-sveltekit/simulator\\";
-				  import { SliceZone } from \\"@prismicio/svelte\\";
+				  import { SliceSimulator, SliceZone } from \\"@prismicio/svelte\\";
 				  import { components } from \\"$lib/slices\\";
 				</script>
 


### PR DESCRIPTION
<!-- Please use a Conventional Commit in your PR title -->
<!-- https://conventionalcommits.org -->
<!-- e.g. "feat: support new field type" -->

Resolves: <!-- GitHub or Linear issue (e.g. #123, DT-123) -->

### Description

This PR updates the Slice Simulator page templates generated during project initialization to import the `<SliceSimulator>` component from its new location in the main SDK packages instead of the adapter's `/simulator` subpath.

**Changes by adapter:**

- **Next.js (`adapter-next`):**
  - App Router: Imports from `@prismicio/next` instead of `@slicemachine/adapter-next/simulator`
  - Pages Router: Imports from `@prismicio/next/pages` instead of `@slicemachine/adapter-next/simulator`

- **Nuxt (`adapter-nuxt`):**
  - Removed the explicit `SliceSimulator` import (now auto-imported by the Nuxt module)
  - Reordered Vue SFC to place `<script>` before `<template>` (follows Vue style guide recommendation)

- **SvelteKit (`adapter-sveltekit`):**
  - Combined `SliceSimulator` and `SliceZone` imports from `@prismicio/svelte` instead of importing `SliceSimulator` from `@slicemachine/adapter-sveltekit/simulator`

### Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- Don't hesitate to ask for help! -->

- [x] If my changes require tests, I added them.
- [x] If my changes affect backward compatibility, it has been discussed.
- [x] If my changes require an update to the CONTRIBUTING.md guide, I updated it.

### Preview

N/A — This change affects generated code during project initialization, not visual components.

### How to QA [^1]

1. Create a new project with each adapter (Next.js App Router, Next.js Pages Router, Nuxt, SvelteKit)
2. Verify the generated Slice Simulator page imports `SliceSimulator` from the correct package:
   - Next.js App Router: `@prismicio/next`
   - Next.js Pages Router: `@prismicio/next/pages`
   - Nuxt: No explicit import (auto-imported)
   - SvelteKit: `@prismicio/svelte`
3. Verify the Slice Simulator page works correctly in each framework

🎉

<!-- A note for reviewers: -->

[^1]:
	Please use these labels when submitting a review:
	:question: #ask:&ensp;Ask a question.
	:bulb: #idea:&ensp;Suggest an idea.
	:warning: #issue:&ensp;Strongly suggest a change.
	:tada: #nice:&ensp;Share a compliment.
