### PR TITLE
Start slicemachine: Add option to allow custom config path

### DIFF
--- a/packages/start-slicemachine/src/StartSliceMachineProcess.ts
+++ b/packages/start-slicemachine/src/StartSliceMachineProcess.ts
@@ -33,6 +33,7 @@ export const createStartSliceMachineProcess = (
 export type StartSliceMachineProcessConstructorArgs = {
 	open: boolean;
 	port?: number;
+	cwd?: string;
 };
 
 /**
@@ -60,7 +61,9 @@ export class StartSliceMachineProcess {
 	private _sliceMachineManager: SliceMachineManager;
 
 	constructor(args: StartSliceMachineProcessConstructorArgs) {
-		this._sliceMachineManager = createSliceMachineManager();
+		this._sliceMachineManager = createSliceMachineManager({
+			cwd: args.cwd,
+		});
 
 		this.open = args.open ?? false;
 		this.port = args.port ?? DEFAULT_SERVER_PORT;

--- a/packages/start-slicemachine/src/cli.ts
+++ b/packages/start-slicemachine/src/cli.ts
@@ -1,3 +1,6 @@
+import * as path from "node:path";
+import * as fs from "node:fs";
+
 import mri from "mri";
 
 import * as pkg from "../package.json";
@@ -5,15 +8,17 @@ import * as pkg from "../package.json";
 type Args = {
 	open: boolean;
 	port: string;
+	config: string;
 	help: boolean;
 	version: boolean;
 };
 
 const args = mri<Args>(process.argv.slice(2), {
 	boolean: ["open", "help", "version"],
-	string: ["port"],
+	string: ["port", "config"],
 	alias: {
 		port: "p",
+		config: "c",
 		help: "h",
 		version: "v",
 	},
@@ -33,6 +38,7 @@ Usage:
 Options:
     --open         Open Slice Machine automatically
     --port, -p     Specify the port on which to run Slice Machine
+    --config, -c   Path to your slicemachine.config.json (directory or config file)
     --help, -h     Show help text
     --version, -v  Show version
 `.trim(),
@@ -58,11 +64,23 @@ if (args.port) {
 	}
 }
 
+let cwd: string | undefined;
+if (args.config) {
+	const configPath = path.resolve(process.cwd(), args.config);
+	// Handle both cases where the config is a directory or a file path
+	if (fs.existsSync(configPath) && fs.statSync(configPath).isDirectory()) {
+		cwd = configPath;
+	} else {
+		cwd = path.dirname(configPath);
+	}
+}
+
 import("./StartSliceMachineProcess").then(
 	({ createStartSliceMachineProcess }) => {
 		const startSliceMachineProcess = createStartSliceMachineProcess({
 			open: args.open,
 			port,
+			cwd,
 		});
 
 		startSliceMachineProcess.run();


### PR DESCRIPTION
<!-- Please use a Conventional Commit in your PR title -->
<!-- https://conventionalcommits.org -->
<!-- e.g. "feat: support new field type" -->

Resolves: https://github.com/prismicio/slice-machine/issues/1764 (Partially only)

### Description

The change adds a CLI option to the `start-slicemachine` script to allow configuring where the slicemachine.config file is located

This allows users to locate their files and directories where they want in their project

### Checklist

This is only a POC but I'm willing to polish and finish the PR if this is of interest for you

<!-- Put an `x` in all the boxes that apply. -->
<!-- Don't hesitate to ask for help! -->

- [ ] If my changes require tests, I added them.
- [ ] If my changes affect backward compatibility, it has been discussed.
- [ ] If my changes require an update to the CONTRIBUTING.md guide, I updated it.

### Preview

N/A

### How to QA [^1]

<!-- When relevant, describe how to QA your changes. -->

<!-- Your favorite emoji is welcome to close your PR! -->

<!-- A note for reviewers: -->

[^1]:
	Please use these labels when submitting a review:
	:question: #ask:&ensp;Ask a question.
	:bulb: #idea:&ensp;Suggest an idea.
	:warning: #issue:&ensp;Strongly suggest a change.
	:tada: #nice:&ensp;Share a compliment.
