### PR TITLE
devops

### DIFF
--- a/packages/manager/src/constants/API_ENDPOINTS.ts
+++ b/packages/manager/src/constants/API_ENDPOINTS.ts
@@ -106,6 +106,7 @@ If you didn't intend to run Slice Machine this way, stop it immediately and unse
 
 		case APPLICATION_MODE.DevTools:
 		case APPLICATION_MODE.MarketingTools:
+		case APPLICATION_MODE.Devops:
 		case APPLICATION_MODE.Platform: {
 			return {
 				PrismicWroom: `https://${process.env.SM_ENV}-wroom.com/`,

--- a/packages/manager/src/constants/API_TOKENS.ts
+++ b/packages/manager/src/constants/API_TOKENS.ts
@@ -11,6 +11,7 @@ export const API_TOKENS: APITokens = (() => {
 		case APPLICATION_MODE.DevTools:
 		case APPLICATION_MODE.MarketingTools:
 		case APPLICATION_MODE.Platform:
+		case APPLICATION_MODE.Devops:
 		case APPLICATION_MODE.Staging:
 			return {
 				SegmentKey: "Ng5oKJHCGpSWplZ9ymB7Pu7rm0sTDeiG",

--- a/packages/manager/src/constants/APPLICATION_MODE.ts
+++ b/packages/manager/src/constants/APPLICATION_MODE.ts
@@ -3,6 +3,7 @@ export const APPLICATION_MODE = {
 	DevTools: "dev-tools",
 	MarketingTools: "marketing-tools",
 	Platform: "platform",
+	Devops: "devops",
 	Staging: "staging",
 	Production: "production",
 } as const;

--- a/scripts/play.ts
+++ b/scripts/play.ts
@@ -48,6 +48,7 @@ type Args = {
     | "production"
     | "development"
     | "dev-tools"
+    | "devops"
     | "marketing-tools"
     | "platform";
 
@@ -109,7 +110,7 @@ Usage:
 Options:
     --new              Create a new playground
     --framework, -f    Specify the playground's framework (next, nuxt, sveltekit) (default: ${DEFAULT_FRAMEWORK})
-    --environment, -e  Specify the playground's environment (staging, dev-tools, marketing-tools, platform, production, development) (default: ${DEFAULT_ENVIRONMENT})
+    --environment, -e  Specify the playground's environment (staging, dev-tools, marketing-tools, platform, devops, production, development) (default: ${DEFAULT_ENVIRONMENT})
     --no-start         Do not start Slice Machine and the website
     --prefix, -p       Specify the prefix for the playground name (default: ${DEFAULT_PREFIX})
     --dry-run, -n      Show what would have happened
@@ -130,6 +131,7 @@ Arguments:
       "development",
       "dev-tools",
       "marketing-tools",
+      "devops",
       "platform",
     ].includes(args.environment)
   ) {
@@ -338,7 +340,7 @@ async function createPlayground(
       { dryRun: options.dryRun },
     );
   } else if (
-    ["dev-tools", "marketing-tools", "platform"].includes(options.environment!)
+    ["dev-tools", "marketing-tools", "devops", "platform"].includes(options.environment!)
   ) {
     await updateSliceMachineConfig(
       dir,


### PR DESCRIPTION
Add devops environment for playground

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new `devops` environment option that affects runtime endpoint/token selection and playground configuration; misconfiguration could point clients to the wrong backend URLs.
> 
> **Overview**
> Adds a new application mode, `devops`, and wires it through environment-based configuration.
> 
> `APPLICATION_MODE` now includes `Devops`, `API_ENDPOINTS`/`API_TOKENS` treat it like other non-production hosted environments, and the `yarn play` CLI accepts `--environment devops` and generates the corresponding Slice Machine `apiEndpoint` URL pattern.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2d97d53b115671f0be9cdb0469e8a071324e9a8d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->