### PR TITLE
feat: enrich Segment events with starter context from config

### DIFF
--- a/packages/init/src/SliceMachineInitProcess.ts
+++ b/packages/init/src/SliceMachineInitProcess.ts
@@ -1084,6 +1084,9 @@ ${chalk.cyan("?")} Your Prismic repository name`.replace("\n", ""),
 								...config,
 								repositoryName: this.context.repository.domain,
 								adapter: this.context.framework.adapterName,
+								...(this.options.starter
+									? { starter: this.options.starter }
+									: {}),
 							},
 						});
 						parentTask.title = "Updated Slice Machine configuration";
@@ -1098,6 +1101,9 @@ ${chalk.cyan("?")} Your Prismic repository name`.replace("\n", ""),
 								repositoryName: this.context.repository.domain,
 								adapter: this.context.framework.adapterName,
 								libraries: ["./slices"],
+								...(this.options.starter
+									? { starter: this.options.starter }
+									: {}),
 							},
 							path: sliceMachineConfigPath,
 						});

--- a/packages/manager/src/lib/decodeSliceMachineConfig.ts
+++ b/packages/manager/src/lib/decodeSliceMachineConfig.ts
@@ -27,6 +27,7 @@ const SliceMachineConfigCodec = t.intersection([
 		localSliceSimulatorURL: t.string,
 		plugins: t.array(SliceMachineConfigPluginRegistrationCodec),
 		labs: t.partial({ legacySliceUpgrader: t.boolean }),
+		starter: t.string,
 	}),
 ]);
 

--- a/packages/manager/src/managers/telemetry/TelemetryManager.ts
+++ b/packages/manager/src/managers/telemetry/TelemetryManager.ts
@@ -111,6 +111,14 @@ export class TelemetryManager extends BaseManager {
 			}
 		}
 
+		let starter: string | undefined;
+		try {
+			const config = await this.project.getSliceMachineConfig();
+			starter = config.starter;
+		} catch {
+			// noop, happen only when the user is not in a project
+		}
+
 		let environmentKind: Environment["kind"] | "_unknown" | undefined =
 			undefined;
 		if (_includeEnvironmentKind) {
@@ -150,6 +158,7 @@ export class TelemetryManager extends BaseManager {
 			properties: {
 				nodeVersion: process.versions.node,
 				environmentKind,
+				starter,
 				...properties,
 			},
 			context: { ...this._context },

--- a/packages/manager/src/managers/telemetry/TelemetryManager.ts
+++ b/packages/manager/src/managers/telemetry/TelemetryManager.ts
@@ -102,21 +102,16 @@ export class TelemetryManager extends BaseManager {
 	async track(args: TelemetryManagerTrackArgs): Promise<void> {
 		const { event, repository, _includeEnvironmentKind, ...properties } = args;
 		let repositoryName = repository;
+		let starter: string | undefined;
 
 		if (repositoryName === undefined) {
 			try {
-				repositoryName = await this.project.getRepositoryName();
-			} catch (error) {
-				// noop, happen only when the user is not in a project
+				const config = await this.project.getSliceMachineConfig();
+				repositoryName = config.repositoryName;
+				starter = config.starter;
+			} catch {
+				// noop, happens only when the user is not in a project
 			}
-		}
-
-		let starter: string | undefined;
-		try {
-			const config = await this.project.getSliceMachineConfig();
-			starter = config.starter;
-		} catch {
-			// noop, happen only when the user is not in a project
 		}
 
 		let environmentKind: Environment["kind"] | "_unknown" | undefined =

--- a/packages/manager/src/types.ts
+++ b/packages/manager/src/types.ts
@@ -32,6 +32,7 @@ export type SliceMachineConfig = {
 	adapter: SliceMachineConfigPluginRegistration;
 	plugins?: SliceMachineConfigPluginRegistration[];
 	labs?: { legacySliceUpgrader?: boolean };
+	starter?: string;
 };
 
 export type OnlyHookErrors<

--- a/packages/plugin-kit/src/lib/decodeSliceMachineConfig.ts
+++ b/packages/plugin-kit/src/lib/decodeSliceMachineConfig.ts
@@ -27,6 +27,7 @@ const SliceMachineConfigCodec = t.intersection([
 		localSliceSimulatorURL: t.string,
 		plugins: t.array(SliceMachineConfigPluginRegistrationCodec),
 		labs: t.partial({ legacySliceUpgrader: t.boolean }),
+		starter: t.string,
 	}),
 ]);
 

--- a/packages/plugin-kit/src/types.ts
+++ b/packages/plugin-kit/src/types.ts
@@ -70,6 +70,7 @@ export type SliceMachineConfig = {
 	adapter: SliceMachineConfigPluginRegistration;
 	plugins?: SliceMachineConfigPluginRegistration[];
 	labs?: { legacySliceUpgrader?: boolean };
+	starter?: string;
 };
 
 /**


### PR DESCRIPTION
## Summary

- Adds an optional `starter` field to `SliceMachineConfig` (types + io-ts codecs in both `@slicemachine/manager` and `@slicemachine/plugin-kit`) so it persists through config decode/write cycles.
- Writes the `starter` value into `slicemachine.config.json` during `@slicemachine/init` when the `--starter` flag is provided.
- Auto-enriches **all** outgoing Segment events in `TelemetryManager.track()` with the `starter` property read from config — no individual event call-sites need changing.

This lets us build an Amplitude funnel (init → models pushed) filtered by `starter` to measure how many agentic-migration-starter users actually complete a migration, not just initialize.

## Context

Builds on #1771 which added the `--starter` flag to `@slicemachine/init`. That PR only tracked the starter name during `command:init:end`. This PR ensures the value is available on **every** Segment event (especially `changes:pushed`) for the lifetime of the project.

## Test plan

- [ ] Run `npx @slicemachine/init --starter agentic-migration` on a fresh project and verify `slicemachine.config.json` contains `"starter": "agentic-migration"`.
- [ ] Run `npx @slicemachine/init` (no `--starter`) and verify the config does **not** contain a `starter` field.
- [ ] Start Slice Machine and push changes — verify the `changes:pushed` Segment event payload includes the `starter` property.
- [ ] For a project without `starter` in config, verify events still fire normally with `starter: undefined`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds an optional `starter` field to config schemas/types and enriches telemetry payloads without changing core project logic or write paths beyond config serialization.
> 
> **Overview**
> Persists an optional `starter` identifier in `SliceMachineConfig` across `@slicemachine/manager` and `@slicemachine/plugin-kit` (types + io-ts decoders) so it survives config decode/write cycles.
> 
> Updates `@slicemachine/init` to write `starter` into `slicemachine.config.json` when `--starter` is provided, and updates `TelemetryManager.track()` to read `starter` from the config (when repository isn’t explicitly passed) and include it on every Segment event payload.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ef07d93e573941b64cee6784342a125ed7a5d082. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->